### PR TITLE
Configure the FileDescriptorMetrics automatically

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -77,6 +78,13 @@ class MeterBindersConfiguration {
     @ConditionalOnMissingBean
     public ProcessorMetrics processorMetrics() {
         return new ProcessorMetrics();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "management.metrics.binders.fds.enabled", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    public FileDescriptorMetrics fileDescriptorMetrics() {
+        return new FileDescriptorMetrics();
     }
 
 }


### PR DESCRIPTION
Conditionally configures the `FileDescriptorMetrics` as long as it is not disabled or configured in user code.