### PR TITLE
Allow subclasses to leverage the `getMostSpecific` method for looking up additional properties

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/PropertyMeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/PropertyMeterFilter.java
@@ -29,7 +29,7 @@ import java.time.Duration;
 public abstract class PropertyMeterFilter implements MeterFilter {
     public abstract <V> V get(String k, Class<V> vClass);
 
-    private <V> V getMostSpecific(String k, String suffix, Class<V> vClass) {
+    protected <V> V getMostSpecific(String k, String suffix, Class<V> vClass) {
         V v = get(k.isEmpty() ? suffix : k + "." + suffix, vClass);
         if(v != null)
             return v;


### PR DESCRIPTION
Now that I'm able to upgrade to `rc5`, I'm adding in my tag combining logic in a subclass and needed to be able to look up the most specific properties.