### PR TITLE
Fixed: Pass percentile precision to child Timer and DistributionSummary

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -199,7 +199,7 @@ public interface DistributionSummary extends Meter, HistogramSupport {
          * @param digitsOfPrecision The digits of precision to maintain for percentile approximations.
          * @return This builder.
          */
-        public Builder percentilePrecision(int digitsOfPrecision) {
+        public Builder percentilePrecision(Integer digitsOfPrecision) {
             this.distributionConfigBuilder.percentilePrecision(digitsOfPrecision);
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -309,7 +309,7 @@ public interface Timer extends Meter, HistogramSupport {
          * @param digitsOfPrecision The digits of precision to maintain for percentile approximations.
          * @return This builder.
          */
-        public Builder percentilePrecision(int digitsOfPrecision) {
+        public Builder percentilePrecision(Integer digitsOfPrecision) {
             this.distributionConfigBuilder.percentilePrecision(digitsOfPrecision);
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
@@ -76,6 +76,7 @@ class CompositeDistributionSummary extends AbstractCompositeMeter<DistributionSu
                 .minimumExpectedValue(distributionStatisticConfig.getMinimumExpectedValue())
                 .distributionStatisticBufferLength(distributionStatisticConfig.getBufferLength())
                 .distributionStatisticExpiry(distributionStatisticConfig.getExpiry())
+                .percentilePrecision(distributionStatisticConfig.getPercentilePrecision())
                 .sla(distributionStatisticConfig.getSlaBoundaries())
                 .scale(scale)
                 .register(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -125,6 +125,7 @@ class CompositeTimer extends AbstractCompositeMeter<Timer> implements Timer {
                 .publishPercentileHistogram(distributionStatisticConfig.isPercentileHistogram())
                 .distributionStatisticBufferLength(distributionStatisticConfig.getBufferLength())
                 .distributionStatisticExpiry(distributionStatisticConfig.getExpiry())
+                .percentilePrecision(distributionStatisticConfig.getPercentilePrecision())
                 .pauseDetector(pauseDetector);
 
         final long[] slaNanos = distributionStatisticConfig.getSlaBoundaries();


### PR DESCRIPTION
When creating a timer with builder API (as below), `precisionDigits` is not passed to child meters

```
        Timer.builder("my_timer")
            .percentilePrecision(2)
            .register(Metrics.globalRegistry);
```