### PR TITLE
Add IOUtils.toString()

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -26,14 +26,12 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.util.IOUtils;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.URIUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -248,12 +246,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
             if (status >= 200 && status < 300) {
                 successHandler.accept(status);
             } else  {
-                String errorBody;
-                try (InputStream in = con.getErrorStream()) {
-                    errorBody = new BufferedReader(new InputStreamReader(in))
-                        .lines().collect(joining("\n"));
-                }
-                errorHandler.accept(status, errorBody);
+                errorHandler.accept(status, IOUtils.toString(con.getErrorStream()));
             }
         } catch (final Throwable e) {
             logger.warn("failed to execute http call to '{}' using method '{}'", url, method, e);

--- a/implementations/micrometer-registry-elastic/build.gradle
+++ b/implementations/micrometer-registry-elastic/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'commons-io:commons-io:latest.release'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -20,10 +20,10 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.IOUtils;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.lang.NonNull;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -19,13 +19,11 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.IOUtils;
 import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -41,7 +39,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 
@@ -234,10 +231,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             if (status >= 200 && status < 300) {
                 logger.info("successfully sent {} events to New Relic", events.size());
             } else if (status >= 400) {
-                try (InputStream in = con.getErrorStream()) {
-                    logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                            .lines().collect(joining("\n")));
-                }
+                logger.error("failed to send metrics: " + IOUtils.toString(con.getErrorStream()));
             } else {
                 logger.error("failed to send metrics: http " + status);
             }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.IOUtils;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
@@ -105,10 +106,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                         if (status >= 200 && status < 300) {
                             logger.info("successfully sent {} metrics to Wavefront", batch.size());
                         } else {
-                            try (InputStream in = con.getErrorStream()) {
-                                logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                                        .lines().collect(joining("\n")));
-                            }
+                            logger.error("failed to send metrics: " + IOUtils.toString(con.getErrorStream()));
                         }
                     } catch (Exception e) {
                         logger.error(e.getMessage(), e);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/IOUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/IOUtils.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+
+/**
+ * Utilities for IO.
+ *
+ * @author Johnny Lim
+ */
+public final class IOUtils {
+
+    private static final int EOF = -1;
+
+    private static final int DEFAULT_BUFFER_SIZE = 1024;
+
+    /**
+     * Create a {@code String} from {@link InputStream} with {@link Charset}.
+     *
+     * @param inputStream source {@link InputStream}
+     * @param charset source {@link Charset}
+     * @return created {@code String}
+     */
+    public static String toString(InputStream inputStream, Charset charset) {
+        try (StringWriter writer = new StringWriter();
+                InputStreamReader reader = new InputStreamReader(inputStream, charset);
+                BufferedReader bufferedReader = new BufferedReader(reader)) {
+            char[] chars = new char[DEFAULT_BUFFER_SIZE];
+            int readChars;
+            while ((readChars = bufferedReader.read(chars)) != EOF) {
+                writer.write(chars, 0, readChars);
+            }
+            return writer.toString();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Create a {@code String} from {@link InputStream} with default {@link Charset}.
+     *
+     * @param inputStream source {@link InputStream}
+     * @return created {@code String}
+     */
+    public static String toString(InputStream inputStream) {
+        return toString(inputStream, Charset.defaultCharset());
+    }
+
+    private IOUtils() {
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/URIUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/URIUtils.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.util;
 
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -36,7 +37,7 @@ public final class URIUtils {
         try {
             return URI.create(uri).toURL();
         } catch (MalformedURLException ex) {
-            throw new RuntimeException(ex);
+            throw new UncheckedIOException(ex);
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IOUtils}.
+ *
+ * @author Johnny Lim
+ */
+class IOUtilsTest {
+
+    @Test
+    public void testToString() {
+        String expected = "This is a sample.";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes());
+
+        assertThat(IOUtils.toString(inputStream)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testToStringWithCharset() {
+        String expected = "This is a sample.";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
This PR adds `IOUtils.toString()`.

This also does:

- replace `IOUtils.toString()` from Apache Commons IO
- use the newly added `IOUtils.toString()`
- polish logging

When I was working on this, I noticed there is charset inconsistency (default vs. UTF-8) among meter registries. If it's not intentional, it would be good to make them consistent. I usually prefer to use UTF-8 but I'm not sure what is the best here. Maybe making it configurable might be necessary.