### PR TITLE
Clamp cloudwatch values to allowable range

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -158,7 +158,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                 .withMetricName(metricName)
                 .withDimensions(toDimensions(tags))
                 .withTimestamp(new Date(wallTime))
-                .withValue(value)
+                .withValue(CloudWatchUtils.clampMetricValue(value))
                 .withUnit(toStandardUnit(id.getBaseUnit()));
     }
 

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+/**
+ * Utilities for cloudwatch registry
+ */
+final class CloudWatchUtils {
+
+    /**
+     * Minimum allowed value as specified by
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     */
+    private static final double MINIMUM_ALLOWED_VALUE = 8.515920e-109;
+
+    /**
+     * Maximum allowed value as specified by
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     */
+    private static final double MAXIMUM_ALLOWED_VALUE = 1.174271e+108;
+
+    private CloudWatchUtils() {
+    }
+
+    /**
+     * Clean up metric to be within the allowable range as specified in
+     * #{{@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}}
+     *
+     * @param value unsanitized value
+     * @return value clamped to allowable range, 0, or NaN
+     */
+    static double clampMetricValue(double value) {
+        final double result;
+        if (!Double.isNaN(value)) {
+            double magnitude = Math.abs(value);
+            if (magnitude == 0) {
+                // Leave zero as zero
+                result = 0;
+            } else {
+                // Non-zero magnitude, clamp to allowed range
+                double clampedMag = Math.min(Math.max(magnitude, MINIMUM_ALLOWED_VALUE), MAXIMUM_ALLOWED_VALUE);
+                result = Math.copySign(clampedMag, value);
+            }
+        } else {
+            // Leave as is and let the SDK reject it
+            result = value;
+        }
+
+        return result;
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
@@ -1,0 +1,53 @@
+package io.micrometer.cloudwatch;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test methods in CloudWatchUtils
+ */
+class CloudWatchUtilsTest {
+
+    private static final double EXPECTED_MIN = 8.515920e-109;
+    private static final double EXPECTED_MAX = 1.174271e+108;
+
+    @Test
+    void testClamp() {
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.NaN))
+            .as("Check NaN")
+            .isEqualTo(Double.NaN);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.MIN_VALUE))
+            .as("Check minimum value")
+            .isEqualTo(EXPECTED_MIN);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.NEGATIVE_INFINITY))
+            .as("Check negative infinity")
+            .isEqualTo(-EXPECTED_MAX);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(Double.POSITIVE_INFINITY))
+            .as("Check positive infinity")
+            .isEqualTo(EXPECTED_MAX);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-Double.MAX_VALUE))
+            .as("Check negative max value")
+            .isEqualTo(-EXPECTED_MAX);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(0))
+            .as("Check 0")
+            .isEqualTo(0);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-0))
+            .as("Check -0")
+            .isEqualTo(0);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(100.1))
+            .as("Check positive value")
+            .isEqualTo(100.1);
+
+        Assertions.assertThat(CloudWatchUtils.clampMetricValue(-10.2))
+            .as("Check negative value")
+            .isEqualTo(-10.2);
+    }
+
+}


### PR DESCRIPTION
"Although the Value parameter accepts numbers of type Double, CloudWatch
rejects values that are either too small or too large. Values must be in
the range of 8.515920e-109 to 1.174271e+108 (Base 10) or 2e-360 to 2e360
(Base 2). In addition, special values (for example, NaN, +Infinity,
-Infinity) are not supported."

http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html