### PR TITLE
Allow SimpleRegistry to be configured into cumulative mode

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CountingMode.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CountingMode.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.simple;
+
+public enum CountingMode {
+    /**
+     * Counts and totals are monotonically increasing.
+     */
+    Cumulative,
+
+    /**
+     * Rate normalize counts and totals.
+     */
+    Step
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeCounter.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.simple;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.Counter;
+
+public class CumulativeCounter extends AbstractMeter implements Counter {
+    private final AtomicDouble value;
+
+    /** Create a new instance. */
+    public CumulativeCounter(Id id) {
+        super(id);
+        this.value = new AtomicDouble();
+    }
+
+    @Override
+    public void increment(double amount) {
+        value.getAndAdd(amount);
+    }
+
+    @Override
+    public double count() {
+        return value.get();
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeTimer.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.simple;
+
+import io.micrometer.core.instrument.AbstractTimer;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.histogram.HistogramConfig;
+import io.micrometer.core.instrument.step.StepLong;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Jon Schneider
+ */
+public class CumulativeTimer extends AbstractTimer {
+    private final AtomicLong count;
+    private final AtomicLong total;
+    private final AtomicLong max;
+
+    /**
+     * Create a new instance.
+     */
+    public CumulativeTimer(Id id, Clock clock, HistogramConfig histogramConfig) {
+        super(id, clock, histogramConfig);
+        this.count = new AtomicLong();
+        this.total = new AtomicLong();
+        this.max = new AtomicLong();
+    }
+
+    @Override
+    protected void recordNonNegative(long amount, TimeUnit unit) {
+        long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
+        count.getAndAdd(1);
+        total.getAndAdd(nanoAmount);
+        max.set(Math.max(nanoAmount, max.get()));
+    }
+
+    @Override
+    public long count() {
+        return (long) count.get();
+    }
+
+    @Override
+    public double totalTime(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(total.get(), unit);
+    }
+
+    @Override
+    public double max(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(max.get(), unit);
+    }
+
+    @Override
+    public Iterable<Measurement> measure() {
+        return Arrays.asList(
+            new Measurement(() -> (double) count(), Statistic.Count),
+            new Measurement(() -> totalTime(TimeUnit.NANOSECONDS), Statistic.TotalTime),
+            new Measurement(() -> totalTime(TimeUnit.NANOSECONDS), Statistic.Max)
+        );
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleConfig.java
@@ -37,4 +37,15 @@ public interface SimpleConfig extends StepRegistryConfig {
         String v = get(prefix() + ".step");
         return v == null ? DEFAULT_STEP : Duration.parse(v);
     }
+
+    default CountingMode mode() {
+        String v = get(prefix() + ".mode");
+        if(v == null)
+            return CountingMode.Cumulative;
+        for (CountingMode countingMode : CountingMode.values()) {
+            if(v.equalsIgnoreCase(countingMode.name()))
+                return countingMode;
+        }
+        throw new IllegalArgumentException("Counting mode must be one of 'cumulative' or 'step' (check property " + prefix() + ".mode)");
+    }
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.micrometer.core.instrument.simple.SimpleConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +59,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @TestPropertySource(properties = {
     "spring.metrics.use-global-registry=false",
     "spring.metrics.filter.my.timer.enabled=true", // overriden by programmatic filter
+    "spring.metrics.simple.cumulative.enabled=true",
 })
 public class MetricsAutoConfigurationTest {
 
@@ -75,9 +75,6 @@ public class MetricsAutoConfigurationTest {
     @Autowired
     private MeterRegistry registry;
 
-    @Autowired
-    private MockClock clock;
-
     @SuppressWarnings("unchecked")
     @Test
     public void restTemplateIsInstrumented() {
@@ -88,7 +85,6 @@ public class MetricsAutoConfigurationTest {
 
         assertThat(external.getForObject("/api/external", String.class)).isEqualTo("hello");
 
-        clock.add(SimpleConfig.DEFAULT_STEP);
         assertThat(registry.find("http.client.requests").timer().map(Timer::count)).isPresent().hasValue(1L);
     }
 
@@ -96,7 +92,6 @@ public class MetricsAutoConfigurationTest {
     public void requestMappingIsInstrumented() {
         loopback.getForObject("/api/people", String.class);
 
-        clock.add(SimpleConfig.DEFAULT_STEP);
         assertThat(registry.find("http.server.requests").timer().map(Timer::count)).isPresent().hasValue(1L);
     }
 


### PR DESCRIPTION
Addresses #193 

I had to duplicate the `newTimer` and `newDistributionSummary` into `SimpleMeterRegistry`. I'm happy to move the logic up into `StepMeterRegistry`