### PR TITLE
TimedAspect should support @Timed histogram

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -73,6 +73,7 @@ public class TimedAspect {
                     .description(timed.description().isEmpty() ? null : timed.description())
                     .tags(timed.extraTags())
                     .tags(tagsBasedOnJoinpoint.apply(pjp))
+                    .publishPercentileHistogram(timed.histogram())
                     .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
                     .register(registry));
         }


### PR DESCRIPTION
If you use TimedAspect, it doesn't use the histogram attribute. 

This PR adds the functionality. I would add a test case but I don't know how. 

I tried _TimedAspectTest_ and _registry.get("something").timer()_, but wasn't able to extract the necessary information from the timer instance.

A hint would be helpful - either a code snippet or a pointer to a test case that already achieves this.