### PR TITLE
Fixed javadoc: `Duration` instead of `Long`

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundary.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundary.java
@@ -24,7 +24,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A service level agreement boundary. Can be specified as either a {@link Long}
- * (applicable to timers and distribution summaries) or a {@link Long} (applicable to only timers).
+ * (applicable to timers and distribution summaries) or a {@link Duration}
+ * (applicable to only timers).
  *
  * @author Phillip Webb
  */


### PR DESCRIPTION
Javadoc told that a value can be given as `Long` or `Long` (twice), but
actually meant `Long` or `Duration`. Fixed that.