### PR TITLE
Introduced TimedInterceptor, fixes #493, revisit #494

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedAnnotationAdvisor.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedAnnotationAdvisor.java
@@ -1,0 +1,52 @@
+package io.micrometer.spring.advice;
+
+import io.micrometer.core.annotation.Timed;
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.springframework.aop.Pointcut;
+import org.springframework.aop.support.AbstractPointcutAdvisor;
+import org.springframework.aop.support.ComposablePointcut;
+import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
+import org.springframework.aop.support.annotation.AnnotationMethodMatcher;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+public class TimedAnnotationAdvisor extends AbstractPointcutAdvisor {
+
+    private final Pointcut pointcut;
+    private final MethodInterceptor advice;
+
+    public TimedAnnotationAdvisor(TimedMethodInterceptor timedMethodInterceptor) {
+        Pointcut cpc = new AnnotationMatchingPointcut(Timed.class, true);
+        Pointcut mpc = new ComposablePointcut(new InheritedAnnotationMethodMatcher(Timed.class));
+        this.pointcut = new ComposablePointcut(cpc).union(mpc);
+        this.advice = timedMethodInterceptor;
+    }
+
+    @Override
+    public Pointcut getPointcut() {
+        return pointcut;
+    }
+
+    @Override
+    public Advice getAdvice() {
+        return advice;
+    }
+
+    private static class InheritedAnnotationMethodMatcher extends AnnotationMethodMatcher {
+
+        private Class<? extends Annotation> annotationType;
+
+        public InheritedAnnotationMethodMatcher(Class<? extends Annotation> annotationType) {
+            super(annotationType);
+            this.annotationType = annotationType;
+        }
+
+        @Override
+        public boolean matches(Method method, Class<?> targetClass) {
+            return AnnotationUtils.findAnnotation(method, annotationType) != null || super.matches(method, targetClass);
+        }
+    }
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedMethodInterceptor.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedMethodInterceptor.java
@@ -1,0 +1,88 @@
+package io.micrometer.spring.advice;
+
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Builder;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+
+public class TimedMethodInterceptor implements MethodInterceptor {
+    public static final String DEFAULT_METRIC_NAME = "method_timed";
+    private final MeterRegistry registry;
+    private final TimedMetricNameResolver timedMetricNameResolver;
+    private final TimedTagsResolver timedTagsResolver;
+
+    public TimedMethodInterceptor(MeterRegistry registry) {
+        this(registry, invocation ->
+            Tags.of("class", invocation.getMethod().getDeclaringClass().getSimpleName(),
+                    "method", invocation.getMethod().getName())
+        );
+    }
+
+    public TimedMethodInterceptor(MeterRegistry registry, TimedTagsResolver timedTagsResolver) {
+        this(registry, (metricName, invocation) -> metricName, timedTagsResolver);
+    }
+
+    public TimedMethodInterceptor(MeterRegistry registry, TimedMetricNameResolver timedMetricNameResolver, TimedTagsResolver timedTagsResolver) {
+        this.registry = registry;
+        this.timedMetricNameResolver = timedMetricNameResolver;
+        this.timedTagsResolver = timedTagsResolver;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        Method method = invocation.getMethod();
+        Timed methodLevelTimed = AnnotatedElementUtils.findMergedAnnotation(method, Timed.class);
+        Timed classLevelTimed = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), Timed.class);
+        if (methodLevelTimed == null) {
+            method = ReflectionUtils.findMethod(invocation.getThis().getClass(), method.getName(), method.getParameterTypes());
+            methodLevelTimed = AnnotatedElementUtils.findMergedAnnotation(method, Timed.class);
+        }
+        if (classLevelTimed == null && methodLevelTimed == null) {
+            return invocation.proceed();
+        }
+
+        Timer.Sample sample = Timer.start(registry);
+        final String metricName;
+        if (methodLevelTimed != null && !methodLevelTimed.value().isEmpty()) {
+            metricName = methodLevelTimed.value();
+        }
+        else if (classLevelTimed != null && !classLevelTimed.value().isEmpty()){
+            metricName = classLevelTimed.value();
+        }
+        else {
+            metricName = DEFAULT_METRIC_NAME;
+        }
+        Builder builder = Timer.builder(timedMetricNameResolver.apply(metricName, invocation));
+        if (methodLevelTimed != null) {
+            builder.description(methodLevelTimed.description().isEmpty() ? null : methodLevelTimed.description())
+                .publishPercentileHistogram(methodLevelTimed.histogram())
+                .publishPercentiles(methodLevelTimed.percentiles().length == 0 ? null : methodLevelTimed.percentiles());
+        }
+        else {
+            builder.description(classLevelTimed.description().isEmpty() ? null : classLevelTimed.description())
+                .publishPercentileHistogram(classLevelTimed.histogram())
+                .publishPercentiles(classLevelTimed.percentiles().length == 0 ? null : classLevelTimed.percentiles());
+        }
+
+        if (classLevelTimed != null) {
+            builder.tags(classLevelTimed.extraTags())
+                .tags(timedTagsResolver.apply(invocation));
+        }
+        if (methodLevelTimed != null) {
+            builder.tags(methodLevelTimed.extraTags())
+                .tags(timedTagsResolver.apply(invocation));
+        }
+        try {
+            return invocation.proceed();
+        } finally {
+            sample.stop(builder.register(registry));
+        }
+    }
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedMetricNameResolver.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedMetricNameResolver.java
@@ -1,0 +1,8 @@
+package io.micrometer.spring.advice;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.util.function.BiFunction;
+
+public interface TimedMetricNameResolver extends BiFunction<String, MethodInvocation, String> {
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedTagsResolver.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/advice/TimedTagsResolver.java
@@ -1,0 +1,9 @@
+package io.micrometer.spring.advice;
+
+import io.micrometer.core.instrument.Tag;
+import org.aopalliance.intercept.MethodInvocation;
+
+import java.util.function.Function;
+
+public interface TimedTagsResolver extends Function<MethodInvocation, Iterable<Tag>> {
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
@@ -1,0 +1,226 @@
+package io.micrometer.spring.advice;
+
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimedMethodInterceptorTest {
+
+    private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    @AfterEach
+    public void after() throws Exception {
+        context.close();
+    }
+
+    @Test
+    public void testExplicitMetricName() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        TimedService service = context.getBean(TimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithExplicitValue();
+        assertThat(registry.get("something")
+            .tag("class", "TimedService")
+            .tag("method", "timeWithExplicitValue")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testDefaultMetricName() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        TimedService service = context.getBean(TimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithoutValue();
+        assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
+            .tag("class", "TimedService")
+            .tag("method", "timeWithoutValue")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testInterfaceMethodTimed() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        TimedInterface service = context.getBean(TimedInterface.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeOnInterface();
+        assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
+            .tag("class", "TimedService")
+            .tag("method", "timeOnInterface")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testCustomNameAndTagResolvers() {
+        context.register(CustomizedTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        TimedService service = context.getBean(TimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithoutValue();
+        assertThat(registry.get("method.invoke")
+            .tag("test", "tag")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testClassTimed() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        AnnotatedTimedService service = context.getBean(AnnotatedTimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithoutValue();
+        assertThat(registry.get("class.invoke")
+            .tag("class", "AnnotatedTimedService")
+            .tag("method", "timeWithoutValue")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testMethodLevelMetricName() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        AnnotatedTimedService service = context.getBean(AnnotatedTimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithMethodLevelName();
+        assertThat(registry.get("my.method")
+            .tag("class", "AnnotatedTimedService")
+            .tag("method", "timeWithMethodLevelName")
+            .tag("extra", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void testMergedClassAndMethodTags() {
+        context.register(DefaultTimedMethodInterceptorConfig.class);
+        context.refresh();
+
+        AnnotatedTimedService service = context.getBean(AnnotatedTimedService.class);
+        MeterRegistry registry = context.getBean(MeterRegistry.class);
+
+        service.timeWithMergedTags();
+        assertThat(registry.get("class.invoke")
+            .tag("class", "AnnotatedTimedService")
+            .tag("method", "timeWithMergedTags")
+            .tag("extra", "tag")
+            .tag("extra2", "tag")
+            .timer().count()).isEqualTo(1);
+    }
+
+    @Configuration
+    @EnableAspectJAutoProxy(proxyTargetClass = true)
+    @Import({ TimedService.class, AnnotatedTimedService.class })
+    static class DefaultTimedMethodInterceptorConfig {
+        @Bean
+        public SimpleMeterRegistry simpleMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        public TimedMethodInterceptor timedMethodInterceptor(MeterRegistry meterRegistry) {
+            return new TimedMethodInterceptor(meterRegistry);
+        }
+
+        @Bean
+        public TimedAnnotationAdvisor timedAnnotationAdvisor(TimedMethodInterceptor timedMethodInterceptor) {
+            return new TimedAnnotationAdvisor(timedMethodInterceptor);
+        }
+    }
+
+    @Configuration
+    @EnableAspectJAutoProxy(proxyTargetClass = true)
+    @Import({ TimedService.class, AnnotatedTimedService.class })
+    static class CustomizedTimedMethodInterceptorConfig {
+        @Bean
+        public SimpleMeterRegistry simpleMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        public TimedMethodInterceptor timedMethodInterceptor(MeterRegistry meterRegistry) {
+            return new TimedMethodInterceptor(meterRegistry, (metricName, invocation) -> "method.invoke", invocation -> Tags.of("test", "tag"));
+        }
+
+        @Bean
+        public TimedAnnotationAdvisor timedAnnotationAdvisor(TimedMethodInterceptor timedMethodInterceptor) {
+            return new TimedAnnotationAdvisor(timedMethodInterceptor);
+        }
+    }
+
+    interface TimedInterface {
+        String timeWithExplicitValue();
+
+        String timeWithoutValue();
+
+        @Timed(extraTags = { "extra", "tag" })
+        String timeOnInterface();
+    }
+
+    @Service
+    static class TimedService implements TimedInterface {
+        @Timed(value = "something", extraTags = { "extra", "tag" })
+        @Override
+        public String timeWithExplicitValue() {
+            return "I'm";
+        }
+
+        @Timed(extraTags = { "extra", "tag" })
+        @Override
+        public String timeWithoutValue() {
+            return "sorry";
+        }
+
+        @Override
+        public String timeOnInterface() {
+            return "Dave,";
+        }
+    }
+
+    @Timed(value = "class.invoke", description = "class description", extraTags = { "extra", "tag" })
+    @Service
+    static class AnnotatedTimedService {
+
+        public String timeWithoutValue() {
+            return "I can't";
+        }
+
+        @Timed("my.method")
+        public String timeWithMethodLevelName() {
+            return "do";
+        }
+
+        @Timed(extraTags = { "extra2", "tag" })
+        public String timeWithMergedTags() {
+            return "that";
+        }
+    }
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
@@ -1,6 +1,7 @@
 package io.micrometer.spring.advice;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -49,7 +50,7 @@ class TimedMethodInterceptorTest {
         MeterRegistry registry = context.getBean(MeterRegistry.class);
 
         service.timeWithoutValue();
-        assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
+        assertThat(registry.get(TimedAspect.DEFAULT_METRIC_NAME)
             .tag("class", "TimedServiceImpl")
             .tag("method", "timeWithoutValue")
             .tag("extra", "tag")
@@ -65,7 +66,7 @@ class TimedMethodInterceptorTest {
         MeterRegistry registry = context.getBean(MeterRegistry.class);
 
         service.timeOnInterface();
-        assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
+        assertThat(registry.get(TimedAspect.DEFAULT_METRIC_NAME)
             .tag("class", "TimedServiceImpl")
             .tag("method", "timeOnInterface")
             .tag("extra", "tag")

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/advice/TimedMethodInterceptorTest.java
@@ -34,7 +34,7 @@ class TimedMethodInterceptorTest {
 
         service.timeWithExplicitValue();
         assertThat(registry.get("something")
-            .tag("class", "TimedService")
+            .tag("class", "TimedServiceImpl")
             .tag("method", "timeWithExplicitValue")
             .tag("extra", "tag")
             .timer().count()).isEqualTo(1);
@@ -50,7 +50,7 @@ class TimedMethodInterceptorTest {
 
         service.timeWithoutValue();
         assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
-            .tag("class", "TimedService")
+            .tag("class", "TimedServiceImpl")
             .tag("method", "timeWithoutValue")
             .tag("extra", "tag")
             .timer().count()).isEqualTo(1);
@@ -61,12 +61,12 @@ class TimedMethodInterceptorTest {
         context.register(DefaultTimedMethodInterceptorConfig.class);
         context.refresh();
 
-        TimedInterface service = context.getBean(TimedInterface.class);
+        TimedService service = context.getBean(TimedService.class);
         MeterRegistry registry = context.getBean(MeterRegistry.class);
 
         service.timeOnInterface();
         assertThat(registry.get(TimedMethodInterceptor.DEFAULT_METRIC_NAME)
-            .tag("class", "TimedService")
+            .tag("class", "TimedServiceImpl")
             .tag("method", "timeOnInterface")
             .tag("extra", "tag")
             .timer().count()).isEqualTo(1);
@@ -97,7 +97,7 @@ class TimedMethodInterceptorTest {
 
         service.timeWithoutValue();
         assertThat(registry.get("class.invoke")
-            .tag("class", "AnnotatedTimedService")
+            .tag("class", "AnnotatedTimedServiceImpl")
             .tag("method", "timeWithoutValue")
             .tag("extra", "tag")
             .timer().count()).isEqualTo(1);
@@ -113,7 +113,7 @@ class TimedMethodInterceptorTest {
 
         service.timeWithMethodLevelName();
         assertThat(registry.get("my.method")
-            .tag("class", "AnnotatedTimedService")
+            .tag("class", "AnnotatedTimedServiceImpl")
             .tag("method", "timeWithMethodLevelName")
             .tag("extra", "tag")
             .timer().count()).isEqualTo(1);
@@ -129,7 +129,7 @@ class TimedMethodInterceptorTest {
 
         service.timeWithMergedTags();
         assertThat(registry.get("class.invoke")
-            .tag("class", "AnnotatedTimedService")
+            .tag("class", "AnnotatedTimedServiceImpl")
             .tag("method", "timeWithMergedTags")
             .tag("extra", "tag")
             .tag("extra2", "tag")
@@ -138,7 +138,7 @@ class TimedMethodInterceptorTest {
 
     @Configuration
     @EnableAspectJAutoProxy(proxyTargetClass = true)
-    @Import({ TimedService.class, AnnotatedTimedService.class })
+    @Import({ TimedServiceImpl.class, AnnotatedTimedServiceImpl.class })
     static class DefaultTimedMethodInterceptorConfig {
         @Bean
         public SimpleMeterRegistry simpleMeterRegistry() {
@@ -158,7 +158,7 @@ class TimedMethodInterceptorTest {
 
     @Configuration
     @EnableAspectJAutoProxy(proxyTargetClass = true)
-    @Import({ TimedService.class, AnnotatedTimedService.class })
+    @Import({ TimedServiceImpl.class, AnnotatedTimedServiceImpl.class })
     static class CustomizedTimedMethodInterceptorConfig {
         @Bean
         public SimpleMeterRegistry simpleMeterRegistry() {
@@ -176,7 +176,7 @@ class TimedMethodInterceptorTest {
         }
     }
 
-    interface TimedInterface {
+    interface TimedService {
         String timeWithExplicitValue();
 
         String timeWithoutValue();
@@ -186,7 +186,7 @@ class TimedMethodInterceptorTest {
     }
 
     @Service
-    static class TimedService implements TimedInterface {
+    static class TimedServiceImpl implements TimedService {
         @Timed(value = "something", extraTags = { "extra", "tag" })
         @Override
         public String timeWithExplicitValue() {
@@ -206,18 +206,30 @@ class TimedMethodInterceptorTest {
     }
 
     @Timed(value = "class.invoke", description = "class description", extraTags = { "extra", "tag" })
-    @Service
-    static class AnnotatedTimedService {
+    interface AnnotatedTimedService {
 
+        String timeWithoutValue();
+
+        String timeWithMethodLevelName();
+
+        String timeWithMergedTags();
+    }
+
+    @Service
+    static class AnnotatedTimedServiceImpl implements AnnotatedTimedService {
+
+        @Override
         public String timeWithoutValue() {
             return "I can't";
         }
 
+        @Override
         @Timed("my.method")
         public String timeWithMethodLevelName() {
             return "do";
         }
 
+        @Override
         @Timed(extraTags = { "extra2", "tag" })
         public String timeWithMergedTags() {
             return "that";


### PR DESCRIPTION
I saw discussion in gitter yesterday regarding `@Timed` enhancements and we've already implemented something like timed to meter specific classes with custom metric name and tags extractors.
I didn't extend existing `TimedAspect` and created spring aware `TimedMethodInterceptor` because aspect doesn't work with annotated interfaces thus is not usable for spring data repositories and feign clients.

In my implementation `@Timed` on method level has higher precedence over class level, but tags are merged from both class level and method level annotations.

cc @davidkarlsen 