### PR TITLE
Add alternative naming convention for Prometheus

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDurationNamingConvention.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDurationNamingConvention.java
@@ -1,0 +1,8 @@
+package io.micrometer.prometheus;
+
+public class PrometheusDurationNamingConvention extends PrometheusNamingConvention {
+
+    public PrometheusDurationNamingConvention() {
+        super("_duration");
+    }
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusDurationNamingConventionTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusDurationNamingConventionTest.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheus;
+
+import io.micrometer.core.instrument.Meter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Clint Checketts
+ */
+class PrometheusDurationNamingConventionTest {
+    private PrometheusNamingConvention convention = new PrometheusDurationNamingConvention();
+
+    @Test
+    void unitsAreAppendedToTimers() {
+        assertThat(convention.name("timer", Meter.Type.Timer)).isEqualTo("timer_duration_seconds");
+        assertThat(convention.name("timer", Meter.Type.LongTaskTimer)).isEqualTo("timer_duration_seconds");
+    }
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusNamingConventionTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusNamingConventionTest.java
@@ -38,8 +38,9 @@ class PrometheusNamingConventionTest {
 
     @Test
     void unitsAreAppendedToTimers() {
-        assertThat(convention.name("timer", Meter.Type.Timer)).isEqualTo("timer_duration_seconds");
-        assertThat(convention.name("timer", Meter.Type.LongTaskTimer)).isEqualTo("timer_duration_seconds");
+        assertThat(convention.name("timer", Meter.Type.Timer)).isEqualTo("timer_seconds");
+        assertThat(convention.name("timer", Meter.Type.LongTaskTimer)).isEqualTo("timer_seconds");
+        assertThat(convention.name("timer.duration", Meter.Type.LongTaskTimer)).isEqualTo("timer_duration_seconds");
     }
 
     @Test


### PR DESCRIPTION
Replaces #269 

FYI @thattolleyguy

This defaults the implementation that doesn't add `_duration`