### PR TITLE
Rename file descriptor metrics

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMetricRenameFilter.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMetricRenameFilter.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheus;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Converts known metric names from Micrometer's preferred name to Prometheus' preferred name.
+ *
+ * @author Tommy Ludwig
+ */
+public class PrometheusMetricRenameFilter implements MeterFilter {
+
+    private static final Map<String, String> MICROMETER_TO_PROMETHEUS_METRIC_NAMES = new HashMap<>();
+
+    static {
+        MICROMETER_TO_PROMETHEUS_METRIC_NAMES.put("process.fds.open", "process.open.fds");
+        MICROMETER_TO_PROMETHEUS_METRIC_NAMES.put("process.fds.max", "process.max.fds");
+    }
+
+    @Override
+    public Meter.Id map(Meter.Id id) {
+        String convertedMetricName = MICROMETER_TO_PROMETHEUS_METRIC_NAMES.get(id.getName());
+        return convertedMetricName == null ? id :
+            new Meter.Id(convertedMetricName, id.getTags(), id.getBaseUnit(), id.getDescription(), id.getType());
+    }
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMetricRenameFilterTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMetricRenameFilterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheus;
+
+import io.micrometer.core.instrument.Meter;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link PrometheusMetricRenameFilter}.
+ *
+ * @author Tommy Ludwig
+ */
+class PrometheusMetricRenameFilterTest {
+
+    private final PrometheusMetricRenameFilter filter = new PrometheusMetricRenameFilter();
+
+    @Test
+    void doesNotChangeUnrelatedMeter() {
+        Meter.Id original = new Meter.Id("system.cpu.count", Collections.emptyList(), null, null, Meter.Type.GAUGE);
+        Meter.Id actual = filter.map(original);
+        assertThat(actual).isEqualTo(original);
+    }
+
+    @Test
+    void doesChangeApplicableMeter() {
+        Meter.Id original = new Meter.Id("process.fds.open", Collections.emptyList(), null, null, Meter.Type.GAUGE);
+        Meter.Id actual = filter.map(original);
+        assertThat(actual).isNotEqualTo(original);
+        assertThat(actual.getName()).isEqualTo("process.open.fds");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
@@ -87,14 +87,14 @@ public class FileDescriptorMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         if (openFdsMethod != null) {
-            Gauge.builder("process.open.fds", osBean, x -> invoke(openFdsMethod))
+            Gauge.builder("process.fds.open", osBean, x -> invoke(openFdsMethod))
                 .tags(tags)
                 .description("The open file descriptor count")
                 .register(registry);
         }
 
         if (maxFdsMethod != null) {
-            Gauge.builder("process.max.fds", osBean, x -> invoke(maxFdsMethod))
+            Gauge.builder("process.fds.max", osBean, x -> invoke(maxFdsMethod))
                 .tags(tags)
                 .description("The maximum file descriptor count")
                 .register(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -40,8 +40,8 @@ class FileDescriptorMetricsTest {
         final OperatingSystemMXBean osBean = mock(UnsupportedOperatingSystemMXBean.class);
         new FileDescriptorMetrics(osBean, Tags.of("some", "tag")).bindTo(registry);
 
-        assertThat(registry.find("process.open.fds").gauge()).isNull();
-        assertThat(registry.find("process.max.fds").gauge()).isNull();
+        assertThat(registry.find("process.fds.open").gauge()).isNull();
+        assertThat(registry.find("process.fds.max").gauge()).isNull();
     }
 
     @Test
@@ -50,9 +50,9 @@ class FileDescriptorMetricsTest {
 
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 
-        assertThat(registry.get("process.open.fds").tags("some", "tag")
+        assertThat(registry.get("process.fds.open").tags("some", "tag")
             .gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("process.max.fds").tags("some", "tag")
+        assertThat(registry.get("process.fds.max").tags("some", "tag")
             .gauge().value()).isGreaterThan(0);
     }
 
@@ -62,8 +62,8 @@ class FileDescriptorMetricsTest {
 
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 
-        assertThat(registry.find("process.open.fds").gauge()).isNull();
-        assertThat(registry.find("process.max.fds").gauge()).isNull();
+        assertThat(registry.find("process.fds.open").gauge()).isNull();
+        assertThat(registry.find("process.fds.max").gauge()).isNull();
     }
 
     /** Represents a JVM implementation we do not currently support. */

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusExportConfiguration.java
@@ -19,6 +19,7 @@ import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheus.PrometheusMetricRenameFilter;
 import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
@@ -67,6 +68,12 @@ public class PrometheusExportConfiguration {
     public PrometheusMeterRegistry prometheusMeterRegistry(PrometheusConfig config, CollectorRegistry collectorRegistry,
                                                            Clock clock) {
         return new PrometheusMeterRegistry(config, collectorRegistry, clock);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public PrometheusMetricRenameFilter prometheusMetricRenameFilter() {
+        return new PrometheusMetricRenameFilter();
     }
 
     @Bean


### PR DESCRIPTION
(Hopefully) makes it more clear that the `open` and `max` part of the metric refers to file descriptors. This may also help querying these metrics since their prefix is now the same.

The `FileDescriptorMetrics` are also never being used, but I will send a separate pull request for that.