### PR TITLE
Format metrics independent of system locale

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -26,8 +26,10 @@ import java.io.*;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
@@ -41,7 +43,7 @@ import static java.util.stream.Collectors.toList;
 public class InfluxMeterRegistry extends StepMeterRegistry {
     private final InfluxConfig config;
     private final Logger logger = LoggerFactory.getLogger(InfluxMeterRegistry.class);
-    private final DecimalFormat format = new DecimalFormat("#.####");
+    private final DecimalFormat format = new DecimalFormat("#.####", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
     // FIXME naming convention not working!
     public InfluxMeterRegistry(InfluxConfig config, Clock clock) {
@@ -186,11 +188,11 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private class Field {
+    class Field {
         final String key;
         final double value;
 
-        private Field(String key, double value) {
+        Field(String key, double value) {
             this.key = key;
             this.value = value;
         }

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.influx;
+
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MockClock;
+
+public class InfluxMeterRegistryFieldToStringTest {
+
+	@Test
+	public void testWithEnglishLocale() {
+		Locale.setDefault(Locale.ENGLISH);
+		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+
+		InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+
+		assertThat(field.toString()).isEqualTo("value=0.01");
+	}
+
+	@Test
+	public void testWithEnglishLocaleWithLargerResolution() {
+		Locale.setDefault(Locale.ENGLISH);
+		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+
+		InfluxMeterRegistry.Field field = instance.new Field("value", 0.00009);
+
+		assertThat(field.toString()).isEqualTo("value=0.0001");
+	}
+
+	@Test
+	public void testWithSwedishLocale() {
+		Locale.setDefault(new Locale("sv", "SE"));
+
+		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+		InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+
+		assertThat(field.toString()).isEqualTo("value=0.01");
+	}
+}


### PR DESCRIPTION
This fix enforces that English locale is used to ensure dot is used as decimal symbol.

Fix for #315