### PR TITLE
make DoubleFormat independent of default locale for WHOLE_OR_DECIMAL

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
@@ -51,8 +51,11 @@ public class DoubleFormat {
         return numberFormatter;
     });
 
-    private static final ThreadLocal<DecimalFormat> WHOLE_OR_DECIMAL = ThreadLocal.withInitial(() ->
-            new DecimalFormat("##0.######"));
+    private static final ThreadLocal<DecimalFormat> WHOLE_OR_DECIMAL = ThreadLocal.withInitial(() -> {
+        // the following will ensure a dot ('.') as decimal separator
+        DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols(Locale.US);
+        return new DecimalFormat("##0.######",otherSymbols);
+    });
 
     /**
      * @param d Number to format.


### PR DESCRIPTION
When I ran the test cases on a system with default locale set to German, the test DoubleFormatTest failed as _DoubleFormat.decimalOrWhole(123456.1234567)_ returned _123456,123457_ (with a comma).

I updated _DoubleFormat_ to always use US locale and therefore a dot instead of a comma. I suppose this is the intended behavior.

/cc: @jkschneider as you seem to be the original author of the class and the commits.

(might be a bug already present in 1.0.1?)