### PR TITLE
Prometheus actuator endpoint produces application/json

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
@@ -69,5 +69,10 @@ public class PrometheusExportConfiguration {
             CollectorRegistry collectorRegistry) {
             return new PrometheusScrapeEndpoint(collectorRegistry);
         }
+
+        @Bean
+        public PrometheusScrapeMvcEndpoint prometheusMvcEndpoint(PrometheusScrapeEndpoint delegate) {
+            return new PrometheusScrapeMvcEndpoint(delegate);
+        }
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusScrapeMvcEndpoint.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusScrapeMvcEndpoint.java
@@ -1,0 +1,18 @@
+package io.micrometer.spring.autoconfigure.export.prometheus;
+
+import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+
+public class PrometheusScrapeMvcEndpoint extends EndpointMvcAdapter {
+
+    PrometheusScrapeMvcEndpoint(PrometheusScrapeEndpoint delegate) {
+        super(delegate);
+    }
+
+    @GetMapping(produces = MediaType.TEXT_PLAIN_VALUE)
+    @Override
+    public Object invoke() {
+        return super.invoke();
+    }
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PrometheusEndpointIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PrometheusEndpointIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.micrometer.spring.autoconfigure;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = MetricsAutoConfigurationTest.MetricsApp.class,
+    properties = {"management.security.enabled=false"})
+public class PrometheusEndpointIntegrationTest {
+
+    @Autowired
+    TestRestTemplate testRestTemplate;
+
+    @Test
+    public void producesTextPlain() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN_VALUE);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<String> result = testRestTemplate.exchange("/prometheus", HttpMethod.GET, request, String.class);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+}


### PR DESCRIPTION
The prometheus actuator endpoint is registered by spring as producing application/json. Therefore it throws HTTP 406 if "Accept: text/plain" is added as header, even though it eventually produces text/plain.