### PR TITLE
Add xmx limit for circleci builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,13 @@ subprojects {
 
     def check = tasks.findByName('check')
     if(check) project.rootProject.tasks.releaseCheck.dependsOn check
+
+    //noinspection GroovyAssignabilityCheck
+    test {
+        // set heap size for the test JVM(s)
+        maxHeapSize = "1500m"
+    }
+
 }
 
 task wrapper(type: Wrapper) {

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
   java:
     version: oraclejdk8
 test:


### PR DESCRIPTION
Docs: https://circleci.com/docs/1.0/oom/#out-of-memory-errors-in-android-builds

Hopefully this will keep circle from killing the builds sporatically