### PR TITLE
Pass injected parameter to Bean constructor

### DIFF
--- a/micrometer-spring/src/main/java/org/springframework/boot/metrics/export/prometheus/PrometheusMetricsConfiguration.java
+++ b/micrometer-spring/src/main/java/org/springframework/boot/metrics/export/prometheus/PrometheusMetricsConfiguration.java
@@ -36,6 +36,6 @@ public class PrometheusMetricsConfiguration {
 
     @Bean
     PrometheusMeterRegistry meterRegistry(CollectorRegistry collectorRegistry) {
-        return new PrometheusMeterRegistry();
+        return new PrometheusMeterRegistry(collectorRegistry);
     }
 }


### PR DESCRIPTION
Method injection is used for the `CollectorRegistry` dependency, but it is not passed to the constructor for `PrometheusMeterRegistry` as mentioned in the following comment: https://github.com/micrometer-metrics/micrometer/commit/45ebbb3144a0ec7864fba4503425a51900fe71dd#commitcomment-23304373