### PR TITLE
Deduplicate the code between TimeWindowHistogram and TimeWindowLatencyHistogram

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -21,7 +21,7 @@ import io.micrometer.core.instrument.histogram.TimeWindowHistogram;
 public abstract class AbstractDistributionSummary extends AbstractMeter implements DistributionSummary {
     private final TimeWindowHistogram histogram;
 
-    public AbstractDistributionSummary(Id id, Clock clock, HistogramConfig histogramConfig) {
+    protected AbstractDistributionSummary(Id id, Clock clock, HistogramConfig histogramConfig) {
         super(id);
         this.histogram = new TimeWindowHistogram(clock, histogramConfig);
     }
@@ -29,7 +29,7 @@ public abstract class AbstractDistributionSummary extends AbstractMeter implemen
     @Override
     public final void record(double amount) {
         if (amount >= 0) {
-            histogram.record(amount);
+            histogram.recordDouble(amount);
             recordNonNegative(amount);
         }
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -85,7 +85,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     @Override
     public final void record(long amount, TimeUnit unit) {
         if(amount >= 0) {
-            histogram.record((long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS));
+            histogram.recordLong(TimeUnit.NANOSECONDS.convert(amount, unit));
             recordNonNegative(amount, unit);
         }
     }
@@ -94,7 +94,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
 
     @Override
     public double percentile(double percentile, TimeUnit unit) {
-        return histogram.percentile(percentile, unit);
+        return TimeUtils.nanosToUnit(histogram.percentile(percentile), unit);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/NoopHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/NoopHistogram.java
@@ -1,0 +1,93 @@
+package io.micrometer.core.instrument.histogram;
+
+import org.HdrHistogram.AbstractHistogram;
+import org.HdrHistogram.Histogram;
+
+final class NoopHistogram extends Histogram {
+
+    private static final long serialVersionUID = 82886959971723882L;
+
+    static final NoopHistogram INSTANCE = new NoopHistogram();
+
+    private NoopHistogram() {
+        super(1, 2, 0);
+    }
+
+    @Override
+    public Histogram copy() {
+        return this;
+    }
+
+    @Override
+    public Histogram copyCorrectedForCoordinatedOmission(long expectedIntervalBetweenValueSamples) {
+        return this;
+    }
+
+    @Override
+    public long getTotalCount() {
+        return 0;
+    }
+
+    @Override
+    public boolean isAutoResize() {
+        return true;
+    }
+
+    @Override
+    public boolean supportsAutoResize() {
+        return true;
+    }
+
+    @Override
+    public void setAutoResize(boolean autoResize) {}
+
+    @Override
+    public void recordValue(long value) {}
+
+    @Override
+    public void recordValueWithCount(long value, long count) {}
+
+    @Override
+    public void recordValueWithExpectedInterval(long value, long expectedIntervalBetweenValueSamples) {}
+
+    @Override
+    public void recordConvertedDoubleValueWithCount(double value, long count) {}
+
+    @Override
+    public void recordValue(long value, long expectedIntervalBetweenValueSamples) {}
+
+    @Override
+    public void reset() {}
+
+    @Override
+    public void copyInto(AbstractHistogram targetHistogram) {}
+
+    @Override
+    public void copyIntoCorrectedForCoordinatedOmission(AbstractHistogram targetHistogram,
+                                                        long expectedIntervalBetweenValueSamples) {}
+
+    @Override
+    public void add(AbstractHistogram otherHistogram) {}
+
+    @Override
+    public void subtract(AbstractHistogram otherHistogram) {}
+
+    @Override
+    public void addWhileCorrectingForCoordinatedOmission(AbstractHistogram otherHistogram,
+                                                         long expectedIntervalBetweenValueSamples) {}
+
+    @Override
+    public void shiftValuesLeft(int numberOfBinaryOrdersOfMagnitude) {}
+
+    @Override
+    public void shiftValuesRight(int numberOfBinaryOrdersOfMagnitude) {}
+
+    @Override
+    public void setStartTimeStamp(long timeStampMsec) {}
+
+    @Override
+    public void setEndTimeStamp(long timeStampMsec) {}
+
+    @Override
+    public void setTag(String tag) {}
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramBase.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramBase.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.histogram;
+
+import io.micrometer.core.instrument.Clock;
+import java.lang.reflect.Array;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.function.ToDoubleFunction;
+
+/**
+ * @param <T> the type of the buckets in a ring buffer
+ * @param <U> the type of accumulated histogram
+ *
+ * @author Jon Schneider
+ * @author Trustin Heuiseung Lee
+ */
+abstract class TimeWindowHistogramBase<T, U> {
+
+    static final int NUM_SIGNIFICANT_VALUE_DIGITS = 2;
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicIntegerFieldUpdater<TimeWindowHistogramBase> rotatingUpdater =
+        AtomicIntegerFieldUpdater.newUpdater(TimeWindowHistogramBase.class, "rotating");
+
+    private final Clock clock;
+
+    private final T[] ringBuffer;
+    private final U accumulatedHistogram;
+    private volatile boolean accumulatedHistogramStale;
+
+    private final long durationBetweenRotatesMillis;
+    private int currentBucket;
+    private volatile long lastRotateTimestampMillis;
+    @SuppressWarnings({ "unused", "FieldCanBeLocal" })
+    private volatile int rotating; // 0 - not rotating, 1 - rotating
+
+    TimeWindowHistogramBase(Clock clock, HistogramConfig histogramConfig, Class<T> bucketType) {
+        this.clock = clock;
+
+        final int ageBuckets = histogramConfig.getHistogramBufferLength();
+        ringBuffer = newRingBuffer(bucketType, ageBuckets, histogramConfig);
+        accumulatedHistogram = newAccumulatedHistogram(ringBuffer);
+
+        durationBetweenRotatesMillis = histogramConfig.getHistogramExpiry().toMillis() / ageBuckets;
+        currentBucket = 0;
+        lastRotateTimestampMillis = clock.wallTime();
+    }
+
+    private T[] newRingBuffer(Class<T> bucketType, int ageBuckets, HistogramConfig histogramConfig) {
+        @SuppressWarnings("unchecked")
+        final T[] ringBuffer = (T[]) Array.newInstance(bucketType, ageBuckets);
+        for (int i = 0; i < ageBuckets; i++) {
+            ringBuffer[i] = newBucket(histogramConfig);
+        }
+        return ringBuffer;
+    }
+
+    abstract T newBucket(HistogramConfig histogramConfig);
+    abstract void recordLong(T bucket, long value);
+    abstract void recordDouble(T bucket, double value);
+    abstract void resetBucket(T bucket);
+
+    abstract U newAccumulatedHistogram(T[] ringBuffer);
+    abstract void accumulate(T sourceBucket, U accumulatedHistogram);
+    abstract void resetAccumulatedHistogram(U accumulatedHistogram);
+
+    abstract double valueAtPercentile(U accumulatedHistogram, double percentile);
+    abstract double countAtValue(U accumulatedHistogram, long value);
+
+    public final double percentile(double percentile) {
+        return get(h -> valueAtPercentile(h, percentile * 100));
+    }
+
+    public final double histogramCountAtValue(long value) {
+        return get(h -> countAtValue(h, value));
+    }
+
+    public final void recordLong(long value) {
+        rotate();
+        try {
+            for (T bucket : ringBuffer) {
+                recordLong(bucket, value);
+            }
+        } catch (IndexOutOfBoundsException ignored) {
+            // the value is so large (or small) that the dynamic range of the histogram cannot be extended to include it
+        } finally {
+            accumulatedHistogramStale = true;
+        }
+    }
+
+    public final void recordDouble(double value) {
+        rotate();
+        try {
+            for (T bucket : ringBuffer) {
+                recordDouble(bucket, value);
+            }
+        } catch (IndexOutOfBoundsException ignored) {
+            // the value is so large (or small) that the dynamic range of the histogram cannot be extended to include it
+        } finally {
+            accumulatedHistogramStale = true;
+        }
+    }
+
+    private void rotate() {
+        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
+        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
+            // Need to wait more for next rotation.
+            return;
+        }
+
+        if (!rotatingUpdater.compareAndSet(this, 0, 1)) {
+            // Being rotated by other thread already.
+            return;
+        }
+
+        try {
+            synchronized (this) {
+                do {
+                    resetBucket(ringBuffer[currentBucket]);
+                    if (++currentBucket >= ringBuffer.length) {
+                        currentBucket = 0;
+                    }
+                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
+                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
+                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis);
+
+                resetAccumulatedHistogram(accumulatedHistogram);
+                accumulatedHistogramStale = true;
+            }
+        } finally {
+            rotating = 0;
+        }
+    }
+
+    private double get(ToDoubleFunction<U> func) {
+        rotate();
+
+        synchronized (this) {
+            if (accumulatedHistogramStale) {
+                accumulate(ringBuffer[currentBucket], accumulatedHistogram);
+                accumulatedHistogramStale = false;
+            }
+
+            return func.applyAsDouble(accumulatedHistogram);
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowLatencyHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowLatencyHistogram.java
@@ -17,120 +17,67 @@ package io.micrometer.core.instrument.histogram;
 
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.util.TimeUtils;
 import org.HdrHistogram.Histogram;
 import org.LatencyUtils.LatencyStats;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.function.ToDoubleFunction;
 
 /**
  * @author Jon Schneider
  * @author Trustin Heuiseung Lee
  */
 @Incubating(since = "1.0.0-rc.3")
-public class TimeWindowLatencyHistogram {
-
-    private static final AtomicIntegerFieldUpdater<TimeWindowLatencyHistogram> rotatingUpdater =
-        AtomicIntegerFieldUpdater.newUpdater(TimeWindowLatencyHistogram.class, "rotating");
-
-    private final Clock clock;
-    private final HistogramConfig config;
-
-    private final LatencyStats[] ringBuffer;
-    private final Histogram accumulatedHistogram;
-    private volatile boolean accumulatedHistogramStale;
-
-    private final long durationBetweenRotatesMillis;
-    private int currentBucket;
-    private volatile long lastRotateTimestampMillis;
-    @SuppressWarnings({ "unused", "FieldCanBeLocal" })
-    private volatile int rotating; // 0 - not rotating, 1 - rotating
+public class TimeWindowLatencyHistogram extends TimeWindowHistogramBase<LatencyStats, Histogram> {
 
     public TimeWindowLatencyHistogram(Clock clock, HistogramConfig histogramConfig) {
-        this.clock = clock;
-        this.config = histogramConfig;
-        int ageBuckets = histogramConfig.getHistogramBufferLength();
-        this.ringBuffer = new LatencyStats[ageBuckets];
-        for (int i = 0; i < ageBuckets; i++) {
-            this.ringBuffer[i] = buildLatencyStats();
-        }
-        this.currentBucket = 0;
-        this.lastRotateTimestampMillis = clock.wallTime();
-        this.durationBetweenRotatesMillis = histogramConfig.getHistogramExpiry().toMillis() / ageBuckets;
-        this.accumulatedHistogram = new Histogram(ringBuffer[0].getIntervalHistogram());
+        super(clock, histogramConfig, LatencyStats.class);
     }
 
-    public double percentile(double percentile, TimeUnit unit) {
-        return TimeUtils.nanosToUnit(get(h -> h.getValueAtPercentile(percentile * 100)), unit);
-    }
-
-    public double histogramCountAtValue(long valueNanos) {
-        return get(h -> h.getCountBetweenValues(0, valueNanos));
-    }
-
-    public void record(long valueNano) {
-        rotate();
-        try {
-            for (LatencyStats histogram : ringBuffer) {
-                histogram.recordLatency(valueNano);
-            }
-        } catch (IndexOutOfBoundsException ignored) {
-            // the value is so large (or small) that the dynamic range of the histogram cannot be extended to include it
-        } finally {
-            accumulatedHistogramStale = true;
-        }
-    }
-
-    private void rotate() {
-        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
-        if (timeSinceLastRotateMillis <= durationBetweenRotatesMillis) {
-            // Need to wait more for next rotation.
-            return;
-        }
-
-        if (!rotatingUpdater.compareAndSet(this, 0, 1)) {
-            // Being rotated by other thread already.
-            return;
-        }
-
-        try {
-            synchronized (this) {
-                do {
-                    ringBuffer[currentBucket] = buildLatencyStats();
-                    if (++currentBucket >= ringBuffer.length) {
-                        currentBucket = 0;
-                    }
-                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
-                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
-                } while (timeSinceLastRotateMillis > durationBetweenRotatesMillis);
-
-                accumulatedHistogram.reset();
-                accumulatedHistogramStale = true;
-            }
-        } finally {
-            rotating = 0;
-        }
-    }
-
-    private double get(ToDoubleFunction<Histogram> func) {
-        rotate();
-
-        synchronized (this) {
-            if (accumulatedHistogramStale) {
-                ringBuffer[currentBucket].addIntervalHistogramTo(accumulatedHistogram);
-                accumulatedHistogramStale = false;
-            }
-
-            return func.applyAsDouble(accumulatedHistogram);
-        }
-    }
-
-    private LatencyStats buildLatencyStats() {
+    @Override
+    LatencyStats newBucket(HistogramConfig histogramConfig) {
         return new LatencyStats.Builder()
-            .lowestTrackableLatency(config.getMinimumExpectedValue())
-            .highestTrackableLatency(config.getMaximumExpectedValue())
+            .lowestTrackableLatency(histogramConfig.getMinimumExpectedValue())
+            .highestTrackableLatency(histogramConfig.getMaximumExpectedValue())
+            .numberOfSignificantValueDigits(NUM_SIGNIFICANT_VALUE_DIGITS)
             .build();
+    }
+
+    @Override
+    void recordLong(LatencyStats bucket, long value) {
+        bucket.recordLatency(value);
+    }
+
+    @Override
+    void recordDouble(LatencyStats bucket, double value) {
+        bucket.recordLatency((long) value);
+    }
+
+    @Override
+    void resetBucket(LatencyStats bucket) {
+        // LatencyStats does not provide a way to reset the counters, so we just drain into a NoopHistogram.
+        bucket.getIntervalHistogramInto(NoopHistogram.INSTANCE);
+    }
+
+    @Override
+    Histogram newAccumulatedHistogram(LatencyStats[] ringBuffer) {
+        return ringBuffer[0].getIntervalHistogram();
+    }
+
+    @Override
+    void accumulate(LatencyStats sourceBucket, Histogram accumulatedHistogram) {
+        sourceBucket.addIntervalHistogramTo(accumulatedHistogram);
+    }
+
+    @Override
+    void resetAccumulatedHistogram(Histogram accumulatedHistogram) {
+        accumulatedHistogram.reset();
+    }
+
+    @Override
+    double valueAtPercentile(Histogram accumulatedHistogram, double percentile) {
+        return accumulatedHistogram.getValueAtPercentile(percentile);
+    }
+
+    @Override
+    double countAtValue(Histogram accumulatedHistogram, long value) {
+        return accumulatedHistogram.getCountBetweenValues(0, value);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramTest.java
@@ -24,11 +24,11 @@ class TimeWindowHistogramTest {
     @Test
     void histogramsAreCumulative() {
         TimeWindowHistogram histogram = new TimeWindowHistogram(new MockClock(), HistogramConfig.DEFAULT);
-        histogram.record(3);
+        histogram.recordDouble(3);
 
         assertThat(histogram.histogramCountAtValue(3)).isEqualTo(1);
 
-        histogram.record(6);
+        histogram.recordDouble(6);
 
         // Proves that the accumulated histogram is truly accumulative, and not just a representation
         // of the last snapshot
@@ -44,7 +44,7 @@ class TimeWindowHistogramTest {
             .maximumExpectedValue(2L)
             .build()
             .merge(HistogramConfig.DEFAULT));
-        histogram.record(3);
+        histogram.recordDouble(3);
         assertThat(histogram.histogramCountAtValue(3)).isEqualTo(1);
     }
 
@@ -54,12 +54,12 @@ class TimeWindowHistogramTest {
 
         // If the dynamic range of the underlying recorder isn't pushed very far to the right, a small value will be handled normally.
         // Doing this primes the 1e-8 sample for failure
-        histogram.record(1000000000);
+        histogram.recordDouble(1000000000);
 
         // This will be out of bounds for the underlying histogram
-        histogram.record(1e-8);
+        histogram.recordDouble(1e-8);
 
         // Regardless of the imputed dynamic bound for the underlying histogram, Double.MAX_VALUE is always too large.
-        histogram.record(Double.MAX_VALUE);
+        histogram.recordDouble(Double.MAX_VALUE);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/histogram/TimeWindowRotationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/histogram/TimeWindowRotationTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.histogram;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MockClock;
+
+class TimeWindowRotationTest {
+
+    private static final MockClock clock = new MockClock();
+    private static final HistogramConfig histogramConfig =
+            HistogramConfig.builder()
+                           .percentiles(0.0, 0.5, 0.75, 0.9, 0.99, 0.999, 1.0)
+                           .histogramExpiry(Duration.ofSeconds(4))
+                           .histogramBufferLength(4)
+                           .build()
+                           .merge(HistogramConfig.DEFAULT);
+
+    static Collection<Class<? extends TimeWindowHistogramBase<?, ?>>> histogramTypes() {
+        return Arrays.asList(TimeWindowHistogram.class, TimeWindowLatencyHistogram.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("histogramTypes")
+    void timeBasedSlidingWindow(Class<? extends TimeWindowHistogramBase<?, ?>> histogramType) throws Exception {
+
+        final MockClock clock = new MockClock();
+        // Start from 0 for more comprehensive timing calculation.
+        clock.add(-1, TimeUnit.NANOSECONDS);
+        assertThat(clock.wallTime()).isZero();
+
+        final TimeWindowHistogramBase<?, ?> q =
+                histogramType.getDeclaredConstructor(Clock.class, HistogramConfig.class)
+                             .newInstance(clock, histogramConfig);
+
+        q.recordLong(10);
+        q.recordLong(20);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(9.0, 11.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(19.0, 21.0);
+
+        clock.add(900, TimeUnit.MILLISECONDS); // 900
+        q.recordLong(30);
+        q.recordLong(40);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(9.0, 11.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(39.0, 41.0);
+
+        clock.add(99, TimeUnit.MILLISECONDS); // 999
+        q.recordLong(9);
+        q.recordLong(60);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(8.0, 10.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(59.0, 61.0);
+
+        clock.add(1, TimeUnit.MILLISECONDS); // 1000
+        q.recordLong(12);
+        q.recordLong(70);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(8.0, 10.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(69.0, 71.0);
+
+        clock.add(1001, TimeUnit.MILLISECONDS); // 2001
+        q.recordLong(13);
+        q.recordLong(80);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(8.0, 10.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(79.0, 81.0);
+
+        clock.add(1000, TimeUnit.MILLISECONDS); // 3001
+        assertThat(q.percentile(0.0)).isStrictlyBetween(8.0, 10.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(79.0, 81.0);
+
+        clock.add(999, TimeUnit.MILLISECONDS); // 4000
+        assertThat(q.percentile(0.0)).isStrictlyBetween(11.0, 13.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(79.0, 81.0);
+        q.recordLong(1);
+        q.recordLong(200);
+        assertThat(q.percentile(0.0)).isStrictlyBetween(0.0, 2.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(199.0, 201.0);
+
+        clock.add(10000, TimeUnit.MILLISECONDS); // 14000
+        assertThat(q.percentile(0.0)).isZero();
+        assertThat(q.percentile(1.0)).isZero();
+        q.recordLong(3);
+
+        clock.add(3999, TimeUnit.MILLISECONDS); // 17999
+        assertThat(q.percentile(0.0)).isStrictlyBetween(2.0, 4.0);
+        assertThat(q.percentile(1.0)).isStrictlyBetween(2.0, 4.0);
+
+        clock.add(1, TimeUnit.MILLISECONDS); // 18000
+        assertThat(q.percentile(0.0)).isZero();
+        assertThat(q.percentile(1.0)).isZero();
+    }
+}


### PR DESCRIPTION
Motivation:

TimeWindowHistogram and TimeWindowLatencyHistogram shares majority of
their logic. A change in one place needs the same change in the other
counterpart, which is error-prone.

Modifications:

- Extract the common logic between TimeWindowHistogram and
  TimeWindowLatencyHistogram into TimeWindowHistogramBase
- Use the same number of significant value digits for both histograms
- Add NoopHistogram and use it to reset LatencyStats
- Add TimeWindowRotationTest to verify that sliding window works as
  expected
- Miscellaneous:
  - Use JDK TimeUnit.convert() instead of TimeUtils.convert() when
    there's no need for casting to double

Result:

- Less code duplication
- Increased code coverage