### PR TITLE
Add OpenTracing to Timers

### DIFF
--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -117,7 +117,7 @@ public class AtlasMeterRegistry extends MeterRegistry {
             PercentileTimer.get(registry, spectatorId(id));
         }
 
-        SpectatorTimer timer = new SpectatorTimer(id, internalTimer, clock, histogramConfig);
+        SpectatorTimer timer = new SpectatorTimer(id, internalTimer, clock, histogramConfig, tracer);
 
         for (long sla : histogramConfig.getSlaBoundaries()) {
             gauge(id.getName(), Tags.concat(getConventionTags(id), "sla", Duration.ofNanos(sla).toString()), sla, timer::histogramCountAtValue);

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorTimer.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorTimer.java
@@ -22,10 +22,12 @@ import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.Tracer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static java.util.stream.StreamSupport.stream;
 
@@ -33,8 +35,8 @@ public class SpectatorTimer extends AbstractTimer {
     private final com.netflix.spectator.api.Timer timer;
     private final Logger logger = LoggerFactory.getLogger(SpectatorTimer.class);
 
-    public SpectatorTimer(Id id, Timer timer, Clock clock, HistogramConfig statsConf) {
-        super(id, clock, statsConf);
+    public SpectatorTimer(Id id, Timer timer, Clock clock, HistogramConfig statsConf, Supplier<Tracer> tracer) {
+        super(id, clock, statsConf, tracer);
         this.timer = timer;
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
@@ -17,7 +17,6 @@ package io.micrometer.prometheus;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.util.MeterEquivalence;
 
 import java.util.concurrent.atomic.DoubleAdder;
@@ -25,7 +24,7 @@ import java.util.concurrent.atomic.DoubleAdder;
 public class PrometheusCounter extends AbstractMeter implements Counter {
     private DoubleAdder count = new DoubleAdder();
 
-    PrometheusCounter(Meter.Id id) {
+    PrometheusCounter(Id id) {
         super(id);
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
@@ -29,7 +29,9 @@ public class PrometheusDistributionSummary extends AbstractDistributionSummary {
     private DoubleAdder amount = new DoubleAdder();
     private StepDouble max;
 
-    PrometheusDistributionSummary(Id id, Clock clock, HistogramConfig histogramConfig, long maxStepMillis) {
+    PrometheusDistributionSummary(Id id, Clock clock,
+                                  HistogramConfig histogramConfig,
+                                  long maxStepMillis) {
         super(id, clock, histogramConfig);
         this.max = new StepDouble(clock, maxStepMillis);
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -148,7 +148,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     protected io.micrometer.core.instrument.Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
         MicrometerCollector collector = collectorByName(id, Collector.Type.SUMMARY);
-        PrometheusTimer timer = new PrometheusTimer(id, clock, histogramConfig, prometheusConfig.step().toMillis());
+        PrometheusTimer timer = new PrometheusTimer(id, clock, histogramConfig, prometheusConfig.step().toMillis(), tracer);
         List<String> tagValues = tagValues(id);
 
         collector.add((conventionName, tagKeys) -> {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
@@ -21,17 +21,19 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.step.StepDouble;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.Tracer;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 
 public class PrometheusTimer extends AbstractTimer implements Timer {
     private final LongAdder count = new LongAdder();
     private final LongAdder totalTime = new LongAdder();
     private final StepDouble max;
 
-    PrometheusTimer(Id id, Clock clock, HistogramConfig histogramConfig, long maxStepMillis) {
-        super(id, clock, histogramConfig);
+    PrometheusTimer(Id id, Clock clock, HistogramConfig histogramConfig, long maxStepMillis, Supplier<Tracer> tracer) {
+        super(id, clock, histogramConfig, tracer);
         this.max = new StepDouble(clock, maxStepMillis);
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.handler.logging.LoggingHandler;
+import io.opentracing.Tracer;
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
@@ -168,7 +169,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
-        Timer timer = new StatsdTimer(id, lineBuilder(id), publisher, clock, histogramConfig, statsdConfig.step().toMillis());
+        Timer timer = new StatsdTimer(id, lineBuilder(id), publisher, clock, histogramConfig, statsdConfig.step().toMillis(),  tracer);
 
         for (double percentile : histogramConfig.getPercentiles()) {
             switch (statsdConfig.flavor()) {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
@@ -21,11 +21,13 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.step.StepDouble;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.Tracer;
 import org.reactivestreams.Processor;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Supplier;
 
 public class StatsdTimer extends AbstractTimer implements Timer {
     private final LongAdder count = new LongAdder();
@@ -36,8 +38,8 @@ public class StatsdTimer extends AbstractTimer implements Timer {
     private final Processor<String, String> publisher;
 
     StatsdTimer(Id id, StatsdLineBuilder lineBuilder, Processor<String, String> publisher, Clock clock,
-                HistogramConfig histogramConfig, long stepMillis) {
-        super(id, clock, histogramConfig);
+                HistogramConfig histogramConfig, long stepMillis, Supplier<Tracer> tracer) {
+        super(id, clock, histogramConfig, tracer);
         this.max = new StepDouble(clock, stepMillis);
         this.lineBuilder = lineBuilder;
         this.publisher = publisher;

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -10,6 +10,8 @@ apply plugin: 'nebula.optional-base'
 dependencies {
     compile 'org.hdrhistogram:HdrHistogram:2.1.10'
     compile 'org.latencyutils:LatencyUtils:2.0.3'
+    compile 'io.opentracing:opentracing-api:0.30.0'
+    compile 'io.opentracing:opentracing-noop:0.30.0'
 
     // instrumentation options
     compile 'io.dropwizard.metrics:metrics-core:3.+', optional

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -17,6 +17,9 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.histogram.TimeWindowHistogram;
+import io.opentracing.Tracer;
+
+import java.util.function.Supplier;
 
 public abstract class AbstractDistributionSummary extends AbstractMeter implements DistributionSummary {
     private final TimeWindowHistogram histogram;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -22,14 +22,19 @@ import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.internal.DefaultFunctionTimer;
 import io.micrometer.core.instrument.noop.*;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.NoopTracer;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
 
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.Tags.zip;
@@ -50,10 +55,13 @@ public abstract class MeterRegistry {
 
     public MeterRegistry(Clock clock) {
         this.clock = clock;
+        Tracer noopTracer = NoopTracerFactory.create();
+        tracer = () -> noopTracer;
     }
 
     private final Map<Meter.Id, Meter> meterMap = new HashMap<>();
     private final List<MeterFilter> filters = new ArrayList<>();
+    protected Supplier<Tracer> tracer;
 
     /**
      * We'll use snake case as a general-purpose default for registries because it is the most
@@ -131,7 +139,7 @@ public abstract class MeterRegistry {
 
     Timer timer(Meter.Id id, HistogramConfig histogramConfig) {
         return registerMeterIfNecessary(Timer.class, id, histogramConfig, (id2, filteredConfig) ->
-            newTimer(id2, filteredConfig.merge(HistogramConfig.DEFAULT)), NoopTimer::new);
+            newTimer(id2, filteredConfig.merge(HistogramConfig.DEFAULT)), (newId) -> new NoopTimer(newId, tracer));
     }
 
     DistributionSummary summary(Meter.Id id, HistogramConfig histogramConfig) {
@@ -180,6 +188,15 @@ public abstract class MeterRegistry {
      * Access to configuration options for this registry.
      */
     public class Config {
+
+        public Config setTracer(Tracer tracer) {
+            if (tracer == null) {
+                throw new NullPointerException("Cannot register setTracer that is <null>.");
+            }
+            MeterRegistry.this.tracer = () -> tracer;
+            return this;
+        }
+
         /**
          * Append a list of common tags to apply to all metrics reported to the monitoring system.
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -139,7 +139,7 @@ public abstract class MeterRegistry {
 
     Timer timer(Meter.Id id, HistogramConfig histogramConfig) {
         return registerMeterIfNecessary(Timer.class, id, histogramConfig, (id2, filteredConfig) ->
-            newTimer(id2, filteredConfig.merge(HistogramConfig.DEFAULT)), (newId) -> new NoopTimer(newId, tracer));
+            newTimer(id2, filteredConfig.merge(HistogramConfig.DEFAULT)), (newId) -> new NoopTimer(newId, clock, tracer));
     }
 
     DistributionSummary summary(Meter.Id id, HistogramConfig histogramConfig) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -49,7 +49,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
-        CompositeTimer timer = new CompositeTimer(id, histogramConfig, tracer);
+        CompositeTimer timer = new CompositeTimer(id, clock, histogramConfig, tracer);
         compositeMeters.add(timer);
         registries.forEach(timer::add);
         return timer;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -49,7 +49,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
-        CompositeTimer timer = new CompositeTimer(id, histogramConfig);
+        CompositeTimer timer = new CompositeTimer(id, histogramConfig, tracer);
         compositeMeters.add(timer);
         registries.forEach(timer::add);
         return timer;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.noop.NoopTimer;
+import io.opentracing.Tracer;
 
 import java.time.Duration;
 import java.util.Map;
@@ -32,10 +33,12 @@ import java.util.function.Supplier;
 public class CompositeTimer extends AbstractMeter implements Timer, CompositeMeter {
     private final Map<MeterRegistry, Timer> timers = new ConcurrentHashMap<>();
     private final HistogramConfig histogramConfig;
+    private final Supplier<Tracer> tracer;
 
-    CompositeTimer(Meter.Id id, HistogramConfig histogramConfig) {
+    CompositeTimer(Meter.Id id, HistogramConfig histogramConfig, Supplier<Tracer> tracer) {
         super(id);
         this.histogramConfig = histogramConfig;
+        this.tracer = tracer;
     }
 
     @Override
@@ -99,7 +102,7 @@ public class CompositeTimer extends AbstractMeter implements Timer, CompositeMet
     }
 
     private Timer firstTimer() {
-        return timers.values().stream().findFirst().orElse(new NoopTimer(getId()));
+        return timers.values().stream().findFirst().orElse(new NoopTimer(getId(), tracer));
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.composite;
 
 import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -32,11 +33,13 @@ import java.util.function.Supplier;
 
 public class CompositeTimer extends AbstractMeter implements Timer, CompositeMeter {
     private final Map<MeterRegistry, Timer> timers = new ConcurrentHashMap<>();
+    private final Clock clock;
     private final HistogramConfig histogramConfig;
     private final Supplier<Tracer> tracer;
 
-    CompositeTimer(Meter.Id id, HistogramConfig histogramConfig, Supplier<Tracer> tracer) {
+    CompositeTimer(Meter.Id id, Clock clock, HistogramConfig histogramConfig, Supplier<Tracer> tracer) {
         super(id);
+        this.clock = clock;
         this.histogramConfig = histogramConfig;
         this.tracer = tracer;
     }
@@ -102,7 +105,7 @@ public class CompositeTimer extends AbstractMeter implements Timer, CompositeMet
     }
 
     private Timer firstTimer() {
-        return timers.values().stream().findFirst().orElse(new NoopTimer(getId(), tracer));
+        return timers.values().stream().findFirst().orElse(new NoopTimer(getId(), clock, tracer));
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -65,7 +65,7 @@ public class DropwizardMeterRegistry extends MeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
-        DropwizardTimer timer = new DropwizardTimer(id, registry.timer(hierarchicalName(id)), clock, histogramConfig);
+        DropwizardTimer timer = new DropwizardTimer(id, registry.timer(hierarchicalName(id)), clock, histogramConfig, tracer);
 
         for (double percentile : histogramConfig.getPercentiles()) {
             gauge(id.getName(), Tags.concat(getConventionTags(id), "percentile", percentileFormat.format(percentile)),

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardTimer.java
@@ -21,17 +21,19 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.step.StepDouble;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.Tracer;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 public class DropwizardTimer extends AbstractTimer {
     private final Timer impl;
     private final AtomicLong totalTime = new AtomicLong(0);
     private final StepDouble max;
 
-    DropwizardTimer(Id id, Timer impl, Clock clock, HistogramConfig histogramConfig) {
-        super(id, clock, histogramConfig);
+    DropwizardTimer(Id id, Timer impl, Clock clock, HistogramConfig histogramConfig, Supplier<Tracer> tracer) {
+        super(id, clock, histogramConfig, tracer);
         this.impl = impl;
         this.max = new StepDouble(clock, 60000);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -17,14 +17,25 @@ package io.micrometer.core.instrument.noop;
 
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
+import io.opentracing.ActiveSpan;
+import io.opentracing.Tracer;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 public class NoopTimer extends NoopMeter implements Timer {
-    public NoopTimer(Id id) {
+    private final Supplier<Tracer> tracer;
+
+    public NoopTimer(Id id, Supplier<Tracer> tracer) {
         super(id);
+        this.tracer = tracer;
+    }
+
+    private ActiveSpan createSpan() {
+        Tracer.SpanBuilder spanBuilder = tracer.get().buildSpan(getId().getName());
+        getId().getTags().forEach(t -> spanBuilder.withTag(t.getKey(), t.getValue()));
+        return spanBuilder.startActive();
     }
 
     @Override
@@ -33,22 +44,44 @@ public class NoopTimer extends NoopMeter implements Timer {
 
     @Override
     public <T> T record(Supplier<T> f) {
-        return f.get();
+        ActiveSpan span = createSpan();
+        try {
+            return f.get();
+        } finally {
+            span.deactivate();
+        }
     }
 
     @Override
     public <T> T recordCallable(Callable<T> f) throws Exception {
-        return f.call();
+        ActiveSpan span = createSpan();
+        try {
+            return f.call();
+        } finally {
+            span.deactivate();
+        }
     }
 
     @Override
     public void record(Runnable f) {
-        f.run();
+        ActiveSpan span = createSpan();
+        try {
+            f.run();
+        } finally {
+            span.deactivate();
+        }
     }
 
     @Override
     public <T> Callable<T> wrap(Callable<T> f) {
-        return f;
+        return () -> {
+            ActiveSpan span = createSpan();
+            try {
+                return f.call();
+            } finally {
+                span.deactivate();
+            }
+        };
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -81,7 +81,7 @@ public abstract class StepMeterRegistry extends MeterRegistry {
             .histogramExpiry(config.step())
             .build());
 
-        Timer timer = new StepTimer(id, clock, histogramConfig, config.step().toMillis());
+        Timer timer = new StepTimer(id, clock, histogramConfig, config.step().toMillis(), tracer);
         histogramConfigs.put(timer, merged);
         return timer;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -18,9 +18,11 @@ package io.micrometer.core.instrument.step;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentracing.Tracer;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * @author Jon Schneider
@@ -33,8 +35,8 @@ public class StepTimer extends AbstractTimer {
     /**
      * Create a new instance.
      */
-    public StepTimer(Id id, Clock clock, HistogramConfig histogramConfig, long step) {
-        super(id, clock, histogramConfig);
+    public StepTimer(Id id, Clock clock, HistogramConfig histogramConfig, long step,  Supplier<Tracer> tracer) {
+        super(id, clock, histogramConfig, tracer);
         this.count = new StepLong(clock, step);
         this.total = new StepLong(clock, step);
         this.max = new StepLong(clock, step);

--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -75,4 +75,5 @@ dependencies {
     samplesCompile 'org.springframework.integration:spring-integration-java-dsl'
     samplesCompile 'org.springframework.integration:spring-integration-ws'
     samplesCompile 'org.springframework.integration:spring-integration-xml'
+    samplesCompile 'com.uber.jaeger:jaeger-core:0.22.0-RC2'
 }

--- a/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/components/PersonController.java
+++ b/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/components/PersonController.java
@@ -43,6 +43,7 @@ public class PersonController {
     @GetMapping("/api/people")
     @Timed(percentiles = {0.5, 0.95, 0.999}, histogram = true)
     public List<String> allPeople() {
+        long startTime = System.nanoTime();
         Timer.builder("the.timer").tags("first tag", "tagVal0", "otherTag", "otherVal1").register(registry).record(() -> {
             ActiveSpan orderSpan = GlobalTracer.get().buildSpan("order_span").startActive();
             Timer.builder("inner.timer")
@@ -54,7 +55,10 @@ public class PersonController {
                 }
             });
             orderSpan.deactivate();
+            Timer.builder("non-callback timer 123").register(registry).record(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
         });
+
+
 
         return people;
     }

--- a/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/components/PersonController.java
+++ b/micrometer-spring-legacy/src/samples/java/io/micrometer/spring/samples/components/PersonController.java
@@ -16,7 +16,12 @@
 package io.micrometer.spring.samples.components;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.opentracing.ActiveSpan;
+import io.opentracing.Span;
+import io.opentracing.util.GlobalTracer;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,11 +43,19 @@ public class PersonController {
     @GetMapping("/api/people")
     @Timed(percentiles = {0.5, 0.95, 0.999}, histogram = true)
     public List<String> allPeople() {
-        try {
-            Thread.sleep(200);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        Timer.builder("the.timer").tags("first tag", "tagVal0", "otherTag", "otherVal1").register(registry).record(() -> {
+            ActiveSpan orderSpan = GlobalTracer.get().buildSpan("order_span").startActive();
+            Timer.builder("inner.timer")
+                .tags("first tag", "tagVal1").register(registry).record(() -> {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            });
+            orderSpan.deactivate();
+        });
+
         return people;
     }
 

--- a/micrometer-spring-legacy/src/samples/resources/application-prometheus.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-prometheus.yml
@@ -18,8 +18,8 @@ management.security.enabled: false
 
 spring.metrics:
   prometheus.enabled: true
-  overrides:
-    ALL.enabled: false
+  filter:
+    enabled: false
     jvm.enabled: true
-    jvm.memory.used: disabled
+    jvm.memory.used.enabled: false
 


### PR DESCRIPTION
@jkschneider This is regarding #28 (@adriancole I would love your feedback too)

Initially I took a 'listener' approach, but it wasn't useful for tracing since you need to have the active span so child spans can display properly.

Here are my findings:
* Listener approach doesn't work
* Only `Timer`s make sense for creating traces
* While I was (kind of) able to hack in support for the non-callback `record` method, those spans weren't useful, they ended up disconnected from the rest of their trace
* Being able to automatically expose the metric's tags in the span was really cool

Since traces were only useful for a sub set of metrics and you had to use the Timer the exactly correct way to get a useful measurement, I'm not in love with this feature.

![image](https://user-images.githubusercontent.com/416063/32695014-dd9d53e6-c70d-11e7-97ca-1dca539b76bc.png)

I'm going to investigate solving this a different way with a `TracingTimer` so users could opt into which timers they wanted traced.  But I am interested to hear if you had any other feedback or suggestions, or if you think the behavior is useful.
