### PR TITLE
Add a Checkstyle module for checking license headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ subprojects {
     checkstyle {
         toolVersion = '8.4'
         configFile = rootProject.file('config/checkstyle/checkstyle.xml')
+        configProperties = [ 'checkstyle.config.dir' : rootProject.file('config/checkstyle') ]
     }
 
     def check = tasks.findByName('check')

--- a/config/checkstyle/checkstyle-header.txt
+++ b/config/checkstyle/checkstyle-header.txt
@@ -1,0 +1,15 @@
+^\Q/**\E$
+^\Q * Copyright 2017 Pivotal Software, Inc.\E$
+^\Q * <p>\E$
+^\Q * Licensed under the Apache License, Version 2.0 (the "License");\E$
+^\Q * you may not use this file except in compliance with the License.\E$
+^\Q * You may obtain a copy of the License at\E$
+^\Q * <p>\E$
+^\Q * http://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q * <p>\E$
+^\Q * Unless required by applicable law or agreed to in writing, software\E$
+^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$
+^\Q * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\E$
+^\Q * See the License for the specific language governing permissions and\E$
+^\Q * limitations under the License.\E$
+^\Q */\E$

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -2,6 +2,12 @@
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
+    <!-- Root Checks -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="${checkstyle.config.dir}/checkstyle-header.txt" />
+        <property name="fileExtensions" value="java" />
+    </module>
+
     <!-- TreeWalker Checks -->
     <module name="TreeWalker">
 


### PR DESCRIPTION
Looking at the commit history, there are a few license header-only commits. This PR adds a Checkstyle module for checking license headers.