### PR TITLE
Fix sending metrics metadata to Datadog

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -89,11 +89,15 @@ class DatadogMetricMetadata {
         }
 
         if (descriptionsEnabled && id.getDescription() != null) {
-            body += ",\"description\":\"" + id.getDescription() + "\"";
+            body += ",\"description\":\"" + escapeQuotes(id.getDescription()) + "\"";
         }
 
         body += "}";
 
         return body;
+    }
+
+    private String escapeQuotes(String str) {
+        return str.replaceAll("\"","\\\"");
     }
 }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -98,6 +98,6 @@ class DatadogMetricMetadata {
     }
 
     private String escapeQuotes(String str) {
-        return str.replaceAll("\"","\\\"");
+        return str.replace("\"","\\\"");
     }
 }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.datadog;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DatadogMetricMetadataTest {
+
+    @Test
+    void escapesStringsInDescription() {
+        DatadogMetricMetadata metricMetadata = new DatadogMetricMetadata(new Meter.Id("name",
+                                                                                      Tags.of(Tag.of("key", "value")),
+                                                                                      null,
+                                                                                      "The \"recent cpu usage\" for the Java Virtual Machine process",
+                                                                                      Meter.Type.GAUGE),
+                                                                         Statistic.COUNT,
+                                                                         true,
+                                                                         null);
+
+        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"description\":\"The \\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
+    }
+
+}


### PR DESCRIPTION
Sending metadata to Datadog results in error message:

> i.m.datadog.DatadogMeterRegistry         : failed to send metric metadata: {"errors": ["request data must be valid JSON"]}

due to sending unescaped quotes in JSON strings, for example:

> {"type":"gauge","description":"The "recent cpu usage" for the whole system"}