### PR TITLE
Fix JSON syntax for Datadog host attribute

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -190,7 +190,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         String host = config.hostTag() == null ? "" : stream(tags.spliterator(), false)
             .filter(t -> config.hostTag().equals(t.getKey()))
             .findAny()
-            .map(t -> ",\"host\":" + t.getValue())
+            .map(t -> ",\"host\":\"" + t.getValue() + "\"")
             .orElse("");
 
         String tagsArray = tags.iterator().hasNext() ?


### PR DESCRIPTION
# Issue

`DatadogMeterRegistry` generates invalid JSON when host is specified via `DatadogConfig.hostTag()`.

# Steps to reproduce

1. Specify not empty `DatadogConfig.hostTag()`.
2. Generate any metric with that tag.
3. Wait for `DatadogMeterRegistry` to send metrics to Datadog.
4. Observe error
```
2017-11-28 13:06:39.322 ERROR 87574 --- [pool-1-thread-1] i.m.datadog.DatadogMeterRegistry         : failed to send metrics: Payload is not in the expected format: invalid character '"' after object key:value pair
```

Sample (formatted) payload:

```json
{
  "series": [
    {
      "metric": "notification-service.jvm.classes.loaded",
      "points": [
        [
          1511866956,
          11527.0
        ]
      ],
      "host": Mykolas-MBP,
      "tags": [
        "hostName:Mykolas-MBP",
        "statistic:value"
      ]
    }
  ]
}
```