### PR TITLE
Add Jetty's ThreadPool metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/InstrumentedQueuedThreadPool.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/InstrumentedQueuedThreadPool.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
+
+    private final MeterRegistry registry;
+    private final Iterable<Tag> tags;
+
+    public InstrumentedQueuedThreadPool(MeterRegistry registry, Iterable<Tag> tags) {
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        JettyServerThreadPoolMetrics threadPoolMetrics = new JettyServerThreadPoolMetrics(this, tags);
+        threadPoolMetrics.bindTo(registry);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+public class JettyServerThreadPoolMetrics implements MeterBinder {
+
+    private final InstrumentedQueuedThreadPool threadPool;
+    private final Iterable<Tag> tags;
+
+    public JettyServerThreadPoolMetrics(InstrumentedQueuedThreadPool threadPool, Iterable<Tag> tags) {
+        this.threadPool = threadPool;
+        this.tags = tags;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder("jetty.threads.min", threadPool, InstrumentedQueuedThreadPool::getMinThreads)
+             .tags(tags)
+             .description("The number of min threads")
+             .register(registry);
+        Gauge.builder("jetty.threads.max", threadPool, InstrumentedQueuedThreadPool::getMaxThreads)
+             .tags(tags)
+             .description("The number of max threads")
+             .register(registry);
+        Gauge.builder("jetty.threads.live", threadPool, InstrumentedQueuedThreadPool::getThreads)
+             .tags(tags)
+             .description("The current number of live threads")
+             .register(registry);
+        Gauge.builder("jetty.threads.idle", threadPool, InstrumentedQueuedThreadPool::getIdleThreads)
+             .tags(tags)
+             .description("The current number of idle threads")
+             .register(registry);
+        Gauge.builder("jetty.threads.busy", threadPool, InstrumentedQueuedThreadPool::getBusyThreads)
+             .tags(tags)
+             .description("The current number of busy threads")
+             .register(registry);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
@@ -40,9 +40,9 @@ public class JettyServerThreadPoolMetrics implements MeterBinder {
              .tags(tags)
              .description("The number of max threads")
              .register(registry);
-        Gauge.builder("jetty.threads.live", threadPool, InstrumentedQueuedThreadPool::getThreads)
+        Gauge.builder("jetty.threads.current", threadPool, InstrumentedQueuedThreadPool::getThreads)
              .tags(tags)
-             .description("The current number of live threads")
+             .description("The current number of current threads")
              .register(registry);
         Gauge.builder("jetty.threads.idle", threadPool, InstrumentedQueuedThreadPool::getIdleThreads)
              .tags(tags)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
@@ -32,21 +32,17 @@ public class JettyServerThreadPoolMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        Gauge.builder("jetty.threads.min", threadPool, InstrumentedQueuedThreadPool::getMinThreads)
+        Gauge.builder("jetty.threads.config.min", threadPool, InstrumentedQueuedThreadPool::getMinThreads)
              .tags(tags)
              .description("The number of min threads")
              .register(registry);
-        Gauge.builder("jetty.threads.max", threadPool, InstrumentedQueuedThreadPool::getMaxThreads)
+        Gauge.builder("jetty.threads.config.max", threadPool, InstrumentedQueuedThreadPool::getMaxThreads)
              .tags(tags)
              .description("The number of max threads")
              .register(registry);
         Gauge.builder("jetty.threads.current", threadPool, InstrumentedQueuedThreadPool::getThreads)
              .tags(tags)
              .description("The current number of current threads")
-             .register(registry);
-        Gauge.builder("jetty.threads.idle", threadPool, InstrumentedQueuedThreadPool::getIdleThreads)
-             .tags(tags)
-             .description("The current number of idle threads")
              .register(registry);
         Gauge.builder("jetty.threads.busy", threadPool, InstrumentedQueuedThreadPool::getBusyThreads)
              .tags(tags)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
@@ -56,10 +56,9 @@ public class JettyServerThreadPoolMetricsTest {
 
     @Test
     void threadsMetrics() throws Exception {
-        assertThat(registry.get("jetty.threads.min").gauge().value()).isEqualTo(32.0);
-        assertThat(registry.get("jetty.threads.max").gauge().value()).isEqualTo(100.0);
+        assertThat(registry.get("jetty.threads.config.min").gauge().value()).isEqualTo(32.0);
+        assertThat(registry.get("jetty.threads.config.max").gauge().value()).isEqualTo(100.0);
         assertThat(registry.get("jetty.threads.current").gauge().value()).isNotEqualTo(0.0);
-        assertThat(registry.get("jetty.threads.idle").gauge().value()).isNotEqualTo(0.0);
         assertThat(registry.get("jetty.threads.busy").gauge().value()).isNotEqualTo(0.0);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
@@ -58,7 +58,7 @@ public class JettyServerThreadPoolMetricsTest {
     void threadsMetrics() throws Exception {
         assertThat(registry.get("jetty.threads.min").gauge().value()).isEqualTo(32.0);
         assertThat(registry.get("jetty.threads.max").gauge().value()).isEqualTo(100.0);
-        assertThat(registry.get("jetty.threads.live").gauge().value()).isNotEqualTo(0.0);
+        assertThat(registry.get("jetty.threads.current").gauge().value()).isNotEqualTo(0.0);
         assertThat(registry.get("jetty.threads.idle").gauge().value()).isNotEqualTo(0.0);
         assertThat(registry.get("jetty.threads.busy").gauge().value()).isNotEqualTo(0.0);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JettyServerThreadPoolMetricsTest {
+    private SimpleMeterRegistry registry;
+    private Server server;
+
+    @BeforeEach
+    void setup() throws Exception {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+        Iterable<Tag> tags = Collections.singletonList(Tag.of("id", "0"));
+        QueuedThreadPool threadPool = new InstrumentedQueuedThreadPool(registry, tags);
+        threadPool.setMinThreads(32);
+        threadPool.setMaxThreads(100);
+        server = new Server(threadPool);
+        ServerConnector connector = new ServerConnector(server);
+        server.setConnectors(new Connector[] { connector });
+        server.start();
+    }
+
+    @AfterEach
+    void teardown() throws Exception {
+        server.stop();
+    }
+
+    @Test
+    void threadsMetrics() throws Exception {
+        assertThat(registry.get("jetty.threads.min").gauge().value()).isEqualTo(32.0);
+        assertThat(registry.get("jetty.threads.max").gauge().value()).isEqualTo(100.0);
+        assertThat(registry.get("jetty.threads.live").gauge().value()).isEqualTo(32.0);
+        assertThat(registry.get("jetty.threads.idle").gauge().value()).isEqualTo(27.0);
+        assertThat(registry.get("jetty.threads.busy").gauge().value()).isEqualTo(5.0);
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
@@ -58,8 +58,8 @@ public class JettyServerThreadPoolMetricsTest {
     void threadsMetrics() throws Exception {
         assertThat(registry.get("jetty.threads.min").gauge().value()).isEqualTo(32.0);
         assertThat(registry.get("jetty.threads.max").gauge().value()).isEqualTo(100.0);
-        assertThat(registry.get("jetty.threads.live").gauge().value()).isEqualTo(32.0);
-        assertThat(registry.get("jetty.threads.idle").gauge().value()).isEqualTo(27.0);
-        assertThat(registry.get("jetty.threads.busy").gauge().value()).isEqualTo(5.0);
+        assertThat(registry.get("jetty.threads.live").gauge().value()).isNotEqualTo(0.0);
+        assertThat(registry.get("jetty.threads.idle").gauge().value()).isNotEqualTo(0.0);
+        assertThat(registry.get("jetty.threads.busy").gauge().value()).isNotEqualTo(0.0);
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
@@ -25,7 +25,10 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Collections;
 
 @Configuration
-@ConditionalOnClass(name = "org.eclipse.jetty.server.Server")
+@ConditionalOnClass(name = {
+    "org.eclipse.jetty.server.Server",
+    "org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory"
+})
 public class JettyMetricsConfiguration {
 
     @Bean

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.web.jetty;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jetty.InstrumentedQueuedThreadPool;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+
+@Configuration
+@ConditionalOnClass(name = "org.eclipse.jetty.server.Server")
+public class JettyMetricsConfiguration {
+
+    @Bean
+    public JettyEmbeddedServletContainerFactory jettyEmbeddedServletContainerFactory(MeterRegistry registry) {
+        JettyEmbeddedServletContainerFactory factory = new JettyEmbeddedServletContainerFactory();
+        factory.setThreadPool(new InstrumentedQueuedThreadPool(registry, Collections.emptyList()));
+        return factory;
+    }
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsConfiguration.java
@@ -18,6 +18,7 @@ package io.micrometer.spring.autoconfigure.web.jetty;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jetty.InstrumentedQueuedThreadPool;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,10 +26,8 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Collections;
 
 @Configuration
-@ConditionalOnClass(name = {
-    "org.eclipse.jetty.server.Server",
-    "org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory"
-})
+@ConditionalOnClass(name = "org.eclipse.jetty.server.Server")
+@ConditionalOnMissingClass("org.apache.catalina.startup.Tomcat")
 public class JettyMetricsConfiguration {
 
     @Bean


### PR DESCRIPTION
I want to monitor whether Jetty's ThreadPool setting is sufficient so I'd like to add several metrics.

# Usage

Example In Spring Boot 2.0.x

```java
@Bean
public JettyServletWebServerFactory webServerFactory(MeterRegistry registry) {
    JettyServletWebServerFactory factory = new JettyServletWebServerFactory();
    tags = Collections.singletonList(Tag.of("id", "0"));
    factory.setThreadPool(new InstrumentedQueuedThreadPool(registry, tags));
    return factory;
}
```