### PR TITLE
Fixed missing active.connections metric for HikariCP

### DIFF
--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     // for testing DataSource metrics
     testCompile 'org.hsqldb:hsqldb'
     testCompile 'org.springframework.boot:spring-boot-starter-jdbc'
+    testCompile 'com.zaxxer:HikariCP'
 
     // for use in mock servers
     testCompile 'org.apache.tomcat.embed:tomcat-embed-core:8.5.15'

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/DataSourceMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/DataSourceMetrics.java
@@ -46,7 +46,7 @@ public class DataSourceMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         if (poolMetadata != null) {
-            registry.gauge(name + ".active.connections", tags, dataSource, dataSource -> poolMetadata.getActive());
+            registry.gauge(name + ".active.connections", tags, dataSource, dataSource -> poolMetadata.getActive() != null ? poolMetadata.getActive() : 0);
             registry.gauge(name + ".max.connections", tags, dataSource, dataSource -> poolMetadata.getMax());
             registry.gauge(name + ".min.connections", tags, dataSource, dataSource -> poolMetadata.getMin());
         }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsHikariTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsHikariTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.sql.DataSource;
+
 import java.sql.SQLException;
 import java.util.Collection;
 
@@ -37,7 +38,7 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
- * @author Jon Schneider
+ * @author Arthur Gavlyukovskiy
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -45,9 +46,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
     "spring.datasource.generate-unique-name=true",
     "management.security.enabled=false",
     "spring.metrics.useGlobalRegistry=false",
-    "spring.datasource.type=org.apache.tomcat.jdbc.pool.DataSource"
+    "spring.datasource.type=com.zaxxer.hikari.HikariDataSource"
 })
-public class DataSourceMetricsTest {
+public class DataSourceMetricsHikariTest {
     @Autowired
     DataSource dataSource;
 
@@ -56,8 +57,7 @@ public class DataSourceMetricsTest {
 
     @Test
     public void dataSourceIsInstrumented() throws SQLException, InterruptedException {
-        dataSource.getConnection().getMetaData();
-        assertThat(registry.find("data.source.max.connections").meter()).isPresent();
+        assertThat(registry.find("data.source.active.connections").meter()).isPresent();
     }
 
     @SpringBootApplication(scanBasePackages = "isolated")


### PR DESCRIPTION
While binding data source metrics HikariCP may not be initialized, if `DataSource#getConnection()` is not called before binding. 
In this case `HikariDataSourcePoolMetadata` returns null because `HikariDataSource#pool` is null and gauge is not even created.

Also I don't think storing pool metadata in static list is not a good way to prevent it being garbage collected, so I stored `dataSource` inside gauge and changed function to use it's `poolMetadata`, so that this metric depends on `dataSource` liveness.

As a workarround `dataSource.getConnection().close()` may be used before binding metrics.
