### PR TITLE
influx: create db inside try (fixes #379)

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -90,9 +90,9 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected void publish() {
-        createDatabaseIfNecessary();
-
         try {
+            createDatabaseIfNecessary();
+
             String write = "/write?consistency=" + config.consistency().toString().toLowerCase() + "&precision=ms&db=" + config.db();
             if (config.retentionPolicy() != null) {
                 write += "&rp=" + config.retentionPolicy();


### PR DESCRIPTION
the `createDatabaseIfNecessary()` method should also be wrapped with try-catch