### PR TITLE
Move DataSourcePoolMetricsAutoConfiguration under autoconfigure package

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/jdbc/DataSourcePoolMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/jdbc/DataSourcePoolMetricsAutoConfiguration.java
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.jdbc;
+package io.micrometer.spring.autoconfigure.jdbc;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
+import io.micrometer.spring.jdbc.DataSourcePoolMetrics;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;

--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -18,5 +18,5 @@ io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfigur
 io.micrometer.spring.autoconfigure.export.signalfx.SignalFxMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.statsd.StatsdMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
-io.micrometer.spring.jdbc.DataSourcePoolMetricsAutoConfiguration,\
+io.micrometer.spring.autoconfigure.jdbc.DataSourcePoolMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.web.jetty.JettyMetricsAutoConfiguration


### PR DESCRIPTION
This PR moves `DataSourcePoolMetricsAutoConfiguration` under `io.micrometer.spring.autoconfigure` package to align with other auto-configuration classes.