### PR TITLE
Fix Jigsaw compatibility for FileDescriptorMetrics and ProcessorMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
@@ -27,19 +27,38 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 
 import static java.util.Collections.emptyList;
 
 /**
- * File descriptor metrics.
+ * File descriptor metrics gathered by the JVM.
+ * <p>
+ * Supported JVM implementations:
+ * <ul>
+ *     <li>HotSpot</li>
+ *     <li>J9</li>
+ * </ul>
  *
  * @author Michael Weirauch
+ * @author Tommy Ludwig
  */
 @NonNullApi
 @NonNullFields
 public class FileDescriptorMetrics implements MeterBinder {
+
+    /** List of public, exported interface class names from supported JVM implementations. */
+    private static final List<String> UNIX_OPERATING_SYSTEM_BEAN_CLASS_NAMES = Arrays.asList(
+        "com.sun.management.UnixOperatingSystemMXBean", // HotSpot
+        "com.ibm.lang.management.UnixOperatingSystemMXBean" // J9
+    );
+
     private final OperatingSystemMXBean osBean;
     private final Iterable<Tag> tags;
+
+    @Nullable
+    private final Class<?> osBeanClass;
 
     @Nullable
     private final Method openFdsMethod;
@@ -60,6 +79,7 @@ public class FileDescriptorMetrics implements MeterBinder {
         this.osBean = osBean;
         this.tags = tags;
 
+        this.osBeanClass = getFirstClassFound(UNIX_OPERATING_SYSTEM_BEAN_CLASS_NAMES);
         this.openFdsMethod = detectMethod("getOpenFileDescriptorCount");
         this.maxFdsMethod = detectMethod("getMaxFileDescriptorCount");
     }
@@ -91,12 +111,26 @@ public class FileDescriptorMetrics implements MeterBinder {
 
     @Nullable
     private Method detectMethod(String name) {
-        try {
-            final Method method = osBean.getClass().getDeclaredMethod(name);
-            method.setAccessible(true);
-            return method;
-        } catch (NoSuchMethodException | SecurityException e) {
+        if (osBeanClass == null) {
             return null;
         }
+        try {
+            // ensure the Bean we have is actually an instance of the interface
+            osBeanClass.cast(osBean);
+            return osBeanClass.getDeclaredMethod(name);
+        } catch (ClassCastException | NoSuchMethodException | SecurityException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private Class<?> getFirstClassFound(List<String> classNames) {
+        for (String className : classNames) {
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException ignore) {
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
![jigsaw crash](https://media.giphy.com/media/tMMv9uqoWVAti/giphy.gif "Jigsaw")

I noticed that some of the JVM-gathered metrics were not Jigsaw compatible and were effectively disabled (or worse, throwing exceptions) on Java 9+. I've done my best to make these compatible with jigsaw, which should allow them to work with Java 9 and beyond.

- using reflection on only public, exported classes' methods (not methods in internal implementation classes)
- do not `import` a specific JVM class

This thread on the same issue was enlightening: http://mail.openjdk.java.net/pipermail/jigsaw-dev/2015-September/004568.html

I don't have a J9 JDK installation to properly test out that support (is there any easy way to get one on OSX?)

Another consequence of this change is that we have to explicitly support JVM flavors by adding their public, exported interface class to the list (which hopefully uses the same method names). Before, if the code ran on Java 8, it could work with any JVM implementation class that used the expected method names. This isn't viable post-Jigsaw unless the implementation class returned from `ManagementFactory.getOperatingSystemMXBean()` is exported, which is not generally expected.

It might be a good idea to consider introducing something like https://github.com/policeman-tools/forbidden-apis and/or switching the build to run with JDK9 and use the compiler flag `release` to target `1.8`, which [is what JUnit 5 does](https://github.com/junit-team/junit5/blob/a1463d903ab9d4ce249f463081e27bd2035643f4/gradle.properties#L13-L17).

/cc @jkschneider @mweirauch 