### PR TITLE
Add missing metadata to enable specific instrumentation

### DIFF
--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -69,3 +69,7 @@ dependencies {
     samplesCompile 'org.springframework.integration:spring-integration-ws'
     samplesCompile 'org.springframework.integration:spring-integration-xml'
 }
+
+license {
+    exclude "**/META-INF/*.json"
+}

--- a/micrometer-spring-legacy/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,46 @@
+{
+  "properties": [
+    {
+      "name": "metrics.atlas.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for Atlas.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.datadog.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for DataDog.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.ganglia.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for Ganglia.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.graphite.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for Graphite.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.influx.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for Influxdb.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.jmx.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for JMX.",
+      "defaultValue": true
+    },
+    {
+      "name": "metrics.prometheus.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable metrics for Prometheus.",
+      "defaultValue": true
+    }
+  ]
+}


### PR DESCRIPTION
Currently, the following property `metrics.<provider>.enabled` validate
if the instrumentation should apply. This commit adds the missing
metadata which can be inspected by the IDE.