### PR TITLE
Improve CloudWatch configuration and sanitize data

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
@@ -43,6 +43,14 @@ public interface CloudWatchConfig extends StepRegistryConfig {
         return v;
     }
 
+    /**
+     * Returns whether to create the CloudWatchMetrics without performing the PUT operation
+     */
+    default boolean dryRun() {
+        String v = get(prefix() + ".dryRun");
+        return Boolean.parseBoolean(v);
+    }
+    
     @Override
     default int batchSize() {
         String v = get(prefix() + ".batchSize");

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+/**
+ * Utilities for cloudwatch registry
+ */
+final class CloudWatchUtils {
+
+    /**
+     * Minimum allowed value as specified by 
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     */
+    private static final double MINIMUM_ALLOWED_VALUE = 8.515920e-109;
+    
+    /**
+     * Maximum allowed value as specified by 
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     */
+    private static final double MAXIMUM_ALLOWED_VALUE = 1.174271e+108;
+
+    private CloudWatchUtils() {
+    }
+
+    /**
+     * Clean up metric to be within the allowable range as specified in 
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     * 
+     * @param value unsanitized value
+     * @return value clamped to allowable range, 0, or NaN
+     */
+    static double clampMetricValue(double value) {
+        final double result;
+        if (!Double.isNaN(value)) {
+            double magnitude = Math.abs(value);
+            if (magnitude == 0) {
+                // Leave zero as zero
+                result = 0;
+            } else {
+                // Non-zero magnitude, clamp to allowed range
+                double clampedMag = Math.min(Math.max(magnitude, MINIMUM_ALLOWED_VALUE), MAXIMUM_ALLOWED_VALUE);
+                result = Math.copySign(clampedMag, value);
+            }
+        } else {
+            // Leave as is and let the SDK reject it
+            result = value;
+        }
+
+        return result;
+    }
+    
+}

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
@@ -1,0 +1,53 @@
+package io.micrometer.cloudwatch;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test methods in CloudWatchUtils
+ */
+class CloudWatchUtilsTest {
+
+    private static final double EXPECTED_MIN = 8.515920e-109;
+    private static final double EXPECTED_MAX = 1.174271e+108;
+
+    @Test
+    public void testClamp() {
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.NaN))
+            .as("Check NaN")
+            .isEqualTo(Double.NaN);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.MIN_VALUE))
+            .as("Check minimum value")
+            .isEqualTo(EXPECTED_MIN);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.NEGATIVE_INFINITY))
+            .as("Check negative infinity")
+            .isEqualTo(-EXPECTED_MAX);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.POSITIVE_INFINITY))
+            .as("Check positive infinity")
+            .isEqualTo(EXPECTED_MAX);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-Double.MAX_VALUE))
+            .as("Check negative max value")
+            .isEqualTo(-EXPECTED_MAX);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(0))
+            .as("Check 0")
+            .isEqualTo(0);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-0))
+            .as("Check -0")
+            .isEqualTo(0);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(100.1))
+            .as("Check positive value")
+            .isEqualTo(100.1);
+        
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-10.2))
+            .as("Check negative value")
+            .isEqualTo(-10.2);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClientBuilder;
 import io.micrometer.cloudwatch.CloudWatchConfig;
 import io.micrometer.cloudwatch.CloudWatchMeterRegistry;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.spring.autoconfigure.export.DefaultStepRegistryConfig;
 import io.micrometer.spring.autoconfigure.export.MetricsExporter;
 import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
@@ -32,6 +33,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Configuration for exporting metrics to CloudWatch.
@@ -44,9 +48,8 @@ import org.springframework.context.annotation.Import;
 @EnableConfigurationProperties(CloudWatchProperties.class)
 public class CloudWatchExportConfiguration {
 
-    private class DefaultCloudWatchConfig extends DefaultStepRegistryConfig implements CloudWatchConfig {
+    private static class DefaultCloudWatchConfig extends DefaultStepRegistryConfig implements CloudWatchConfig {
         private final CloudWatchProperties props;
-        private final CloudWatchConfig defaults = k -> null;
 
         private DefaultCloudWatchConfig(CloudWatchProperties props) {
             super(props);
@@ -55,7 +58,18 @@ public class CloudWatchExportConfiguration {
 
         @Override
         public String namespace() {
-            return props.getNamespace() == null ? namespace() : props.getNamespace();
+            return props.getNamespace() == null ? DEFAULT.namespace() : props.getNamespace();
+        }
+
+        @Override
+        public int batchSize() {
+            // Override to leverage the CloudWatchConfig batch size instead of StepRegistryConfig
+            return props.getBatchSize() == null ? DEFAULT.batchSize() : props.getBatchSize();
+        }
+
+        @Override
+        public boolean dryRun() {
+            return props.dryRun() == null ? DEFAULT.dryRun() : props.dryRun();
         }
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchProperties.java
@@ -26,6 +26,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.metrics.export.cloudwatch")
 public class CloudWatchProperties extends StepRegistryProperties {
     private String namespace;
+    
+    private Boolean dryRun;
 
     public String getNamespace() {
         return namespace;
@@ -33,5 +35,13 @@ public class CloudWatchProperties extends StepRegistryProperties {
 
     public void setNamespace(String namespace) {
         this.namespace = namespace;
+    }
+
+    public Boolean dryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
     }
 }


### PR DESCRIPTION
After trying out the CloudWatch registry, here's some bugfixes and new capabilities.  

Bugfixes:
* Use batch size of 20 if not configured in spring-legacy
* Clamp values to allowable range

Features:
* Support dry-run mode
* ~Support tagging metrics with EC2 metadata~
* ~Support tagging metrics with custom tags~

Let me know what you think.  Thanks!