### PR TITLE
Fix samples after recent refactoring

### DIFF
--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/AtlasSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/AtlasSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class AtlasSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/AtlasSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/AtlasSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class AtlasSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/DatadogSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/DatadogSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class DatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/DatadogSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/DatadogSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class DatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/InfluxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/InfluxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class InfluxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/InfluxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/InfluxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class InfluxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/JmxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/JmxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class JmxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/JmxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/JmxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class JmxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/NewRelicSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/NewRelicSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class NewRelicSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/NewRelicSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/NewRelicSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class NewRelicSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/PrometheusSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/PrometheusSample.java
@@ -21,7 +21,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class PrometheusSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/PrometheusSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/PrometheusSample.java
@@ -21,7 +21,9 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class PrometheusSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SignalfxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SignalfxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class SignalfxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SignalfxSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SignalfxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class SignalfxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SimpleSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SimpleSample.java
@@ -22,7 +22,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class SimpleSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SimpleSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/SimpleSample.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.boot1.samples;
 
+import io.micrometer.boot1.samples.components.PersonController;
 import io.micrometer.core.instrument.histogram.pause.NoPauseDetector;
 import io.micrometer.spring.autoconfigure.MeterRegistryConfigurer;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -22,7 +23,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class SimpleSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdDatadogSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdDatadogSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class StatsdDatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdDatadogSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdDatadogSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class StatsdDatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdTelegrafSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdTelegrafSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
+import io.micrometer.boot1.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class StatsdTelegrafSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdTelegrafSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/StatsdTelegrafSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot1.samples.components")
 @EnableScheduling
 public class StatsdTelegrafSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/AtlasSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/AtlasSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class AtlasSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/AtlasSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/AtlasSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class AtlasSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DatadogSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DatadogSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class DatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DatadogSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/DatadogSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class DatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/InfluxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/InfluxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class InfluxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/InfluxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/InfluxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class InfluxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/JmxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/JmxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class JmxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/JmxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/JmxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class JmxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/NewRelicSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/NewRelicSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class NewRelicSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/NewRelicSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/NewRelicSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class NewRelicSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/PrometheusSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/PrometheusSample.java
@@ -21,7 +21,9 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class PrometheusSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/PrometheusSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/PrometheusSample.java
@@ -21,7 +21,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class PrometheusSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SignalfxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SignalfxSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class SignalfxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SignalfxSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SignalfxSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class SignalfxSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
@@ -22,7 +22,7 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class SimpleSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
@@ -15,14 +15,16 @@
  */
 package io.micrometer.boot2.samples;
 
-import io.micrometer.core.instrument.histogram.pause.NoPauseDetector;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryConfigurer;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+import io.micrometer.core.instrument.histogram.pause.NoPauseDetector;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class SimpleSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdDatadogSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdDatadogSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class StatsdDatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdDatadogSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdDatadogSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class StatsdDatadogSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdTelegrafSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdTelegrafSample.java
@@ -19,7 +19,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
+import io.micrometer.boot2.samples.components.PersonController;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
 @EnableScheduling
 public class StatsdTelegrafSample {
     public static void main(String[] args) {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdTelegrafSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/StatsdTelegrafSample.java
@@ -19,7 +19,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication(scanBasePackages = "io.micrometer.spring.samples.components")
+@SpringBootApplication(scanBasePackages = "io.micrometer.boot2.samples.components")
 @EnableScheduling
 public class StatsdTelegrafSample {
     public static void main(String[] args) {


### PR DESCRIPTION
As I encounter that problem trying to explain why my application doesn't want to leverage the `@Timed` annotation :).

By the way I made them a little bit less fragile replacing `scanBasePackages` with `scanBasePackageClasses` (I abandoned the idea of creating an artificial class just to point to that package instead of `PersonController`).

To make it even safer there could be integrations tests enumerating the samples and trying to execute them.

Btw, if ran just a few of them, but one of them `JmxSample` for Spring Boot 2 still fails with:
```
 Exception encountered during context initialization - cancelling refresh attempt:
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean
with name  'personController' defined in file [/home/szpak/Code/pc/inne/micrometer/samples
/micrometer-samples-boot2/out/production/classes/io/micrometer/boot2/samples/components/PersonController.class]:
Unsatisfied dependency expressed through constructor parameter 0; nested exception is
org.springframework.beans.factory.BeanCreationException: Error creating bean with name
'compositeMeterRegistry' defined in class path resource [org/springframework/boot/actuate
/autoconfigure/metrics/MetricsAutoConfiguration.class]: Bean instantiation via factory method failed;
nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate
[io.micrometer.core.instrument.composite.CompositeMeterRegistry]: Factory method 
'compositeMeterRegistry' threw exception; nested exception is java.lang.NoSuchMethodError: 
io.micrometer.jmx.JmxMeterRegistry.<init>(Lio/micrometer/jmx/JmxConfig;Lio/micrometer
/core/instrument/util/HierarchicalNameMapper;Lio/micrometer/core/instrument/Clock;)V
```
due to a recent swapping arguments order in a `JmxMeterRegistry`. However, I may have some old snapshots cached.

Btw, I already accepted CLA.