### PR TITLE
Add URI_ROOT to WebMvcTags

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
@@ -39,6 +39,8 @@ public final class WebMvcTags {
 
     private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
+    private static final Tag URI_ROOT = Tag.of("uri", "root");
+
     private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
 
     private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
@@ -96,7 +98,10 @@ public final class WebMvcTags {
                 }
             }
             String pathInfo = getPathInfo(request);
-            return Tag.of("uri", pathInfo.isEmpty() ? "root" : pathInfo);
+            if (pathInfo.isEmpty()) {
+                return URI_ROOT;
+            }
+            return Tag.of("uri", pathInfo);
         }
         return URI_UNKNOWN;
     }


### PR DESCRIPTION
This PR adds `URI_ROOT` constant to `WebMvcTags` as it could be a constant.