### PR TITLE
Align exception message with condition for durationBetweenRotatesMillis

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramBase.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowHistogramBase.java
@@ -70,7 +70,7 @@ abstract class TimeWindowHistogramBase<T, U> {
         durationBetweenRotatesMillis = histogramConfig.getHistogramExpiry().toMillis() / ageBuckets;
         if (durationBetweenRotatesMillis <= 0) {
             rejectHistogramConfig("histogramExpiry (" + histogramConfig.getHistogramExpiry().toMillis() +
-                                  "ms) / histogramBufferLength (" + ageBuckets + ") must be greater than 1.");
+                                  "ms) / histogramBufferLength (" + ageBuckets + ") must be greater than 0.");
         }
 
         currentBucket = 0;


### PR DESCRIPTION
This PR aligns the exception message with the condition for `durationBetweenRotatesMillis`.