### PR TITLE
Restore default Locale in InfluxMeterRegistryFieldToStringTest

### DIFF
--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
@@ -18,11 +18,26 @@ package io.micrometer.influx;
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.MockClock;
 
 public class InfluxMeterRegistryFieldToStringTest {
+
+    private Locale originalLocale;
+
+    @BeforeEach
+    public void setUp() {
+        this.originalLocale = Locale.getDefault();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        Locale.setDefault(this.originalLocale);
+    }
 
 	@Test
 	public void testWithEnglishLocale() {


### PR DESCRIPTION
This PR restores default `Locale` in `InfluxMeterRegistryFieldToStringTest`.