### PR TITLE
Added auto-configuration for AsyncRestTemplate beans

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizer.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizer.java
@@ -17,7 +17,9 @@ package io.micrometer.spring.web.client;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplateHandler;
 
@@ -55,6 +57,16 @@ public class MetricsRestTemplateCustomizer implements RestTemplateCustomizer {
         templateHandler = this.interceptor.createUriTemplateHandler(templateHandler);
         restTemplate.setUriTemplateHandler(templateHandler);
         List<ClientHttpRequestInterceptor> interceptors = new ArrayList<>();
+        interceptors.add(this.interceptor);
+        interceptors.addAll(restTemplate.getInterceptors());
+        restTemplate.setInterceptors(interceptors);
+    }
+
+    public void customize(final AsyncRestTemplate restTemplate) {
+        UriTemplateHandler templateHandler = restTemplate.getUriTemplateHandler();
+        templateHandler = this.interceptor.createUriTemplateHandler(templateHandler);
+        restTemplate.setUriTemplateHandler(templateHandler);
+        List<AsyncClientHttpRequestInterceptor> interceptors = new ArrayList<>();
         interceptors.add(this.interceptor);
         interceptors.addAll(restTemplate.getInterceptors());
         restTemplate.setInterceptors(interceptors);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsConfigurationTest.java
@@ -25,21 +25,31 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = RestTemplateMetricsConfigurationTest.ClientApp.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = "security.ignored=/**")
+@SpringBootTest(classes = RestTemplateMetricsConfigurationTest.ClientApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+    "management.port=-1", // Disable the entire Spring Boot actuator, so that it does not get needlessly instrumented
+    "security.ignored=/**",
+})
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class RestTemplateMetricsConfigurationTest {
     @Autowired
     private MeterRegistry registry;
@@ -53,25 +63,39 @@ public class RestTemplateMetricsConfigurationTest {
     @Autowired
     private RestTemplateBuilder restTemplateBuilder;
 
+    @Autowired
+    private AsyncRestTemplate asyncClient;
+
+    private String rootUri;
+
     private RestTemplate client;
 
     @Before
     public void before() {
+        rootUri = "http://localhost:" + port;
         client = restTemplateBuilder
-            .rootUri("http://localhost:" + port)
+            .rootUri(rootUri)
             .build();
     }
 
     @Test
     public void restTemplatesCreatedWithBuilderAreInstrumented() {
         client.getForObject("/it/1", String.class);
-        registry.get("http.client.requests").meter();
+        assertThat(registry.get("http.client.requests").meters()).hasSize(1);
+    }
+
+    @Test
+    public void asyncRestTemplatesInContextAreInstrumented() throws Exception {
+        // There's no way to inject local server port retrospectively into the autowired async template bean,
+        // therefore a full absolute URI is used
+        asyncClient.getForEntity(rootUri + "/it/2", String.class).get();
+        assertThat(registry.get("http.client.requests").meters()).hasSize(1);
     }
 
     @Test
     public void afterMaxUrisReachedFurtherUrisAreDenied() {
         int maxUriTags = metricsProperties.getWeb().getClient().getMaxUriTags();
-        for(int i = 0; i < maxUriTags + 10; i++) {
+        for (int i = 0; i < maxUriTags + 10; i++) {
             client.getForObject("/it/" + i, String.class);
         }
 
@@ -87,8 +111,10 @@ public class RestTemplateMetricsConfigurationTest {
         }
 
         @Bean
-        public RestTemplate restTemplate(RestTemplateBuilder builder) {
-            return builder.build();
+        public AsyncRestTemplate asyncRestTemplate() {
+            final SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            requestFactory.setTaskExecutor(new SimpleAsyncTaskExecutor());
+            return new AsyncRestTemplate(requestFactory);
         }
     }
 


### PR DESCRIPTION
This adds metrics instrumentation to all `AsyncRestTemplate` bean instances registered in the spring context.
Previously, outbound asynchronous REST calls would not be automatically covered by metrics.