### PR TITLE
Introduce a field for size() in MeterPartition, MetricDatumPartition

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
@@ -28,23 +28,25 @@ import java.util.List;
  */
 public class MetricDatumPartition extends AbstractList<List<MetricDatum>> {
     private final List<MetricDatum> list;
-    private final int size;
+    private final int partitionSize;
+    private final int partitionCount;
 
-    public MetricDatumPartition(List<MetricDatum> metricData, int size) {
+    public MetricDatumPartition(List<MetricDatum> metricData, int partitionSize) {
         this.list = metricData;
-        this.size = size;
+        this.partitionSize = partitionSize;
+        this.partitionCount = MathUtils.divideWithCeilingRoundingMode(list.size(), partitionSize);
     }
 
     @Override
     public List<MetricDatum> get(int index) {
-        int start = index * size;
-        int end = Math.min(start + size, list.size());
+        int start = index * partitionSize;
+        int end = Math.min(start + partitionSize, list.size());
         return list.subList(start, end);
     }
 
     @Override
     public int size() {
-        return MathUtils.divideWithCeilingRoundingMode(list.size(), size);
+        return this.partitionCount;
     }
 
     @Override
@@ -52,7 +54,7 @@ public class MetricDatumPartition extends AbstractList<List<MetricDatum>> {
         return list.isEmpty();
     }
 
-    public static List<List<MetricDatum>> partition(List<MetricDatum> metricData, int size) {
-        return new MetricDatumPartition(metricData, size);
+    public static List<List<MetricDatum>> partition(List<MetricDatum> metricData, int partitionSize) {
+        return new MetricDatumPartition(metricData, partitionSize);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/MeterPartition.java
@@ -28,23 +28,25 @@ import java.util.List;
  */
 public class MeterPartition extends AbstractList<List<Meter>> {
     private final List<Meter> list;
-    private final int size;
+    private final int partitionSize;
+    private final int partitionCount;
 
-    public MeterPartition(MeterRegistry registry, int size) {
+    public MeterPartition(MeterRegistry registry, int partitionSize) {
         this.list = registry.getMeters();
-        this.size = size;
+        this.partitionSize = partitionSize;
+        this.partitionCount = MathUtils.divideWithCeilingRoundingMode(list.size(), partitionSize);
     }
 
     @Override
     public List<Meter> get(int index) {
-        int start = index * size;
-        int end = Math.min(start + size, list.size());
+        int start = index * partitionSize;
+        int end = Math.min(start + partitionSize, list.size());
         return list.subList(start, end);
     }
 
     @Override
     public int size() {
-        return MathUtils.divideWithCeilingRoundingMode(list.size(), size);
+        return this.partitionCount;
     }
 
     @Override
@@ -52,7 +54,7 @@ public class MeterPartition extends AbstractList<List<Meter>> {
         return list.isEmpty();
     }
 
-    public static List<List<Meter>> partition(MeterRegistry registry, int size) {
-        return new MeterPartition(registry, size);
+    public static List<List<Meter>> partition(MeterRegistry registry, int partitionSize) {
+        return new MeterPartition(registry, partitionSize);
     }
 }


### PR DESCRIPTION
The value for `size()` in `MeterPartition`, `MetricDatumPartition` doesn't change, so recalculation on `size()` invocation isn't necessary. This PR introduces a field for it and initializes it in its constructor.

And the original `size` field means the size of a partition but it looks confusing with `size()` which means the number of partiions. So this PR also renames it to `partitionSize` to avoid confusion with `size()` method.