### PR TITLE
Fix indentation

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -14,5 +14,13 @@
             <property name="processJavadoc" value="true" />
         </module>
 
+        <!-- Regexp -->
+        <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+            <property name="format" value="^ *\t+ *\S" />
+            <property name="message"
+                      value="Line has leading tab characters; indentation should be performed with spaces only." />
+            <property name="ignoreComments" value="true" />
+        </module>
+
     </module>
 </module>

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceNamingConvention.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceNamingConvention.java
@@ -23,7 +23,7 @@ import io.micrometer.core.lang.Nullable;
 
 public class DynatraceNamingConvention implements NamingConvention {
 
-	private static final Pattern KEY_CLEANUP_PATTERN = Pattern.compile("[^\\w.-]");
+    private static final Pattern KEY_CLEANUP_PATTERN = Pattern.compile("[^\\w.-]");
 	
     private final NamingConvention delegate;
 
@@ -42,6 +42,6 @@ public class DynatraceNamingConvention implements NamingConvention {
 
     @Override
     public String tagKey(String key) {
-    	return KEY_CLEANUP_PATTERN.matcher(delegate.tagKey(key)).replaceAll("_");
+        return KEY_CLEANUP_PATTERN.matcher(delegate.tagKey(key)).replaceAll("_");
     }
 }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -54,7 +54,7 @@ import java.util.stream.Stream;
  */
 public class ElasticMeterRegistry extends StepMeterRegistry {
 
-	private final Logger logger = LoggerFactory.getLogger(ElasticMeterRegistry.class);
+    private final Logger logger = LoggerFactory.getLogger(ElasticMeterRegistry.class);
 
     private static final ZoneId UTC_ZONE = ZoneId.of("UTC");
     private static final String ES_METRICS_TEMPLATE = "/_template/metrics_template";
@@ -107,13 +107,13 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                 outputStream.flush();
                 
                 if (putTemplateConnection.getResponseCode() != 200) {
-                	logger.error("Error adding metrics template to elasticsearch: {}/{}", putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
-                	return;
+                    logger.error("Error adding metrics template to elasticsearch: {}/{}", putTemplateConnection.getResponseCode(), putTemplateConnection.getResponseMessage());
+                    return;
                 }
             }
             finally {
-            	putTemplateConnection.disconnect();
-			}
+                putTemplateConnection.disconnect();
+            }
 
             checkedForIndexTemplate = true;
         } catch (IOException ex) {
@@ -303,7 +303,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         }
 
         private static String indexLine(ElasticConfig config, long wallTime) {
-			ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(wallTime), UTC_ZONE);
+            ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(wallTime), UTC_ZONE);
             String indexName = config.index() + "-" + DateTimeFormatter.ofPattern(config.indexDateFormat()).format(dt);
             return "{\"index\":{\"_index\":\"" + indexName + "\",\"_type\":\"doc\"}}\n";
         }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticNamingConvention.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticNamingConvention.java
@@ -21,9 +21,9 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 
 public class ElasticNamingConvention implements NamingConvention {
-	
-	private static final Pattern FIRST_UNDERSCORE_PATTERN = Pattern.compile("^_+");
-	 
+
+    private static final Pattern FIRST_UNDERSCORE_PATTERN = Pattern.compile("^_+");
+
     private final NamingConvention delegate;
 
     public ElasticNamingConvention() {
@@ -47,7 +47,7 @@ public class ElasticNamingConvention implements NamingConvention {
             key = "type.tag";
         } else if (key.startsWith("_")) {
             // Fields that start with _ are considered reserved and ignored by Kibana. See https://github.com/elastic/kibana/issues/2551
-        	key = FIRST_UNDERSCORE_PATTERN.matcher(key).replaceFirst("");
+            key = FIRST_UNDERSCORE_PATTERN.matcher(key).replaceFirst("");
         }
 
         return delegate.tagKey(key);

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldToStringTest.java
@@ -32,33 +32,33 @@ class InfluxMeterRegistryFieldToStringTest {
         Locale.setDefault(this.originalLocale);
     }
 
-	@Test
+    @Test
     void testWithEnglishLocale() {
-		Locale.setDefault(Locale.ENGLISH);
-		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+        Locale.setDefault(Locale.ENGLISH);
+        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
 
-		InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+        InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
 
-		assertThat(field.toString()).isEqualTo("value=0.01");
-	}
+        assertThat(field.toString()).isEqualTo("value=0.01");
+    }
 
-	@Test
+    @Test
     void testWithEnglishLocaleWithLargerResolution() {
-		Locale.setDefault(Locale.ENGLISH);
-		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+        Locale.setDefault(Locale.ENGLISH);
+        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
 
-		InfluxMeterRegistry.Field field = instance.new Field("value", 0.0000009);
+        InfluxMeterRegistry.Field field = instance.new Field("value", 0.0000009);
 
-		assertThat(field.toString()).isEqualTo("value=0.000001");
-	}
+        assertThat(field.toString()).isEqualTo("value=0.000001");
+    }
 
-	@Test
+    @Test
     void testWithSwedishLocale() {
-		Locale.setDefault(new Locale("sv", "SE"));
+        Locale.setDefault(new Locale("sv", "SE"));
 
-		InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
-		InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
+        InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
 
-		assertThat(field.toString()).isEqualTo("value=0.01");
-	}
+        assertThat(field.toString()).isEqualTo("value=0.01");
+    }
 }

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -28,15 +28,15 @@ import io.micrometer.core.lang.Nullable;
  * @author Jon Schneider
  */
 public class SignalFxNamingConvention implements NamingConvention {
-	
-	private static final Pattern START_UNDERSCORE_PATTERN = Pattern.compile("^_");
-	private static final Pattern SF_PATTERN = Pattern.compile("^sf_");
-	private static final Pattern START_LETTERS_PATTERN = Pattern.compile("^[a-zA-Z].*");
-	
-	private static final int NAME_MAX_LENGTH = 256;
-	private static final int TAG_VALUE_MAX_LENGTH = 256;
-	private static final int KEY_MAX_LENGTH = 128;
-	
+
+    private static final Pattern START_UNDERSCORE_PATTERN = Pattern.compile("^_");
+    private static final Pattern SF_PATTERN = Pattern.compile("^sf_");
+    private static final Pattern START_LETTERS_PATTERN = Pattern.compile("^[a-zA-Z].*");
+
+    private static final int NAME_MAX_LENGTH = 256;
+    private static final int TAG_VALUE_MAX_LENGTH = 256;
+    private static final int KEY_MAX_LENGTH = 128;
+
     private final NamingConvention delegate;
 
     public SignalFxNamingConvention() {

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
@@ -24,8 +24,8 @@ import io.micrometer.core.lang.Nullable;
 
 public class WavefrontNamingConvention implements NamingConvention {
 	
-	private static final Pattern NAME_CLEANUP_PATTERN = Pattern.compile("[^a-zA-Z0-9\\-_\\./,]");
-	private static final Pattern KEY_CLEANUP_PATTERN = Pattern.compile("[^a-zA-Z0-9\\-_\\.]");
+    private static final Pattern NAME_CLEANUP_PATTERN = Pattern.compile("[^a-zA-Z0-9\\-_\\./,]");
+    private static final Pattern KEY_CLEANUP_PATTERN = Pattern.compile("[^a-zA-Z0-9\\-_\\.]");
 	
     private final NamingConvention delegate;
 
@@ -47,7 +47,7 @@ public class WavefrontNamingConvention implements NamingConvention {
      */
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-    	String sanitizedName = NAME_CLEANUP_PATTERN.matcher(delegate.name(name, type, baseUnit)).replaceAll("_");
+        String sanitizedName = NAME_CLEANUP_PATTERN.matcher(delegate.name(name, type, baseUnit)).replaceAll("_");
 
         // add name prefix if prefix exists
         if (namePrefix != null) {
@@ -61,7 +61,7 @@ public class WavefrontNamingConvention implements NamingConvention {
      */
     @Override
     public String tagKey(String key) {
-    	return KEY_CLEANUP_PATTERN.matcher(delegate.tagKey(key)).replaceAll("_");
+        return KEY_CLEANUP_PATTERN.matcher(delegate.tagKey(key)).replaceAll("_");
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  */
 public final class TimeUtils {
 	
-	private static final Pattern PARSE_PATTERN = Pattern.compile("[,_ ]");
+    private static final Pattern PARSE_PATTERN = Pattern.compile("[,_ ]");
 	
     private static final long C0 = 1L;
     private static final long C1 = C0 * 1000L;

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
@@ -38,7 +38,7 @@ import io.micrometer.core.instrument.Tag;
  */
 public final class DefaultJerseyTagsProvider implements JerseyTagsProvider {
 
-	private static final Pattern URI_CLEANUP_PATTERN = Pattern.compile("//+");
+    private static final Pattern URI_CLEANUP_PATTERN = Pattern.compile("//+");
 	
     // VisibleForTesting
     static final String TAG_METHOD = "method";

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Import;
  * @since 2.0.0
  */
 @Import({ NoOpMeterRegistryConfiguration.class,
-		CompositeMeterRegistryConfiguration.class })
+        CompositeMeterRegistryConfiguration.class })
 @ConditionalOnClass(CompositeMeterRegistry.class)
 public class CompositeMeterRegistryAutoConfiguration {
 


### PR DESCRIPTION
There are a few places using tabs for indentation.

This PR fixes to use spaces only for indentation. This PR also adds a CheckStyle rule to prevent tabs from sneaking into codebase again.