### PR TITLE
Rename totalTimeFunctionUnits

### DIFF
--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -173,8 +173,8 @@ public class AtlasMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
-        FunctionTimer ft = new StepFunctionTimer<>(id, clock, atlasConfig.step().toMillis(), obj, countFunction, totalTimeFunction, totalTimeFunctionUnits, getBaseTimeUnit());
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        FunctionTimer ft = new StepFunctionTimer<>(id, clock, atlasConfig.step().toMillis(), obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
         newMeter(id, Meter.Type.TIMER, ft.measure());
         return ft;
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -248,9 +248,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
         MicrometerCollector collector = collectorByName(id);
-        FunctionTimer ft = new CumulativeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits, getBaseTimeUnit());
+        FunctionTimer ft = new CumulativeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
         List<String> tagValues = tagValues(id);
 
         collector.add((conventionName, tagKeys) -> Stream.of(new MicrometerCollector.Family(Collector.Type.SUMMARY, conventionName, Stream.of(

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
@@ -30,9 +30,9 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
     private final AtomicReference<Double> lastTime = new AtomicReference<>(0.0);
 
     StatsdFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction,
-                        TimeUnit totalTimeFunctionUnits, TimeUnit baseTimeUnit,
+                        TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit,
                         StatsdLineBuilder lineBuilder, Subscriber<String> publisher) {
-        super(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits, baseTimeUnit);
+        super(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, baseTimeUnit);
         this.lineBuilder = lineBuilder;
         this.publisher = publisher;
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -287,8 +287,8 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T
             obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit
-                                                         totalTimeFunctionUnits) {
-        StatsdFunctionTimer ft = new StatsdFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits,
+                                                         totalTimeFunctionUnit) {
+        StatsdFunctionTimer ft = new StatsdFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit,
                 getBaseTimeUnit(), lineBuilder(id), publisher);
         pollableMeters.add(ft);
         return ft;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
@@ -33,8 +33,8 @@ import java.util.function.ToLongFunction;
 public interface FunctionTimer extends Meter {
     static <T> Builder<T> builder(String name, T obj, ToLongFunction<T> countFunction,
                                   ToDoubleFunction<T> totalTimeFunction,
-                                  TimeUnit totalTimeFunctionUnits) {
-        return new Builder<>(name, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits);
+                                  TimeUnit totalTimeFunctionUnit) {
+        return new Builder<>(name, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit);
     }
 
     /**
@@ -78,7 +78,7 @@ public interface FunctionTimer extends Meter {
         private final String name;
         private final ToLongFunction<T> countFunction;
         private final ToDoubleFunction<T> totalTimeFunction;
-        private final TimeUnit totalTimeFunctionUnits;
+        private final TimeUnit totalTimeFunctionUnit;
         private final List<Tag> tags = new ArrayList<>();
 
         @Nullable
@@ -90,12 +90,12 @@ public interface FunctionTimer extends Meter {
         private Builder(String name, @Nullable T obj,
                         ToLongFunction<T> countFunction,
                         ToDoubleFunction<T> totalTimeFunction,
-                        TimeUnit totalTimeFunctionUnits) {
+                        TimeUnit totalTimeFunctionUnit) {
             this.name = name;
             this.obj = obj;
             this.countFunction = countFunction;
             this.totalTimeFunction = totalTimeFunction;
-            this.totalTimeFunctionUnits = totalTimeFunctionUnits;
+            this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         }
 
         /**
@@ -144,7 +144,7 @@ public interface FunctionTimer extends Meter {
          */
         public FunctionTimer register(MeterRegistry registry) {
             return registry.more().timer(new Meter.Id(name, tags, null, description, Type.TIMER), obj, countFunction, totalTimeFunction,
-                    totalTimeFunctionUnits);
+                    totalTimeFunctionUnit);
         }
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -174,11 +174,11 @@ public abstract class MeterRegistry implements AutoCloseable {
      * @param obj                    The state object from which the count and total functions derive measurements.
      * @param countFunction          A monotonically increasing count function.
      * @param totalTimeFunction      A monotonically increasing total time function.
-     * @param totalTimeFunctionUnits The base unit of time of the totals returned by the total time function.
+     * @param totalTimeFunctionUnit The base unit of time of the totals returned by the total time function.
      * @param <T>                    The type of the object upon which the value functions derives their measurements.
      * @return A new function timer.
      */
-    protected abstract <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits);
+    protected abstract <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit);
 
     /**
      * Build a new function counter to be added to the registry. This is guaranteed to only be called if the function counter doesn't already exist.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeFunctionTimer.java
@@ -29,15 +29,15 @@ class CompositeFunctionTimer<T> extends AbstractCompositeMeter<FunctionTimer> im
     private final WeakReference<T> ref;
     private final ToLongFunction<T> countFunction;
     private final ToDoubleFunction<T> totalTimeFunction;
-    private final TimeUnit totalTimeFunctionUnits;
+    private final TimeUnit totalTimeFunctionUnit;
 
     CompositeFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction,
-                           ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
+                           ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.countFunction = countFunction;
         this.totalTimeFunction = totalTimeFunction;
-        this.totalTimeFunctionUnits = totalTimeFunctionUnits;
+        this.totalTimeFunctionUnit = totalTimeFunctionUnit;
     }
 
     @Override
@@ -68,7 +68,7 @@ class CompositeFunctionTimer<T> extends AbstractCompositeMeter<FunctionTimer> im
         }
 
         return FunctionTimer.builder(getId().getName(), obj, countFunction,
-            totalTimeFunction, totalTimeFunctionUnits)
+            totalTimeFunction, totalTimeFunctionUnit)
             .tags(getId().getTags())
             .description(getId().getDescription())
             .register(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -101,8 +101,8 @@ public class CompositeMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
-        return new CompositeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits);
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        return new CompositeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
@@ -34,19 +34,19 @@ public class CumulativeFunctionTimer<T> implements FunctionTimer {
     private final WeakReference<T> ref;
     private final ToLongFunction<T> countFunction;
     private final ToDoubleFunction<T> totalTimeFunction;
-    private final TimeUnit totalTimeFunctionUnits;
+    private final TimeUnit totalTimeFunctionUnit;
     private final TimeUnit baseTimeUnit;
 
     private volatile long lastCount = 0;
     private volatile double lastTime = 0.0;
 
     public CumulativeFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction,
-                                   TimeUnit totalTimeFunctionUnits, TimeUnit baseTimeUnit) {
+                                   TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit) {
         this.id = id;
         this.ref = new WeakReference<>(obj);
         this.countFunction = countFunction;
         this.totalTimeFunction = totalTimeFunction;
-        this.totalTimeFunctionUnits = totalTimeFunctionUnits;
+        this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.baseTimeUnit = baseTimeUnit;
     }
 
@@ -66,7 +66,7 @@ public class CumulativeFunctionTimer<T> implements FunctionTimer {
         if (obj2 == null)
             return lastTime;
         return (lastTime = Math.max(TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2),
-            totalTimeFunctionUnits,
+            totalTimeFunctionUnit,
             unit), 0));
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
@@ -34,7 +34,7 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
     private final WeakReference<T> ref;
     private final ToLongFunction<T> countFunction;
     private final ToDoubleFunction<T> totalTimeFunction;
-    private final TimeUnit totalTimeFunctionUnits;
+    private final TimeUnit totalTimeFunctionUnit;
 
     private final AtomicLong lastCount = new AtomicLong(0);
     private final DropwizardRate rate;
@@ -45,13 +45,13 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
     DropwizardFunctionTimer(Meter.Id id, Clock clock,
                             T obj, ToLongFunction<T> countFunction,
                             ToDoubleFunction<T> totalTimeFunction,
-                            TimeUnit totalTimeFunctionUnits,
+                            TimeUnit totalTimeFunctionUnit,
                             TimeUnit registryBaseTimeUnit) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.countFunction = countFunction;
         this.totalTimeFunction = totalTimeFunction;
-        this.totalTimeFunctionUnits = totalTimeFunctionUnits;
+        this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.rate = new DropwizardRate(clock);
         this.registryBaseTimeUnit = registryBaseTimeUnit;
         this.dropwizardMeter = new Timer(null, new DropwizardClock(clock)) {
@@ -148,7 +148,7 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
         if (obj2 == null)
             return lastTime;
         return (lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2),
-            totalTimeFunctionUnits,
+            totalTimeFunctionUnit,
             unit));
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -99,9 +99,9 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
         DropwizardFunctionTimer ft = new DropwizardFunctionTimer<>(id, clock, obj, countFunction, totalTimeFunction,
-                totalTimeFunctionUnits, getBaseTimeUnit());
+                totalTimeFunctionUnit, getBaseTimeUnit());
         registry.register(hierarchicalName(id), ft.getDropwizardMeter());
         return ft;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
@@ -120,8 +120,8 @@ public class SimpleMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
-        return new CumulativeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnits, getBaseTimeUnit());
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        return new CumulativeFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -34,7 +34,7 @@ public class StepFunctionTimer<T> implements FunctionTimer {
     private final WeakReference<T> ref;
     private final ToLongFunction<T> countFunction;
     private final ToDoubleFunction<T> totalTimeFunction;
-    private final TimeUnit totalTimeFunctionUnits;
+    private final TimeUnit totalTimeFunctionUnit;
     private final TimeUnit baseTimeUnit;
 
     private volatile long lastCount = 0;
@@ -44,12 +44,12 @@ public class StepFunctionTimer<T> implements FunctionTimer {
     private StepDouble total;
 
     public StepFunctionTimer(Id id, Clock clock, long stepMillis, T obj, ToLongFunction<T> countFunction,
-                             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits, TimeUnit baseTimeUnit) {
+                             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit) {
         this.id = id;
         this.ref = new WeakReference<>(obj);
         this.countFunction = countFunction;
         this.totalTimeFunction = totalTimeFunction;
-        this.totalTimeFunctionUnits = totalTimeFunctionUnits;
+        this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.baseTimeUnit = baseTimeUnit;
         this.count = new StepLong(clock, stepMillis);
         this.total = new StepDouble(clock, stepMillis);
@@ -75,7 +75,7 @@ public class StepFunctionTimer<T> implements FunctionTimer {
         T obj2 = ref.get();
         if (obj2 != null) {
             double prevLast = lastTime;
-            lastTime = Math.max(TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnits, unit), 0);
+            lastTime = Math.max(TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnit, unit), 0);
             total.getCurrent().add(lastTime - prevLast);
         }
         return total.poll();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -107,8 +107,8 @@ public abstract class StepMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnits) {
-        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), obj, countFunction, totalTimeFunction, totalTimeFunctionUnits, getBaseTimeUnit());
+    protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
+        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
     }
 
     @Override


### PR DESCRIPTION
This PR renames `totalTimeFunctionUnits` to `totalTimeFunctionUnit` as it's singular but named as plural.