### PR TITLE
Add IllegalImportCheck Checkstyle module against Guava

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -6,6 +6,10 @@
     <module name="TreeWalker">
 
         <!-- Imports -->
+        <module name="IllegalImportCheck" >
+            <property name="illegalPkgs" value="com.google.common.(?!cache).*"/>
+            <property name="regexp" value="true"/>
+        </module>
         <module name="UnusedImports">
             <property name="processJavadoc" value="true" />
         </module>


### PR DESCRIPTION
This PR adds `IllegalImportCheck` Checkstyle module against Guava except `cache` package to prevent them from sneaking into codebase again like https://github.com/micrometer-metrics/micrometer/pull/296, https://github.com/micrometer-metrics/micrometer/pull/297.