### PR TITLE
CumulativeDistributionSummary - prevent losing the maximum in case of data-race 

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeDistributionSummary.java
@@ -43,7 +43,7 @@ public class CumulativeDistributionSummary extends AbstractDistributionSummary {
     protected void recordNonNegative(double amount) {
         count.getAndAdd(1);
         total.getAndAdd(amount);
-        max.set(Math.max(amount, max.get()));
+        updateMax(amount);
     }
 
     @Override
@@ -69,4 +69,17 @@ public class CumulativeDistributionSummary extends AbstractDistributionSummary {
             new Measurement(this::max, Statistic.Max)
         );
     }
+
+    private void updateMax(double amount) {
+        while (true) {
+            double currentMax = max.get();
+            if (currentMax >= amount) {
+                return;
+            }
+            if (max.compareAndSet(currentMax, amount)) {
+                return;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Currently there is data-race inside CumulativeDistributionSummary when two threads coming in parallel to ```recordNonNegative``` method, as result max value can be lost by missed write.

Fail scenario:
- Preconditions: Thera are two thread **T1** which wants to write 42 and **T2** which wants to write 666. Current max is 13.
- Both **T1** and **T2** reached the recordNonNegative in same time, both got 13 as current maximum.
- **T2** seen that 666 greater than 13 and did the write.
- **T1** seen that 42 greater than 13 and did the overwrite.
- As result actual maximum 666 is missed.