### PR TITLE
Add statsD sysdig flavor

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFlavor.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFlavor.java
@@ -32,5 +32,10 @@ public enum StatsdFlavor {
      * For gauges to work as expected, you should set `delete_gauges = false` in your input options as documented here:
      * https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
      */
-    TELEGRAF
+    TELEGRAF,
+
+    /**
+     * https://support.sysdig.com/hc/en-us/articles/204376099-Metrics-integrations-StatsD
+     */
+    SYSDIG
 }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -349,6 +349,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     private static NamingConvention namingConventionFromFlavor(StatsdFlavor flavor) {
         switch (flavor) {
             case DATADOG:
+            case SYSDIG:
                 return NamingConvention.dot;
             case TELEGRAF:
                 return NamingConvention.snakeCase;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/FlavorStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/FlavorStatsdLineBuilder.java
@@ -45,7 +45,7 @@ public class FlavorStatsdLineBuilder implements StatsdLineBuilder {
     private final MeterRegistry.Config config;
 
     private final Function<NamingConvention, String> datadogTagString;
-    private final Function<NamingConvention, String> telegrafTagString;
+    private final Function<NamingConvention, String> defaultTagString;
 
     public FlavorStatsdLineBuilder(Meter.Id id, StatsdFlavor flavor, HierarchicalNameMapper nameMapper, MeterRegistry.Config config) {
         this.id = id;
@@ -63,7 +63,7 @@ public class FlavorStatsdLineBuilder implements StatsdLineBuilder {
         );
 
         // service=payroll,region=us-west
-        this.telegrafTagString = memoize(convention ->
+        this.defaultTagString = memoize(convention ->
                 id.getTags().iterator().hasNext() ?
                         id.getConventionTags(convention).stream()
                                 .map(t -> t.getKey() + "=" + t.getValue())
@@ -98,9 +98,11 @@ public class FlavorStatsdLineBuilder implements StatsdLineBuilder {
                 return metricName(stat) + ":" + amount + "|" + type;
             case DATADOG:
                 return metricName(stat) + ":" + amount + "|" + type + tags(stat, datadogTagString.apply(config.namingConvention()),":", "|#");
+            case SYSDIG:
+                return metricName(stat) + tags(stat, defaultTagString.apply(config.namingConvention()), "=", "#") + ":" + amount + "|" + type;
             case TELEGRAF:
             default:
-                return metricName(stat) + tags(stat, telegrafTagString.apply(config.namingConvention()),"=", ",") + ":" + amount + "|" + type;
+                return metricName(stat) + tags(stat, defaultTagString.apply(config.namingConvention()),"=", ",") + ":" + amount + "|" + type;
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -65,6 +65,12 @@ class StatsdMeterRegistryTest {
                 break;
             case TELEGRAF:
                 line = "my_counter,statistic=count,my_tag=val:2|c";
+                break;
+            case SYSDIG:
+                line = "my.counter#statistic=count,my.tag=val:2|c";
+                break;
+            default:
+                fail("Unexpected flavor");
         }
 
         final Processor<String, String> lines = lineProcessor();
@@ -95,6 +101,9 @@ class StatsdMeterRegistryTest {
                 break;
             case TELEGRAF:
                 line = "my_gauge,statistic=value,my_tag=val:2|g";
+                break;
+            case SYSDIG:
+                line = "my.gauge#statistic=value,my.tag=val:2|g";
                 break;
             default:
                 fail("Unexpected flavor");
@@ -131,6 +140,9 @@ class StatsdMeterRegistryTest {
             case TELEGRAF:
                 line = "my_timer,my_tag=val:1|ms";
                 break;
+            case SYSDIG:
+                line = "my.timer#my.tag=val:1|ms";
+                break;
             default:
                 fail("Unexpected flavor");
         }
@@ -160,6 +172,9 @@ class StatsdMeterRegistryTest {
                 break;
             case TELEGRAF:
                 line = "my_summary,my_tag=val:1|h";
+                break;
+            case SYSDIG:
+                line = "my.summary#my.tag=val:1|h";
                 break;
             default:
                 fail("Unexpected flavor");
@@ -201,6 +216,12 @@ class StatsdMeterRegistryTest {
                 expectLines = new String[]{
                         "my_long_task,statistic=activeTasks,my_tag=val:1|g",
                         "my_long_task,statistic=duration,my_tag=val:" + stepMillis + "|g",
+                };
+                break;
+            case SYSDIG:
+                expectLines = new String[]{
+                    "my.long.task#statistic=activeTasks,my.tag=val:1|g",
+                    "my.long.task#statistic=duration,my.tag=val:" + stepMillis + "|g",
                 };
                 break;
             default:

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
@@ -193,6 +193,26 @@ public class SampleRegistries {
         }, Clock.SYSTEM);
     }
 
+    public static StatsdMeterRegistry sysdigStatsd() {
+        return new StatsdMeterRegistry(new StatsdConfig() {
+            @Override
+            public Duration step() {
+                return Duration.ofSeconds(10);
+            }
+
+            @Override
+            @Nullable
+            public String get(String k) {
+                return null;
+            }
+
+            @Override
+            public StatsdFlavor flavor() {
+                return StatsdFlavor.SYSDIG;
+            }
+        }, Clock.SYSTEM);
+    }
+
     public static GangliaMeterRegistry ganglia() {
         return new GangliaMeterRegistry(new GangliaConfig() {
             @Override


### PR DESCRIPTION
Add support for [statsD Sysdig format](https://support.sysdig.com/hc/en-us/articles/204376099-Metrics-integrations-StatsD) which is defined as:

`<metric_name>[#<tagname>=<tagvalue>,<tagname>]:<value>|<type>[|@<sampling_ratio>]`

Sysdig metric names typically follow the dot notation naming convention.