### PR TITLE
Use statKeys and statValues in PrometheusMeterRegistry.newMeter()

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -321,7 +321,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                                         break;
                                 }
 
-                                return new Collector.MetricFamilySamples.Sample(name, tagKeys, tagValues, m.getValue());
+                                return new Collector.MetricFamilySamples.Sample(name, statKeys, statValues, m.getValue());
                             })));
         });
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -89,9 +89,12 @@ class PrometheusMeterRegistryTest {
         Meter.builder("name", Meter.Type.COUNTER, Collections.singletonList(new Measurement(() -> 1.0, Statistic.COUNT)))
                 .register(registry);
 
-        assertThat(registry.getPrometheusRegistry().metricFamilySamples().nextElement().type)
+        Collector.MetricFamilySamples metricFamilySamples = registry.getPrometheusRegistry().metricFamilySamples().nextElement();
+        assertThat(metricFamilySamples.type)
                 .describedAs("custom counter with a type of COUNTER")
                 .isEqualTo(Collector.Type.COUNTER);
+        assertThat(metricFamilySamples.samples.get(0).labelNames).containsExactly("statistic");
+        assertThat(metricFamilySamples.samples.get(0).labelValues).containsExactly("COUNT");
     }
 
     @DisplayName("attempts to register different meter types with the same name fail somewhat gracefully")


### PR DESCRIPTION
`statKeys` and `statValues` in `PrometheusMeterRegistry.newMeter()` look meant to be used but unused, so this PR changes to use them.