### PR TITLE
added properties to enable/disable scheduled aspect and rest client

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -88,7 +88,7 @@ public class MetricsAutoConfiguration {
     // If AOP is not enabled, scheduled interception will not work.
     @Bean
     @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
-    @ConditionalOnProperty(value = "spring.aop.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = {"spring.aop.enabled", "management.metrics.binders.scheduled.enabled"}, havingValue = "true", matchIfMissing = true)
     public ScheduledMethodMetrics metricsSchedulingAspect(MeterRegistry registry) {
         return new ScheduledMethodMetrics(registry);
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -53,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
     "org.springframework.web.client.AsyncRestTemplate",
     "org.springframework.boot.web.client.RestTemplateCustomizer" // didn't exist until Boot 1.4
 })
+@ConditionalOnProperty(value = "management.metrics.binders.client.enabled", havingValue = "true", matchIfMissing = true)
 public class RestTemplateMetricsConfiguration {
     private final Logger logger = LoggerFactory.getLogger(RestTemplateMetricsConfiguration.class);
 


### PR DESCRIPTION
Following question [#554](https://github.com/micrometer-metrics/micrometer/issues/554) I added some properties to be able to disable certain binders. Tried following the convention of naming properties for other binders