### PR TITLE
Close HTTP connections to prevent connection leak

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -139,8 +139,11 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
     // TODO HTTP/1.1 Persistent connections are supported
     private void sendEvents(URL insightsEndpoint, List<Event> events) {
+
+        HttpURLConnection con = null;
+
         try {
-            HttpURLConnection con = (HttpURLConnection) insightsEndpoint.openConnection();
+            con = (HttpURLConnection) insightsEndpoint.openConnection();
             con.setConnectTimeout((int) config.connectTimeout().toMillis());
             con.setReadTimeout((int) config.readTimeout().toMillis());
             con.setRequestMethod("POST");
@@ -169,9 +172,21 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
                 logger.error("failed to send metrics: http " + status);
             }
 
-            con.disconnect();
         } catch (Throwable e) {
             logger.warn("failed to send metrics", e);
+        }
+        finally {
+            quietlyCloseUrlConnection(con);
+        }
+    }
+
+    private void quietlyCloseUrlConnection(HttpURLConnection con) {
+        if (con == null)
+            return;
+        try {
+            con.disconnect();
+        }
+        catch (Exception ignore) {
         }
     }
 


### PR DESCRIPTION
Noticed InfluxMeterRegistry was not always closing its HTTP connection.  I went ahead and created a pull request for this along with DatadogMeterRegistry and NewRelicMeterRegistry.  If I need to create an Issue first or need clarification on the fix, let me know.  