### PR TITLE
Add support for file descriptor metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * File descriptor metrics.
+ *
+ * @author Michael Weirauch
+ */
+public class FileDescriptorMetrics implements MeterBinder {
+
+    private final OperatingSystemMXBean osBean;
+    private final Iterable<Tag> tags;
+    private Method openFdsMethod;
+    private Method maxFdsMethod;
+
+    public FileDescriptorMetrics() {
+        this(emptyList());
+    }
+
+    public FileDescriptorMetrics(Iterable<Tag> tags) {
+        this(ManagementFactory.getOperatingSystemMXBean(), tags);
+    }
+
+    // VisibleForTesting
+    FileDescriptorMetrics(OperatingSystemMXBean osBean, Iterable<Tag> tags) {
+        this.osBean = requireNonNull(osBean);
+        this.tags = tags;
+
+        this.openFdsMethod = detectMethod("getOpenFileDescriptorCount");
+        this.maxFdsMethod = detectMethod("getMaxFileDescriptorCount");
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        registry.gauge(
+                registry.createId("process.fds.open", tags, "The open file descriptor count"),
+                osBean, x -> invoke(openFdsMethod));
+        registry.gauge(
+                registry.createId("process.fds.max", tags, "The maximum file descriptor count"),
+                osBean, x -> invoke(maxFdsMethod));
+    }
+
+    private long invoke(Method method) {
+        try {
+            return (long) (method != null ? method.invoke(osBean) : -1l);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            return -1l;
+        }
+    }
+
+    private Method detectMethod(String name) {
+        Objects.requireNonNull(name);
+
+        try {
+            final Method method = osBean.getClass().getDeclaredMethod(name);
+            method.setAccessible(true);
+            return method;
+        } catch (NoSuchMethodException | SecurityException e) {
+            return null;
+        }
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * File descriptor metrics.
+ *
+ * @author Michael Weirauch
+ */
+public class FileDescriptorMetricsTest {
+
+    private interface HotSpotLikeOperatingSystemMXBean extends OperatingSystemMXBean {
+
+        public long getOpenFileDescriptorCount();
+
+        public long getMaxFileDescriptorCount();
+
+    }
+
+    @Test
+    @SuppressWarnings("restriction")
+    void fileDescriptorMetricsRuntime() {
+        // currently only supporting HotSpot JVM
+        final OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+        assumeTrue(osBean instanceof com.sun.management.UnixOperatingSystemMXBean);
+
+        final MeterRegistry registry = new SimpleMeterRegistry();
+        new FileDescriptorMetrics().bindTo(registry);
+
+        assertThat(registry.find("process.fds.open").gauge()).isPresent();
+        assertThat(registry.find("process.fds.max").gauge()).isPresent();
+    }
+
+    @Test
+    void fileDescriptorMetricsUnsupportedOsBeanMock() {
+        final MeterRegistry registry = new SimpleMeterRegistry();
+        final OperatingSystemMXBean osBean = mock(OperatingSystemMXBean.class);
+        new FileDescriptorMetrics(osBean, Tags.zip("some", "tag")).bindTo(registry);
+
+        assertThat(registry.find("process.fds.open").tags("some", "tag")
+                .value(Statistic.Value, -1.0).gauge()).isPresent();
+        assertThat(registry.find("process.fds.max").tags("some", "tag").value(Statistic.Value, -1.0)
+                .gauge()).isPresent();
+    }
+
+    @Test
+    void fileDescriptorMetricsSupportedOsBeanMock() {
+        final MeterRegistry registry = new SimpleMeterRegistry();
+        final HotSpotLikeOperatingSystemMXBean osBean = mock(
+                HotSpotLikeOperatingSystemMXBean.class);
+        when(osBean.getOpenFileDescriptorCount()).thenReturn(Long.valueOf(512));
+        when(osBean.getMaxFileDescriptorCount()).thenReturn(Long.valueOf(1024));
+        new FileDescriptorMetrics(osBean, Tags.zip("some", "tag")).bindTo(registry);
+
+        assertThat(registry.find("process.fds.open").tags("some", "tag")
+                .value(Statistic.Value, 512.0).gauge()).isPresent();
+        assertThat(registry.find("process.fds.max").tags("some", "tag")
+                .value(Statistic.Value, 1024.0).gauge()).isPresent();
+    }
+
+    @Test
+    void fileDescriptorMetricsInvocationException() {
+        final MeterRegistry registry = new SimpleMeterRegistry();
+        final HotSpotLikeOperatingSystemMXBean osBean = mock(
+                HotSpotLikeOperatingSystemMXBean.class);
+        when(osBean.getOpenFileDescriptorCount()).thenThrow(InvocationTargetException.class);
+        when(osBean.getMaxFileDescriptorCount()).thenThrow(InvocationTargetException.class);
+        new FileDescriptorMetrics(osBean, Tags.zip("some", "tag")).bindTo(registry);
+
+        assertThat(registry.find("process.fds.open").tags("some", "tag")
+                .value(Statistic.Value, -1.0).gauge()).isPresent();
+        assertThat(registry.find("process.fds.max").tags("some", "tag").value(Statistic.Value, -1.0)
+                .gauge()).isPresent();
+    }
+
+}


### PR DESCRIPTION
This PR only targets the HotSpot JVM. If time permits I am going to look at OpenJ9 later.

Fixes #130.
