### PR TITLE
Influx: createDatabaseIfNecessary catching Throwable (fixes #379)

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -81,7 +81,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                             .lines().collect(joining("\n")));
                 }
             }
-        } catch (IOException e) {
+        } catch (Throwable e) {
             logger.warn("unable to create database '{}'", config.db(), e);
         } finally {
             quietlyCloseUrlConnection(con);


### PR DESCRIPTION
Catching Throwable inside `createDatabaseIfNecessary()` is an alternative for https://github.com/micrometer-metrics/micrometer/pull/460