### PR TITLE
Append 'Test' to CompositeMeterRegistryCompatibility

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
@@ -62,7 +62,7 @@ class CompositeLongTaskTimer extends AbstractCompositeMeter<LongTaskTimer> imple
                 return mapping.ltt.duration(mapping.id, unit);
             }
         }
-        return 0.0;
+        return -1.0;
     }
 
     @Override

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryCompatibilityTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryCompatibilityTest.java
@@ -21,7 +21,7 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 
-class CompositeMeterRegistryCompatibility extends MeterRegistryCompatibilityKit {
+class CompositeMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
     @Override
     public MeterRegistry registry() {
         return new CompositeMeterRegistry(new MockClock()) {{


### PR DESCRIPTION
.. so that JUnit 5 runner runs it. This commit also fixes a bug in
CompositeLongTaskTimer.duration(long, TimeUnit).