### PR TITLE
Add TimerContext that record a duration after the fact.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -72,6 +72,11 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     }
 
     @Override
+    public TimerContext time() {
+        return new TimerContext(clock, this);
+    }
+
+    @Override
     public final void record(long amount, TimeUnit unit) {
         if(amount >= 0) {
             histogram.recordLong(TimeUnit.NANOSECONDS.convert(amount, unit));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -108,6 +108,13 @@ public interface Timer extends Meter {
     }
 
     /**
+     * Begin timing an operation.
+     *
+     * @return TimerContext
+     */
+    TimerContext time();
+
+    /**
      * The maximum time of a single event.
      */
     double max(TimeUnit unit);
@@ -135,6 +142,30 @@ public interface Timer extends Meter {
     @Override
     default Type type() {
         return Type.Timer;
+    }
+
+
+    class TimerContext {
+        private final long startTime;
+        private final Clock clock;
+        private final Timer timer;
+
+        public TimerContext(Clock clock, Timer timer) {
+            this.clock = clock;
+            this.timer = timer;
+            this.startTime = clock.monotonicTime();
+        }
+
+        /**
+         * Records the duration of the operation
+         *
+         * @return The duration that was record in nanoseconds
+         */
+        public long record(){
+            long durationNs = clock.monotonicTime() - startTime;
+            timer.record(durationNs, TimeUnit.NANOSECONDS);
+            return durationNs;
+        }
     }
 
     static Builder builder(String name) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -84,6 +84,11 @@ class CompositeTimer extends AbstractCompositeMeter<Timer> implements Timer {
     }
 
     @Override
+    public TimerContext time() {
+        return firstChild().time();
+    }
+
+    @Override
     public long count() {
         return firstChild().count();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopTimer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.noop;
 
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.HistogramSnapshot;
 import io.micrometer.core.instrument.Timer;
 
@@ -44,6 +45,11 @@ public class NoopTimer extends NoopMeter implements Timer {
     @Override
     public void record(Runnable f) {
         f.run();
+    }
+
+    @Override
+    public TimerContext time() {
+        return new TimerContext(Clock.SYSTEM, this);
     }
 
     @Override

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/TimerTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/TimerTest.java
@@ -99,6 +99,22 @@ interface TimerTest {
         }
     }
 
+
+    @Test
+    @DisplayName("record with TimerContext")
+    default void recordWithTimerContext(MeterRegistry registry) throws Exception {
+        Timer timer = registry.timer("myTimer");
+        Timer.TimerContext t = timer.time();
+
+        clock(registry).add(10, TimeUnit.NANOSECONDS);
+
+        long duration = t.record();
+        clock(registry).add(step());
+
+        assertAll(() -> assertEquals(1L, timer.count()),
+            () -> assertEquals(10, timer.totalTime(TimeUnit.NANOSECONDS) ,1.0e-12));
+    }
+
     @Test
     default void recordMax(MeterRegistry registry) {
         Timer timer = registry.timer("my.timer");


### PR DESCRIPTION
TimerContext::record returns the duration as nanos to be used in cases like logging

Address #339 

Usage:

```
TimerContext timer = registry.timer("myTimer").time();
// do work
t.record();
```