### PR TITLE
Polish GarbageCollectionNotificationInfo guard in GC metrics binder

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -201,7 +201,7 @@ public class JvmGcMetrics implements MeterBinder {
             Class.forName("com.sun.management.GarbageCollectionNotificationInfo", false,
                 JvmGcMetrics.class.getClassLoader());
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (Throwable e) {
             // We are operating in a JVM without access to this level of detail
             logger.warn("GC notifications will not be available because " +
                 "com.sun.management.GarbageCollectionNotificationInfo is not present");


### PR DESCRIPTION
This is a minor polish of changes from #401.

It might be wise to catch `Throwable` instead of `ClassNotFoundException` in guard function, especially since this get evaluated during initialization. Whichever exceptional situation occurs while resolving `GarbageCollectionNotificationInfo`, the result should be `false`.

Spring's [`ClassUtils#isPresent`](https://github.com/spring-projects/spring-framework/blob/master/spring-core/src/main/java/org/springframework/util/ClassUtils.java#L344) also takes this approach.