### PR TITLE
Align property names with Spring Boot 2.0.0.BUILD-SNAPSHOT

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/SpringEnvironmentMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/SpringEnvironmentMeterFilter.java
@@ -36,7 +36,7 @@ public class SpringEnvironmentMeterFilter extends PropertyMeterFilter {
     @Override
     public <V> V get(String k, Class<V> vClass) {
         if (conversionService.canConvert(String.class, vClass)) {
-            Object val = environment.getProperty("spring.metrics.filter." + k);
+            Object val = environment.getProperty("management.metrics.filter." + k);
             try {
                 return conversionService.convert(val, vClass);
             } catch (ConversionFailedException e) {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
@@ -16,7 +16,9 @@
 package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
@@ -35,29 +37,43 @@ import org.springframework.context.annotation.Configuration;
 class MeterBindersConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.binders.jvmmemory.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.binders.jvm.enabled", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    public JvmGcMetrics jvmGcMetrics() {
+        return new JvmGcMetrics();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "management.metrics.binders.jvm.enabled", matchIfMissing = true)
     @ConditionalOnMissingBean
     public JvmMemoryMetrics jvmMemoryMetrics() {
         return new JvmMemoryMetrics();
     }
 
     @Bean
-    @ConditionalOnClass(name = "ch.qos.logback.classic.Logger")
-    @ConditionalOnProperty(value = "spring.metrics.binders.logback.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.binders.jvm.enabled", matchIfMissing = true)
     @ConditionalOnMissingBean
+    public JvmThreadMetrics jvmThreadMetrics() {
+        return new JvmThreadMetrics();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(LogbackMetrics.class)
+    @ConditionalOnProperty(value = "management.metrics.binders.logback.enabled", matchIfMissing = true)
+    @ConditionalOnClass(name = "ch.qos.logback.classic.Logger")
     public LogbackMetrics logbackMetrics() {
         return new LogbackMetrics();
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.binders.uptime.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.binders.uptime.enabled", matchIfMissing = true)
     @ConditionalOnMissingBean
     public UptimeMetrics uptimeMetrics() {
         return new UptimeMetrics();
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.binders.processor.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.binders.processor.enabled", matchIfMissing = true)
     @ConditionalOnMissingBean
     public ProcessorMetrics processorMetrics() {
         return new ProcessorMetrics();

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -155,7 +155,7 @@ public class MetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnClass(name = "com.netflix.hystrix.strategy.HystrixPlugins")
-    @ConditionalOnProperty(value = "spring.metrics.export.hystrix.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.hystrix.enabled", matchIfMissing = true)
     public HystrixMetricsBinder hystrixMetricsBinder() {
         return new HystrixMetricsBinder();
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties("spring.metrics")
+@ConfigurationProperties("management.metrics")
 public class MetricsProperties {
 
     private Web web = new Web();

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasExportConfiguration.java
@@ -95,7 +95,7 @@ public class AtlasExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.atlas.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.atlas.enabled", matchIfMissing = true)
     public MetricsExporter atlasExporter(AtlasConfig config, Clock clock) {
         return () -> new AtlasMeterRegistry(config, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
@@ -25,7 +25,7 @@ import java.time.Duration;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.atlas")
+@ConfigurationProperties(prefix = "management.metrics.export.atlas")
 public class AtlasProperties extends StepRegistryProperties {
     /**
      * The URI for the Atlas backend

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchExportConfiguration.java
@@ -71,7 +71,7 @@ public class CloudWatchExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.cloudwatch.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.cloudwatch.enabled", matchIfMissing = true)
     public MetricsExporter cloudwatchExporter(CloudWatchConfig config, Clock clock, AmazonCloudWatchAsync client) {
         return () -> new CloudWatchMeterRegistry(config, clock, client);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/cloudwatch/CloudWatchProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.cloudwatch")
+@ConfigurationProperties(prefix = "management.metrics.export.cloudwatch")
 public class CloudWatchProperties extends StepRegistryProperties {
     private String namespace;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogExportConfiguration.java
@@ -82,7 +82,7 @@ public class DatadogExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.datadog.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.datadog.enabled", matchIfMissing = true)
     public MetricsExporter datadogExporter(DatadogConfig config, Clock clock) {
         return () -> new DatadogMeterRegistry(config, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.datadog")
+@ConfigurationProperties(prefix = "management.metrics.export.datadog")
 public class DatadogProperties extends StepRegistryProperties {
     /**
      * Your API key, found in your account settings at datadoghq. This property is required.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaExportConfiguration.java
@@ -109,7 +109,7 @@ public class GangliaExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.ganglia.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.ganglia.enabled", matchIfMissing = true)
     public MetricsExporter gangliaExporter(GangliaConfig config,
                                            HierarchicalNameMapper nameMapper, Clock clock) {
         return () -> new GangliaMeterRegistry(config, nameMapper, clock);

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaProperties.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.ganglia")
+@ConfigurationProperties(prefix = "management.metrics.export.ganglia")
 public class GangliaProperties {
     /**
      * Enable publishing to the backend.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteExportConfiguration.java
@@ -99,7 +99,7 @@ public class GraphiteExportConfiguration {
     }
     
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.graphite.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.graphite.enabled", matchIfMissing = true)
     public MetricsExporter graphiteExporter(GraphiteConfig config,
                                             HierarchicalNameMapper nameMapper, Clock clock) {
         return () -> new GraphiteMeterRegistry(config, nameMapper, clock);

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteProperties.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.graphite")
+@ConfigurationProperties(prefix = "management.metrics.export.graphite")
 public class GraphiteProperties {
     /**
      * Enable publishing to the backend.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxExportConfiguration.java
@@ -92,7 +92,7 @@ public class InfluxExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.influx.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.influx.enabled", matchIfMissing = true)
     public MetricsExporter influxExporter(InfluxConfig config, Clock clock) {
         return () -> new InfluxMeterRegistry(config, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.influx")
+@ConfigurationProperties(prefix = "management.metrics.export.influx")
 public class InfluxProperties extends StepRegistryProperties {
     /**
      * The tag that will be mapped to "host" when shipping metrics to Influx, or {@code null} if

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxExportConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 public class JmxExportConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.jmx.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.jmx.enabled", matchIfMissing = true)
     public MetricsExporter jmxExporter(HierarchicalNameMapper nameMapper, Clock clock) {
         return () -> new JmxMeterRegistry(nameMapper, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicExportConfiguration.java
@@ -73,7 +73,7 @@ public class NewRelicExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.newrelic.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.newrelic.enabled", matchIfMissing = true)
     public MetricsExporter newRelicExporter(NewRelicConfig config, Clock clock) {
         return () -> new NewRelicMeterRegistry(config, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.newrelic")
+@ConfigurationProperties(prefix = "management.metrics.export.newrelic")
 public class NewRelicProperties extends StepRegistryProperties {
     /**
      * Your API key, found in your account settings at New Relic. This property is required.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
@@ -75,7 +75,7 @@ public class PrometheusExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.prometheus.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.prometheus.enabled", matchIfMissing = true)
     public MetricsExporter prometheusExporter(PrometheusConfig config,
                                               CollectorRegistry collectorRegistry, Clock clock) {
         return () -> new PrometheusMeterRegistry(config, collectorRegistry, clock);

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
@@ -24,7 +24,7 @@ import java.time.Duration;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.prometheus")
+@ConfigurationProperties(prefix = "management.metrics.export.prometheus")
 public class PrometheusProperties {
     /**
      * Enable publishing to Prometheus.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 public class SimpleExportConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.simple.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.simple.enabled", matchIfMissing = true)
     @ConditionalOnMissingBean(MetricsExporter.class)
     public MetricsExporter simpleExporter(SimpleConfig config, Clock clock) {
         return () -> new SimpleMeterRegistry(config, clock);

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleProperties.java
@@ -24,7 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.simple")
+@ConfigurationProperties(prefix = "management.metrics.export.simple")
 public class SimpleProperties {
 
     private boolean enabled = true;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdExportConfiguration.java
@@ -98,7 +98,7 @@ public class StatsdExportConfiguration {
     }
 
     @Bean
-    @ConditionalOnProperty(value = "spring.metrics.export.statsd.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.export.statsd.enabled", matchIfMissing = true)
     public MetricsExporter statsdExporter(StatsdConfig config, HierarchicalNameMapper hierarchicalNameMapper, Clock clock) {
         return () -> new StatsdMeterRegistry(config, hierarchicalNameMapper, clock);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
@@ -25,7 +25,7 @@ import java.time.Duration;
  *
  * @author Jon Schneider
  */
-@ConfigurationProperties(prefix = "spring.metrics.export.statsd")
+@ConfigurationProperties(prefix = "management.metrics.export.statsd")
 public class StatsdProperties {
     /**
      * Enable publishing to the backend.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/tomcat/TomcatMetricsConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/tomcat/TomcatMetricsConfiguration.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 public class TomcatMetricsConfiguration {
 
         @Bean
-        @ConditionalOnProperty(value = "spring.metrics.export.tomcat.enabled", matchIfMissing = true)
+        @ConditionalOnProperty(value = "management.metrics.export.tomcat.enabled", matchIfMissing = true)
         public TomcatMetrics metrics(ApplicationContext applicationContext) {
             Manager manager = null;
             if (applicationContext instanceof EmbeddedWebApplicationContext) {

--- a/micrometer-spring-legacy/src/samples/resources/application-atlas.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-atlas.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-spring.metrics.export:
+management.metrics.export:
   atlas:
     enabled: true
     step: PT10S

--- a/micrometer-spring-legacy/src/samples/resources/application-datadog.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-datadog.yml
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-spring.metrics.datadog:
+management.metrics.export.datadog:
   enabled: true
   apiKey: fake

--- a/micrometer-spring-legacy/src/samples/resources/application-influx.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-influx.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-spring.metrics.export:
+management.metrics.export:
   influx:
     enabled: true
     step: PT10S

--- a/micrometer-spring-legacy/src/samples/resources/application-jmx.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-jmx.yml
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-spring.metrics.export.jmx.enabled: true
+management.metrics.export.jmx.enabled: true

--- a/micrometer-spring-legacy/src/samples/resources/application-prometheus.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-prometheus.yml
@@ -16,7 +16,7 @@
 
 management.security.enabled: false
 
-spring.metrics.export:
+management.metrics.export:
   prometheus.enabled: true
   filter:
     hystrix.latency:

--- a/micrometer-spring-legacy/src/samples/resources/application-statsd-datadog.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-statsd-datadog.yml
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-spring.metrics.statsd:
+management.metrics.export.statsd:
   enabled: true
   flavor: datadog

--- a/micrometer-spring-legacy/src/samples/resources/application-statsd-telegraf.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application-statsd-telegraf.yml
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-spring.metrics.statsd:
+management.metrics.export.statsd:
   enabled: true
   flavor: telegraf

--- a/micrometer-spring-legacy/src/samples/resources/application.yml
+++ b/micrometer-spring-legacy/src/samples/resources/application.yml
@@ -21,7 +21,7 @@ management.security.enabled: false
 logging.level.org.springframework.integration.support.MessageBuilder: WARN
 logging.level.org.springframework.boot: INFO
 
-spring.metrics.export:
+management.metrics.export:
   atlas.enabled: false
   datadog.enabled: false
   ganglia.enabled: false

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/SpringEnvironmentMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/SpringEnvironmentMeterFilterTest.java
@@ -37,15 +37,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource(properties = {
-    "spring.metrics.filter.enabled=false", // turn off all metrics by default
-    "spring.metrics.filter.my.timer.enabled=true",
-    "spring.metrics.filter.my.timer.maximumExpectedValue=PT10S",
-    "spring.metrics.filter.my.timer.minimumExpectedValue=1ms",
-    "spring.metrics.filter.my.timer.percentiles=0.5,0.95",
-    "spring.metrics.filter.my.timer.that.is.misconfigured.enabled=troo",
+    "management.metrics.filter.enabled=false", // turn off all metrics by default
+    "management.metrics.filter.my.timer.enabled=true",
+    "management.metrics.filter.my.timer.maximumExpectedValue=PT10S",
+    "management.metrics.filter.my.timer.minimumExpectedValue=1ms",
+    "management.metrics.filter.my.timer.percentiles=0.5,0.95",
+    "management.metrics.filter.my.timer.that.is.misconfigured.enabled=troo",
 
-    "spring.metrics.filter.my.summary.enabled=true",
-    "spring.metrics.filter.my.summary.maximumExpectedValue=100",
+    "management.metrics.filter.my.summary.enabled=true",
+    "management.metrics.filter.my.summary.maximumExpectedValue=100",
 })
 public class SpringEnvironmentMeterFilterTest {
     private HistogramConfig histogramConfig;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryConfigurerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryConfigurerTest.java
@@ -34,16 +34,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {
-    "spring.metrics.useGlobalRegistry=false",
-    "spring.metrics.export.atlas.enabled=false",
-    "spring.metrics.export.prometheus.enabled=false",
-    "spring.metrics.export.datadog.enabled=false",
-    "spring.metrics.export.ganglia.enabled=false",
-    "spring.metrics.export.graphite.enabled=false",
-    "spring.metrics.export.influx.enabled=false",
-    "spring.metrics.export.jmx.enabled=false",
-    "spring.metrics.export.statsd.enabled=false",
-    "spring.metrics.export.newrelic.enabled=false"
+    "management.metrics.useGlobalRegistry=false",
+    "management.metrics.export.atlas.enabled=false",
+    "management.metrics.export.prometheus.enabled=false",
+    "management.metrics.export.datadog.enabled=false",
+    "management.metrics.export.ganglia.enabled=false",
+    "management.metrics.export.graphite.enabled=false",
+    "management.metrics.export.influx.enabled=false",
+    "management.metrics.export.jmx.enabled=false",
+    "management.metrics.export.statsd.enabled=false",
+    "management.metrics.export.newrelic.enabled=false"
 })
 public class MeterRegistryConfigurerTest {
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -57,9 +57,9 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = MetricsAutoConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = {
-    "spring.metrics.use-global-registry=false",
-    "spring.metrics.filter.my.timer.enabled=true", // overriden by programmatic filter
-    "spring.metrics.simple.cumulative.enabled=true",
+    "management.metrics.use-global-registry=false",
+    "management.metrics.filter.my.timer.enabled=true", // overriden by programmatic filter
+    "management.metrics.simple.cumulative.enabled=true",
 })
 public class MetricsAutoConfigurationTest {
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsConfigurationCompositeTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsConfigurationCompositeTest.java
@@ -35,15 +35,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {
-    "spring.metrics.useGlobalRegistry=false",
-    "spring.metrics.export.atlas.enabled=false",
-    "spring.metrics.export.datadog.enabled=false",
-    "spring.metrics.export.ganglia.enabled=false",
-    "spring.metrics.export.influx.enabled=false",
-    "spring.metrics.export.jmx.enabled=false",
-    "spring.metrics.export.statsd.enabled=false",
-    "spring.metrics.export.prometheus.enabled=true",
-    "spring.metrics.export.newrelic.enabled=false"
+    "management.metrics.useGlobalRegistry=false",
+    "management.metrics.export.atlas.enabled=false",
+    "management.metrics.export.datadog.enabled=false",
+    "management.metrics.export.ganglia.enabled=false",
+    "management.metrics.export.influx.enabled=false",
+    "management.metrics.export.jmx.enabled=false",
+    "management.metrics.export.statsd.enabled=false",
+    "management.metrics.export.prometheus.enabled=true",
+    "management.metrics.export.newrelic.enabled=false"
 })
 public class MetricsConfigurationCompositeTest {
     @Autowired

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/simple/SimpleExportConfigurationTest.java
@@ -33,15 +33,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {
-    "spring.metrics.export.atlas.enabled=false",
-    "spring.metrics.export.prometheus.enabled=false",
-    "spring.metrics.export.datadog.enabled=false",
-    "spring.metrics.export.ganglia.enabled=false",
-    "spring.metrics.export.graphite.enabled=false",
-    "spring.metrics.export.influx.enabled=false",
-    "spring.metrics.export.jmx.enabled=false",
-    "spring.metrics.export.statsd.enabled=false",
-    "spring.metrics.export.newrelic.enabled=false"
+    "management.metrics.export.atlas.enabled=false",
+    "management.metrics.export.prometheus.enabled=false",
+    "management.metrics.export.datadog.enabled=false",
+    "management.metrics.export.ganglia.enabled=false",
+    "management.metrics.export.graphite.enabled=false",
+    "management.metrics.export.influx.enabled=false",
+    "management.metrics.export.jmx.enabled=false",
+    "management.metrics.export.statsd.enabled=false",
+    "management.metrics.export.newrelic.enabled=false"
 })
 public class SimpleExportConfigurationTest {
     @Autowired

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
@@ -40,14 +40,14 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {
-    "spring.metrics.useGlobalRegistry=false",
-    "spring.metrics.export.atlas.enabled=false",
-    "spring.metrics.export.datadog.enabled=false",
-    "spring.metrics.export.ganglia.enabled=false",
-    "spring.metrics.export.influx.enabled=false",
-    "spring.metrics.export.jmx.enabled=false",
-    "spring.metrics.export.statsd.enabled=false",
-    "spring.metrics.export.newrelic.enabled=false"
+    "management.metrics.useGlobalRegistry=false",
+    "management.metrics.export.atlas.enabled=false",
+    "management.metrics.export.datadog.enabled=false",
+    "management.metrics.export.ganglia.enabled=false",
+    "management.metrics.export.influx.enabled=false",
+    "management.metrics.export.jmx.enabled=false",
+    "management.metrics.export.statsd.enabled=false",
+    "management.metrics.export.newrelic.enabled=false"
 })
 public class SpringIntegrationMetricsTest {
     @Autowired

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsHikariTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsHikariTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @TestPropertySource(properties = {
     "spring.datasource.generate-unique-name=true",
     "management.security.enabled=false",
-    "spring.metrics.useGlobalRegistry=false",
+    "management.metrics.useGlobalRegistry=false",
     "spring.datasource.type=com.zaxxer.hikari.HikariDataSource"
 })
 public class DataSourceMetricsHikariTest {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourceMetricsTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 @TestPropertySource(properties = {
     "spring.datasource.generate-unique-name=true",
     "management.security.enabled=false",
-    "spring.metrics.useGlobalRegistry=false",
+    "management.metrics.useGlobalRegistry=false",
     "spring.datasource.type=org.apache.tomcat.jdbc.pool.DataSource"
 })
 public class DataSourceMetricsTest {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-@TestPropertySource(properties = "spring.metrics.useGlobalRegistry=false")
+@TestPropertySource(properties = "management.metrics.useGlobalRegistry=false")
 @Ignore("Race condition still...")
 public class ScheduledMethodMetricsTest {
 

--- a/micrometer-spring-legacy/src/test/resources/application.yml
+++ b/micrometer-spring-legacy/src/test/resources/application.yml
@@ -18,7 +18,7 @@
 logging.level.org.springframework.integration.support.MessageBuilder: WARN
 logging.level.org.springframework.boot: INFO
 
-spring.metrics.export:
+management.metrics.export:
   atlas.enabled: false
   datadog.enabled: false
   ganglia.enabled: false


### PR DESCRIPTION
This PR changes to align property names in `micrometer-spring-legacy` with Spring Boot 2.0.0.BUILD-SNAPSHOT.