### PR TITLE
When Hibernate is on the classpath and an EntityManagerFactory is

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'net.sf.ehcache:ehcache:2.10.3', optional
     compile 'javax.cache:cache-api:1.0.0', optional
     compile 'com.hazelcast:hazelcast:3.8.+', optional
+    compile 'org.hibernate:hibernate-entitymanager:5.2.12.Final', optional
 
     // log monitoring
     compile 'ch.qos.logback:logback-classic:latest.release', optional

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jpa;
+
+import java.util.function.ToDoubleFunction;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceException;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * A {@link MeterBinder} implementation that provides Hibernate metrics. It exposes the
+ * same stats as would be exposed when calling {@code Statistics#logSummary}.
+ *
+ * @author Marten Deinum
+ * @since 2.0.0
+ */
+public class HibernateMetrics implements MeterBinder {
+
+    public static void monitor(MeterRegistry meterRegistry, EntityManagerFactory emf, String name, String... tags) {
+        monitor(meterRegistry, emf, name, Tags.zip(tags));
+    }
+
+    public static void monitor(MeterRegistry meterRegistry, EntityManagerFactory emf, String name, Iterable<Tag> tags) {
+        new HibernateMetrics(emf, name, tags).bindTo(meterRegistry);
+    }
+
+    private final String name;
+    private final Iterable<Tag> tags;
+    private final EntityManagerFactory emf;
+
+
+    private HibernateMetrics(EntityManagerFactory emf, String name, Iterable<Tag> tags) {
+        this.emf=emf;
+        this.name=name;
+        this.tags=tags;
+    }
+
+    private void addMetric(MeterRegistry registry, Statistics stats, String name, ToDoubleFunction<Statistics> value) {
+
+        Gauge.builder(name, stats, value)
+            .tags(tags).tags("entityManagerFactory", this.name)
+            .register(registry);
+    }
+
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+
+        if (!hasStatisticsEnabled(this.emf)) {
+            return;
+        }
+
+        final Statistics stats = getStatistics(this.emf);
+
+        // Session stats
+        addMetric(registry, stats,"hibernate.sessions.open", Statistics::getSessionOpenCount);
+        addMetric(registry, stats,"hibernate.sessions.close", Statistics::getSessionCloseCount);
+
+        // Transaction stats
+        addMetric(registry, stats,"hibernate.transactions", Statistics::getTransactionCount);
+        addMetric(registry, stats,"hibernate.transactions.success", Statistics::getSuccessfulTransactionCount);
+
+        addMetric(registry, stats,"hibernate.optimistic_failure_count", Statistics::getOptimisticFailureCount);
+        addMetric(registry, stats,"hibernate.flushes", Statistics::getFlushCount);
+        addMetric(registry, stats,"hibernate.connections.obtained", Statistics::getConnectCount);
+
+        // Statements
+        addMetric(registry, stats,"hibernate.statements.prepared", Statistics::getPrepareStatementCount);
+        addMetric(registry, stats,"hibernate.statements.closed", Statistics::getCloseStatementCount);
+
+        // Second Level Caching
+        addMetric(registry, stats,"hibernate.cache.second_level.hits", Statistics::getSecondLevelCacheHitCount);
+        addMetric(registry, stats,"hibernate.cache.second_level.misses", Statistics::getSecondLevelCacheMissCount);
+        addMetric(registry, stats,"hibernate.cache.second_level.puts", Statistics::getSecondLevelCachePutCount);
+
+        // Entity information
+        addMetric(registry, stats,"hibernate.entities.deleted", Statistics::getEntityDeleteCount);
+        addMetric(registry, stats,"hibernate.entities.fetched", Statistics::getEntityFetchCount);
+        addMetric(registry, stats,"hibernate.entities.inserted", Statistics::getEntityInsertCount);
+        addMetric(registry, stats,"hibernate.entities.loaded", Statistics::getEntityLoadCount);
+        addMetric(registry, stats,"hibernate.entities.updated", Statistics::getOptimisticFailureCount);
+
+        // Collections
+        addMetric(registry, stats,"hibernate.collections.removed", Statistics::getCollectionRemoveCount);
+        addMetric(registry, stats,"hibernate.collections.fetched", Statistics::getCollectionFetchCount);
+        addMetric(registry, stats,"hibernate.collections.loaded", Statistics::getCollectionLoadCount);
+        addMetric(registry, stats,"hibernate.collections.recreated", Statistics::getCollectionRecreateCount);
+        addMetric(registry, stats,"hibernate.collections.updated", Statistics::getCollectionUpdateCount);
+
+        // Natural Id cache
+        addMetric(registry, stats,"hibernate.cache.natural_id.hits", Statistics::getNaturalIdCacheHitCount);
+        addMetric(registry, stats,"hibernate.cache.natural_id.misses", Statistics::getNaturalIdCacheMissCount);
+        addMetric(registry, stats,"hibernate.cache.natural_id.puts", Statistics::getNaturalIdCachePutCount);
+        addMetric(registry, stats,"hibernate.query.natural_id.execution.count", Statistics::getNaturalIdQueryExecutionCount);
+        addMetric(registry, stats,"hibernate.query.natural_id.execution.max_time", Statistics::getNaturalIdQueryExecutionMaxTime);
+
+        // Query stats
+        addMetric(registry, stats,"hibernate.query.execution.count", Statistics::getQueryExecutionCount);
+        addMetric(registry, stats,"hibernate.query.execution.max_time", Statistics::getQueryExecutionMaxTime);
+
+        // Update timestamp cache
+        addMetric(registry, stats,"hibernate.cache.update_timestamps.hits", Statistics::getUpdateTimestampsCacheHitCount);
+        addMetric(registry, stats,"hibernate.cache.update_timestamps.misses", Statistics::getUpdateTimestampsCacheMissCount);
+        addMetric(registry, stats,"hibernate.cache.update_timestamps.puts", Statistics::getUpdateTimestampsCachePutCount);
+
+        // Query Caching
+        addMetric(registry, stats,"hibernate.cache.query.hits", Statistics::getQueryCacheHitCount);
+        addMetric(registry, stats,"hibernate.cache.query.misses", Statistics::getQueryCacheMissCount);
+        addMetric(registry, stats,"hibernate.cache.query.puts", Statistics::getQueryCachePutCount);
+    }
+
+    private boolean hasStatisticsEnabled(EntityManagerFactory emf) {
+        final Statistics stats = getStatistics(emf);
+        return (stats != null && stats.isStatisticsEnabled());
+    }
+
+    /**
+     * Get the {@code Statistics} object from the underlying {@code SessionFactory}. If it isn't hibernate that is
+     * used return {@code null}.
+     *
+     * @param emf a {@code EntityManagerFactory}
+     * @return the {@code Statistics} from the underlying {@code SessionFactory} or {@code null}.
+     */
+    private Statistics getStatistics(EntityManagerFactory emf) {
+        try {
+            SessionFactory sf = emf.unwrap(SessionFactory.class);
+            return sf.getStatistics();
+        }  catch (PersistenceException pe) {
+            return null;
+        }
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -1,0 +1,99 @@
+package io.micrometer.core.instrument.binder.jpa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+
+import javax.persistence.EntityManagerFactory;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class HibernateMetricsTest {
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setup() throws SQLException {
+        registry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    void shouldExposeMetricsWhenStatsEnabled() {
+        HibernateMetrics.monitor(registry, createEntityManagerFactoryMock(true), "entityManagerFactory");
+        assertThat(registry.find("hibernate.sessions.open").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.sessions.close").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.transactions").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.transactions.success").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.optimistic_failure_count").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.flushes").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.connections.obtained").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.statements.prepared").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.statements.closed").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.cache.second_level.hits").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.second_level.misses").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.second_level.puts").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.entities.deleted").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.entities.fetched").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.entities.inserted").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.entities.loaded").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.entities.updated").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.collections.removed").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.collections.fetched").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.collections.loaded").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.collections.recreated").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.collections.updated").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.cache.natural_id.hits").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.natural_id.misses").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.natural_id.puts").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.query.natural_id.execution.count").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.query.natural_id.execution.max_time").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.query.execution.count").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.query.execution.max_time").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.cache.update_timestamps.hits").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.update_timestamps.misses").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.update_timestamps.puts").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+        assertThat(registry.find("hibernate.cache.query.hits").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.query.misses").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+        assertThat(registry.find("hibernate.cache.query.puts").gauge().map(Gauge::value)).isPresent().hasValue(42.0d);
+
+    }
+
+    @Test
+    void shouldNotExposeMetricsWhenStatsEnabled() {
+        HibernateMetrics.monitor(registry, createEntityManagerFactoryMock(false), "entityManagerFactory");
+        assertThat(registry.find("hibernate.sessions.open").gauge()).isNotPresent();
+    }
+
+    private static EntityManagerFactory createEntityManagerFactoryMock(final boolean statsEnabled) {
+        EntityManagerFactory emf = Mockito.mock(EntityManagerFactory.class);
+        SessionFactory sf = Mockito.mock(SessionFactory.class);
+        Statistics stats = Mockito.mock(Statistics.class, invocation -> {
+            if (invocation.getMethod().getName().equals("isStatisticsEnabled")) {
+                return statsEnabled;
+            }
+            return 42L;
+        });
+        when(emf.unwrap(SessionFactory.class)).thenReturn(sf);
+        when(sf.getStatistics()).thenReturn(stats);
+        return emf;
+    }
+
+}


### PR DESCRIPTION
configured then you can register a `HibernateMetrics `bean so that the
statistics from hibernate get collected.

The exposed statistics are the same as those that would be exposed using
`Statistics.logSummary` from hibernate itself.

Issue: gh-180