### PR TITLE
Rename JettyMetricsConfiguration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnClass(name = "org.eclipse.jetty.server.Server")
 @ConditionalOnMissingClass("org.apache.catalina.startup.Tomcat")
-public class JettyMetricsConfiguration {
+public class JettyMetricsAutoConfiguration {
 
     @Bean
     JettyMetricsPostProcessor jettyMetricsPostProcessor(MeterRegistry registry) {

--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -1,8 +1,9 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
 io.micrometer.spring.MetricsEnvironmentPostProcessor
+
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.micrometer.spring.autoconfigure.MetricsAutoConfiguration,\
-  io.micrometer.spring.autoconfigure.CompositeMeterRegistryAutoConfiguration,\
+io.micrometer.spring.autoconfigure.CompositeMeterRegistryAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.atlas.AtlasMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.datadog.DatadogMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.dynatrace.DynatraceMetricsExportAutoConfiguration,\
@@ -18,4 +19,4 @@ io.micrometer.spring.autoconfigure.export.signalfx.SignalFxMetricsExportAutoConf
 io.micrometer.spring.autoconfigure.export.statsd.StatsdMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
 io.micrometer.spring.jdbc.DataSourcePoolMetricsAutoConfiguration,\
-io.micrometer.spring.autoconfigure.web.jetty.JettyMetricsConfiguration
+io.micrometer.spring.autoconfigure.web.jetty.JettyMetricsAutoConfiguration


### PR DESCRIPTION
This PR renames `JettyMetricsConfiguration` to align with other auto-configuration classes.