### PR TITLE
Some throughput improvements for Simple Meters with decreasing count of created objects during measurement process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 .gradle/
 gradle.properties
+*.iml
+.idea

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -47,8 +47,5 @@ dependencies {
 
 jmh {
     jmhVersion = '1.18'
-    warmupIterations = 2
-    iterations = 5
-    fork = 0
     duplicateClassesStrategy = 'warn'
 }

--- a/micrometer-core/src/jmh/java/io/micrometer/core/benchmark/QuantilesBenchmark.java
+++ b/micrometer-core/src/jmh/java/io/micrometer/core/benchmark/QuantilesBenchmark.java
@@ -27,6 +27,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
+@Warmup(iterations = 2)
+@Fork(value = 0)
+@Measurement(iterations = 5)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)

--- a/micrometer-core/src/jmh/java/io/micrometer/core/benchmark/SimpleMeasureBenchmark.java
+++ b/micrometer-core/src/jmh/java/io/micrometer/core/benchmark/SimpleMeasureBenchmark.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.benchmark;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.simple.*;
+import io.micrometer.core.instrument.util.MeterId;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Dmitry Poluyanov
+ * @since 22.07.17
+ */
+@Warmup(iterations = 10)
+@Fork(jvmArgs = {/*"-XX:+PrintGCDetails", "-XX:+PrintGCTimeStamps", */"-Xmx8m"})
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class SimpleMeasureBenchmark {
+
+    private Timer timer;
+    private LongTaskTimer longTaskTimer;
+    private Counter counter;
+    private Gauge gauge;
+    private DistributionSummary distributionSummary;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(SimpleMeasureBenchmark.class.getSimpleName())
+                .warmupIterations(20)
+                .measurementIterations(30)
+                .mode(Mode.Throughput)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        MeterId meterId = new MeterId("tested.timer", Tag.of("tag1", "v1"), Tag.of("tag2", "v2"));
+        timer = new SimpleTimer(meterId, Clock.SYSTEM);
+        longTaskTimer = new SimpleLongTaskTimer(meterId, Clock.SYSTEM);
+        counter = new SimpleCounter(meterId);
+        List<Integer> testListReference = Arrays.asList(1, 2);
+        gauge = new SimpleGauge<>(meterId, testListReference, List::size);
+        distributionSummary = new SimpleDistributionSummary(meterId);
+    }
+
+    @Benchmark
+    public Iterable<io.micrometer.core.instrument.Measurement> timerMeasure() {
+        return timer.measure();
+    }
+
+    @Benchmark
+    public Iterable<io.micrometer.core.instrument.Measurement> longTaskTimerMeasure() {
+        return longTaskTimer.measure();
+    }
+
+    @Benchmark
+    public Iterable<io.micrometer.core.instrument.Measurement> counterMeasure() {
+        return counter.measure();
+    }
+
+    @Benchmark
+    public Iterable<io.micrometer.core.instrument.Measurement> gaugeMeasure() {
+        return gauge.measure();
+    }
+
+    @Benchmark
+    public Iterable<io.micrometer.core.instrument.Measurement> distributionSummaryMeasure() {
+        return distributionSummary.measure();
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleCounter.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.simple;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.util.MeterId;
 
 import java.util.Collections;
@@ -26,10 +27,13 @@ import java.util.concurrent.atomic.DoubleAdder;
  * @author Jon Schneider
  */
 public class SimpleCounter extends AbstractSimpleMeter implements Counter {
+    private static final Tag TYPE_TAG = SimpleUtils.typeTag(Type.Counter);
+    private final MeterId countId;
     private DoubleAdder count = new DoubleAdder();
 
     public SimpleCounter(MeterId id) {
         super(id);
+        this.countId = id.withTags(TYPE_TAG);
     }
 
     @Override
@@ -49,6 +53,6 @@ public class SimpleCounter extends AbstractSimpleMeter implements Counter {
 
     @Override
     public Iterable<Measurement> measure() {
-        return Collections.singletonList(id.withTags(SimpleUtils.typeTag(getType())).measurement(count()));
+        return Collections.singletonList(countId.measurement(count()));
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleDistributionSummary.java
@@ -15,26 +15,35 @@
  */
 package io.micrometer.core.instrument.simple;
 
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.util.MeterId;
-import io.micrometer.core.instrument.DistributionSummary;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 
 public class SimpleDistributionSummary extends AbstractSimpleMeter implements DistributionSummary {
+    private static final Tag STAT_COUNT_TAG = Tag.of("statistic", "count");
+    private static final Tag STAT_AMOUNT_TAG = Tag.of("statistic", "amount");
+    private static final Tag TYPE_TAG = SimpleUtils.typeTag(Type.DistributionSummary);
+
+    private final MeterId countId;
+    private final MeterId amountId;
+
     private LongAdder count = new LongAdder();
     private DoubleAdder amount = new DoubleAdder();
 
     public SimpleDistributionSummary(MeterId id) {
         super(id);
+        this.countId = id.withTags(TYPE_TAG, STAT_COUNT_TAG);
+        this.amountId = id.withTags(TYPE_TAG, STAT_AMOUNT_TAG);
     }
 
     @Override
     public void record(double amount) {
-        if(amount >= 0) {
+        if (amount >= 0) {
             count.increment();
             this.amount.add(amount);
         }
@@ -53,8 +62,7 @@ public class SimpleDistributionSummary extends AbstractSimpleMeter implements Di
     @Override
     public Iterable<Measurement> measure() {
         return Arrays.asList(
-            id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "count")).measurement(count()),
-            id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "amount")).measurement(totalAmount())
-        );
+                countId.measurement(count()),
+                amountId.measurement(totalAmount()));
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleGauge.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.simple;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.util.MeterId;
 
 import java.lang.ref.WeakReference;
@@ -24,13 +25,16 @@ import java.util.Collections;
 import java.util.function.ToDoubleFunction;
 
 public class SimpleGauge<T> extends AbstractSimpleMeter implements Gauge {
+    private static final Tag TYPE_TAG = SimpleUtils.typeTag(Type.Gauge);
     private final WeakReference<T> ref;
     private final ToDoubleFunction<T> value;
+    private final MeterId gaugeId;
 
     public SimpleGauge(MeterId id, T obj, ToDoubleFunction<T> value) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.value = value;
+        this.gaugeId = id.withTags(TYPE_TAG);
     }
 
     @Override
@@ -40,6 +44,6 @@ public class SimpleGauge<T> extends AbstractSimpleMeter implements Gauge {
 
     @Override
     public Iterable<Measurement> measure() {
-        return Collections.singletonList(id.withTags(SimpleUtils.typeTag(getType())).measurement(value()));
+        return Collections.singletonList(gaugeId.measurement(value()));
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleLongTaskTimer.java
@@ -27,13 +27,22 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class SimpleLongTaskTimer extends AbstractSimpleMeter implements LongTaskTimer {
+    private static final Tag TYPE_TAG = SimpleUtils.typeTag(Type.LongTaskTimer);
+    private static final Tag STAT_ACTIVE_TASKS_TAG = Tag.of("statistic", "activeTasks");
+    private static final Tag STAT_DURATION_TAG = Tag.of("statistic", "duration");
+
     private final ConcurrentMap<Long, Long> tasks = new ConcurrentHashMap<>();
     private final AtomicLong nextTask = new AtomicLong(0L);
     private final Clock clock;
 
+    private final MeterId activeTasksId;
+    private final MeterId durationId;
+
     public SimpleLongTaskTimer(MeterId id, Clock clock) {
         super(id);
         this.clock = clock;
+        this.activeTasksId = id.withTags(TYPE_TAG, STAT_ACTIVE_TASKS_TAG);
+        this.durationId = id.withTags(TYPE_TAG, STAT_DURATION_TAG);
     }
 
     @Override
@@ -78,8 +87,7 @@ public class SimpleLongTaskTimer extends AbstractSimpleMeter implements LongTask
     @Override
     public Iterable<Measurement> measure() {
         return Arrays.asList(
-                id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "activeTasks")).measurement(activeTasks()),
-                id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "duration")).measurement(duration())
-        );
+                activeTasksId.measurement(activeTasks()),
+                durationId.measurement(duration()));
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleTimer.java
@@ -30,16 +30,24 @@ import java.util.concurrent.atomic.LongAdder;
  * @author Jon Schneider
  */
 public class SimpleTimer extends AbstractTimer {
+    private static final Tag STAT_COUNT_TAG = Tag.of("statistic", "count");
+    private static final Tag STAT_AMOUNT_TAG = Tag.of("statistic", "amount");
+    private static final Tag TYPE_TAG = SimpleUtils.typeTag(Type.Timer);
+
+    private final MeterId countId;
+    private final MeterId amountId;
     private LongAdder count = new LongAdder();
     private LongAdder totalTime = new LongAdder();
 
     public SimpleTimer(MeterId id, Clock clock) {
         super(id, clock);
+        this.countId = id.withTags(TYPE_TAG, STAT_COUNT_TAG);
+        this.amountId = id.withTags(TYPE_TAG, STAT_AMOUNT_TAG);
     }
 
     @Override
     public void record(long amount, TimeUnit unit) {
-        if(amount >= 0) {
+        if (amount >= 0) {
             count.increment();
             totalTime.add(TimeUnit.NANOSECONDS.convert(amount, unit));
         }
@@ -58,8 +66,7 @@ public class SimpleTimer extends AbstractTimer {
     @Override
     public Iterable<Measurement> measure() {
         return Arrays.asList(
-                id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "count")).measurement(count()),
-                id.withTags(SimpleUtils.typeTag(getType()), Tag.of("statistic", "amount")).measurement(totalTime(TimeUnit.NANOSECONDS))
-        );
+                countId.measurement(count()),
+                amountId.measurement(totalTime(TimeUnit.NANOSECONDS)));
     }
 }


### PR DESCRIPTION
This can be useful for all backends in #48 
```
e.g: on MBP 2014  (with Xmx8m)
Before fix
SimpleMeasureBenchmark.timerMeasure                  thrpt   30  546,673 ± 5,144  ops/ms
SimpleMeasureBenchmark.longTaskTimerMeasure          thrpt   30  480,073 ± 10,585  ops/ms
SimpleMeasureBenchmark.counterMeasure                thrpt   30  1158,556 ± 13,378  ops/ms
SimpleMeasureBenchmark.gaugeMeasure                  thrpt   30  1119,509 ± 14,784  ops/ms
SimpleMeasureBenchmark.distributionSummaryMeasure    thrpt   30  514,463 ± 5,484  ops/ms

After fix
SimpleMeasureBenchmark.timerMeasure                  thrpt   30  2088,021 ± 14,168  ops/ms
SimpleMeasureBenchmark.longTaskTimerMeasure          thrpt   30  1665,487 ± 17,270  ops/ms
SimpleMeasureBenchmark.counterMeasure                thrpt   30  5129,027 ± 48,356  ops/ms
SimpleMeasureBenchmark.gaugeMeasure                  thrpt   30  4904,147 ± 55,073  ops/ms
SimpleMeasureBenchmark.distributionSummaryMeasure    thrpt   30  2040,290 ± 15,672  ops/ms
```