### PR TITLE
Remove an unnecessary null check

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowLatencyHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/histogram/TimeWindowLatencyHistogram.java
@@ -67,8 +67,6 @@ public class TimeWindowLatencyHistogram extends TimeWindowHistogramBase<LatencyS
     @SuppressWarnings("ConstantConditions")
     @Override
     LatencyStats newBucket(HistogramConfig histogramConfig) {
-        requireNonNull(pauseDetector);
-
         return new LatencyStats.Builder()
             .pauseDetector(pauseDetector)
             .lowestTrackableLatency(histogramConfig.getMinimumExpectedValue())


### PR DESCRIPTION
This PR removes an unnecessary `null` check as it has been already checked in its initialisation.