### PR TITLE
Suppress Java compiler warnings

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
@@ -30,6 +30,8 @@ class StatsdGaugeTest {
     private AtomicInteger value = new AtomicInteger(1);
 
     private StatsdLineBuilder lineBuilder = mock(StatsdLineBuilder.class);
+
+    @SuppressWarnings("unchecked")
     private Subscriber<String> publisher = mock(Subscriber.class);
 
     @Test

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -512,6 +512,7 @@ public abstract class MeterRegistry implements AutoCloseable {
         return registerMeterIfNecessary(meterClass, id, null, (id2, conf) -> builder.apply(id2), noopBuilder);
     }
 
+    @SuppressWarnings("unchecked")
     private <M extends Meter> M registerMeterIfNecessary(Class<M> meterClass, Meter.Id id,
                                                          @Nullable DistributionStatisticConfig config, BiFunction<Meter.Id, DistributionStatisticConfig, Meter> builder,
                                                          Function<Meter.Id, M> noopBuilder) {
@@ -526,7 +527,6 @@ public abstract class MeterRegistry implements AutoCloseable {
             throw new IllegalArgumentException("There is already a registered meter of a different type with the same name");
         }
 
-        //noinspection unchecked
         return (M) m;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
@@ -59,6 +59,7 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
     @Nullable
     private U accumulatedHistogram;
 
+    @SuppressWarnings("unchecked")
     AbstractTimeWindowHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig, Class<T> bucketType,
                                 boolean supportsAggregablePercentiles) {
         this.clock = clock;
@@ -70,7 +71,6 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
             rejectHistogramConfig("bufferLength (" + ageBuckets + ") must be greater than 0.");
         }
 
-        //noinspection unchecked
         ringBuffer = (T[]) Array.newInstance(bucketType, ageBuckets);
 
         durationBetweenRotatesMillis = distributionStatisticConfig.getExpiry().toMillis() / ageBuckets;


### PR DESCRIPTION
This PR changes to use `@SuppressWarnings` to suppress Java compiler unchecked warnings as `noinspection` line comment works only for IntelliJ.