### PR TITLE
Add Tomcat metrics that are tracked via JMX

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -25,10 +25,21 @@ import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.apache.catalina.Manager;
 
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public class TomcatMetrics implements MeterBinder {
     private final Manager manager;
+    private final Duration maxRegistrationWait;
+    private final Supplier<MBeanServer> mBeanServerProvider;
 
     private Iterable<Tag> tags;
 
@@ -41,14 +52,32 @@ public class TomcatMetrics implements MeterBinder {
     }
 
     public TomcatMetrics(Manager manager, Iterable<Tag> tags) {
+        this(manager, tags, Duration.ofHours(24), ManagementFactory::getPlatformMBeanServer);
+    }
+
+    public TomcatMetrics(Manager manager, Iterable<Tag> tags, Duration maxRegistrationWait, Supplier<MBeanServer> mBeanServerProvider) {
         this.tags = tags;
         this.manager = manager;
+        this.maxRegistrationWait = maxRegistrationWait;
+        this.mBeanServerProvider = mBeanServerProvider;
     }
 
     @Override
     public void bindTo(MeterRegistry reg) {
-        if(manager == null){
-            //If the binder is created but unable to find the session manager don't register anything
+        Thread tomcatRegisterThread = new Thread(() -> {
+            waitForTomcatJmxRegistration();
+
+            MBeanServer server = mBeanServerProvider.get();
+            registerGlobalRequestMetrics(reg, server);
+            registerServletMetrics(reg, server);
+            registerCacheMetrics(reg, server);
+            registerThreadPoolMetrics(reg, server);
+        });
+        tomcatRegisterThread.setName("tomcat-jmx-metrics-register");
+        tomcatRegisterThread.start();
+
+        if (manager == null) {
+            //If the binder is created but unable to find the session manager don't register those metrics
             return;
         }
 
@@ -71,5 +100,146 @@ public class TomcatMetrics implements MeterBinder {
         FunctionCounter.builder("tomcat.sessions.created", manager, Manager::getSessionCounter)
             .tags(tags)
             .register(reg);
+    }
+
+
+    private void waitForTomcatJmxRegistration() {
+        MBeanServer server = mBeanServerProvider.get();
+        long endWait = System.currentTimeMillis() + maxRegistrationWait.toMillis();
+
+        //noinspection InfiniteLoopStatement
+        while (System.currentTimeMillis() < endWait) {
+            try {
+                if(!server.queryNames(new ObjectName("Tomcat:type=GlobalRequestProcessor,*"), null).isEmpty()){
+                    return;
+                }
+
+                Thread.sleep(500);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    private void registerThreadPoolMetrics(MeterRegistry reg, MBeanServer server) {
+        for (ObjectName name : findNames(server, "Tomcat:type=ThreadPool,*")) {
+            Iterable<Tag> tags = Tags.concat(this.tags, safeTags(name, "name"));
+
+            Gauge.builder("tomcat.threads.config.max", server,
+                s -> safeDouble(() -> s.getAttribute(name, "maxThreads")))
+                .tags(tags)
+                .register(reg);
+
+            Gauge.builder("tomcat.threads.busy", server,
+                s -> safeDouble(() -> s.getAttribute(name, "currentThreadsBusy")))
+                .tags(tags)
+                .register(reg);
+            Gauge.builder("tomcat.threads.current", server,
+                s -> safeDouble(() -> s.getAttribute(name, "currentThreadCount")))
+                .tags(tags)
+                .register(reg);
+        }
+    }
+
+
+    private void registerCacheMetrics(MeterRegistry reg, MBeanServer server) {
+        for (ObjectName name : findNames(server, "Tomcat:type=StringCache,*")) {
+            FunctionCounter.builder("tomcat.cache.access", server,
+                s -> safeDouble(() -> s.getAttribute(name, "accessCount")))
+                .register(reg);
+
+            FunctionCounter.builder("tomcat.cache.hit", server,
+                s -> safeDouble(() -> s.getAttribute(name, "hitCount")))
+                .register(reg);
+        }
+    }
+
+    private void registerServletMetrics(MeterRegistry reg, MBeanServer server) {
+        for (ObjectName name : findNames(server, "Tomcat:j2eeType=Servlet,*")) {
+            Iterable<Tag> tags = Tags.concat(this.tags, safeTags(name, "name"));
+
+            FunctionCounter.builder("tomcat.servlet.error", server,
+                s -> safeDouble(() -> s.getAttribute(name, "errorCount")))
+                .tags(tags)
+                .register(reg);
+
+            FunctionTimer.builder("tomcat.servlet.request", server,
+                s -> safeLong(() -> s.getAttribute(name, "requestCount")),
+                s -> safeDouble(() -> s.getAttribute(name, "processingTime")), TimeUnit.MILLISECONDS)
+                .tags(tags)
+                .register(reg);
+
+            TimeGauge.builder("tomcat.servlet.request.max", server, TimeUnit.MILLISECONDS,
+                s -> safeDouble(() -> s.getAttribute(name, "maxTime")))
+                .tags(tags)
+                .register(reg);
+        }
+    }
+
+    private void registerGlobalRequestMetrics(MeterRegistry reg, MBeanServer server) {
+        for (ObjectName name : findNames(server, "Tomcat:type=GlobalRequestProcessor,*")) {
+            Iterable<Tag> tags = Tags.concat(this.tags, safeTags(name, "name"));
+
+            FunctionCounter.builder("tomcat.global.sent", server,
+                s -> safeDouble(() -> s.getAttribute(name, "bytesSent")))
+                .tags(tags)
+                .baseUnit("bytes")
+                .register(reg);
+            FunctionCounter.builder("tomcat.global.received", server,
+                s -> safeDouble(() -> s.getAttribute(name, "bytesReceived")))
+                .tags(tags)
+                .baseUnit("bytes")
+                .register(reg);
+
+            FunctionCounter.builder("tomcat.global.error", server,
+                s -> safeDouble(() -> s.getAttribute(name, "errorCount")))
+                .tags(tags)
+                .register(reg);
+
+            FunctionTimer.builder("tomcat.global.request", server,
+                s -> safeLong(() -> s.getAttribute(name, "requestCount")),
+                s -> safeDouble(() -> s.getAttribute(name, "processingTime")), TimeUnit.MILLISECONDS)
+                .tags(tags)
+                .register(reg);
+
+            TimeGauge.builder("tomcat.global.request.max", server, TimeUnit.MILLISECONDS,
+                s -> safeDouble(() -> s.getAttribute(name, "maxTime")))
+                .tags(tags)
+                .register(reg);
+        }
+    }
+
+    private Set<ObjectName> findNames(MBeanServer server, String query) {
+        try {
+            return server.queryNames(new ObjectName(query), null);
+        } catch (MalformedObjectNameException e) {
+            throw new RuntimeException("Error registering Tomcat JMX based metrics", e);
+        }
+    }
+
+
+    private double safeDouble(Callable<Object> callable) {
+        try {
+            return Double.parseDouble(callable.call().toString());
+        } catch (Exception e) {
+            return 0.0;
+        }
+    }
+
+    private long safeLong(Callable<Object> callable) {
+        try {
+            return Long.parseLong(callable.call().toString());
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private Iterable<Tag> safeTags(ObjectName name, String tagName) {
+        if (name.getKeyProperty(tagName) != null) {
+            return Tags.zip(tagName, name.getKeyProperty(tagName).replaceAll("\"", ""));
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -87,10 +87,10 @@ public class TomcatMetrics implements MeterBinder {
         Gauge.builder("tomcat.sessions.active.current", manager, Manager::getActiveSessions)
             .tags(tags)
             .register(reg);
-        Gauge.builder("tomcat.sessions.expired", manager, Manager::getExpiredSessions)
+        FunctionCounter.builder("tomcat.sessions.expired", manager, Manager::getExpiredSessions)
             .tags(tags)
             .register(reg);
-        Gauge.builder("tomcat.sessions.rejected", manager, Manager::getRejectedSessions)
+        FunctionCounter.builder("tomcat.sessions.rejected", manager, Manager::getRejectedSessions)
             .tags(tags)
             .register(reg);
         TimeGauge.builder("tomcat.sessions.alive.max", manager, TimeUnit.SECONDS, Manager::getSessionMaxAliveTime)
@@ -113,10 +113,9 @@ public class TomcatMetrics implements MeterBinder {
                 if(!server.queryNames(new ObjectName("Tomcat:type=GlobalRequestProcessor,*"), null).isEmpty()){
                     return;
                 }
-
                 Thread.sleep(500);
             } catch (Exception e) {
-                e.printStackTrace();
+                //NO OP
             }
         }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -80,8 +80,8 @@ class TomcatMetricsTest {
 
         assertThat(registry.find("tomcat.sessions.active.max").tags(tags).gauge().map(Gauge::value)).hasValue(3.0);
         assertThat(registry.find("tomcat.sessions.active.current").tags(tags).gauge().map(Gauge::value)).hasValue(2.0);
-        assertThat(registry.find("tomcat.sessions.expired").tags(tags).gauge().map(Gauge::value)).hasValue(1.0);
-        assertThat(registry.find("tomcat.sessions.rejected").tags(tags).gauge().map(Gauge::value)).hasValue(1.0);
+        assertThat(registry.find("tomcat.sessions.expired").tags(tags).functionCounter().map(FunctionCounter::count)).hasValue(1.0);
+        assertThat(registry.find("tomcat.sessions.rejected").tags(tags).functionCounter().map(FunctionCounter::count)).hasValue(1.0);
         assertThat(registry.find("tomcat.sessions.created").tags(tags).functionCounter().map(FunctionCounter::count)).hasValue(3.0);
         assertThat(registry.find("tomcat.sessions.alive.max").tags(tags).gauge().map(Gauge::value).get()).isGreaterThan(1.0);
     }

--- a/micrometer-spring-legacy/src/samples/resources/application.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application.yml
@@ -31,6 +31,5 @@ spring.metrics:
   prometheus.enabled: false
   statsd.enabled: false
   newrelic.enabled: false
-  tomcat.enabled: false
 
 security.ignored: /**


### PR DESCRIPTION
This adds in several additional Tomcat metrics that are tracked/exposed via JMX.

Cache Metrics (counters)
```
tomcat_cache_hit_total 0.0
tomcat_cache_access_total 0.0
```

Threadpool metrics
```
tomcat_threads_busy{name="http-nio-8080",} 1.0
tomcat_threads_current{name="http-nio-8080",} 10.0
tomcat_threads_config_max{name="http-nio-8080",} 200.0
```

Servlet/Global metrics
```
tomcat_servlet_request_duration_seconds_count{name="default",} 0.0
tomcat_servlet_request_duration_seconds_sum{name="default",} 0.0
tomcat_servlet_request_duration_seconds_count{name="dispatcherServlet",} 7.0
tomcat_servlet_request_duration_seconds_sum{name="dispatcherServlet",} 0.182
tomcat_servlet_error_total{name="default",} 0.0
tomcat_servlet_error_total{name="dispatcherServlet",} 0.0
tomcat_servlet_request_max_seconds{name="default",} 0.0
tomcat_servlet_request_max_seconds{name="dispatcherServlet",} 0.144

tomcat_global_request_max_seconds{name="http-nio-8080",} 0.0
tomcat_global_request_duration_seconds_count{name="http-nio-8080",} 4.0
tomcat_global_request_duration_seconds_sum{name="http-nio-8080",} 7.317
tomcat_global_sent_bytes_total{name="http-nio-8080",} 0.0
tomcat_global_received_bytes_total{name="http-nio-8080",} 0.0
```

The `name` label is the `mbean` `name` property since it is possible to have multiple servlets, and possible to have multiple globals (I'm guessing by having multiple Tomcat instances embedded on separate ports in the same JVM)

I wasn't able to use the JMX Seraver in the unit tests and ended up mocking them out. I also don't love the extra thread that polls to register once it detects the JMX registration has occurred. I'm including it for now, until I can propose an improvement to Micrometer that will allow for a better hook.

FYI @jkschneider @mweirauch 