### PR TITLE
Fixed typo in hystrix binding conditional

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -95,7 +95,7 @@ public class MetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnClass(name = "com.netflix.hystrix.strategy.HystrixPlugins")
-    @ConditionalOnProperty(value = "management.metrics.export.hystrix.enabled", matchIfMissing = true)
+    @ConditionalOnProperty(value = "management.metrics.binders.hystrix.enabled", matchIfMissing = true)
     public HystrixMetricsBinder hystrixMetricsBinder() {
         return new HystrixMetricsBinder();
     }


### PR DESCRIPTION
Changed `management.metrics.export.hystrix.enabled` to `management.metrics.binders.hystrix.enabled` to follow general convention.