### PR TITLE
Add missing dot

### DIFF
--- a/starter/micrometer-influx-starter/src/main/java/io/micrometer/influx/InfluxConfig.java
+++ b/starter/micrometer-influx-starter/src/main/java/io/micrometer/influx/InfluxConfig.java
@@ -76,7 +76,7 @@ public interface InfluxConfig extends StepRegistryConfig {
      * {@code http://localhost:8086/write}.
      */
     default String uri() {
-        String v = get(prefix() + "uri");
+        String v = get(prefix() + ".uri");
         return (v == null) ? "http://localhost:8086/write" : v;
     }
 


### PR DESCRIPTION
Property `influx.uri` is specified in the docs. Previously, property
`influxuri` was used. This commit adds the missing dot.