### PR TITLE
Simplify computation of the status code

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
@@ -20,10 +20,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
 
+import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.ExtendedUriInfo;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.uri.UriTemplate;
@@ -92,14 +92,11 @@ public final class DefaultJerseyTagsProvider implements JerseyTagsProvider {
     }
 
     private static int statusCode(RequestEvent event) {
-        Throwable exception = event.getException();
-        if (exception != null) {
-            if (exception instanceof WebApplicationException) {
-                return ((WebApplicationException) exception).getResponse().getStatus();
-            }
-            return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
+        ContainerResponse containerResponse = event.getContainerResponse();
+        if (containerResponse != null) {
+            return containerResponse.getStatus();
         }
-        return event.getContainerResponse().getStatus();
+        return Response.Status.INTERNAL_SERVER_ERROR.getStatusCode();
     }
 
     private static boolean isRedirect(int status) {

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/exception/ResourceGoneException.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/exception/ResourceGoneException.java
@@ -1,0 +1,16 @@
+package io.micrometer.jersey2.server.exception;
+
+public class ResourceGoneException extends RuntimeException {
+
+    public ResourceGoneException() {
+        super();
+    }
+
+    public ResourceGoneException(String message) {
+        super(message);
+    }
+
+    public ResourceGoneException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/mapper/ResourceGoneExceptionMapper.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/mapper/ResourceGoneExceptionMapper.java
@@ -1,0 +1,15 @@
+package io.micrometer.jersey2.server.mapper;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import io.micrometer.jersey2.server.exception.ResourceGoneException;
+
+public class ResourceGoneExceptionMapper implements ExceptionMapper<ResourceGoneException> {
+
+    @Override
+    public Response toResponse(ResourceGoneException exception) {
+        return Response.status(Status.GONE).build();
+    }
+}

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/resources/TestResource.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/resources/TestResource.java
@@ -28,6 +28,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import io.micrometer.jersey2.server.exception.ResourceGoneException;
+
 /**
  * @author Michael Weirauch
  */
@@ -79,6 +81,12 @@ public class TestResource {
     @Path("throws-webapplication-exception")
     public String throwsWebApplicationException() {
         throw new NotAuthorizedException("notauth", Response.status(Status.UNAUTHORIZED).build());
+    }
+
+    @GET
+    @Path("throws-mappable-exception")
+    public String throwsMappableException() {
+        throw new ResourceGoneException("Resource has been permanently removed.");
     }
 
     @GET


### PR DESCRIPTION
Given that the status code is computed for `RequestEvent` of type `FINISHED`, we can simply use the `ContainerResponse` to figure out the status code.
That way we handle both `WebApplicationException` and `MappableException` with registered `ExceptionMapper` (see https://github.com/micrometer-metrics/micrometer/issues/658).

In cases in which the `ContainerResponse` is not there, we fallback to `Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()`.