### PR TITLE
Rename autoconfigured clocks to avoid beanId collisions

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasExportConfiguration.java
@@ -102,7 +102,7 @@ public class AtlasExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogExportConfiguration.java
@@ -86,7 +86,7 @@ public class DatadogExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaExportConfiguration.java
@@ -117,7 +117,7 @@ public class GangliaExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteExportConfiguration.java
@@ -107,7 +107,7 @@ public class GraphiteExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
@@ -111,7 +111,7 @@ public class InfluxExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxExportConfiguration.java
@@ -42,7 +42,7 @@ public class JmxExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
@@ -94,7 +94,7 @@ public class PrometheusExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfiguration.java
@@ -42,7 +42,7 @@ public class SimpleExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdExportConfiguration.java
@@ -104,7 +104,7 @@ public class StatsdExportConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Clock clock() {
+    public Clock micrometerClock() {
         return Clock.SYSTEM;
     }
 }


### PR DESCRIPTION
By default bean's get an ID that matches the method name. Unfortunately Spring assumes if a bean has a matching beanID that is should override the other bean, causing bean to disappear.

There is a large chance that `java.time.Clock` beans will clash with the micrometer name. By making it more unique we can save folks headaches.