### PR TITLE
NoOpTimer fails to call `record(Runnable)`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -43,6 +43,7 @@ public class NoopTimer extends NoopMeter implements Timer {
 
     @Override
     public void record(Runnable f) {
+        f.run();
     }
 
     @Override


### PR DESCRIPTION
This manifests in unit tests because CompositeTimer is empty. 