### PR TITLE
Influx registry improvements

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -22,6 +22,8 @@ import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.DoubleFormat;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.lang.Nullable;
+
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,7 +98,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
         try {
             String write = "/write?consistency=" + config.consistency().toString().toLowerCase() + "&precision=ms&db=" + config.db();
-            if (config.retentionPolicy() != null) {
+            if (StringUtils.isNotBlank(config.retentionPolicy())) {
                 write += "&rp=" + config.retentionPolicy();
             }
             URL influxEndpoint = URI.create(config.uri() + write).toURL();

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -84,7 +84,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 }
             }
         } catch (Throwable e) {
-            logger.warn("unable to create database '{}'", config.db(), e);
+            logger.error("unable to create database '{}'", config.db(), e);
         } finally {
             quietlyCloseUrlConnection(con);
         }
@@ -181,7 +181,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Malformed InfluxDB publishing endpoint, see '" + config.prefix() + ".uri'", e);
         } catch (Throwable e) {
-            logger.warn("failed to send metrics", e);
+            logger.error("failed to send metrics", e);
         }
     }
 


### PR DESCRIPTION
Here I solve two problems that I encountered when trying to inject the environment variable with retention policy.

My goal is to allow to specify retention policy through an env var, called for example INFLUX_RET_POLICY. And default policy should be used if there's no such var defined. To do that I firstly tried (knowing that it's wrong, just for test) to set the property like that:
`management.metrics.export.influx.retentionPolicy=${INFLUX_RET_POLICY}` and tested what happens when there's no such variable defined.

As a result the placeholder was not resolved and the `config.retentionPolicy()` was eqal to "${INFLUX_RET_POLICY}". Which in turn resulted in a wrong URL and publishing metrics failed. But as my logging level for `InfluxMeterRegistry` was set to `ERROR`, I saw nothing in logs. So first commit is to fix that.

Then I changed the property to `${INFLUX_RET_POLICY:}` which was resolved as empty string. For example in Telegraf that's the way for using default policy. But not here. I had to change null check for empty-string check.