### PR TITLE
Fix thread safety issue in MeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -101,6 +101,7 @@ public class DropwizardMeterRegistry extends MeterRegistry {
         return summary;
     }
 
+    @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
         LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock);
         registry.register(hierarchicalName(id.withTag(Statistic.ActiveTasks)), (Gauge<Integer>) ltt::activeTasks);


### PR DESCRIPTION
Motivation:

MeterRegistry.getMeters() returns meterMap.values(), which exposes the
value collection without any protection. It means:

- The caller can remove a meter from the map without restriction.
- The caller may get ConcurrentModificationException while iterating
  over the collection.

Modifications:

- Use ConcurrentHashMap instead of HashMap for meterMap
  - Add some comment about why ConcurrentHashMap.computeIfAbsent() is
    not used
- Improve the efficiency of Search.meters()
- Overall code clean up
  - Removal of redundant package names of imported classes
  - Removal of redundant class names of static-imported methods
  - Add missing curly braces
  - Fix incorrect location of Search.tags(String...) Javadoc
  - Use EnumMap instead of HashMap if applicable

Result:

- Fixes #208
- Thread safety
- Potentially less contention
- Closes the loophole that allowed a user to remove a Meter from a registry