### PR TITLE
Unparsabled values are reported with details of the error

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/ConfigurationException.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/ConfigurationException.java
@@ -1,10 +1,6 @@
 package io.micrometer.spring;
 
 public class ConfigurationException extends RuntimeException {
-    public ConfigurationException(String message) {
-        super(message);
-    }
-
     public ConfigurationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/ConfigurationException.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/ConfigurationException.java
@@ -1,0 +1,11 @@
+package io.micrometer.spring;
+
+public class ConfigurationException extends RuntimeException {
+    public ConfigurationException(String message) {
+        super(message);
+    }
+
+    public ConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/SpringEnvironmentMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/SpringEnvironmentMeterFilter.java
@@ -35,12 +35,12 @@ public class SpringEnvironmentMeterFilter extends PropertyMeterFilter {
 
     @Override
     public <V> V get(String k, Class<V> vClass) {
-        if(conversionService.canConvert(String.class, vClass)) {
+        if (conversionService.canConvert(String.class, vClass)) {
             Object val = environment.getProperty("spring.metrics.filter." + k);
             try {
                 return conversionService.convert(val, vClass);
             } catch (ConversionFailedException e) {
-                throw new ConfigurationException("Invalid configuration for '"+k+"' value '"+val+"' as "+vClass);
+                throw new ConfigurationException("Invalid configuration for '" + k + "' value '" + val + "' as " + vClass, e);
             }
         }
         return null;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/SpringEnvironmentMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/SpringEnvironmentMeterFilterTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     "spring.metrics.filter.my.timer.maximumExpectedValue=PT10S",
     "spring.metrics.filter.my.timer.minimumExpectedValue=1ms",
     "spring.metrics.filter.my.timer.percentiles=0.5,0.95",
+    "spring.metrics.filter.my.timer.that.is.misconfigured.enabled=troo",
 
     "spring.metrics.filter.my.summary.enabled=true",
     "spring.metrics.filter.my.summary.maximumExpectedValue=100",
@@ -93,6 +95,13 @@ public class SpringEnvironmentMeterFilterTest {
     public void summaryHistogramConfig() {
         registry.summary("my.summary");
         assertThat(histogramConfig.getMaximumExpectedValue()).isEqualTo(100);
+    }
+
+    @Test
+    public void configErrorMessage(){
+        assertThatThrownBy(() -> registry.timer("my.timer.that.is.misconfigured"))
+            .isInstanceOf(ConfigurationException.class)
+            .hasMessage("Invalid configuration for 'my.timer.that.is.misconfigured.enabled' value 'troo' as class java.lang.Boolean");
     }
 
     @Configuration


### PR DESCRIPTION
I'm OK if you think this is un-needed and should be closed. I mainly did it to inspect that the API would allow the detail if I needed it.

At first I was worried we would need this due to how config is parsed lazily. But it turns out that is actually beneficial, because the user's code the is calling `Timer...register()` will be in the stack, so the metrics name will be locate-able. 

This change just points directly to the config line if the `my.threadpool` config was bad for the `my.threadpool.counter`, so the user won't have to look very hard