### PR TITLE
Remove org.apache.commons.text.StringEscapeUtils references

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -7,7 +7,7 @@
 
         <!-- Imports -->
         <module name="IllegalImportCheck" >
-            <property name="illegalPkgs" value="com.google.common.(?!cache).*"/>
+            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*"/>
             <property name="regexp" value="true"/>
         </module>
         <module name="UnusedImports">

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -17,8 +17,8 @@ package io.micrometer.datadog;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
-import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.*;
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -36,7 +36,7 @@ class DatadogMetricMetadataTest {
                 true,
                 null);
 
-        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"description\":\"The \\/\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
+        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
     }
 
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.dynatrace;
 
+import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
-import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Collections;
 import java.util.Map;

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMetricDefinitionTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMetricDefinitionTest.java
@@ -39,7 +39,7 @@ class DynatraceMetricDefinitionTest {
                 "The /\"recent cpu usage\" for the Java Virtual Machine process",
                 null, null, technologyTypes);
 
-        assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"The \\/\\\"recent cpu usage\\\" for the Java Virtual Machine process\",\"types\":[\"java\"]}");
+        assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\",\"types\":[\"java\"]}");
     }
 
     @Test


### PR DESCRIPTION
`org.apache.commons.text.StringEscapeUtils` looks accidentally used as there is `io.micrometer.core.instrument.util.StringEscapeUtils`. So this PR replaces it with the intended one.

This PR also does:
- add a Checkstyle rule to prevent classes in `org.apache.commons.text` from sneaking into codebase again.
- update the related tests as `org.apache.commons.text.StringEscapeUtils` escapes "/" but AFAICT it doesn't look right because "/" doesn't need to be escaped for JSON.