### PR TITLE
This adds a FilterRegistry that that you can wrap another registry with.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FilterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FilterRegistry.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.filter.FilterProperties;
+import io.micrometer.core.instrument.histogram.StatsConfig;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToLongFunction;
+
+public class FilterRegistry extends MeterRegistry {
+
+    private final MeterRegistry delegate;
+    private final FilterProperties filterProperties;
+    private final ConcurrentHashMap<Meter.Id, FilterResult> filtered = new ConcurrentHashMap<>();
+    private final CompositeMeterRegistry noopRegistry = new CompositeMeterRegistry();
+    private final More more = new FilterMore();
+
+    public FilterRegistry(MeterRegistry delegate, FilterProperties filterProperties) {
+        this(delegate, filterProperties, Clock.SYSTEM);
+    }
+
+    public FilterRegistry(MeterRegistry delegate, FilterProperties filterProperties, Clock clock) {
+        super(clock);
+        this.delegate = delegate;
+        this.filterProperties = filterProperties;
+    }
+
+    @Override
+    public Collection<Meter> getMeters() {
+        return delegate.getMeters();
+    }
+
+    @Override
+    public Config config() {
+        return delegate.config();
+    }
+
+    @Override
+    public Search find(String name) {
+        return delegate.find(name);
+    }
+
+    @Override
+    public More more() {
+        return more;
+    }
+
+    @Override
+    Counter counter(Meter.Id id) {
+        FilterResult result = filter(id);
+        return result.registry.counter(result.id);
+    }
+
+    @Override
+    Timer timer(Meter.Id id, StatsConfig statsConfig) {
+        FilterResult result = filter(id);
+        return result.registry.timer(result.id, statsConfig);
+    }
+
+    @Override
+    <T> Gauge gauge(Meter.Id id, T obj, ToDoubleFunction<T> f) {
+        FilterResult result = filter(id);
+        return result.registry.gauge(result.id, obj, f);
+    }
+
+    @Override
+    DistributionSummary summary(Meter.Id id, StatsConfig statsConfig) {
+        FilterResult result = filter(id);
+        return result.registry.summary(result.id, statsConfig);
+    }
+
+    @Override
+    Meter register(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        FilterResult result = filter(id);
+        return result.registry.register(result.id, type, measurements);
+    }
+
+    @Override
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> f) {
+        //No OP since we delegate before getting to this point
+        return null;
+    }
+
+    @Override
+    protected Counter newCounter(Meter.Id id) {
+        //No OP since we delegate before getting to this point
+        return null;
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
+        //No OP since we delegate before getting to this point
+        return null;
+    }
+
+    @Override
+    protected Timer newTimer(Meter.Id id, StatsConfig statsConfig) {
+        //No OP since we delegate before getting to this point
+        return null;
+    }
+
+    @Override
+    protected DistributionSummary newDistributionSummary(Meter.Id id, StatsConfig statsConfig) {
+        //No OP since we delegate before getting to this point
+        return null;
+    }
+
+    @Override
+    protected void newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        //No OP since we delegate before getting to this point
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return null;
+    }
+
+    public class FilterMore extends More {
+
+        @Override
+        LongTaskTimer longTaskTimer(Meter.Id id) {
+            FilterResult result = filter(id);
+            return result.registry.more().longTaskTimer(result.id);
+        }
+
+        @Override
+        <T> FunctionCounter counter(Meter.Id id, T obj, ToDoubleFunction<T> f) {
+            FilterResult result = filter(id);
+            return result.registry.more().counter(result.id, obj, f);
+        }
+
+        @Override
+        <T> FunctionTimer timer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
+            FilterResult result = filter(id);
+            return result.registry.more().timer(result.id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits);
+        }
+
+        @Override
+        <T> TimeGauge timeGauge(Meter.Id id, T obj, TimeUnit fUnit, ToDoubleFunction<T> f) {
+            FilterResult result = filter(id);
+            return result.registry.more().timeGauge(result.id, obj, fUnit, f);
+        }
+    }
+
+    private FilterResult filter(Meter.Id id){
+        FilterResult existingResult = filtered.get(id);
+        if(existingResult != null) {
+            return existingResult;
+        }
+
+        String filterStatus = filterProperties.filterStatus(id.getName());
+        MeterRegistry reg = filterStatus.equals(FilterProperties.EXCLUDE) ? noopRegistry : delegate;
+
+        Iterable<Tag> filteredTags = filterProperties.combineTags(id);
+        Meter.Id resultId = new Meter.Id(id.getName(),filteredTags, id.getBaseUnit(), id.getDescription());
+
+        FilterResult result = new FilterResult(reg, resultId);
+        filtered.put(id, result);
+        return result;
+    }
+
+    public static class FilterResult {
+        private final MeterRegistry registry;
+        private final Meter.Id id;
+
+        public FilterResult(MeterRegistry registry, Meter.Id id) {
+            this.registry = registry;
+            this.id = id;
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/filter/FilterProperties.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/filter/FilterProperties.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.filter;
+
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class FilterProperties {
+    public static final String INCLUDE = "include";
+    public static final String EXCLUDE = "exclude";
+
+    private String defaultCombinedBucketName = "other";
+    private String defaultFilter = INCLUDE;
+    private Map<String, String> filter = new HashMap<>();
+    private Map<String, String> combine = new HashMap<>();
+
+    public String getDefaultFilter() {
+        return defaultFilter;
+    }
+
+    public void setDefaultFilter(String defaultFilter) {
+        this.defaultFilter = defaultFilter;
+    }
+
+    public void setDefaultCombinedBucketName(String defaultCombinedBucketName) {
+        this.defaultCombinedBucketName = defaultCombinedBucketName;
+    }
+
+    public String getDefaultCombinedBucketName() {
+        return defaultCombinedBucketName;
+    }
+
+    public Map<String, String> getFilter() {
+        return filter;
+    }
+
+    public Map<String, String> getCombine() {
+        return combine;
+    }
+
+    public String findMostSpecificRule(String name, Map<String,String> map, String defaultVal) {
+        String filterStatus = defaultVal;
+        String filterLookup = map.get(name);
+        if(filterLookup != null) {
+            filterStatus = filterLookup;
+        } else if(name.contains(".")) {
+            filterStatus = findMostSpecificRule(name.substring(0,name.lastIndexOf(".")), map, defaultVal);
+        }
+
+        return filterStatus;
+    }
+
+    public String filterStatus(String name) {
+        return findMostSpecificRule(name, filter, getDefaultFilter());
+    }
+
+    public Iterable<Tag> combineTags(Meter.Id id) {
+        String tagRule = findMostSpecificRule(id.getName(), combine, "");
+        if(tagRule.isEmpty()) {
+            return id.getTags();
+        }
+
+        List<Tag> tagRules = Arrays.stream(tagRule.split(";")).map(rule -> {
+            String[] values = rule.split("\\|");
+            if(values.length == 2) {
+                return new ImmutableTag(values[0],values[1]);
+            } else {
+                return new ImmutableTag(values[0],"");
+            }
+        }).collect(Collectors.toList());
+
+        Iterable<Tag> filteredTags = StreamSupport.stream(id.getTags().spliterator(), false).map(origTag -> {
+            Optional<Tag> tagRuleMatch = tagRules.stream().filter(ruleTag -> origTag.getKey().equalsIgnoreCase(ruleTag.getKey())).findFirst();
+
+            if(!tagRuleMatch.isPresent()) {
+                return origTag;
+            }
+
+            return new ImmutableTag(origTag.getKey(), combineTagValue(tagRuleMatch.get().getValue(), origTag.getValue()));
+        }).collect(Collectors.toList());
+
+        return filteredTags;
+    }
+
+    private String combineTagValue(String allowedValues, String value) {
+        for(String allowedVal : allowedValues.split(",")) {
+            if(allowedVal.equalsIgnoreCase(value)) {
+                return value;
+            }
+        }
+        return getDefaultCombinedBucketName();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FilterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FilterRegistryTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.FilterRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.filter.FilterProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.step.StepDouble;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class FilterRegistryTest {
+
+    @Test
+    public void it_shouldExcludeMetrics(){
+        FilterProperties filterProperties = new FilterProperties();
+        filterProperties.getFilter().put("test.filter","exclude");
+
+        FilterRegistry f1 = new FilterRegistry(new SimpleMeterRegistry(), filterProperties);
+
+        f1.counter("test.filter.me","tag1","val1").increment();
+        f1.counter("test.keep.me","tag1","val1").increment();
+
+        assertThat(f1.find("test.filter.me").meter()).isNotPresent();
+        assertThat(f1.find("test.keep.me").meter()).isPresent();
+    }
+
+    @Test
+    public void it_shouldCombineTagValues(){
+        FilterProperties filterProperties = new FilterProperties();
+        filterProperties.getCombine().put("test.combine","big|val2,val5;second;;;");
+
+        FilterRegistry f1 = new FilterRegistry(createTestRegistry(), filterProperties);
+
+        f1.counter("test.combine.me","big","val1","second","val4").increment();
+        f1.counter("test.combine.me","big","val2","second","val3").increment();
+        f1.counter("test.combine.me","big","val3","second","val2").increment();
+        f1.counter("test.combine.me","big","val4","second","val1").increment();
+        f1.counter("test.combine.me","big","val4","second","val1").increment();
+        f1.counter("test.combine.me","big","val4","second","val1").increment();
+
+        assertThat(f1.find("test.combine.me").tags("big","val2", "second", "other").firstValue()).hasValue(1.0);
+        assertThat(f1.find("test.combine.me").tags("big","other", "second", "other").firstValue()).hasValue(5.0);
+    }
+
+    @Test
+    public void it_shouldAllowSettingTheCombinedTagValue() throws InterruptedException {
+        FilterProperties filterProperties = new FilterProperties();
+        filterProperties.setDefaultCombinedBucketName("combined");
+        filterProperties.getCombine().put("test.combine","big|val2");
+
+        FilterRegistry f1 = new FilterRegistry(createTestRegistry(), filterProperties);
+
+
+        f1.counter("test.combine.me","big","val1","second","val4").increment();
+        f1.counter("test.combine.me","big","val1","second","val4").increment();
+        f1.counter("test.combine.me","big","val2","second","val3").increment();
+
+
+        f1.getMeters().forEach(m -> m.measure().forEach( e -> System.out.println("Meter:"+m+" - "+ e.getValue()+" "+ e.getStatistic()+" "+e.getValueFunction().get())));
+
+
+        assertThat(f1.find("test.combine.me").tags("big","combined", "second", "val4").firstValue()).hasValue(2.0);
+        assertThat(f1.find("test.combine.me").tags("big","val2", "second", "val3").firstValue()).hasValue(1.0);
+    }
+
+    private MeterRegistry createTestRegistry() {
+        return new SimpleMeterRegistry() {
+            @Override
+            protected Counter newCounter(Meter.Id id) {
+                return new SimpleCounter(id);
+            }
+        };
+    }
+
+
+    public class SimpleCounter extends AbstractMeter implements Counter {
+        private final AtomicDouble value;
+
+        /** Create a new instance. */
+        public SimpleCounter(Id id) {
+            super(id);
+            this.value = new AtomicDouble();
+        }
+
+        @Override
+        public void increment(double amount) {
+            value.getAndAdd(amount);
+        }
+
+        @Override
+        public double count() {
+            return value.get();
+        }
+    }
+
+    @Test
+    public void it_ShouldAllowFilteringToBeTheDefault(){
+        FilterProperties filterProperties = new FilterProperties();
+        filterProperties.setDefaultFilter(FilterProperties.EXCLUDE);
+        filterProperties.getFilter().put("test.include","include");
+        filterProperties.getFilter().put("test.include.not","exclude");
+
+        FilterRegistry f1 = new FilterRegistry(new SimpleMeterRegistry(), filterProperties);
+
+        f1.counter("any.metric").increment();
+        f1.counter("test.include.not.me").increment();
+        f1.counter("test.include.me").increment();
+
+        assertThat(f1.find("any.metric").meter()).isNotPresent();
+        assertThat(f1.find("test.include.not.me").meter()).isNotPresent();
+        assertThat(f1.find("test.include.me").meter()).isPresent();
+    }
+
+
+    @Test
+    public void it_ShouldBeAbleToFilterAllMetricTypes(){
+        FilterProperties filterProperties = new FilterProperties();
+        filterProperties.setDefaultFilter(FilterProperties.EXCLUDE);
+
+        FilterRegistry f1 = new FilterRegistry(new SimpleMeterRegistry(), filterProperties);
+
+        f1.summary("any.summary").record(1);;
+        f1.timer("some.timer").record(1, TimeUnit.MILLISECONDS);
+        f1.register(new Meter.Id("a.meter", Collections.emptyList(), " ", " "), Meter.Type.Gauge,
+            Arrays.asList(
+                new Measurement(() -> 1.0, Statistic.Count),
+                new Measurement(() -> 2.0, Statistic.Total)
+            ));
+        f1.gauge("a.gauge", 10);
+        f1.more().counter(new Meter.Id("more.counter", Collections.emptyList(), " ", " "), 10, x -> x);
+        f1.more().timeGauge(new Meter.Id("more.timeGauge", Collections.emptyList(), " ", " "), 10, TimeUnit.SECONDS, x -> x);
+        f1.more().timer(new Meter.Id("more.timer", Collections.emptyList(), " ", " "), 10, x -> x, x -> x, TimeUnit.NANOSECONDS);
+        f1.more().longTaskTimer(new Meter.Id("more.longTaskTimer", Collections.emptyList(), " ", " ")).duration(123, TimeUnit.MILLISECONDS);
+
+
+        assertThat(f1.getMeters().size()).isEqualTo(0);
+    }
+
+
+
+    /**
+
+metrics:
+  combined.bucket.name: other
+  filter:
+    test.filter: exclude
+   combine:
+    test.combine: big|val1,val3;second;
+
+     */
+
+}


### PR DESCRIPTION
This addresses #70 and #17

I would love feedback on the combine syntax. 


I didn't add in the Spring config properties yet. But here is the idea. In one of my projects we are pushing to 3 registries, and so will have 3 different config sections.
```
spring.micrometer.metrics:
  defaultCombinedBucketName: other
  filter:
    test.filter: exclude
  combine:
    test.combine: tagKey|val1,val3;tagKey2
```