### PR TITLE
Apply WhitespaceAroundCheck Checkstyle rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -14,5 +14,7 @@
             <property name="processJavadoc" value="true" />
         </module>
 
+        <!-- Whitespace -->
+        <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck" />
     </module>
 </module>

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorTimer.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorTimer.java
@@ -55,7 +55,7 @@ public class SpectatorTimer extends AbstractTimer {
     @Override
     public double max(TimeUnit unit) {
         for (Measurement measurement : timer.measure()) {
-            if(stream(measurement.id().tags().spliterator(), false)
+            if (stream(measurement.id().tags().spliterator(), false)
                 .anyMatch(tag -> tag.key().equals("statistic") && tag.value().equals(Statistic.max.toString()))) {
                 return TimeUtils.secondsToUnit(measurement.value(), unit);
             }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
@@ -40,7 +40,7 @@ public interface CloudWatchConfig extends StepRegistryConfig {
 
     default String namespace() {
         String v = get(prefix() + ".namespace");
-        if(v == null)
+        if (v == null)
             throw new MissingRequiredConfigurationException("namespace must be set to report metrics to CloudWatch");
         return v;
     }
@@ -52,7 +52,7 @@ public interface CloudWatchConfig extends StepRegistryConfig {
             return MAX_BATCH_SIZE;
         }
         int vInt = Integer.parseInt(v);
-        if(vInt > MAX_BATCH_SIZE)
+        if (vInt > MAX_BATCH_SIZE)
             throw new InvalidConfigurationException("batchSize must be <= " + MAX_BATCH_SIZE);
 
         return vInt;

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -85,7 +85,7 @@ class DatadogMetricMetadata {
             String whitelistedBaseUnit = UNIT_WHITELIST.contains(baseUnit) ? baseUnit :
                 PLURALIZED_UNIT_MAPPING.get(baseUnit);
 
-            if(whitelistedBaseUnit != null) {
+            if (whitelistedBaseUnit != null) {
                 body += ",\"unit\":\"" + whitelistedBaseUnit + "\"";
             }
         }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogNamingConvention.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogNamingConvention.java
@@ -49,11 +49,11 @@ public class DatadogNamingConvention implements NamingConvention {
 
         // Metrics that don't start with a letter get dropped on the floor by the Datadog publish API,
         // so we will prepend them with 'm.'.
-        if(!Character.isLetter(sanitized.charAt(0))) {
+        if (!Character.isLetter(sanitized.charAt(0))) {
             sanitized = "m." + sanitized;
         }
 
-        if(sanitized.length() > 200)
+        if (sanitized.length() > 200)
             return sanitized.substring(0, 200);
         return sanitized;
     }
@@ -65,7 +65,7 @@ public class DatadogNamingConvention implements NamingConvention {
     @Override
     public String tagKey(String key) {
         String sanitized = StringEscapeUtils.escapeJson(delegate.tagKey(key));
-        if(Character.isDigit(sanitized.charAt(0))) {
+        if (Character.isDigit(sanitized.charAt(0))) {
             sanitized = "m." + sanitized;
         }
         return sanitized;

--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -50,7 +50,7 @@ public class GangliaMeterRegistry extends DropwizardMeterRegistry {
                     .convertDurationsTo(config.durationUnits())
                     .build(ganglia);
 
-            if(config.enabled())
+            if (config.enabled())
                 start();
         } catch (IOException e) {
             throw new RuntimeException("Failed to configure Ganglia metrics reporting", e);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
@@ -31,7 +31,7 @@ public class PrometheusCounter extends AbstractMeter implements Counter {
 
     @Override
     public void increment(double amount) {
-        if(amount > 0)
+        if (amount > 0)
             count.add(amount);
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
@@ -43,7 +43,7 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
             long count = (long) count();
             long newTimingsCount = count - prevCount;
 
-            if(newTimingsCount > 0) {
+            if (newTimingsCount > 0) {
                 lastTime.updateAndGet(prevTime -> {
                     double totalTime = totalTime(TimeUnit.MILLISECONDS);
                     double newTimingsSum = totalTime - prevTime;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMetrics.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMetrics.java
@@ -22,7 +22,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 public class StatsdMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
-        if(registry instanceof StatsdMeterRegistry) {
+        if (registry instanceof StatsdMeterRegistry) {
             StatsdMeterRegistry statsdRegistry = (StatsdMeterRegistry) registry;
 
             Gauge.builder("statsd.queue.size", statsdRegistry, StatsdMeterRegistry::queueSize)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -108,7 +108,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
             return new NoopPauseDetector();
         }));
 
-        if(pauseDetector instanceof SimplePauseDetector) {
+        if (pauseDetector instanceof SimplePauseDetector) {
             this.intervalEstimator = new TimeCappedMovingAverageIntervalEstimator(128,
                     10000000000L, pauseDetector);
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -331,5 +331,6 @@ public interface Meter extends AutoCloseable {
     }
 
     @Override
-    default void close() {}
+    default void close() {
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -125,7 +125,7 @@ class MetricsTurboFilter extends TurboFilter {
     @Override
     public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
         Boolean ignored = LogbackMetrics.ignoreMetrics.get();
-        if(ignored != null && ignored) {
+        if (ignored != null && ignored) {
             return FilterReply.NEUTRAL;
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -206,7 +206,7 @@ public final class RequiredSearch {
                 .map(clazz::cast)
                 .collect(toList());
 
-        if(meters.isEmpty()) {
+        if (meters.isEmpty()) {
             throw MeterNotFoundException.forSearch(this, clazz);
         }
 
@@ -220,7 +220,7 @@ public final class RequiredSearch {
     public Collection<Meter> meters() {
         List<Meter> meters = meterStream().collect(Collectors.toList());
 
-        if(meters.isEmpty()) {
+        if (meters.isEmpty()) {
             throw MeterNotFoundException.forSearch(this, Meter.class);
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
@@ -58,7 +58,7 @@ public final class Search {
      * @return This search.
      */
     public Search name(@Nullable Predicate<String> nameMatches) {
-        if(nameMatches != null)
+        if (nameMatches != null)
             this.nameMatches = nameMatches;
         return this;
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -44,6 +44,7 @@ class TimedAspectTest {
 
     static class TimedService {
         @Timed(value = "call", extraTags = {"extra", "tag"})
-        void call() {}
+        void call() {
+        }
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogramTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogramTest.java
@@ -216,7 +216,7 @@ class TimeWindowPercentileHistogramTest {
 
     private double percentileValue(Histogram histogram, double p) {
         for (ValueAtPercentile valueAtPercentile : histogram.takeSnapshot(0, 0, 0).percentileValues()) {
-            if(valueAtPercentile.percentile() == p)
+            if (valueAtPercentile.percentile() == p)
                 return valueAtPercentile.value();
         }
         return Double.NaN;

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
@@ -69,7 +69,7 @@ public class MetricsRequestEventListener implements RequestEventListener {
 
         switch (event.getType()) {
             case ON_EXCEPTION:
-                if(!(event.getException() instanceof NotFoundException)) {
+                if (!(event.getException() instanceof NotFoundException)) {
                     break;
                 }
             case REQUEST_MATCHED:
@@ -113,7 +113,7 @@ public class MetricsRequestEventListener implements RequestEventListener {
             return Collections.singleton(registry.timer(metricName, tagsProvider.httpRequestTags(event)));
         }
 
-        if(timed == null) {
+        if (timed == null) {
             return Collections.emptySet();
         }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/ConcurrentMapCacheMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/ConcurrentMapCacheMetrics.java
@@ -137,7 +137,7 @@ public class ConcurrentMapCacheMetrics extends CacheMeterBinder {
         @Nullable
         private ValueWrapper countGet(Object key) {
             ValueWrapper valueWrapper = delegate.get(key);
-            if(valueWrapper != null)
+            if (valueWrapper != null)
                 hitCount.incrementAndGet();
             else
                 missCount.incrementAndGet();
@@ -152,7 +152,7 @@ public class ConcurrentMapCacheMetrics extends CacheMeterBinder {
 
         @Override
         public ValueWrapper putIfAbsent(Object key, Object value) {
-            if(!getNativeCache().containsKey(key)) {
+            if (!getNativeCache().containsKey(key)) {
                 // no need to synchronize this with the subsequent putIfAbsent, as put count is
                 // OK to be an approximation.
                 putCount.incrementAndGet();

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
@@ -98,7 +98,7 @@ public final class WebMvcTags {
                 }
             }
             String pathInfo = getPathInfo(request);
-            if(pathInfo.isEmpty()) {
+            if (pathInfo.isEmpty()) {
                 return URI_ROOT;
             }
         }

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java
@@ -51,7 +51,7 @@ public abstract class CacheMeterBinderCompatibilityKit {
         put("k", "v");
         assertThat(binder.size()).isIn(null, 1L);
 
-        if(binder.size() != null) {
+        if (binder.size() != null) {
             assertThat(registry.get("cache.size")
                     .tag("cache", "mycache")
                     .gauge().value())
@@ -82,7 +82,7 @@ public abstract class CacheMeterBinderCompatibilityKit {
                 .functionCounter().count())
                 .isEqualTo(1);
 
-        if(binder.missCount() != null) {
+        if (binder.missCount() != null) {
             // will be 2 for Guava/Caffeine caches where LoadingCache considers a get against a non-existent key a "miss"
             assertThat(binder.missCount()).isIn(1L, 2L);
 

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsCompatibilityTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsCompatibilityTest.java
@@ -37,7 +37,7 @@ public class CaffeineCacheMetricsCompatibilityTest extends CacheMeterBinderCompa
                 @Override
                 public String load(@Nonnull String key) throws Exception {
                     String val = loadValue.getAndSet(null);
-                    if(val == null)
+                    if (val == null)
                         throw new Exception("don't load this key");
                     return val;
                 }
@@ -60,7 +60,7 @@ public class CaffeineCacheMetricsCompatibilityTest extends CacheMeterBinderCompa
     public String get(String key) {
         try {
             return cache.get(key);
-        } catch(Exception ignored) {
+        } catch (Exception ignored) {
             return null;
         }
     }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ExecutorServiceSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ExecutorServiceSample.java
@@ -36,6 +36,7 @@ public class ExecutorServiceSample {
         es.scheduleWithFixedDelay(() -> Mono.delay(Duration.ofMillis(20)).block(), 0,
                 10, TimeUnit.MILLISECONDS);
 
-        while(true) {}
+        while (true) {
+        }
     }
 }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/LongTaskTimerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/LongTaskTimerSample.java
@@ -50,7 +50,7 @@ public class LongTaskTimerSample {
                 .doOnEach(d -> {
                     if (incomingRequests.nextDouble() + 0.4 > 0 && tasks.isEmpty()) {
                         int taskDur;
-                        while((taskDur = duration.nextInt()) < 0);
+                        while ((taskDur = duration.nextInt()) < 0);
                         synchronized (tasks) {
                             tasks.put(timer.start(), new CountDownLatch(taskDur));
                         }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/SimulatedEndpointInstrumentation.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/SimulatedEndpointInstrumentation.java
@@ -77,7 +77,7 @@ public class SimulatedEndpointInstrumentation {
             .doOnEach(d -> {
                 // are we going to receive a request for /api/foo?
                 if (incomingRequests.nextDouble() + 0.4 > 0) {
-                    if(successOrFail.nextDouble() + 0.8 > 0) {
+                    if (successOrFail.nextDouble() + 0.8 > 0) {
                         // pretend the request took some amount of time, such that the time is
                         // distributed normally with a mean of 250ms
                         e1Success.record(latencyForThisSecond.get(), TimeUnit.MILLISECONDS);
@@ -94,7 +94,7 @@ public class SimulatedEndpointInstrumentation {
             .doOnEach(d -> {
                 // are we going to receive a request for /api/bar?
                 if (incomingRequests.nextDouble() + 0.4 > 0) {
-                    if(successOrFail.nextDouble() + 0.8 > 0) {
+                    if (successOrFail.nextDouble() + 0.8 > 0) {
                         // pretend the request took some amount of time, such that the time is
                         // distributed normally with a mean of 250ms
                         e2Success.record(latencyForThisSecond2.get(), TimeUnit.MILLISECONDS);


### PR DESCRIPTION
This PR applies `WhitespaceAroundCheck` Checkstyle rule mainly for adding consistent whitespaces to `if` statements but also polishing other bits to align with its default configuration which looks generally sensible.