### PR TITLE
better performance of creating web mvc tags

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
@@ -39,6 +39,14 @@ public final class WebMvcTags {
 
     private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
+    private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
+
+    private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
+
+    private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+
+    private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
+
     private WebMvcTags() {
     }
 
@@ -50,9 +58,7 @@ public final class WebMvcTags {
      * @return the method tag whose value is a capitalized method (e.g. GET).
      */
     public static Tag method(@Nullable HttpServletRequest request) {
-        return request == null ?
-                Tag.of("method", "UNKNOWN") :
-                Tag.of("method", request.getMethod());
+        return request == null ? METHOD_UNKNOWN : Tag.of("method", request.getMethod());
     }
 
     /**
@@ -62,7 +68,7 @@ public final class WebMvcTags {
      * @return the status tag derived from the status of the response
      */
     public static Tag status(@Nullable HttpServletResponse response) {
-        return response == null ? Tag.of("status", "UNKNOWN") : Tag.of("status", ((Integer) response.getStatus()).toString());
+        return response == null ? STATUS_UNKNOWN : Tag.of("status", Integer.toString(response.getStatus()));
     }
 
     /**
@@ -92,7 +98,7 @@ public final class WebMvcTags {
             String pathInfo = getPathInfo(request);
             return Tag.of("uri", pathInfo.isEmpty() ? "root" : pathInfo);
         }
-        return Tag.of("uri", "UNKNOWN");
+        return URI_UNKNOWN;
     }
 
     @Nullable
@@ -125,8 +131,6 @@ public final class WebMvcTags {
      * @return the exception tag derived from the exception
      */
     public static Tag exception(@Nullable Throwable exception) {
-        return exception == null ?
-                Tag.of("exception", "None") :
-                Tag.of("exception", exception.getClass().getSimpleName());
+        return exception == null ? EXCEPTION_NONE : Tag.of("exception", exception.getClass().getSimpleName());
     }
 }


### PR DESCRIPTION
Moving some tags to constants instead of creating every time should be obvious.
Creation of response status is slightly faster, as we're not casting anymore. More details in [benchmark](https://gist.github.com/mkrichevsky/ade345b10f1540c6a7a84f78e9248991) and [results](https://gist.github.com/mkrichevsky/c5f8ac70509c220ce2a38bb18149da65)