### PR TITLE
POC of fluent interface for meter creation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractMeterRegistry.java
@@ -24,12 +24,17 @@ import java.util.function.ToDoubleFunction;
 
 import static java.util.stream.StreamSupport.stream;
 
-public abstract class AbstractMeterRegistry implements MeterRegistry {
+public abstract class AbstractMeterRegistry implements MeterRegistry, MeterRegistryConfigurator {
     protected final Clock clock;
     protected final List<Tag> commonTags = new ArrayList<>();
 
     protected AbstractMeterRegistry(Clock clock) {
         this.clock = clock;
+    }
+
+    @Override
+    public MeterIdBuilder meter(String name) {
+        return new MeterIdBuilder(name, this);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
@@ -1,0 +1,43 @@
+package io.micrometer.core.instrument;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.ToDoubleFunction;
+
+public class MeterIdBuilder {
+
+  private String name;
+  private List<Tag> tags;
+  private MeterRegistry registry;
+
+  public MeterIdBuilder(String name, MeterRegistry registry) {
+    this.name = name;
+    this.registry = registry;
+    this.tags = new ArrayList<>();
+  }
+
+  public MeterIdBuilder tag(String key, String value) {
+    tags.add(new ImmutableTag(key, value));
+    return this;
+  }
+
+  public Counter counter(){
+    return registry.counter(name, tags);
+  }
+
+  public <T> T gauge(T obj, ToDoubleFunction<T> f){
+    return registry.gauge(name, tags, obj, f);
+  }
+
+  public MeterIdBuilder tags(Iterable<Tag> moreTags) {
+    for(Tag t : moreTags) {
+      tags.add(t);
+    }
+    return this;
+  }
+
+  public AtomicLong counter(AtomicLong atomicLong) {
+    return registry.counter(name, tags, atomicLong);
+  }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.core.instrument;
 
 import java.util.ArrayList;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterIdBuilder.java
@@ -16,43 +16,90 @@
 package io.micrometer.core.instrument;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ToDoubleFunction;
 
+import static java.util.Collections.emptyList;
+
 public class MeterIdBuilder {
 
-  private String name;
-  private List<Tag> tags;
-  private MeterRegistry registry;
+    private String name;
+    private List<Tag> tags;
+    private MeterRegistry registry;
 
-  public MeterIdBuilder(String name, MeterRegistry registry) {
-    this.name = name;
-    this.registry = registry;
-    this.tags = new ArrayList<>();
-  }
-
-  public MeterIdBuilder tag(String key, String value) {
-    tags.add(new ImmutableTag(key, value));
-    return this;
-  }
-
-  public Counter counter(){
-    return registry.counter(name, tags);
-  }
-
-  public <T> T gauge(T obj, ToDoubleFunction<T> f){
-    return registry.gauge(name, tags, obj, f);
-  }
-
-  public MeterIdBuilder tags(Iterable<Tag> moreTags) {
-    for(Tag t : moreTags) {
-      tags.add(t);
+    public MeterIdBuilder(String name, MeterRegistry registry) {
+        this.name = name;
+        this.registry = registry;
+        this.tags = new ArrayList<>();
     }
-    return this;
-  }
 
-  public AtomicLong counter(AtomicLong atomicLong) {
-    return registry.counter(name, tags, atomicLong);
-  }
+    public MeterIdBuilder tag(String key, String value) {
+        tags.add(new ImmutableTag(key, value));
+        return this;
+    }
+
+    public MeterIdBuilder tags(Iterable<Tag> moreTags) {
+        for (Tag t : moreTags) {
+            tags.add(t);
+        }
+        return this;
+    }
+
+
+    public Counter counter() {
+        return registry.counter(name, tags);
+    }
+
+    public AtomicLong counter(AtomicLong atomicLong) {
+        return registry.counter(name, tags, atomicLong);
+    }
+
+
+    public <T> Gauge gauge(T obj, ToDoubleFunction<T> f) {
+        return registry.gaugeBuilder(name, obj, f).tags(tags).create();
+    }
+
+    /**
+     * Build a new Distribution Summary, which is registered with this registry once {@link DistributionSummary.Builder#create()} is called.
+     *
+     * @return The builder.
+     */
+    DistributionSummary.Builder summaryBuilder(){
+        return registry.summaryBuilder(name);
+    }
+
+
+    /**
+     * Measures the sample distribution of events.
+     */
+    public DistributionSummary summary() {
+        return registry.summary(name, tags);
+    }
+
+    /**
+     * Build a new Timer, which is registered with this registry once {@link Timer.Builder#create()} is called.
+     *
+     * @return The builder.
+     */
+    Timer.Builder timerBuilder() {
+        return registry.timerBuilder(name);
+    }
+
+    /**
+     * Measures the time taken for short tasks.
+     */
+    public Timer timer() {
+        return timerBuilder().tags(tags).create();
+    }
+
+    /**
+     * Measures the time taken for short tasks.
+     */
+    LongTaskTimer longTaskTimer() {
+        return registry.longTaskTimer(name, tags);
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -251,4 +251,8 @@ public interface MeterRegistry {
      * @return The builder.
      */
     <T> Gauge.Builder gaugeBuilder(String name, T obj, ToDoubleFunction<T> f);
+
+    default MeterIdBuilder meter(String name){
+        return new MeterIdBuilder(name, this);
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistryConfigurator.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistryConfigurator.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.ToDoubleFunction;
+
+import static io.micrometer.core.instrument.Tags.zip;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+/**
+ * Creates and manages your application's set of meters. Exporters use the meter registry to iterate
+ * over the set of meters instrumenting your application, and then further iterate over each meter's metrics, generally
+ * resulting in a time series in the metrics backend for each combination of metrics and dimensions.
+ *
+ * @author Jon Schneider
+ */
+public interface MeterRegistryConfigurator {
+
+    /**
+     * Append a list of common tags to apply to all metrics reported to the monitoring system.
+     * Use {@link Tags#zip(String...) as a simple way to generate tags}
+     */
+    void commonTags(Iterable<Tag> tags);
+
+    <M extends Meter> Optional<M> findMeter(Class<M> mClass, String name, Iterable<Tag> tags);
+
+    /**
+     * @return The set of registered meters.
+     */
+    Collection<Meter> getMeters();
+
+    Optional<Meter> findMeter(Meter.Type type, String name, Iterable<Tag> tags);
+
+    Clock getClock();
+
+    static MeterRegistryConfigurator as(MeterRegistry registry) {
+        return (MeterRegistryConfigurator)registry;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/JvmGcMetrics.java
@@ -60,11 +60,11 @@ public class JvmGcMetrics implements MeterBinder {
 
         // Incremented for any positive increases in the size of the old generation memory pool
         // before GC to after GC
-        Counter promotionRate = registry.counter("jvm_gc_promotion_rate");
+        Counter promotionRate = registry.meter("jvm_gc_promotion_rate").counter();
 
         // Incremented for the increase in the size of the young generation memory pool after one GC
         // to before the next
-        Counter allocationRate = registry.counter("jvm_gc_allocation_rate");
+        Counter allocationRate = registry.meter("jvm_gc_allocation_rate").counter();
 
         // start watching for GC notifications
         final AtomicLong youngGenSizeAfter = new AtomicLong(0L);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/LogbackMetrics.java
@@ -41,11 +41,11 @@ class MetricsTurboFilter extends TurboFilter {
     private final Counter traceCounter;
 
     MetricsTurboFilter(MeterRegistry registry) {
-        errorCounter = registry.counter("logback_events", "level", "error");
-        warnCounter = registry.counter("logback_events", "level", "warn");
-        infoCounter = registry.counter("logback_events", "level", "info");
-        debugCounter = registry.counter("logback_events", "level", "debug");
-        traceCounter = registry.counter("logback_events", "level", "trace");
+        errorCounter = registry.meter("logback_events").tag("level", "error").counter();
+        warnCounter = registry.meter("logback_events").tag("level", "warn").counter();
+        infoCounter = registry.meter("logback_events").tag("level", "info").counter();
+        debugCounter = registry.meter("logback_events").tag("level", "debug").counter();
+        traceCounter = registry.meter("logback_events").tag("level", "trace").counter();
     }
 
     @Override

--- a/micrometer-core/src/samples/java/io/micrometer/core/samples/CounterSample.java
+++ b/micrometer-core/src/samples/java/io/micrometer/core/samples/CounterSample.java
@@ -26,7 +26,7 @@ import java.time.Duration;
 
 public class CounterSample {
     public static void main(String[] args) {
-        Counter counter = Registries.influx().counter("counter");
+        Counter counter = Registries.influx().meter("counter").counter();
 
         RandomEngine r = new MersenneTwister64(0);
         Normal dist = new Normal(0, 1, r);


### PR DESCRIPTION
This solves the intermixing of overloaded methods in `MeterRegistry`. I haven't done that in this PR yet, since I wanted to get feedback first.

This change introduces `MeterIdBuilder`.

Example usage:

Create a meter with a name:
`registry.meter("my_counter").counter()`

Create a meter with a set of tags:
`registry.meter("my_tagged_counter").tag("level", "error").counter()`

Create a meter with lots of tags:
`registry.meter("counter_with_tags").tag("first","tag").tag("second","tag").counter()`
`registry.meter("counter_with_tags").tags(Tags.zip("first","tag","second","tag")).counter()`

It also lays the groundwork to address #80 since the `MeterIdBuilder` could be the location to process the name that is built as in: `.meter("tag", "that", "isformated").tag...`

It also means that we could remove the String var arg methods from `MeterRegistry`.