### PR TITLE
Initial Caffeine cache metric support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.java]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 build/
 .gradle/
 gradle.properties
+out/
+
 *.iml
+*.ipr
+*.iws
 .idea

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     // cache monitoring
     compile 'com.google.guava:guava:21.0', optional
+    compile 'com.github.ben-manes.caffeine:caffeine:2.3.0', optional
 
     // log monitoring
     compile 'ch.qos.logback:logback-classic:latest.release', optional
@@ -39,6 +40,7 @@ dependencies {
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.0.0-M5'
 
     testCompile 'org.assertj:assertj-core:3.+'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 
     jmh 'org.openjdk.jmh:jmh-core:latest.release'
     jmh 'org.openjdk.jmh:jmh-generator-annprocess:latest.release'

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CacheMetrics.java
@@ -16,14 +16,8 @@
 package io.micrometer.core.instrument.binder;
 
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 import io.micrometer.core.instrument.*;
-
-import java.util.Arrays;
-import java.util.Collections;
-
-import static java.util.Collections.singletonList;
 
 /**
  * @author Jon Schneider

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Pivotal Software, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -57,49 +57,45 @@ import java.util.List;
   * @author Clint Checketts
  */
 public class CaffeineCacheMetrics implements MeterBinder {
-  private final String name;
-  private final Cache<?, ?> cache;
+    private final String name;
+    private final Cache<?, ?> cache;
 
-  /**
-   * @param name  The named of the cache, exposed as the 'cache' dimension
-   * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
-   */
-  public CaffeineCacheMetrics(String name, Cache<?, ?> cache) {
-    this.name = name;
-    this.cache = cache;
-  }
-
-
-  /**
-   * @param name  The named of the cache, exposed as the 'cache' dimension
-   * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
-   */
-  public CaffeineCacheMetrics(String name, AsyncLoadingCache<?, ?> cache) {
-    this.name = name;
-    this.cache = cache.synchronous();
-  }
-
-  @Override
-  public void bindTo(MeterRegistry registry) {
-    List<Tag> tags = Tags.zip("cache", name);
-    registry.gauge("caffeine_cache_estimated_size", tags, cache, Cache::estimatedSize);
-
-    registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "miss"), cache, c -> c.stats().missCount());
-    registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "hit"), cache, c -> c.stats().hitCount());
-    registry.counter("caffeine_cache_requests_total", tags, cache, c -> c.stats().requestCount());
-    registry.counter("caffeine_cache_evictions_total", tags, cache, c -> c.stats().evictionCount());
-    registry.gauge("caffeine_cache_eviction_weight", tags, cache, c -> c.stats().evictionWeight());
-
-    if (cache instanceof LoadingCache) {
-      // dividing these gives you a measure of load latency
-      registry.counter("caffeine_cache_load_duration_seconds_sum", tags, cache, c -> c.stats().totalLoadTime());
-      registry.counter("caffeine_cache_load_duration_seconds_count", tags, cache, c -> c.stats().loadCount());
-
-      registry.counter("caffeine_cache_load_failures_total", tags, cache, c -> c.stats().loadFailureCount());
+    /**
+     * @param name  The named of the cache, exposed as the 'cache' dimension
+     * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
+     */
+    public CaffeineCacheMetrics(String name, Cache<?, ?> cache) {
+        this.name = name;
+        this.cache = cache;
     }
 
-    if (cache instanceof AsyncLoadingCache) {
 
+    /**
+     * @param name  The named of the cache, exposed as the 'cache' dimension
+     * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
+     */
+    public CaffeineCacheMetrics(String name, AsyncLoadingCache<?, ?> cache) {
+        this.name = name;
+        this.cache = cache.synchronous();
     }
-  }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        List<Tag> tags = Tags.zip("cache", name);
+        registry.gauge("caffeine_cache_estimated_size", tags, cache, Cache::estimatedSize);
+
+        registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "miss"), cache, c -> c.stats().missCount());
+        registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "hit"), cache, c -> c.stats().hitCount());
+        registry.counter("caffeine_cache_requests_total", tags, cache, c -> c.stats().requestCount());
+        registry.counter("caffeine_cache_evictions_total", tags, cache, c -> c.stats().evictionCount());
+        registry.gauge("caffeine_cache_eviction_weight", tags, cache, c -> c.stats().evictionWeight());
+
+        if (cache instanceof LoadingCache) {
+            // dividing these gives you a measure of load latency
+            registry.counter("caffeine_cache_load_duration_seconds_sum", tags, cache, c -> c.stats().totalLoadTime());
+            registry.counter("caffeine_cache_load_duration_seconds_count", tags, cache, c -> c.stats().loadCount());
+
+            registry.counter("caffeine_cache_load_failures_total", tags, cache, c -> c.stats().loadFailureCount());
+        }
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+import java.util.List;
+
+/* Collect metrics from Caffeine's com.github.benmanes.caffeine.cache.Cache.
+  * <p>
+  * <pre>{@code
+  *
+  * // Note that `recordStats()` is required to gather non-zero statistics
+  * Cache<String, String> cache = Caffeine.newBuilder().recordStats().build();
+  * CacheMetricsCollector cacheMetrics = new CacheMetricsCollector().register();
+  * cacheMetrics.addCache("mycache", cache);
+  *
+  * }</pre>
+  *
+  * Exposed metrics are labeled with the provided cache name.
+  *
+  * With the example above, sample metric names would be:
+  * <pre>
+  *     caffeine_cache_hit_total{cache="mycache"} 10.0
+  *     caffeine_cache_miss_total{cache="mycache"} 3.0
+  *     caffeine_cache_requests_total{cache="mycache"} 13.0
+  *     caffeine_cache_eviction_total{cache="mycache"} 1.0
+  *     caffeine_cache_estimated_size{cache="mycache"} 5.0
+  * </pre>
+  *
+  * Additionally if the cache includes a loader, the following metrics would be provided:
+  * <pre>
+  *     caffeine_cache_load_failure_total{cache="mycache"} 2.0
+  *     caffeine_cache_loads_total{cache="mycache"} 7.0
+  *     caffeine_cache_load_duration_seconds_count{cache="mycache"} 7.0
+  *     caffeine_cache_load_duration_seconds_sum{cache="mycache"} 0.0034
+  * </pre>
+  *
+  * @author Clint Checketts
+ */
+public class CaffeineCacheMetrics implements MeterBinder {
+  private final String name;
+  private final Cache<?, ?> cache;
+
+  /**
+   * @param name  The named of the cache, exposed as the 'cache' dimension
+   * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
+   */
+  public CaffeineCacheMetrics(String name, Cache<?, ?> cache) {
+    this.name = name;
+    this.cache = cache;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    List<Tag> tags = Tags.zip("cache", name);
+    registry.gauge("caffeine_cache_estimated_size", tags, cache, Cache::estimatedSize);
+
+    registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "miss"), cache, c -> c.stats().missCount());
+    registry.counter("caffeine_cache_requests", Tags.zip("cache", name, "result", "hit"), cache, c -> c.stats().hitCount());
+    registry.counter("caffeine_cache_requests_total", tags, cache, c -> c.stats().requestCount());
+    registry.counter("caffeine_cache_evictions_total", tags, cache, c -> c.stats().evictionCount());
+    registry.gauge("caffeine_cache_eviction_weight", tags, cache, c -> c.stats().evictionWeight());
+
+    if (cache instanceof LoadingCache) {
+      // dividing these gives you a measure of load latency
+      registry.counter("caffeine_cache_load_duration_seconds_sum", tags, cache, c -> c.stats().totalLoadTime());
+      registry.counter("caffeine_cache_load_duration_seconds_count", tags, cache, c -> c.stats().loadCount());
+
+      registry.counter("caffeine_cache_load_failures_total", tags, cache, c -> c.stats().loadFailureCount());
+    }
+  }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Pivotal Software, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/CaffeineCacheMetrics.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder;
 
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -68,6 +69,16 @@ public class CaffeineCacheMetrics implements MeterBinder {
     this.cache = cache;
   }
 
+
+  /**
+   * @param name  The named of the cache, exposed as the 'cache' dimension
+   * @param cache The cache to be instrumented. Be certain to enable <cade></cade>
+   */
+  public CaffeineCacheMetrics(String name, AsyncLoadingCache<?, ?> cache) {
+    this.name = name;
+    this.cache = cache.synchronous();
+  }
+
   @Override
   public void bindTo(MeterRegistry registry) {
     List<Tag> tags = Tags.zip("cache", name);
@@ -85,6 +96,10 @@ public class CaffeineCacheMetrics implements MeterBinder {
       registry.counter("caffeine_cache_load_duration_seconds_count", tags, cache, c -> c.stats().loadCount());
 
       registry.counter("caffeine_cache_load_failures_total", tags, cache, c -> c.stats().loadFailureCount());
+    }
+
+    if (cache instanceof AsyncLoadingCache) {
+
     }
   }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
@@ -1,0 +1,115 @@
+package io.micrometer.core.instrument.binder;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Executor;
+
+import static io.micrometer.core.instrument.Meter.Type.Counter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CaffeineCacheMetricsTest {
+
+
+  @Test
+  public void cacheExposesMetricsForHitMissAndEviction() throws Exception {
+    Cache<String, String> cache = Caffeine.newBuilder().maximumSize(2).recordStats().executor(new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        // Run cleanup in same thread, to remove async behavior with evictions
+        command.run();
+      }
+    }).build();
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    CaffeineCacheMetrics collector = new CaffeineCacheMetrics("users", cache);
+    collector.bindTo(registry);
+
+    cache.getIfPresent("user1");
+    cache.getIfPresent("user1");
+    cache.put("user1", "First User");
+    cache.getIfPresent("user1");
+
+    // Add to cache to trigger eviction.
+    cache.put("user2", "Second User");
+    cache.put("user3", "Third User");
+    cache.put("user4", "Fourth User");
+
+    assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "hit"),"users", 1.0, "caffeine_cache_requests");
+    assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "miss"),"users", 2.0, "caffeine_cache_requests");
+    assertMetric(registry, Counter, "users", 3.0, "caffeine_cache_requests_total");
+    assertMetric(registry, Counter, "users", 2.0, "caffeine_cache_evictions_total");
+  }
+
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void loadingCacheExposesMetricsForLoadsAndExceptions() throws Exception {
+    CacheLoader<String, String> loader = mock(CacheLoader.class);
+    when(loader.load(anyString()))
+            .thenReturn("First User")
+            .thenThrow(new RuntimeException("Seconds time fails"))
+            .thenReturn("Third User");
+
+    LoadingCache<String, String> cache = Caffeine.newBuilder().recordStats().build(loader);
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    CaffeineCacheMetrics collector = new CaffeineCacheMetrics("loadingusers", cache);
+    collector.bindTo(registry);
+
+    cache.get("user1");
+    cache.get("user1");
+    try {
+      cache.get("user2");
+    } catch (Exception e) {
+      // ignoring.
+    }
+    cache.get("user3");
+
+    assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "hit"), "loadingusers", 1.0, "caffeine_cache_requests");
+    assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "miss"),  "loadingusers", 3.0, "caffeine_cache_requests");
+
+    assertMetric(registry, Counter, "loadingusers", 1.0, "caffeine_cache_load_failures_total");
+    assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
+
+    assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
+//    assertMetricGreatThan(registry, Counter,"caffeine_cache_load_duration_seconds_sum", "loadingusers", 0.0);
+  }
+
+  private void assertMetric(MeterRegistry registry, Meter.Type type, String cacheName, double value, String name) {
+    assertMetric(registry, type, Tags.zip("cache", cacheName), cacheName, value, name);
+  }
+
+  private void assertMetric(MeterRegistry registry, Meter.Type type, List<Tag> tags, String cacheName, double value, String name) {
+    Optional<Meter> meter = registry.findMeter(type, name, tags);
+    if(!meter.isPresent()){
+      System.out.println("boom");
+    }
+    assertThat(meter).as("Meter should be in registry type="+type+" tags="+tags+" metricName=").isPresent();
+
+    assertThat(meter.get().measure().stream().findFirst().map(Measurement::getValue).get()).isEqualTo(value);
+  }
+
+
+//  private void assertMetricGreatThan(MeterRegistry registry,  Meter.Type type, String name, String cacheName, double value) {
+//    assertThat(registry.findMeter(type, name, Tags.zip("cache", name)).get().measure())
+//            .extracting(Measurement::getValue).
+//            .isGreaterThan(value);
+//  }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Pivotal Software, Inc.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,85 +40,85 @@ import static org.mockito.Mockito.when;
 class CaffeineCacheMetricsTest {
 
 
-  @Test
-  public void cacheExposesMetricsForHitMissAndEviction() throws Exception {
-    Cache<String, String> cache = Caffeine.newBuilder().maximumSize(2).recordStats().executor(new Executor() {
-      @Override
-      public void execute(Runnable command) {
-        // Run cleanup in same thread, to remove async behavior with evictions
-        command.run();
-      }
-    }).build();
-    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    @Test
+    public void cacheExposesMetricsForHitMissAndEviction() throws Exception {
+        Cache<String, String> cache = Caffeine.newBuilder().maximumSize(2).recordStats().executor(new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                // Run cleanup in same thread, to remove async behavior with evictions
+                command.run();
+            }
+        }).build();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
-    CaffeineCacheMetrics collector = new CaffeineCacheMetrics("users", cache);
-    collector.bindTo(registry);
+        CaffeineCacheMetrics collector = new CaffeineCacheMetrics("users", cache);
+        collector.bindTo(registry);
 
-    cache.getIfPresent("user1");
-    cache.getIfPresent("user1");
-    cache.put("user1", "First User");
-    cache.getIfPresent("user1");
+        cache.getIfPresent("user1");
+        cache.getIfPresent("user1");
+        cache.put("user1", "First User");
+        cache.getIfPresent("user1");
 
-    // Add to cache to trigger eviction.
-    cache.put("user2", "Second User");
-    cache.put("user3", "Third User");
-    cache.put("user4", "Fourth User");
+        // Add to cache to trigger eviction.
+        cache.put("user2", "Second User");
+        cache.put("user3", "Third User");
+        cache.put("user4", "Fourth User");
 
-    assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "hit"),"users", 1.0, "caffeine_cache_requests");
-    assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "miss"),"users", 2.0, "caffeine_cache_requests");
-    assertMetric(registry, Counter, "users", 3.0, "caffeine_cache_requests_total");
-    assertMetric(registry, Counter, "users", 2.0, "caffeine_cache_evictions_total");
-  }
+        assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "hit"), "users", 1.0, "caffeine_cache_requests");
+        assertMetric(registry, Counter, Tags.zip("cache", "users", "result", "miss"), "users", 2.0, "caffeine_cache_requests");
+        assertMetric(registry, Counter, "users", 3.0, "caffeine_cache_requests_total");
+        assertMetric(registry, Counter, "users", 2.0, "caffeine_cache_evictions_total");
+    }
 
 
-  @SuppressWarnings("unchecked")
-  @Test
-  public void loadingCacheExposesMetricsForLoadsAndExceptions() throws Exception {
-    CacheLoader<String, String> loader = mock(CacheLoader.class);
-    when(loader.load(anyString()))
+    @SuppressWarnings("unchecked")
+    @Test
+    public void loadingCacheExposesMetricsForLoadsAndExceptions() throws Exception {
+        CacheLoader<String, String> loader = mock(CacheLoader.class);
+        when(loader.load(anyString()))
             .thenReturn("First User")
             .thenThrow(new RuntimeException("Seconds time fails"))
             .thenReturn("Third User");
 
-    LoadingCache<String, String> cache = Caffeine.newBuilder().recordStats().build(loader);
+        LoadingCache<String, String> cache = Caffeine.newBuilder().recordStats().build(loader);
 
-    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
-    CaffeineCacheMetrics collector = new CaffeineCacheMetrics("loadingusers", cache);
-    collector.bindTo(registry);
+        CaffeineCacheMetrics collector = new CaffeineCacheMetrics("loadingusers", cache);
+        collector.bindTo(registry);
 
-    cache.get("user1");
-    cache.get("user1");
-    try {
-      cache.get("user2");
-    } catch (Exception e) {
-      // ignoring.
-    }
-    cache.get("user3");
+        cache.get("user1");
+        cache.get("user1");
+        try {
+            cache.get("user2");
+        } catch (Exception e) {
+            // ignoring.
+        }
+        cache.get("user3");
 
-    assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "hit"), "loadingusers", 1.0, "caffeine_cache_requests");
-    assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "miss"),  "loadingusers", 3.0, "caffeine_cache_requests");
+        assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "hit"), "loadingusers", 1.0, "caffeine_cache_requests");
+        assertMetric(registry, Counter, Tags.zip("cache", "loadingusers", "result", "miss"), "loadingusers", 3.0, "caffeine_cache_requests");
 
-    assertMetric(registry, Counter, "loadingusers", 1.0, "caffeine_cache_load_failures_total");
-    assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
+        assertMetric(registry, Counter, "loadingusers", 1.0, "caffeine_cache_load_failures_total");
+        assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
 
-    assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
+        assertMetric(registry, Counter, "loadingusers", 3.0, "caffeine_cache_load_duration_seconds_count");
 //    assertMetricGreatThan(registry, Counter,"caffeine_cache_load_duration_seconds_sum", "loadingusers", 0.0);
-  }
-
-  private void assertMetric(MeterRegistry registry, Meter.Type type, String cacheName, double value, String name) {
-    assertMetric(registry, type, Tags.zip("cache", cacheName), cacheName, value, name);
-  }
-
-  private void assertMetric(MeterRegistry registry, Meter.Type type, List<Tag> tags, String cacheName, double value, String name) {
-    Optional<Meter> meter = registry.findMeter(type, name, tags);
-    if(!meter.isPresent()){
-      System.out.println("boom");
     }
-    assertThat(meter).as("Meter should be in registry type="+type+" tags="+tags+" metricName=").isPresent();
 
-    assertThat(meter.get().measure().stream().findFirst().map(Measurement::getValue).get()).isEqualTo(value);
-  }
+    private void assertMetric(MeterRegistry registry, Meter.Type type, String cacheName, double value, String name) {
+        assertMetric(registry, type, Tags.zip("cache", cacheName), cacheName, value, name);
+    }
+
+    private void assertMetric(MeterRegistry registry, Meter.Type type, List<Tag> tags, String cacheName, double value, String name) {
+        Optional<Meter> meter = registry.findMeter(type, name, tags);
+        if (!meter.isPresent()) {
+            System.out.println("boom");
+        }
+        assertThat(meter).as("Meter should be in registry type=" + type + " tags=" + tags + " metricName=").isPresent();
+
+        assertThat(meter.get().measure().stream().findFirst().map(Measurement::getValue).get()).isEqualTo(value);
+    }
 
 
 //  private void assertMetricGreatThan(MeterRegistry registry,  Meter.Type type, String name, String cacheName, double value) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2017 Pivotal Software, Inc.
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/CaffeineCacheMetricsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.core.instrument.binder;
 
 import com.github.benmanes.caffeine.cache.Cache;


### PR DESCRIPTION
Note that I changed some of the approach from the Guava monitoring

* Cache name isn't a prefix, but rather a dimension now, this allows grouping and aggregating among the caches
* Adds Mockito as a test dependency (just checking if that is OK)
* Also neglected the `Meters.cache` helper method. Wanted to discuss tradeoffs of just using the constructor directly.
