### PR TITLE
Wavefront - beta push

### DIFF
--- a/implementations/micrometer-registry-wavefront/build.gradle
+++ b/implementations/micrometer-registry-wavefront/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
     compile project(':micrometer-core')
+    compile 'com.fasterxml.jackson.core:jackson-databind:latest.release'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -25,6 +25,9 @@ import java.time.Duration;
 public interface WavefrontConfig extends StepRegistryConfig {
     WavefrontConfig DEFAULT = k -> null;
 
+    // mode to specify whether to use wavefront proxy or submit directly
+    public enum mode {proxy, direct};
+
     @Override
     default Duration step() {
         String v = get(prefix() + ".step");
@@ -61,6 +64,23 @@ public interface WavefrontConfig extends StepRegistryConfig {
     default boolean enableHistograms() {
         String v = get(prefix() + ".enableHistograms");
         return v == null || Boolean.valueOf(v);
+    }
+
+    default mode mode() {
+        String v = get(prefix() + ".mode");
+        return v == null ? mode.proxy : mode.valueOf(v);
+    }
+
+    @Nullable
+    default String apitoken() {
+        String v = get(prefix() + ".apitoken");
+        return v == null ? null : v.trim().length() > 0 ? v : null;
+    }
+
+    @Nullable
+    default String apihost() {
+        String v = get(prefix() + ".apihost");
+        return v == null ? null : v.trim().length() > 0 ? v : null;
     }
 
     /**

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -26,7 +26,7 @@ public interface WavefrontConfig extends StepRegistryConfig {
     WavefrontConfig DEFAULT = k -> null;
 
     // mode to specify whether to use wavefront proxy or submit directly
-    public enum mode {proxy, direct};
+    public enum mode {proxy, direct, pcf};
 
     @Override
     default Duration step() {
@@ -81,6 +81,12 @@ public interface WavefrontConfig extends StepRegistryConfig {
     default String apihost() {
         String v = get(prefix() + ".apihost");
         return v == null ? null : v.trim().length() > 0 ? v : null;
+    }
+
+    @Nullable
+    default String servicename() {
+        String v = get(prefix() + ".servicename");
+        return v == null ? "wavefront-proxy" : v.trim().length() > 0 ? v : "wavefront-proxy";
     }
 
     /**

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/SimpleSample.java
@@ -16,11 +16,8 @@
 package io.micrometer.boot2.samples;
 
 import io.micrometer.boot2.samples.components.PersonController;
-import io.micrometer.core.instrument.histogram.pause.NoPauseDetector;
-import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryConfigurer;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackageClasses = PersonController.class)
@@ -28,10 +25,5 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class SimpleSample {
     public static void main(String[] args) {
         new SpringApplicationBuilder(SimpleSample.class).profiles("simple").run(args);
-    }
-
-    @Bean
-    public MeterRegistryConfigurer configurer() {
-        return r -> r.config().pauseDetector(new NoPauseDetector());
     }
 }

--- a/samples/micrometer-samples-boot2/src/main/resources/application-wavefront.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application-wavefront.yml
@@ -16,7 +16,7 @@
 
 management.metrics.export.wavefront:
   enabled: true
-  # [proxy|direct]
+  # [proxy|direct|pcf]
   mode: proxy
   # proxy settings
   host: localhost
@@ -24,6 +24,8 @@ management.metrics.export.wavefront:
   # direct settings
   apihost: try.wavefront.com
   apitoken: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  # pcf setting
+  servicename: wavefront-proxy
   step: PT10S
   test: false
   nameprefix: micrometer

--- a/samples/micrometer-samples-boot2/src/main/resources/application-wavefront.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application-wavefront.yml
@@ -16,8 +16,14 @@
 
 management.metrics.export.wavefront:
   enabled: true
+  # [proxy|direct]
+  mode: proxy
+  # proxy settings
   host: localhost
   port: 2878
+  # direct settings
+  apihost: try.wavefront.com
+  apitoken: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
   step: PT10S
   test: false
   nameprefix: micrometer


### PR DESCRIPTION
New configuration : mode between proxy and direct mode.
apitoken and apihost to define api end point when direct mode is used (default is proxy mode).

IMPORTANT NOTE: Wavefront's direct mode uses JSON as its message payload, and each metric being reported looks like this:
`
{
  "aws.rds.ext.metric1": {
    "value": 2,
    "tags": {
      "accountId": "293993588345",
      "DatabaseClass": "db.m3.medium"
    }
  },
  "aws.rds.ext.metric2": {
    "value": 1000,
    "tags": {
      "accountId": "293993588345",
      "DatabaseClass": "db.m3.medium"
    }
  }
}
`
There exists a potential problem when using direct load, that if the name of the metrics are identical, it would cause JSON parsing error, as each object name should be unique. However, I've seen there are metrics which gets reported together that has same name, but with different tag values. Various approaches can be made to solve that problem, but I would like to have it as an ongoing discussion, as I also would like to hear from others' opinions on that.