### PR TITLE
Remove unused imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'checkstyle'
 
     if(!project.name.contains('samples')) {
         apply plugin: 'io.spring.publishing'
@@ -46,6 +47,11 @@ subprojects {
 
     repositories {
         mavenCentral()
+    }
+
+    checkstyle {
+        toolVersion = '8.4'
+        configFile = rootProject.file('config/checkstyle/checkstyle.xml')
     }
 
     def check = tasks.findByName('check')

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+
+    <!-- TreeWalker Checks -->
+    <module name="TreeWalker">
+
+        <!-- Imports -->
+        <module name="UnusedImports">
+            <property name="processJavadoc" value="true" />
+        </module>
+
+    </module>
+</module>

--- a/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/SpectatorTimerTest.java
+++ b/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/SpectatorTimerTest.java
@@ -18,10 +18,8 @@ package io.micrometer.atlas;
 import com.netflix.spectator.atlas.AtlasConfig;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.simple.SimpleConfig;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.core.instrument.MockClock.clock;

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -18,7 +18,6 @@ package io.micrometer.prometheus;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
 import org.assertj.core.api.Condition;

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -31,7 +31,6 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
 import reactor.ipc.netty.options.ClientOptions;
-import reactor.ipc.netty.udp.UdpClient;
 import reactor.ipc.netty.udp.UdpServer;
 import reactor.test.StepVerifier;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
 import io.micrometer.core.instrument.histogram.TimeWindowLatencyHistogram;
 import io.micrometer.core.instrument.util.MeterEquivalence;
-import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopFunctionTimer.java
@@ -16,7 +16,6 @@
 package io.micrometer.core.instrument.noop;
 
 import io.micrometer.core.instrument.FunctionTimer;
-import io.micrometer.core.instrument.Meter;
 
 import java.util.concurrent.TimeUnit;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -17,7 +17,6 @@ package io.micrometer.core.instrument.noop;
 
 import io.micrometer.core.instrument.HistogramSnapshot;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.histogram.HistogramConfig;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeDistributionSummary.java
@@ -21,8 +21,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
-import io.micrometer.core.instrument.step.StepDouble;
-import io.micrometer.core.instrument.step.StepLong;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/CumulativeTimer.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
-import io.micrometer.core.instrument.step.StepLong;
 import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.util.Arrays;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 
 import java.math.RoundingMode;
 import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument.util;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
@@ -25,10 +25,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import org.slf4j.helpers.BasicMarker;
-import org.slf4j.helpers.BasicMarkerFactory;
-
-import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.core.instrument.MockClock.clock;
 import static io.micrometer.core.instrument.Statistic.Count;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
@@ -18,8 +18,6 @@ package io.micrometer.spring.autoconfigure.export.datadog;
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.time.Duration;
-
 /**
  * {@link ConfigurationProperties} for configuring Datadog metrics export.
  *

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
@@ -30,8 +30,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import java.time.Duration;
-
 /**
  * Configuration for exporting metrics to Influx.
  *

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
@@ -19,8 +19,6 @@ import io.micrometer.influx.InfluxConsistency;
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import java.time.Duration;
-
 /**
  * {@link ConfigurationProperties} for configuring Influx metrics export.
  *

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
@@ -19,7 +19,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleConfig;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/MetricsFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/MetricsFilterTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsIntegrationTest.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.spring.TimedUtilsTest;
 import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsConfiguration;
 import org.junit.Before;
 import org.junit.Test;
@@ -40,9 +39,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/CounterTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/CounterTest.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.Statistic;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.micrometer.core.instrument.MockClock.clock;

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/DistributionSummaryTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/DistributionSummaryTest.java
@@ -20,8 +20,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
 import static io.micrometer.core.instrument.MockClock.clock;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
This PR also applies Checkstyle plugin and adds its `UnusedImports` module to prevent unused imports from sneaking into codebase again.