### PR TITLE
Fix erroneously set description set as baseunit for ThreadPoolExecutor

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -140,11 +140,11 @@ public class ExecutorServiceMetrics implements MeterBinder {
             return;
         }
 
-        registry.more().counter(registry.createId(name + ".completed", tags, null,
+        registry.more().counter(registry.createId(name + ".completed", tags,
                 "The approximate total number of tasks that have completed execution"),
             tp, ThreadPoolExecutor::getCompletedTaskCount);
 
-        registry.gauge(registry.createId(name + ".active", tags, null,
+        registry.gauge(registry.createId(name + ".active", tags,
             "The approximate number of threads that are actively executing tasks"),
             tp, ThreadPoolExecutor::getActiveCount);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -106,6 +106,8 @@ class ExecutorServiceMetricsTest {
     private void assertThreadPoolExecutorMetrics() {
         assertThat(registry.find("exec.completed").tags(userTags).meter()).isPresent();
         assertThat(registry.find("exec.queued").tags(userTags).gauge()).isPresent();
+        assertThat(registry.find("exec.active").tags(userTags).gauge()).isPresent();
         assertThat(registry.find("exec.pool").tags(userTags).gauge()).isPresent();
+        assertThat(registry.find("exec").tags(userTags).timer()).isPresent();
     }
 }


### PR DESCRIPTION
Also added assert for "active" gauge and the timer itself.