### PR TITLE
NamingConvention small improvements

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
@@ -72,11 +72,12 @@ public interface NamingConvention {
 
         private String toCamelCase(String value) {
             String[] parts = value.split("\\.");
-            StringBuilder conventionName = new StringBuilder();
+            StringBuilder conventionName = new StringBuilder(value.length());
             for (int i = 0; i < parts.length; i++) {
                 String str = parts[i];
-                if (StringUtils.isEmpty(str))
+                if (StringUtils.isEmpty(str)) {
                     continue;
+                }
 
                 if (i == 0) {
                     conventionName.append(str);
@@ -104,7 +105,12 @@ public interface NamingConvention {
             if (name.length() == 0) {
                 return name;
             }
-            char chars[] = name.toCharArray();
+            
+            if (Character.isUpperCase(name.charAt(0))) {
+            	return name;
+            }
+            
+            char[] chars = name.toCharArray();
             chars[0] = Character.toUpperCase(chars[0]);
             return new String(chars);
         }


### PR DESCRIPTION
upperCamelCase : do not allocate the string twice if the first character is already in uppercase
camelCase : better default sizing of the buffer