### PR TITLE
Align MBeanServer lookup in TomcatMetrics with Tomcat

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -22,6 +22,7 @@ import org.apache.catalina.Manager;
 import javax.management.*;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -44,8 +45,16 @@ public class TomcatMetrics implements MeterBinder {
         new TomcatMetrics(manager, tags).bindTo(meterRegistry);
     }
 
+    public static MBeanServer getMBeanServer() {
+        List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
+        if (!mBeanServers.isEmpty()) {
+            return mBeanServers.get(0);
+        }
+        return ManagementFactory.getPlatformMBeanServer();
+    }
+
     public TomcatMetrics(Manager manager, Iterable<Tag> tags) {
-        this(manager, tags, ManagementFactory.getPlatformMBeanServer());
+        this(manager, tags, getMBeanServer());
     }
 
     public TomcatMetrics(Manager manager, Iterable<Tag> tags, MBeanServer mBeanServer) {


### PR DESCRIPTION
`TomcatMetricsTest` itself passes alone but when all tests run together, it fails as follows:

```
Failures (2):
  JUnit Jupiter:TomcatMetricsTest:mbeansAvailableBeforeBinder()
    MethodSource [className = 'io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest', methodName = 'mbeansAvailableBeforeBinder', methodParameterTypes = '']
    => java.lang.AssertionError: 
Expecting Optional to contain a value but was empty.
  JUnit Jupiter:TomcatMetricsTest:mbeansAvailableAfterBinder()
    MethodSource [className = 'io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest', methodName = 'mbeansAvailableAfterBinder', methodParameterTypes = '']
    => java.lang.AssertionError: 
Expecting Optional to contain a value but was empty.
```

When I checked the latest build, it passed: https://circleci.com/gh/micrometer-metrics/micrometer/713

Looking it a bit more, Tomcat looks up `MBeanServer` as follows:

```java
    public synchronized MBeanServer getMBeanServer() {
        if (server == null) {
            long t1 = System.currentTimeMillis();
            if (MBeanServerFactory.findMBeanServer(null).size() > 0) {
                server = MBeanServerFactory.findMBeanServer(null).get(0);
                if (log.isDebugEnabled()) {
                    log.debug("Using existing MBeanServer " + (System.currentTimeMillis() - t1));
                }
            } else {
                server = ManagementFactory.getPlatformMBeanServer();
                if (log.isDebugEnabled()) {
                    log.debug("Creating MBeanServer" + (System.currentTimeMillis() - t1));
                }
            }
        }
        return server;
    }
```

and `JCacheMetricsTest` registers two `MBeanServer`s.

So there's a chance to be a problem by execution order.

This PR aligns `MBeanServer` lookup in `TomcatMetrics` with Tomcat.