### PR TITLE
add area tag (heap,nonheap) to JVM memory pools

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/JvmMemoryMetrics.java
@@ -22,8 +22,7 @@ import io.micrometer.core.instrument.Tags;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
-
-import static java.util.Collections.singletonList;
+import java.lang.management.MemoryType;
 
 /**
  * Record metrics that report utilization of various memory and buffer pools.
@@ -52,7 +51,8 @@ public class JvmMemoryMetrics implements MeterBinder {
         }
 
         for (MemoryPoolMXBean memoryPoolBean : ManagementFactory.getPlatformMXBeans(MemoryPoolMXBean.class)) {
-            Iterable<Tag> tags = Tags.zip("id", memoryPoolBean.getName());
+            String area = MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap";
+            Iterable<Tag> tags = Tags.zip("id", memoryPoolBean.getName(), "area", area);
 
             registry.gaugeBuilder("jvm.memory.used", memoryPoolBean, (mem) -> mem.getUsage().getUsed())
                 .baseUnit("bytes")


### PR DESCRIPTION
This way you can easily aggregate heap and non-heap memory usage without
having to know pool names assigned by the different garbage collector
implementations. (Especially useful when graphing different JVMs running
different GC implementations in a common "JVM" dashboard.)