### PR TITLE
StatsD: Always publish unchanged meters 

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -8,4 +8,5 @@ dependencies {
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor:reactor-test:3.1.2.RELEASE'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.0.0'
+    testCompile 'org.mockito:mockito-core:2.11.0'
 }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -118,4 +118,13 @@ public interface StatsdConfig extends MeterRegistryConfig {
         String v = get(prefix() + ".step");
         return v == null ? Duration.ofMinutes(1) : Duration.parse(v);
     }
+
+    /**
+     * Returns true if unchanged meters should be published to the StatsD server. Default is {@code true}.
+     */
+    default boolean publishUnchangedMeters() {
+        String v = get(prefix() + ".publishUnchangedMeters");
+        return v == null || Boolean.valueOf(v);
+    }
+
 }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
@@ -30,21 +30,24 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
     private final AtomicReference<Long> lastActive = new AtomicReference<>(Long.MIN_VALUE);
     private final AtomicReference<Double> lastDuration = new AtomicReference<>(Double.NEGATIVE_INFINITY);
 
-    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, Clock clock) {
+    private final boolean alwaysPublish;
+
+    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, Clock clock, boolean alwaysPublish) {
         super(id, clock);
         this.lineBuilder = lineBuilder;
         this.publisher = publisher;
+        this.alwaysPublish = alwaysPublish;
     }
 
     @Override
     public void poll() {
         long active = activeTasks();
-        if(lastActive.getAndSet(active) != active) {
+        if (alwaysPublish || lastActive.getAndSet(active) != active) {
             publisher.onNext(lineBuilder.gauge(active, Statistic.ACTIVE_TASKS));
         }
 
         double duration = duration(TimeUnit.MILLISECONDS);
-        if(lastDuration.getAndSet(duration) != duration) {
+        if (alwaysPublish || lastDuration.getAndSet(duration) != duration) {
             publisher.onNext(lineBuilder.gauge(duration, Statistic.DURATION));
         }
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -103,7 +103,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
-        StatsdGauge<T> gauge = new StatsdGauge<>(id, lineBuilder(id), publisher, obj, valueFunction);
+        StatsdGauge<T> gauge = new StatsdGauge<>(id, lineBuilder(id), publisher, obj, valueFunction, statsdConfig.publishUnchangedMeters());
         pollableMeters.add(gauge);
         return gauge;
     }
@@ -115,7 +115,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        StatsdLongTaskTimer ltt = new StatsdLongTaskTimer(id, lineBuilder(id), publisher, clock);
+        StatsdLongTaskTimer ltt = new StatsdLongTaskTimer(id, lineBuilder(id), publisher, clock, statsdConfig.publishUnchangedMeters());
         pollableMeters.add(ltt);
         return ltt;
     }

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
@@ -1,0 +1,53 @@
+package io.micrometer.statsd;
+
+import io.micrometer.core.instrument.Meter;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.*;
+
+class StatsdGaugeTest {
+
+
+    private AtomicInteger value = new AtomicInteger(1);
+
+    private StatsdLineBuilder lineBuilder = mock(StatsdLineBuilder.class);
+    private Subscriber<String> publisher = mock(Subscriber.class);
+
+    @Test
+    void shouldAlwaysPublishValue() {
+        StatsdGauge<?> alwaysPublishingGauge = gauge(true);
+
+        alwaysPublishingGauge.poll();
+        alwaysPublishingGauge.poll();
+
+        verify(publisher, times(2)).onNext(any());
+    }
+
+    @Test
+    void shoulOnlyPublishValue_WhenValueChanges() {
+        StatsdGauge<?> guagePublishingOnChange = gauge(false);
+
+        guagePublishingOnChange.poll();
+        guagePublishingOnChange.poll();
+
+        verify(publisher, times(1)).onNext(any());
+
+        //update value and expect the publisher to be called again
+        value.incrementAndGet();
+        guagePublishingOnChange.poll();
+
+
+        verify(publisher, times(2)).onNext(any());
+    }
+
+
+    private StatsdGauge<?> gauge(boolean alwaysPublish) {
+        Meter.Id meterId = new Meter.Id("test", Collections.emptyList(), null, null, Meter.Type.GAUGE);
+        return new StatsdGauge<>(meterId, lineBuilder, publisher, value, AtomicInteger::get, alwaysPublish);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
@@ -65,6 +65,11 @@ public class StatsdProperties {
      */
     private Integer queueSize = Integer.MAX_VALUE;
 
+    /**
+     * Enables or disables sending of unchanged meters to StatsD server
+     */
+    private Boolean publishUnchangedMeters = true;
+
     public Boolean getEnabled() {
         return this.enabled;
     }
@@ -119,6 +124,14 @@ public class StatsdProperties {
 
     public void setQueueSize(Integer queueSize) {
         this.queueSize = queueSize;
+    }
+
+    public Boolean getPublishUnchangedMeters() {
+        return publishUnchangedMeters;
+    }
+
+    public void setPublishUnchangedMeters(Boolean publishUnchangedMeters) {
+        this.publishUnchangedMeters = publishUnchangedMeters;
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -74,4 +74,9 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
         return get(StatsdProperties::getQueueSize, StatsdConfig.super::queueSize);
     }
 
+    @Override
+    public boolean publishUnchangedMeters() {
+        return get(StatsdProperties::getPublishUnchangedMeters, StatsdConfig.super::publishUnchangedMeters);
+    }
+
 }


### PR DESCRIPTION
`StatsdGauge` and `StatsdLongTaskTimer` were only publishing values when the values changed. This was in conflict with `deleteIdleStats` config option in StatsD server which enables deleting of stale metrics (metrics that weren't updated in last 10 seconds).

This PR adds `publishUnchangedMeters` setting that is propagated to both meters mentioned above. Default value is `true` which means by default these meters will publish values on every poll.

I wasn't sure how to test this so for now I just created a simple unit test for the `StatsdGauge` meter. I'm happy to add more tests if needed.

Fixes #403 

PS I will of course rebase and squash the commits to one once we're done here :)