### PR TITLE
Simplify record(Supplier) in LongTaskTimer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -71,7 +71,7 @@ public interface LongTaskTimer extends Meter {
      * @param f Function to execute and measure the execution time.
      * @return The return value of `f`.
      */
-    default <T> T record(Supplier<T> f) throws Exception {
+    default <T> T record(Supplier<T> f) {
         Sample sample = start();
         try {
             return f.get();


### PR DESCRIPTION
There is no need to declare throwing checked exception. It seems to be copied from `recordCallable()` placed above. The same method in `Timer` doesn't do that.