### PR TITLE
Add a missing return in ElasticMeterRegistry.createIndexIfNeeded()

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -102,6 +102,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             putTemplateConnection.disconnect();
             if (putTemplateConnection.getResponseCode() != 200) {
                 logger.error("Error adding metrics template to elasticsearch: {}/{}" + putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
+                return;
             }
 
             checkedForIndexTemplate = true;


### PR DESCRIPTION
This PR adds a missing `return` in `ElasticMeterRegistry.createIndexIfNeeded()` when a template creation for metrics has been failed.