### PR TITLE
MetricsFilter does not correctly tag http 500s

### DIFF
--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsIntegrationTest.java
@@ -81,7 +81,7 @@ public class WebMvcMetricsIntegrationTest {
 
         clock.add(SimpleConfig.DEFAULT_STEP);
         assertThat(this.registry.find("http.server.requests")
-            .tags("exception", "Exception1").value(Statistic.Count, 1.0).timer())
+            .tags("exception", "Exception1", "status", "500").value(Statistic.Count, 1.0).timer())
             .isPresent();
     }
 
@@ -92,7 +92,7 @@ public class WebMvcMetricsIntegrationTest {
 
         clock.add(SimpleConfig.DEFAULT_STEP);
         assertThat(this.registry.find("http.server.requests")
-            .tags("exception", "Exception2").value(Statistic.Count, 1.0).timer())
+            .tags("exception", "Exception2", "status", "500").value(Statistic.Count, 1.0).timer())
             .isPresent();
     }
 


### PR DESCRIPTION
I noticed that when my application was showing errors, like 500 HTTP status codes, the metrics exposed by micrometer were still tagged with `status=200`.
Adding a try/catch block to my controller endpoint, and make it return an `ResponseEntity` object with an status code of 500 when catching an exception, metrics are tagged as expected with `status=500`. But if I let exceptions to be thrown, then the status tag contains the value 200, even though my site is showing an error 500 status code.

I don't really know how to fix it, so I've pushed this PR trying to demonstrate the error. If you give me some hints, I could give it a shot and try to fix it.