### PR TITLE
If a controller has async operation, e.g. which returns DeferredResul…

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetrics.java
@@ -81,7 +81,9 @@ public class WebMvcMetrics {
     }
 
     void preHandle(HttpServletRequest request, Object handler) {
-        request.setAttribute(TIMING_REQUEST_ATTRIBUTE, System.nanoTime());
+        if (request.getAttribute(TIMING_REQUEST_ATTRIBUTE) == null) {
+            request.setAttribute(TIMING_REQUEST_ATTRIBUTE, System.nanoTime());
+        }
         request.setAttribute(HANDLER_REQUEST_ATTRIBUTE, handler);
         longTaskTimed(handler).forEach((config) -> {
             if (config.getName() == null) {


### PR DESCRIPTION
…t<T>, then MetricsFilter.doFilterInternal is executed twice: when request handling starts and when completes. So called preHandle method should not reset TIMING_REQUEST_ATTRIBUTE value the second time.