### PR TITLE
Fix null or empty String handling in StringEscapeUtils.escapeJson()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringEscapeUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringEscapeUtils.java
@@ -17,7 +17,13 @@ package io.micrometer.core.instrument.util;
 
 import io.micrometer.core.lang.Nullable;
 
-public class StringEscapeUtils {
+/**
+ * Utilities for escaping {@code String}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
+public final class StringEscapeUtils {
     /**
      * Modified from the quote method in:
      * https://github.com/codehaus/jettison/blob/master/src/main/java/org/codehaus/jettison/json/JSONObject.java
@@ -27,11 +33,11 @@ public class StringEscapeUtils {
      */
     public static String escapeJson(@Nullable String string) {
         if (StringUtils.isEmpty(string)) {
-            return "\"\"";
+            return "";
         }
 
         int len = string.length();
-        StringBuilder sb = new StringBuilder(len + 4);
+        StringBuilder sb = new StringBuilder(len + 2);
 
         for (int i = 0; i < len; i += 1) {
             char c = string.charAt(i);
@@ -67,4 +73,8 @@ public class StringEscapeUtils {
         }
         return sb.toString();
     }
+
+    private StringEscapeUtils() {
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringEscapeUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringEscapeUtilsTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StringEscapeUtils}.
+ *
+ * @author Johnny Lim
+ */
+class StringEscapeUtilsTest {
+
+    @Test
+    void escapeJsonWhenNullShouldReturnEmptyString() {
+        assertThat(StringEscapeUtils.escapeJson(null)).isEmpty();
+    }
+
+    @Test
+    void escapeJsonWhenEmptyStringShouldReturnEmptyString() {
+        assertThat(StringEscapeUtils.escapeJson("")).isEmpty();
+    }
+
+    @Test
+    void escapeJsonWhenDoubleQuotesShouldReturnEscapedString() {
+        assertThat(StringEscapeUtils.escapeJson("\"Hello, world!\"")).isEqualTo("\\\"Hello, world!\\\"");
+    }
+
+}


### PR DESCRIPTION
This PR fixes `null` or empty `String` handling in `StringEscapeUtils.escapeJson()`.

This PR also changes `StringBuilder`'s initial size as it doesn't contain double quotes unlike `org.codehaus.jettison.json.JSONObject.quote()` although I don't know how the initial size was determined in the first place.