### PR TITLE
Use CopyOnWriteArrayList for CompositeMeter's child meter list

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -59,19 +59,6 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     }
 
     @Override
-    public <T> Callable<T> wrap(Callable<T> f) {
-        return () -> {
-            final long s = clock.monotonicTime();
-            try {
-                return f.call();
-            } finally {
-                final long e = clock.monotonicTime();
-                record(e - s, TimeUnit.NANOSECONDS);
-            }
-        };
-    }
-
-    @Override
     public void record(Runnable f) {
         final long s = clock.monotonicTime();
         try {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -88,7 +88,9 @@ public interface Timer extends Meter {
      * @param f The Callable to time when it is invoked.
      * @return The wrapped Callable.
      */
-    <T> Callable<T> wrap(Callable<T> f);
+    default <T> Callable<T> wrap(Callable<T> f) {
+        return () -> recordCallable(f);
+    }
 
     /**
      * The number of times that record has been called on this timer.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.composite;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter implements CompositeMeter {
+
+    @SuppressWarnings("rawtypes")
+    private static final AtomicReferenceFieldUpdater<AbstractCompositeMeter, Meter> firstMeterUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(AbstractCompositeMeter.class, Meter.class, "firstMeter");
+
+    private final List<Entry> children = new CopyOnWriteArrayList<>();
+
+    @SuppressWarnings("unused")
+    private volatile T firstMeter;
+    private volatile T noopMeter;
+
+    AbstractCompositeMeter(Id id) {
+        super(id);
+    }
+
+    abstract T newNoopMeter();
+    abstract T registerNewMeter(MeterRegistry registry);
+
+    final void forEachChild(Consumer<T> task) {
+        children.forEach(e -> task.accept(e.meter()));
+    }
+
+    final Stream<T> childStream() {
+        return children.stream().map(Entry::meter);
+    }
+
+    final T firstChild() {
+        for (;;) {
+            T firstMeter = this.firstMeter;
+            if (firstMeter != null) {
+                return firstMeter;
+            }
+
+            firstMeter = findFirstChild();
+            if (firstMeter == null) {
+                break;
+            }
+
+            if (firstMeterUpdater.compareAndSet(this, null, firstMeter)) {
+                return firstMeter;
+            }
+        }
+
+        // There are no child meters at the moment. Return a lazily instantiated no-op meter.
+        final T noopMeter = this.noopMeter;
+        if (noopMeter != null) {
+            return noopMeter;
+        } else {
+            return this.noopMeter = newNoopMeter();
+        }
+    }
+
+    private T findFirstChild() {
+        if (children.isEmpty()) {
+            return null;
+        }
+
+        final Iterator<Entry> i = children.iterator();
+        return i.hasNext() ? i.next().meter() : null;
+    }
+
+    @Override
+    public final void add(MeterRegistry registry) {
+        final T newMeter = registerNewMeter(registry);
+        if (newMeter == null) {
+            return;
+        }
+
+        children.add(new Entry(registry, newMeter));
+        firstMeterUpdater.compareAndSet(this, null, newMeter);
+    }
+
+    @Override
+    public final void remove(MeterRegistry registry) {
+        // Not very efficient, but this operation is expected to be used rarely.
+        final AtomicReference<T> meterHolder = new AtomicReference<>();
+        children.removeIf(e -> {
+            if (e.registry() == registry) {
+                meterHolder.set(e.meter());
+                return true;
+            } else {
+                return false;
+            }
+        });
+
+        final T removedMeter = meterHolder.get();
+        if (removedMeter != null) {
+            firstMeterUpdater.compareAndSet(this, removedMeter, null);
+        }
+    }
+
+    private static final class Entry {
+        private final MeterRegistry registry;
+        private final Meter meter;
+
+        Entry(MeterRegistry registry, Meter meter) {
+            this.registry = registry;
+            this.meter = meter;
+        }
+
+        MeterRegistry registry() {
+            return registry;
+        }
+
+        @SuppressWarnings("unchecked")
+        <U> U meter() {
+            return (U) meter;
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCustomMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCustomMeter.java
@@ -19,7 +19,7 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class CompositeCustomMeter implements CompositeMeter {
+class CompositeCustomMeter implements CompositeMeter {
     private final Meter.Id id;
     private final Meter.Type type;
     private final Iterable<Measurement> measurements;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
@@ -15,18 +15,14 @@
  */
 package io.micrometer.core.instrument.composite;
 
-import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.noop.NoopLongTaskTimer;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-public class CompositeLongTaskTimer extends AbstractMeter implements LongTaskTimer, CompositeMeter {
-    private final Map<MeterRegistry, LongTaskTimer> timers = new ConcurrentHashMap<>();
+class CompositeLongTaskTimer extends AbstractCompositeMeter<LongTaskTimer> implements LongTaskTimer {
 
     CompositeLongTaskTimer(Meter.Id id) {
         super(id);
@@ -34,52 +30,51 @@ public class CompositeLongTaskTimer extends AbstractMeter implements LongTaskTim
 
     @Override
     public long start() {
-        return timers.values().stream()
-            .map(LongTaskTimer::start)
+        // FIXME: Broken; some children may return different task IDs.
+        return childStream()
+            .mapToLong(LongTaskTimer::start)
             .reduce((t1, t2) -> t2)
             .orElse(-1L);
     }
 
     @Override
     public long stop(long task) {
-        return timers.values().stream()
-            .map(ltt -> ltt.stop(task))
+        // FIXME: Broken; some children may return different task IDs.
+        return childStream()
+            .mapToLong(ltt -> ltt.stop(task))
             .reduce((t1, t2) -> t2 == -1 ? t1 : t2)
             .orElse(-1L);
     }
 
     @Override
     public double duration(long task, TimeUnit unit) {
-        return timers.values().stream()
-            .map(ltt -> ltt.duration(task, unit))
+        // FIXME: Broken; some children may return different task IDs.
+        return childStream()
+            .mapToDouble(ltt -> ltt.duration(task, unit))
             .reduce((t1, t2) -> t2 == -1 ? t1 : t2)
             .orElse(-1.0);
     }
 
     @Override
     public double duration(TimeUnit unit) {
-        return firstLongTaskTimer().duration(unit);
+        return firstChild().duration(unit);
     }
 
     @Override
     public int activeTasks() {
-        return firstLongTaskTimer().activeTasks();
-    }
-
-    private LongTaskTimer firstLongTaskTimer() {
-        return timers.values().stream().findFirst().orElse(new NoopLongTaskTimer(getId()));
+        return firstChild().activeTasks();
     }
 
     @Override
-    public void add(MeterRegistry registry) {
-        timers.put(registry, LongTaskTimer.builder(getId().getName())
-            .tags(getId().getTags())
-            .description(getId().getDescription())
-            .register(registry));
+    LongTaskTimer newNoopMeter() {
+        return new NoopLongTaskTimer(getId());
     }
 
     @Override
-    public void remove(MeterRegistry registry) {
-        timers.remove(registry);
+    LongTaskTimer registerNewMeter(MeterRegistry registry) {
+        return LongTaskTimer.builder(getId().getName())
+                            .tags(getId().getTags())
+                            .description(getId().getDescription())
+                            .register(registry);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeter.java
@@ -18,7 +18,7 @@ package io.micrometer.core.instrument.composite;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-public interface CompositeMeter extends Meter {
+interface CompositeMeter extends Meter {
     void add(MeterRegistry registry);
     void remove(MeterRegistry registry);
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -36,7 +37,8 @@ import java.util.function.ToLongFunction;
  */
 public class CompositeMeterRegistry extends MeterRegistry {
     private final Set<MeterRegistry> registries = ConcurrentHashMap.newKeySet();
-    private Collection<CompositeMeter> compositeMeters = new CopyOnWriteArrayList<>();
+    private final Set<MeterRegistry> unmodifiableRegistries = Collections.unmodifiableSet(registries);
+    private final Collection<CompositeMeter> compositeMeters = new CopyOnWriteArrayList<>();
 
     public CompositeMeterRegistry() {
         this(Clock.SYSTEM);
@@ -49,7 +51,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, HistogramConfig histogramConfig) {
-        CompositeTimer timer = new CompositeTimer(id, histogramConfig);
+        CompositeTimer timer = new CompositeTimer(id, clock, histogramConfig);
         compositeMeters.add(timer);
         registries.forEach(timer::add);
         return timer;
@@ -105,7 +107,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     @Override
     protected TimeUnit getBaseTimeUnit() {
-        return null;
+        return TimeUnit.SECONDS;
     }
 
     @Override
@@ -130,6 +132,6 @@ public class CompositeMeterRegistry extends MeterRegistry {
     }
 
     public Set<MeterRegistry> getRegistries() {
-        return registries;
+        return unmodifiableRegistries;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimeGauge.java
@@ -20,13 +20,14 @@ import io.micrometer.core.instrument.TimeGauge;
 import java.util.concurrent.TimeUnit;
 
 public class NoopTimeGauge extends NoopMeter implements TimeGauge {
+
     public NoopTimeGauge(Id id) {
         super(id);
     }
 
     @Override
     public TimeUnit getBaseTimeUnit() {
-        return null;
+        return TimeUnit.NANOSECONDS;
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -48,11 +48,6 @@ public class NoopTimer extends NoopMeter implements Timer {
     }
 
     @Override
-    public <T> Callable<T> wrap(Callable<T> f) {
-        return f;
-    }
-
-    @Override
     public long count() {
         return 0;
     }


### PR DESCRIPTION
Motivation:

In a CompositeMeter, add(MeterRegistry) and remove(MeterRegistry) are
not used very often. Vast majority of access is the iteration of the
child Meters.

Modifications:

- Extract the common logic of child Meter management into
  AbstractCompositeMeter
- Use CopyOnWriteArrayList instead of ConcurrentHashMap for faster child
  Meter list iteration at the cost of slower add(MeterRegistry) and
  remove(MeterRegistry)
- Miscellaneous:
  - Replace AbstractTimer.wrap(Callable) with a new default method in Timer
  - Add some FIXMEs to the broken CompositeLongTaskTimer
  - Fix incorrect record() implementations in CompositeTimer
  - Close the loophole in CompositeMeterRegistry.getRegistries() that
    allowed a user to remove a registry directly

Result:

- Reduced memory footprint
- Faster recording
- CompositeTimer.record() works as expected.
- Now we know CompositeLongTaskTimer is broken.