### PR TITLE
Make `tomcat.sessions.[expired,rejected]` FunctionCounters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -52,17 +52,16 @@ public class TomcatMetrics implements MeterBinder {
         Gauge.builder("tomcat.sessions.active.current", manager, Manager::getActiveSessions)
             .tags(tags)
             .register(reg);
-        Gauge.builder("tomcat.sessions.expired", manager, Manager::getExpiredSessions)
+        FunctionCounter.builder("tomcat.sessions.created", manager, Manager::getSessionCounter)
             .tags(tags)
             .register(reg);
-        Gauge.builder("tomcat.sessions.rejected", manager, Manager::getRejectedSessions)
+        FunctionCounter.builder("tomcat.sessions.expired", manager, Manager::getExpiredSessions)
+            .tags(tags)
+            .register(reg);
+        FunctionCounter.builder("tomcat.sessions.rejected", manager, Manager::getRejectedSessions)
             .tags(tags)
             .register(reg);
         TimeGauge.builder("tomcat.sessions.alive.max", manager, TimeUnit.SECONDS, Manager::getSessionMaxAliveTime)
-            .tags(tags)
-            .register(reg);
-
-        FunctionCounter.builder("tomcat.sessions.created", manager, Manager::getSessionCounter)
             .tags(tags)
             .register(reg);
     }


### PR DESCRIPTION
This PR is just here in case #263 doesn't make it into `rc.6`.
It contains a meter type "fix" for Tomcat session metrics which made it into master with #257 which is part of the `rc.6` milestone.

/cc @checketts 