### PR TITLE
Improve registering meters with single tag

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -345,13 +345,6 @@ public abstract class MeterRegistry {
 
     /**
      * Tracks a monotonically increasing value.
-     */
-    public Counter counter(String name, Tag tag) {
-        return counter(name, Collections.singletonList(tag));
-    }
-
-    /**
-     * Tracks a monotonically increasing value.
      *
      * @param name The base metric name
      * @param tags MUST be an even number of arguments representing key/value pairs of tags.
@@ -369,13 +362,6 @@ public abstract class MeterRegistry {
 
     /**
      * Measures the sample distribution of events.
-     */
-    public DistributionSummary summary(String name, Tag tag) {
-        return summary(name, Arrays.asList(tag));
-    }
-
-    /**
-     * Measures the sample distribution of events.
      *
      * @param name The base metric name
      * @param tags MUST be an even number of arguments representing key/value pairs of tags.
@@ -389,13 +375,6 @@ public abstract class MeterRegistry {
      */
     public Timer timer(String name, Iterable<Tag> tags) {
         return Timer.builder(name).tags(tags).register(this);
-    }
-
-    /**
-     * Measures the time taken for short tasks and the count of these tasks.
-     */
-    public Timer timer(String name, Tag tag) {
-        return timer(name, Collections.singletonList(tag));
     }
 
     /**
@@ -520,28 +499,6 @@ public abstract class MeterRegistry {
     }
 
     /**
-     * Register a gauge that reports the value of the object after the function
-     * {@code f} is applied. The registration will keep a weak reference to the object so it will
-     * not prevent garbage collection. Applying {@code f} on the object should be thread safe.
-     * <p>
-     * If multiple gauges are registered with the same id, then the values will be aggregated and
-     * the sum will be reported. For example, registering multiple gauges for active threads in
-     * a thread pool with the same id would produce a value that is the overall number
-     * of active threads. For other behaviors, manage it on the user side and avoid multiple
-     * registrations.
-     *
-     * @param name Name of the gauge being registered.
-     * @param tag  Dimension for breaking down the name.
-     * @param obj  Object used to compute a value.
-     * @param f    Function that is applied on the value for the number.
-     * @return The number that was passed in so the registration can be done as part of an assignment
-     * statement.
-     */
-    public <T> T gauge(String name, Tag tag, T obj, ToDoubleFunction<T> f) {
-        return gauge(name, Collections.singletonList(tag), obj, f);
-    }
-
-    /**
      * Register a gauge that reports the value of the {@link Number}.
      *
      * @param name   Name of the gauge being registered.
@@ -552,19 +509,6 @@ public abstract class MeterRegistry {
      */
     public <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
         return gauge(name, tags, number, Number::doubleValue);
-    }
-
-    /**
-     * Register a gauge that reports the value of the {@link Number}.
-     *
-     * @param name   Name of the gauge being registered.
-     * @param tag    Dimension for breaking down the name.
-     * @param number Thread-safe implementation of {@link Number} used to access the value.
-     * @return The number that was passed in so the registration can be done as part of an assignment
-     * statement.
-     */
-    public <T extends Number> T gauge(String name, Tag tag, T number) {
-        return gauge(name, Collections.singletonList(tag), number);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -20,8 +20,6 @@ import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
-import io.micrometer.core.instrument.internal.DefaultFunctionCounter;
-import io.micrometer.core.instrument.internal.DefaultFunctionTimer;
 import io.micrometer.core.instrument.noop.*;
 import io.micrometer.core.instrument.util.TimeUtils;
 
@@ -347,6 +345,13 @@ public abstract class MeterRegistry {
 
     /**
      * Tracks a monotonically increasing value.
+     */
+    public Counter counter(String name, Tag tag) {
+        return counter(name, Collections.singletonList(tag));
+    }
+
+    /**
+     * Tracks a monotonically increasing value.
      *
      * @param name The base metric name
      * @param tags MUST be an even number of arguments representing key/value pairs of tags.
@@ -364,6 +369,13 @@ public abstract class MeterRegistry {
 
     /**
      * Measures the sample distribution of events.
+     */
+    public DistributionSummary summary(String name, Tag tag) {
+        return summary(name, Arrays.asList(tag));
+    }
+
+    /**
+     * Measures the sample distribution of events.
      *
      * @param name The base metric name
      * @param tags MUST be an even number of arguments representing key/value pairs of tags.
@@ -377,6 +389,13 @@ public abstract class MeterRegistry {
      */
     public Timer timer(String name, Iterable<Tag> tags) {
         return Timer.builder(name).tags(tags).register(this);
+    }
+
+    /**
+     * Measures the time taken for short tasks and the count of these tasks.
+     */
+    public Timer timer(String name, Tag tag) {
+        return timer(name, Collections.singletonList(tag));
     }
 
     /**
@@ -501,6 +520,28 @@ public abstract class MeterRegistry {
     }
 
     /**
+     * Register a gauge that reports the value of the object after the function
+     * {@code f} is applied. The registration will keep a weak reference to the object so it will
+     * not prevent garbage collection. Applying {@code f} on the object should be thread safe.
+     * <p>
+     * If multiple gauges are registered with the same id, then the values will be aggregated and
+     * the sum will be reported. For example, registering multiple gauges for active threads in
+     * a thread pool with the same id would produce a value that is the overall number
+     * of active threads. For other behaviors, manage it on the user side and avoid multiple
+     * registrations.
+     *
+     * @param name Name of the gauge being registered.
+     * @param tag  Dimension for breaking down the name.
+     * @param obj  Object used to compute a value.
+     * @param f    Function that is applied on the value for the number.
+     * @return The number that was passed in so the registration can be done as part of an assignment
+     * statement.
+     */
+    public <T> T gauge(String name, Tag tag, T obj, ToDoubleFunction<T> f) {
+        return gauge(name, Collections.singletonList(tag), obj, f);
+    }
+
+    /**
      * Register a gauge that reports the value of the {@link Number}.
      *
      * @param name   Name of the gauge being registered.
@@ -511,6 +552,19 @@ public abstract class MeterRegistry {
      */
     public <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
         return gauge(name, tags, number, Number::doubleValue);
+    }
+
+    /**
+     * Register a gauge that reports the value of the {@link Number}.
+     *
+     * @param name   Name of the gauge being registered.
+     * @param tag    Dimension for breaking down the name.
+     * @param number Thread-safe implementation of {@link Number} used to access the value.
+     * @return The number that was passed in so the registration can be done as part of an assignment
+     * statement.
+     */
+    public <T extends Number> T gauge(String name, Tag tag, T number) {
+        return gauge(name, Collections.singletonList(tag), number);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -24,6 +25,7 @@ import static java.util.stream.StreamSupport.stream;
 
 /**
  * @author Jon Schneider
+ * @author Maciej Walkowiak
  */
 public final class Tags {
     private Tags() {}
@@ -47,5 +49,9 @@ public final class Tags {
 
     public static Iterable<Tag> concat(Iterable<Tag> tags, String... keyValues) {
         return concat(tags, zip(keyValues));
+    }
+
+    public static Iterable<Tag> singletonList(String tagKey, String tagValue) {
+        return Collections.singletonList(Tag.of(tagKey, tagValue));
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.core.instrument;
 
-import java.util.Optional;
-
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.histogram.HistogramConfig;
@@ -72,50 +70,5 @@ class MeterRegistryTest {
         });
         
         registry.timer("my.timer");
-    }
-
-    @Test
-    void registersCounterWithSingleTag() {
-        Counter counter = registry.counter("my.counter", Tag.of("k1", "v1"));
-
-        assertThat(counter.getId().getTags()).containsExactly(Tag.of("k1", "v1"));
-    }
-
-    @Test
-    void registersTimerWithSingleTag() {
-        Timer timer = registry.timer("my.timer", Tag.of("k1", "v1"));
-
-        assertThat(timer.getId().getTags()).containsExactly(Tag.of("k1", "v1"));
-    }
-
-    @Test
-    void registersSummaryWithSingleTag() {
-        DistributionSummary summary = registry.summary("my.summary", Tag.of("k1", "v1"));
-
-        assertThat(summary.getId().getTags()).containsExactly(Tag.of("k1", "v1"));
-    }
-
-    @Test
-    void registersGaugeWithSingleTag() {
-        registry.gauge("my.gauge", Tag.of("k1", "v1"), 1);
-
-        Optional<Meter.Id> gaugeId = registry.getMeters().stream()
-                                        .map(Meter::getId)
-                                        .filter(id -> id.getName().equals("my.gauge"))
-                                        .findFirst();
-
-        assertThat(gaugeId).hasValueSatisfying(id -> assertThat(id.getTags()).contains(Tag.of("k1", "v1")));
-    }
-
-    @Test
-    void registersGaugeWithFunctionWithSingleTag() {
-        registry.gauge("my.gauge", Tag.of("k1", "v1"), 1, it -> Double.MAX_VALUE);
-
-        Optional<Meter.Id> gaugeId = registry.getMeters().stream()
-                                             .map(Meter::getId)
-                                             .filter(id -> id.getName().equals("my.gauge"))
-                                             .findFirst();
-
-        assertThat(gaugeId).hasValueSatisfying(id -> assertThat(id.getTags()).contains(Tag.of("k1", "v1")));
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
@@ -1,0 +1,18 @@
+package io.micrometer.core.instrument;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Maciej Walkowiak
+ */
+class TagsTest {
+
+    @Test
+    void createsListWithSingleTag() {
+        Iterable<Tag> tags = Tags.singletonList("k1", "v1");
+
+        assertThat(tags).containsExactly(Tag.of("k1", "v1"));
+    }
+}


### PR DESCRIPTION
The goal of this PR is to improve registering metrics with single tag.

Currently there are two ways of registering metrics - lets take `Counter` as an example:

```java
meterRegistry.counter("message.received", "tagKey", "tagValue")
```
This method does not give compilation time safety - if number of `String` parameters passed as tags is not even then code will throw exception in runtime.

```java
metrics.counter("message.received", Arrays.asList(Tag.of("tagKey", "tagValue")))
```
This method adds extra boilerplate.

This PR simplifies it to:
```java
metrics.counter("message.received", Tag.of("tagKey", "tagValue"))
```
which guarantees compilation time safety and eliminates boilerplate.

I guess similar methods could/should be added to `Metrics` class.