### PR TITLE
Rename timeStamp to timestamp

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -84,8 +84,8 @@ public interface ElasticConfig extends StepRegistryConfig {
      *
      * @return field name for timestamp
      */
-    default String timeStampFieldName() {
-        String v = get(prefix() + ".timeStampFieldName");
+    default String timestampFieldName() {
+        String v = get(prefix() + ".timestampFieldName");
         return v == null ? "@timestamp" : v;
     }
 

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -263,7 +263,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
         private IndexBuilder(ElasticConfig config, String name, String type, List<Tag> tags, long wallTime) {
             indexLine.append(indexLine(config, wallTime))
-                    .append("{\"").append(config.timeStampFieldName()).append("\":\"").append(timestamp(wallTime)).append("\"")
+                    .append("{\"").append(config.timestampFieldName()).append("\":\"").append(timestamp(wallTime)).append("\"")
                     .append(",\"name\":\"").append(name).append("\"")
                     .append(",\"type\":\"").append(type).append("\"");
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -50,7 +50,7 @@ public class ElasticProperties extends StepRegistryProperties {
     /**
      * The name of the timestamp field.
      */
-    private String timeStampFieldName;
+    private String timestampFieldName;
 
     /**
      * Whether to create the index automatically if it doesn't exist.
@@ -99,12 +99,12 @@ public class ElasticProperties extends StepRegistryProperties {
         this.bulkSize = bulkSize;
     }
 
-    public String getTimeStampFieldName() {
-        return timeStampFieldName;
+    public String getTimestampFieldName() {
+        return timestampFieldName;
     }
 
-    public void setTimeStampFieldName(String timeStampFieldName) {
-        this.timeStampFieldName = timeStampFieldName;
+    public void setTimestampFieldName(String timestampFieldName) {
+        this.timestampFieldName = timestampFieldName;
     }
 
     public boolean isAutoCreateIndex() {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -45,8 +45,8 @@ public class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfig
     }
 
     @Override
-    public String timeStampFieldName() {
-        return get(ElasticProperties::getTimeStampFieldName, ElasticConfig.super::timeStampFieldName);
+    public String timestampFieldName() {
+        return get(ElasticProperties::getTimestampFieldName, ElasticConfig.super::timestampFieldName);
     }
 
     @Override


### PR DESCRIPTION
This PR renames `timeStamp` to `timestamp` for consistency.