### PR TITLE
Initial pass for creating basic hystrix stats

### DIFF
--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     compile 'javax.servlet:javax.servlet-api:3.1.0', optional
     compile 'org.aspectj:aspectjweaver:1.8.+', optional
 
+    compile 'com.netflix.hystrix:hystrix-javanica:1.5.8'
+
     ['atlas', 'prometheus', 'datadog', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd'].each { sys ->
         compile project(":micrometer-registry-$sys"), optional
     }

--- a/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/MicrometerMetricsPublisher.java
+++ b/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/MicrometerMetricsPublisher.java
@@ -1,0 +1,29 @@
+package io.micrometer.spring.samples;
+
+import com.netflix.hystrix.HystrixCircuitBreaker;
+import com.netflix.hystrix.HystrixCollapserKey;
+import com.netflix.hystrix.HystrixCollapserMetrics;
+import com.netflix.hystrix.HystrixCollapserProperties;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisher;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherCollapser;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherCommand;
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class MicrometerMetricsPublisher extends HystrixMetricsPublisher {
+
+    private final MeterRegistry meterRegistry;
+
+    public MicrometerMetricsPublisher(MeterRegistry meterRegistry) {
+
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public HystrixMetricsPublisherCommand getMetricsPublisherForCommand(HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties) {
+        return new MicrometerMetricsPublisherCommand(meterRegistry, commandKey, commandGroupKey, metrics, circuitBreaker, properties);
+    }
+}

--- a/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/MicrometerMetricsPublisherCommand.java
+++ b/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/MicrometerMetricsPublisherCommand.java
@@ -1,0 +1,74 @@
+package io.micrometer.spring.samples;
+
+import com.netflix.hystrix.HystrixCircuitBreaker;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandKey;
+import com.netflix.hystrix.HystrixCommandMetrics;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.metric.consumer.CumulativeCommandEventCounterStream;
+import com.netflix.hystrix.metric.consumer.RollingCommandEventCounterStream;
+import com.netflix.hystrix.metric.consumer.RollingCommandLatencyDistributionStream;
+import com.netflix.hystrix.metric.consumer.RollingCommandMaxConcurrencyStream;
+import com.netflix.hystrix.metric.consumer.RollingCommandUserLatencyDistributionStream;
+import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherCommand;
+import com.netflix.hystrix.util.HystrixRollingNumberEvent;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class MicrometerMetricsPublisherCommand implements HystrixMetricsPublisherCommand {
+    private static final Logger LOG = LoggerFactory.getLogger(MicrometerMetricsPublisherCommand.class);
+
+    private final MeterRegistry meterRegistry;
+    private final HystrixCommandMetrics metrics;
+    private final HystrixCircuitBreaker circuitBreaker;
+    private final List<Tag> tags;
+    private final HystrixCommandProperties properties;
+    private final HystrixCommandKey commandKey;
+
+    public MicrometerMetricsPublisherCommand(MeterRegistry meterRegistry, HystrixCommandKey commandKey, HystrixCommandGroupKey commandGroupKey, HystrixCommandMetrics metrics, HystrixCircuitBreaker circuitBreaker, HystrixCommandProperties properties) {
+        this.meterRegistry = meterRegistry;
+        this.metrics = metrics;
+        this.circuitBreaker = circuitBreaker;
+        this.commandKey = commandKey;
+        this.properties = properties;
+        tags = Tags.zip("commandGroupKey", commandGroupKey.name(), "key", commandKey.name());
+    }
+
+    @Override
+    public void initialize() {
+        Gauge.builder("hystrix.circuit.breaker.open", circuitBreaker, c -> c.isOpen() ? 1 : 0)
+            .tags(tags).register(meterRegistry);
+
+        createCounter("hystrix.circuit.breaker.bad.requests", HystrixRollingNumberEvent.BAD_REQUEST);
+        createCounter("hystrix.circuit.breaker.short.circuited", HystrixRollingNumberEvent.SHORT_CIRCUITED);
+        createCounter("hystrix.circuit.breaker.success", HystrixRollingNumberEvent.SUCCESS);
+        createCounter("hystrix.circuit.breaker.failure", HystrixRollingNumberEvent.FALLBACK_SUCCESS);
+
+//        RollingCommandEventCounterStream.getInstance(key, properties).startCachingStreamValuesIfUnstarted();
+        CumulativeCommandEventCounterStream.getInstance(commandKey, properties).startCachingStreamValuesIfUnstarted();
+//        RollingCommandLatencyDistributionStream.getInstance(key, properties).startCachingStreamValuesIfUnstarted();
+//        RollingCommandUserLatencyDistributionStream.getInstance(key, properties).startCachingStreamValuesIfUnstarted();
+//        RollingCommandMaxConcurrencyStream.getInstance(key, properties).startCachingStreamValuesIfUnstarted();
+
+    }
+
+    private void createCounter(String name, HystrixRollingNumberEvent event) {
+
+
+        meterRegistry.more().counter(meterRegistry.createId(name, tags, " "), metrics, m -> {
+                try {
+                    return m.getCumulativeCount(event);
+                } catch (NoSuchFieldError error) {
+                    LOG.error("While publishing metrics, error looking up eventType for : {}.  Please check that all Hystrix versions are the same!", name);
+                    return 0L;
+                }
+        });
+    }
+}


### PR DESCRIPTION
Here is a quick Hystrix sample I got up and running. I'm able to track if circuits are open and if given commands are failing or succeeding.

Any request @spencergibb or @jkschneider? Do you want the callback approach from the [Servo example](https://github.com/Netflix/Hystrix/blob/master/hystrix-contrib/hystrix-servo-metrics-publisher/src/main/java/com/netflix/hystrix/contrib/servopublisher/HystrixServoMetricsPublisherCommand.java#L182) ?

```
# HELP hystrix_circuit_breaker_open  
# TYPE hystrix_circuit_breaker_open gauge
hystrix_circuit_breaker_open{commandGroupKey="ExampleGroup",key="CommandHelloSuccess",} 0.0
hystrix_circuit_breaker_open{commandGroupKey="ExampleGroup",key="CommandHelloFailure",} 1.0
# HELP hystrix_circuit_breaker_failure_total  
# TYPE hystrix_circuit_breaker_failure_total counter
hystrix_circuit_breaker_failure_total{commandGroupKey="ExampleGroup",key="CommandHelloFailure",} 48.0
hystrix_circuit_breaker_failure_total{commandGroupKey="ExampleGroup",key="CommandHelloSuccess",} 0.0
# HELP hystrix_circuit_breaker_short_circuited_total  
# TYPE hystrix_circuit_breaker_short_circuited_total counter
hystrix_circuit_breaker_short_circuited_total{commandGroupKey="ExampleGroup",key="CommandHelloFailure",} 22.0
hystrix_circuit_breaker_short_circuited_total{commandGroupKey="ExampleGroup",key="CommandHelloSuccess",} 0.0
# HELP hystrix_circuit_breaker_success_total  
# TYPE hystrix_circuit_breaker_success_total counter
hystrix_circuit_breaker_success_total{commandGroupKey="ExampleGroup",key="CommandHelloFailure",} 0.0
hystrix_circuit_breaker_success_total{commandGroupKey="ExampleGroup",key="CommandHelloSuccess",} 18.0
```