### PR TITLE
Remove StatsdConfig.queueSize()

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -105,17 +105,6 @@ public interface StatsdConfig extends MeterRegistryConfig {
     }
 
     /**
-     * Governs the maximum size of the queue of items waiting to be sent to a StatsD agent over UDP.
-     *
-     * @return Maximum queue size.
-     * @deprecated No longer configurable and unbounded queue will be always used instead.
-     */
-    @Deprecated
-    default int queueSize() {
-        return getInteger(this, "queueSize").orElse(Integer.MAX_VALUE);
-    }
-
-    /**
      * @return The step size to use in computing windowed statistics like max. The default is 1 minute.
      * To get the most out of these statistics, align the step interval to be close to your scrape interval.
      */


### PR DESCRIPTION
This PR removes `StatsdConfig.queueSize()` as it's not used since d1edf7d907d88f30bd8f26cebdafb1ded18945e5.