### PR TITLE
Add a way to take a snapshot from DistributionSummary and Timer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -17,13 +17,16 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.histogram.TimeWindowHistogram;
+import io.micrometer.core.instrument.util.MeterEquivalence;
 
 public abstract class AbstractDistributionSummary extends AbstractMeter implements DistributionSummary {
     private final TimeWindowHistogram histogram;
+    private final HistogramConfig histogramConfig;
 
     protected AbstractDistributionSummary(Id id, Clock clock, HistogramConfig histogramConfig) {
         super(id);
         this.histogram = new TimeWindowHistogram(clock, histogramConfig);
+        this.histogramConfig = histogramConfig;
     }
 
     @Override
@@ -44,5 +47,25 @@ public abstract class AbstractDistributionSummary extends AbstractMeter implemen
     @Override
     public double histogramCountAtValue(long value) {
         return histogram.histogramCountAtValue(value);
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return histogram.takeSnapshot(count(), totalAmount(), max(), supportsAggregablePercentiles);
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object o) {
+        return MeterEquivalence.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return MeterEquivalence.hashCode(this);
+    }
+
+    public HistogramConfig statsConfig() {
+        return histogramConfig;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -94,12 +94,18 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
 
     @Override
     public double percentile(double percentile, TimeUnit unit) {
-        return TimeUtils.nanosToUnit(histogram.percentile(percentile), unit);
+        return histogram.percentile(percentile, unit);
     }
 
     @Override
     public double histogramCountAtValue(long valueNanos) {
         return histogram.histogramCountAtValue(valueNanos);
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return histogram.takeSnapshot(count(), totalTime(TimeUnit.NANOSECONDS), max(TimeUnit.NANOSECONDS),
+                                      supportsAggregablePercentiles);
     }
 
     @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/CountAtValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/CountAtValue.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.util.TimeUtils;
+
+public final class CountAtValue {
+
+    public static CountAtValue of(long value, double count) {
+        return new CountAtValue(value, count);
+    }
+
+    private final long value;
+    private final double count;
+
+    private CountAtValue(long value, double count) {
+        this.value = value;
+        this.count = count;
+    }
+
+    public long value() {
+        return value;
+    }
+
+    public double value(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(value, unit);
+    }
+
+    public double count() {
+        return count;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + count + " at " + value + ')';
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -62,6 +62,8 @@ public interface DistributionSummary extends Meter {
 
     double histogramCountAtValue(long value);
 
+    HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles);
+
     static Builder builder(String name) {
         return new Builder(name);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/HistogramSnapshot.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/HistogramSnapshot.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.util.TimeUtils;
+
+public final class HistogramSnapshot {
+
+    private static final ValueAtPercentile[] EMPTY_VALUES = new ValueAtPercentile[0];
+    private static final CountAtValue[] EMPTY_COUNTS = new CountAtValue[0];
+    private static final HistogramSnapshot EMPTY = new HistogramSnapshot(0, 0, 0, null, null);
+
+    public static HistogramSnapshot of(long count, double total, double max,
+                                       ValueAtPercentile[] percentileValues,
+                                       CountAtValue[] histogramCounts) {
+        return new HistogramSnapshot(count, total, max, percentileValues, histogramCounts);
+    }
+
+    public static HistogramSnapshot empty() {
+        return EMPTY;
+    }
+
+    private final long count;
+    private final double total;
+    private final double max;
+    private final ValueAtPercentile[] percentileValues;
+    private final CountAtValue[] histogramCounts;
+
+    private HistogramSnapshot(long count, double total, double max,
+                              ValueAtPercentile[] percentileValues, CountAtValue[] histogramCounts) {
+        this.count = count;
+        this.total = total;
+        this.max = max;
+        this.percentileValues = percentileValues != null ? percentileValues : EMPTY_VALUES;
+        this.histogramCounts = histogramCounts != null ? histogramCounts : EMPTY_COUNTS;
+    }
+
+    public long count() {
+        return count;
+    }
+
+    public double total() {
+        return total;
+    }
+
+    public double total(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(total, unit);
+    }
+
+    public double max() {
+        return max;
+    }
+
+    public double max(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(max, unit);
+    }
+
+    public double mean() {
+        return count == 0 ? 0 : total / count;
+    }
+
+    public double mean(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(mean(), unit);
+    }
+
+    public ValueAtPercentile[] percentileValues() {
+        return percentileValues;
+    }
+
+    public CountAtValue[] histogramCounts() {
+        return histogramCounts;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("HistogramSnapshot{count=");
+        buf.append(count);
+        buf.append(", total=");
+        buf.append(total);
+        buf.append(", mean=");
+        buf.append(mean());
+        buf.append(", max=");
+        buf.append(max);
+        if (percentileValues.length > 0) {
+            buf.append(", percentileValues=");
+            buf.append(Arrays.toString(percentileValues));
+        }
+        if (histogramCounts.length > 0) {
+            buf.append(", histogramCounts=");
+            buf.append(Arrays.toString(histogramCounts));
+        }
+        buf.append('}');
+        return buf.toString();
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -116,6 +116,8 @@ public interface Timer extends Meter {
 
     double histogramCountAtValue(long valueNanos);
 
+    HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles);
+
     @Override
     default Iterable<Measurement> measure() {
         return Arrays.asList(

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/ValueAtPercentile.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/ValueAtPercentile.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.util.TimeUtils;
+
+public final class ValueAtPercentile {
+
+    public static ValueAtPercentile of(double percentile, double value) {
+        return new ValueAtPercentile(percentile, value);
+    }
+
+    private final double percentile;
+    private final double value;
+
+    private ValueAtPercentile(double percentile, double value) {
+        this.percentile = percentile;
+        this.value = value;
+    }
+
+    public double percentile() {
+        return percentile;
+    }
+
+    public double value() {
+        return value;
+    }
+
+    public double value(TimeUnit unit) {
+        return TimeUtils.nanosToUnit(value, unit);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + value + " at " + percentile * 100 + "%)";
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.composite;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.HistogramSnapshot;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
@@ -67,6 +68,11 @@ public class CompositeDistributionSummary extends AbstractMeter implements Distr
     @Override
     public double percentile(double percentile) {
         return firstSummary().percentile(percentile);
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return firstSummary().takeSnapshot(supportsAggregablePercentiles);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.composite;
 
 import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.HistogramSnapshot;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -96,6 +97,11 @@ public class CompositeTimer extends AbstractMeter implements Timer, CompositeMet
     @Override
     public double histogramCountAtValue(long valueNanos) {
         return firstTimer().histogramCountAtValue(valueNanos);
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return firstTimer().takeSnapshot(supportsAggregablePercentiles);
     }
 
     private Timer firstTimer() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopDistributionSummary.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.noop;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.HistogramSnapshot;
 
 public class NoopDistributionSummary extends NoopMeter implements DistributionSummary {
     public NoopDistributionSummary(Id id) {
@@ -49,5 +50,10 @@ public class NoopDistributionSummary extends NoopMeter implements DistributionSu
     @Override
     public double histogramCountAtValue(long value) {
         return 0;
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return HistogramSnapshot.empty();
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.noop;
 
+import io.micrometer.core.instrument.HistogramSnapshot;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 
@@ -74,5 +75,10 @@ public class NoopTimer extends NoopMeter implements Timer {
     @Override
     public double histogramCountAtValue(long valueNanos) {
         return 0;
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot(boolean supportsAggregablePercentiles) {
+        return HistogramSnapshot.empty();
     }
 }


### PR DESCRIPTION
Motivation:

Calling percentile(double) or histogramCountAtValue(long) for all
monitored percentiles or buckets are inefficient because each call may
involve an accumulation of two histograms when a new value was recorded
in-between, which is often the case when a user application is handling
a lot of requests simultaneously.

Modifications:

- Add HistogramSnapshot, ValueAtPercentile and CountAtValue to hold the
  snapshot of a Timer of a DistributionSummary
- Add Timer.takeSnapshot() and DistributionSummary.takeSnapshot()
- Use takeSnapshot() for:
  - PrometheusMeterRegistry
  - InfluxMeterRegistry
  - DatadogMeterRegistry
  - Note: Other MeterRegistry implementations were not updated since it
    registers an individual gauge for each percentile, which needs
    non-trivial changes.

Result:

- Fixes #211