### PR TITLE
Apply Eclipse Gradle plugin

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -6,6 +6,7 @@ plugins {
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'me.champeau.gradle.jmh'
 apply plugin: 'nebula.optional-base'
+apply plugin: 'eclipse'
 
 dependencies {
     // JSR-305 only used for non-required meta-annotations


### PR DESCRIPTION
Helps setting up the missing JMH dependencies (jmh, colt).
Now I don't need to re-add them to the classpath after
importing or updating the Gradle project.

Tested with Eclipse Oxygen SR2 (4.7.2).

Assumption: No influence on IDEA users. If somebody could give it a try?