### PR TITLE
Added auto-configuration for ClassLoaderMetrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'checkstyle'
 
+    compileJava.options.encoding = 'UTF-8'
+    compileTestJava.options.encoding = 'UTF-8'
+
     if(!project.name.contains('samples')) {
         apply plugin: 'io.spring.publishing'
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
@@ -16,6 +16,7 @@
 package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
@@ -55,6 +56,13 @@ class MeterBindersConfiguration {
     @ConditionalOnMissingBean
     public JvmThreadMetrics jvmThreadMetrics() {
         return new JvmThreadMetrics();
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "management.metrics.binders.jvm.enabled", matchIfMissing = true)
+    @ConditionalOnMissingBean
+    public ClassLoaderMetrics classLoaderMetrics() {
+        return new ClassLoaderMetrics();
     }
 
     @Bean

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -18,8 +18,12 @@ package io.micrometer.spring.autoconfigure;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,7 +94,12 @@ public class MetricsAutoConfigurationTest {
     public void automaticallyRegisteredBinders() {
         assertThat(context.getBeansOfType(MeterBinder.class).values())
             .hasAtLeastOneElementOfType(LogbackMetrics.class)
-            .hasAtLeastOneElementOfType(JvmMemoryMetrics.class);
+            .hasAtLeastOneElementOfType(JvmGcMetrics.class)
+            .hasAtLeastOneElementOfType(JvmGcMetrics.class)
+            .hasAtLeastOneElementOfType(JvmThreadMetrics.class)
+            .hasAtLeastOneElementOfType(ClassLoaderMetrics.class)
+            .hasAtLeastOneElementOfType(UptimeMetrics.class)
+            .hasAtLeastOneElementOfType(ProcessorMetrics.class);
     }
 
     @Test


### PR DESCRIPTION
For some reason, `ClassLoaderMetrics` was left out of the default configuration.
I assume it was simply an omission rather than a deliberate exclusion.

I also had to enforce source encoding as UTF-8 in Gradle, because `WavefrontNamingConventionTest` containing Japanese characters kept failing on my Windows PC.