### PR TITLE
Add configuration for domain and object name factory into JmxConfig

### DIFF
--- a/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxConfig.java
+++ b/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxConfig.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.jmx;
 
+import com.codahale.metrics.DefaultObjectNameFactory;
+import com.codahale.metrics.ObjectNameFactory;
 import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
 
 public interface JmxConfig extends DropwizardConfig {
@@ -26,5 +28,13 @@ public interface JmxConfig extends DropwizardConfig {
     @Override
     default String prefix() {
         return "jmx";
+    }
+
+    default String domain() {
+        return "metrics";
+    }
+
+    default ObjectNameFactory objectNameFactory() {
+        return new DefaultObjectNameFactory();
     }
 }

--- a/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxMeterRegistry.java
+++ b/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxMeterRegistry.java
@@ -38,7 +38,10 @@ public class JmxMeterRegistry extends DropwizardMeterRegistry {
     public JmxMeterRegistry(JmxConfig config, Clock clock, HierarchicalNameMapper nameMapper, MetricRegistry metricRegistry) {
         super(config, metricRegistry, nameMapper, clock);
 
-        this.reporter = JmxReporter.forRegistry(getDropwizardRegistry()).build();
+        this.reporter = JmxReporter.forRegistry(getDropwizardRegistry())
+            .inDomain(config.domain())
+            .createsObjectNamesWith(config.objectNameFactory())
+            .build();
         this.reporter.start();
     }
 


### PR DESCRIPTION
I am currently missing possibility to specify `domain` and `ObjectNameFactory` for `JmxReporter` inside `JmxMeterRegistry`. Do you think we can add it into `JmxConfig`?