### PR TITLE
added check for empty values for lookup

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
@@ -67,6 +67,10 @@ public class PropertiesMeterFilter implements MeterFilter {
     }
 
     private <T> T lookup(Map<String, T> values, Meter.Id id, @Nullable T defaultValue) {
+        if (values.isEmpty()) {
+            return defaultValue;
+        }
+
         String name = id.getName();
         while (StringUtils.hasLength(name)) {
             T result = values.get(name);


### PR DESCRIPTION
I believe it would be nice to return  `defaultValue` if `values` map is empty and there's no need to do the rest of search.

UPD
I also did some benchmarking solely for the `lookup` method with lookup by `http.server.requests` id string.
The initial time for lookup on empty map on my machine is `0.107 ± 0.006  us/op` and with empty check it's `0.063 ± 0.007  us/op`. If the map is not empty the're is almost no difference whether there's empty check present: `0.067 ± 0.002  us/op` vs `0.064 ± 0.001  us/op`.