### PR TITLE
Move metermap to unmodificable instance

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -56,7 +56,7 @@ public abstract class MeterRegistry {
         this.clock = clock;
     }
 
-    private Map<Id, Meter> meterMap = Collections.emptyMap();
+    private volatile Map<Id, Meter> meterMap = Collections.emptyMap();
     private final List<MeterFilter> filters = new ArrayList<>();
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -56,6 +56,7 @@ public abstract class MeterRegistry {
         this.clock = clock;
     }
 
+    private final Object meterMapLock = new Object();
     private volatile Map<Id, Meter> meterMap = Collections.emptyMap();
     private final List<MeterFilter> filters = new ArrayList<>();
 
@@ -658,7 +659,7 @@ public abstract class MeterRegistry {
         Meter m = meterMap.get(mappedId);
 
         if (m == null) {
-            synchronized (this) {
+            synchronized (meterMapLock) {
                 m = meterMap.get(mappedId);
 
                 if (m == null) {


### PR DESCRIPTION
This is what I tried to explain on #241

This way we can use a double check, at cost of O(N) on register a new instance on the `MeterRegistry` which I think is much better than locking in case of having dynamic meter (N=meterMap.length()).

Keep in mind that before this PR using `MeterRegistry.registerMeterIfNecessary(...)` it will always cause a lock. Now it will only lock in case the `meterMap` needs to be updated.

I don't know if I miss something :)