### PR TITLE
Fix wrapper deprecation message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects {
 
 }
 
-task wrapper(type: Wrapper) {
+wrapper {
     gradleVersion = '4.8'
 }
 


### PR DESCRIPTION
This PR fixes the following deprecation message:

```
Creating a custom task named 'wrapper' has been deprecated and is scheduled to be removed in Gradle 5.0. You can configure the existing task using the 'wrapper { }' syntax or create your custom task under a different name.'.
        at build_concrwv4ri5vqa5q32unk0im9.run(/Users/xxx/yyy/micrometer/build.gradle:77)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```