### PR TITLE
Remove IntMath usage in MeterPartition

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
@@ -16,13 +16,15 @@
 package io.micrometer.cloudwatch;
 
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import io.micrometer.core.instrument.util.MathUtils;
 
-import java.math.RoundingMode;
 import java.util.AbstractList;
 import java.util.List;
 
 /**
- * Modified from {@link io.micrometer.core.instrument.util.MeterPartition}
+ * Modified from {@link io.micrometer.core.instrument.util.MeterPartition}.
+ *
+ * @author Dawid Kublik
  */
 public class MetricDatumPartition extends AbstractList<List<MetricDatum>> {
     private final List<MetricDatum> list;
@@ -42,33 +44,7 @@ public class MetricDatumPartition extends AbstractList<List<MetricDatum>> {
 
     @Override
     public int size() {
-        return divideWithCeilingRoundingMode(list.size(), size);
-    }
-
-    /**
-     * simplified {@link com.google.common.math.IntMath#divide(int, int, RoundingMode)}
-     */
-    private int divideWithCeilingRoundingMode(int p, int q) {
-        if (q == 0) {
-            throw new ArithmeticException("/ by zero"); // for GWT
-        }
-        int div = p / q;
-        int rem = p - q * div; // equal to p % q
-
-        if (rem == 0) {
-            return div;
-        }
-
-        /*
-         * Normal Java division rounds towards 0, consistently with RoundingMode.DOWN. We just have to
-         * deal with the cases where rounding towards 0 is wrong, which typically depends on the sign of
-         * p / q.
-         *
-         * signum is 1 if p and q are both nonnegative or both negative, and -1 otherwise.
-         */
-        int signum = 1 | ((p ^ q) >> (Integer.SIZE - 1));
-        boolean increment = signum > 0;
-        return increment ? div + signum : div;
+        return MathUtils.divideWithCeilingRoundingMode(list.size(), size);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MathUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MathUtils.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+/**
+ * Utilities for math.
+ *
+ * @author Dawid Kublik
+ */
+public final class MathUtils {
+
+    /**
+     * Simplified {@link com.google.common.math.IntMath#divide(int, int, java.math.RoundingMode)}.
+     */
+    public static int divideWithCeilingRoundingMode(int p, int q) {
+        if (q == 0) {
+            throw new ArithmeticException("/ by zero"); // for GWT
+        }
+        int div = p / q;
+        int rem = p - q * div; // equal to p % q
+
+        if (rem == 0) {
+            return div;
+        }
+
+        /*
+         * Normal Java division rounds towards 0, consistently with RoundingMode.DOWN. We just have to
+         * deal with the cases where rounding towards 0 is wrong, which typically depends on the sign of
+         * p / q.
+         *
+         * signum is 1 if p and q are both nonnegative or both negative, and -1 otherwise.
+         */
+        int signum = 1 | ((p ^ q) >> (Integer.SIZE - 1));
+        boolean increment = signum > 0;
+        return increment ? div + signum : div;
+    }
+
+    private MathUtils() {
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
@@ -15,16 +15,16 @@
  */
 package io.micrometer.core.instrument.util;
 
-import com.google.common.math.IntMath;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 
-import java.math.RoundingMode;
 import java.util.AbstractList;
 import java.util.List;
 
 /**
- * Modified from {@link com.google.common.collect.Lists#partition(List, int)}
+ * Modified from {@link com.google.common.collect.Lists#partition(List, int)}.
+ *
+ * @author Jon Schneider
  */
 public class MeterPartition extends AbstractList<List<Meter>> {
     private final List<Meter> list;
@@ -44,7 +44,7 @@ public class MeterPartition extends AbstractList<List<Meter>> {
 
     @Override
     public int size() {
-        return IntMath.divide(list.size(), size, RoundingMode.CEILING);
+        return MathUtils.divideWithCeilingRoundingMode(list.size(), size);
     }
 
     @Override


### PR DESCRIPTION
Using `IntMath` looks unintentional as `guava` is `optional`. This PR extracts `divideWithCeilingRoundingMode()` introduced in b2b13fb9fcca5ef5170cb9b0bb9ce91f93a2fe27 into `MathUtils` and replaces `IntMath` with it.