### PR TITLE
Add ID to filter 'configure'

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterFilter.java
@@ -56,10 +56,12 @@ public interface MeterFilter {
      * This is only called when filtering new timers and distribution summaries (i.e. those meter types
      * that use {@link HistogramConfig}).
      *
+     *
+     * @param id Id with {@link MeterFilter#map} transformations applied.
      * @param config A histogram configuration guaranteed to be non-null.
      * @return Overrides to any part of the histogram config, when applicable.
      */
-    default HistogramConfig configure(HistogramConfig config) {
+    default HistogramConfig configure(Meter.Id id, HistogramConfig config) {
         return config;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -628,7 +628,7 @@ public abstract class MeterRegistry {
         HistogramConfig mappedConfig = config;
         if (mappedConfig != null) {
             for (MeterFilter filter : filters) {
-                mappedConfig = filter.configure(mappedConfig);
+                mappedConfig = filter.configure(mappedId, mappedConfig);
             }
         }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -59,7 +59,7 @@ class MeterRegistryTest {
 
         registry.config().meterFilter(new MeterFilter() {
             @Override
-            public HistogramConfig configure(HistogramConfig config) {
+            public HistogramConfig configure(Meter.Id mappedId, HistogramConfig config) {
                 return HistogramConfig.builder()
                     .percentilesHistogram(true)
                     .build()


### PR DESCRIPTION
ID is needed so we can lookup the config (or use the ID for other logic)