### PR TITLE
Fix early MeterRegistry creation with JettyMetricsAutoConfiguration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -43,7 +44,7 @@ import org.springframework.context.annotation.Configuration;
 public class JettyMetricsAutoConfiguration {
 
     @Bean
-    public JettyMetricsPostProcessor jettyMetricsPostProcessor(MeterRegistry registry) {
-        return new JettyMetricsPostProcessor(registry);
+    public JettyMetricsPostProcessor jettyMetricsPostProcessor(ApplicationContext context) {
+        return new JettyMetricsPostProcessor(context);
     }
 }


### PR DESCRIPTION
This regression was introduced with #633. Looking up the MeterRegistry
within the JettyMetricsPostProcessor fixes this. (One effect was
common tags not being applied.)

This PR is based on #662 which should be merged before.
