### PR TITLE
Use @Issue

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -71,9 +71,9 @@ class PrometheusMeterRegistryTest {
         assertThat(prometheusRegistry.metricFamilySamples()).has(withNameAndQuantile("ds"));
     }
 
+    @Issue("#27")
     @DisplayName("custom distribution summaries respect varying tags")
     @Test
-    /** Issue #27 */
     void customSummaries() {
         Arrays.asList("v1", "v2").forEach(v -> {
             registry.summary("s", "k", v).record(1.0);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.spring.web.client;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
@@ -73,9 +74,7 @@ public class MetricsRestTemplateCustomizerTest {
         mockServer.verify();
     }
 
-    /**
-     * Issue #283
-     */
+    @Issue("#283")
     @Test
     public void normalizeUriToContainLeadingSlash() {
         mockServer.expect(MockRestRequestMatchers.requestTo("test/123"))


### PR DESCRIPTION
This PR changes to use `@Issue` instead of comments for issue numbers.