### PR TITLE
Graphite name mapper improvements (memory)

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
@@ -32,23 +32,26 @@ public class GraphiteHierarchicalNameMapper implements HierarchicalNameMapper {
 
     @Override
     public String toHierarchicalName(Meter.Id id, NamingConvention convention) {
-        StringBuilder prefix = new StringBuilder();
+        StringBuilder buffer = new StringBuilder(50);
         for (String tagPrefix : tagsAsPrefix) {
             String value = id.getTag(tagPrefix);
             if (value != null) {
-                prefix.append(convention.tagValue(value)).append(".");
+                buffer.append(convention.tagValue(value)).append('.');
             }
         }
 
-        StringBuilder tags = new StringBuilder();
+        buffer.append(id.getConventionName(convention));
+        
         for (Tag tag : id.getTags()) {
             if (!tagsAsPrefix.contains(tag.getKey())) {
-                tags.append(("." + convention.tagKey(tag.getKey()) + "." + convention.tagValue(tag.getValue()))
-                        .replace(" ", "_"));
+            	buffer.append('.');
+            	buffer.append(convention.tagKey(tag.getKey()).replace(' ', '_'));
+            	buffer.append('.');
+            	buffer.append(convention.tagValue(tag.getValue()).replace(' ', '_'));
             }
         }
 
-        return prefix.toString() + id.getConventionName(convention) + tags;
+        return buffer.toString();
     }
 }
 

--- a/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteHierarchicalNameMapperTest.java
+++ b/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteHierarchicalNameMapperTest.java
@@ -34,4 +34,13 @@ class GraphiteHierarchicalNameMapperTest {
         assertThat(nameMapper.toHierarchicalName(id, NamingConvention.camelCase))
                 .isEqualTo("PROD.MYAPP.myName.otherTag.value");
     }
+    
+    @Test
+    void noSpaceInTags() {
+    	Meter.Id idWithSpace = new Meter.Id("my.name", Tags.of("app.name", "MYAPP", "stack", "PROD", "other tag", "va lue"),
+    			null, null, Meter.Type.COUNTER);
+        assertThat(nameMapper.toHierarchicalName(idWithSpace, NamingConvention.camelCase))
+                .isEqualTo("PROD.MYAPP.myName.other_tag.va_lue");
+    }
+    
 }


### PR DESCRIPTION
Avoid String concatenation and re-use a single buffer