### PR TITLE
Polish logging in meter registries

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -78,7 +78,9 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 logger.debug("influx database {} is ready to receive metrics", config.db());
                 databaseExists = true;
             } else if (status >= 400) {
-                logger.error("unable to create database '{}': {}", config.db(), IOUtils.toString(con.getErrorStream()));
+                if (logger.isErrorEnabled()) {
+                    logger.error("unable to create database '{}': {}", config.db(), IOUtils.toString(con.getErrorStream()));
+                }
             }
         } catch (Throwable e) {
             logger.error("unable to create database '{}'", config.db(), e);
@@ -163,9 +165,11 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                         logger.info("successfully sent {} metrics to influx", batch.size());
                         databaseExists = true;
                     } else if (status >= 400) {
-                        logger.error("failed to send metrics: " + IOUtils.toString(con.getErrorStream()));
+                        if (logger.isErrorEnabled()) {
+                            logger.error("failed to send metrics: {}", IOUtils.toString(con.getErrorStream()));
+                        }
                     } else {
-                        logger.error("failed to send metrics: http " + status);
+                        logger.error("failed to send metrics: http {}", status);
                     }
 
                 } finally {

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -231,9 +231,11 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             if (status >= 200 && status < 300) {
                 logger.info("successfully sent {} events to New Relic", events.size());
             } else if (status >= 400) {
-                logger.error("failed to send metrics: " + IOUtils.toString(con.getErrorStream()));
+                if (logger.isErrorEnabled()) {
+                    logger.error("failed to send metrics: {}", IOUtils.toString(con.getErrorStream()));
+                }
             } else {
-                logger.error("failed to send metrics: http " + status);
+                logger.error("failed to send metrics: http {}", status);
             }
 
         } catch (Throwable e) {

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -106,7 +106,9 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                         if (status >= 200 && status < 300) {
                             logger.info("successfully sent {} metrics to Wavefront", batch.size());
                         } else {
-                            logger.error("failed to send metrics: " + IOUtils.toString(con.getErrorStream()));
+                            if (logger.isErrorEnabled()) {
+                                logger.error("failed to send metrics: {}", IOUtils.toString(con.getErrorStream()));
+                            }
                         }
                     } catch (Exception e) {
                         logger.error(e.getMessage(), e);


### PR DESCRIPTION
This PR polishes logging in meter registries, mostly by adding log level guards to where any computation is necessary.