### PR TITLE
Specify urlTemplate is nullable (fixed #453)

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProvider.java
@@ -32,9 +32,9 @@ public class DefaultRestTemplateExchangeTagsProvider
     implements RestTemplateExchangeTagsProvider {
 
     @Override
-    public Iterable<Tag> getTags(String urlTemplate, HttpRequest request,
+    public Iterable<Tag> getTags(@Nullable String urlTemplate, HttpRequest request,
                                  @Nullable ClientHttpResponse response) {
-        Tag uriTag = StringUtils.hasText(urlTemplate)
+        Tag uriTag = urlTemplate != null && StringUtils.hasText(urlTemplate)
             ? RestTemplateExchangeTags.uri(urlTemplate)
             : RestTemplateExchangeTags.uri(request);
         return Arrays.asList(RestTemplateExchangeTags.method(request), uriTag,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/MetricsClientHttpRequestInterceptor.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/MetricsClientHttpRequestInterceptor.java
@@ -118,7 +118,7 @@ class MetricsClientHttpRequestInterceptor implements ClientHttpRequestIntercepto
         };
     }
 
-    private Timer.Builder getTimeBuilder(String urlTemplate, HttpRequest request,
+    private Timer.Builder getTimeBuilder(@Nullable String urlTemplate, HttpRequest request,
                                          @Nullable ClientHttpResponse response) {
         return Timer.builder(this.metricName)
                 .tags(this.tagProvider.getTags(urlTemplate, request, response))

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTagsProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTagsProvider.java
@@ -39,7 +39,7 @@ public interface RestTemplateExchangeTagsProvider {
      * @param response    the response (may be {@code null} if the exchange failed)
      * @return the tags
      */
-    Iterable<Tag> getTags(String urlTemplate, HttpRequest request,
+    Iterable<Tag> getTags(@Nullable String urlTemplate, HttpRequest request,
                           @Nullable ClientHttpResponse response);
 
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProviderTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProviderTest.java
@@ -1,0 +1,53 @@
+package io.micrometer.spring.web.client;
+
+import io.micrometer.core.instrument.Tag;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultRestTemplateExchangeTagsProviderTest {
+
+    private DefaultRestTemplateExchangeTagsProvider tagsProvider = new DefaultRestTemplateExchangeTagsProvider();
+
+    private MockClientHttpRequest httpRequest = new MockClientHttpRequest();
+    private ClientHttpResponse httpResponse = new MockClientHttpResponse(new byte[]{}, HttpStatus.OK);
+
+    @Before
+    public void before() throws URISyntaxException {
+        httpRequest.setMethod(HttpMethod.GET);
+        httpRequest.setURI(new URI("http://localhost/test/123"));
+    }
+
+    @Test
+    public void uriTagSetFromUriTemplate() {
+        Iterable<Tag> tags = tagsProvider.getTags("/test/{id}", httpRequest, httpResponse);
+
+        assertThat(tags).contains(Tag.of("uri", "/test/{id}"));
+    }
+
+    @Test
+    public void uriTagSetFromRequestWhenNoUriTemplate() {
+        Iterable<Tag> tags = tagsProvider.getTags(null, httpRequest, httpResponse);
+
+        assertThat(tags).contains(Tag.of("uri", "/test/123"));
+    }
+
+    @Test
+    public void uriTagSetFromRequestWhenUriTemplateIsBlank() {
+        Iterable<Tag> tags = tagsProvider.getTags(" ", httpRequest, httpResponse);
+
+        assertThat(tags).contains(Tag.of("uri", "/test/123"));
+    }
+}


### PR DESCRIPTION
urlTemplate was previously not nullable but as of 1.0.0
a null is now provided to RestTemplateExchangeTagsProvider
when a URI is used with RestTemplate.