### PR TITLE
Fix defaults in DefaultCloudWatchConfig

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
@@ -46,7 +46,6 @@ public class CloudWatchExportConfiguration {
 
     private class DefaultCloudWatchConfig extends DefaultStepRegistryConfig implements CloudWatchConfig {
         private final CloudWatchProperties props;
-        private final CloudWatchConfig defaults = k -> null;
 
         private DefaultCloudWatchConfig(CloudWatchProperties props) {
             super(props);
@@ -55,7 +54,13 @@ public class CloudWatchExportConfiguration {
 
         @Override
         public String namespace() {
-            return props.getNamespace() == null ? namespace() : props.getNamespace();
+            return props.getNamespace() == null ? DEFAULT.namespace() : props.getNamespace();
+        }
+
+        @Override
+        public int batchSize() {
+            // Override to leverage the CloudWatchConfig batch size instead of StepRegistryConfig
+            return props.getBatchSize() == null ? DEFAULT.batchSize() : props.getBatchSize();
         }
     }
 


### PR DESCRIPTION
* Fix infinite loop when namespace not provided
* Use CloudWatchConfig default batch size of 20 instead of 10000
from StepRegistryConfig