### PR TITLE
Make DatadogNamingConvention.tagKey() respect its delegate

### DIFF
--- a/implementations/micrometer-registry-datadog/build.gradle
+++ b/implementations/micrometer-registry-datadog/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     compile 'org.apache.commons:commons-text:latest.release' lock '1.2'
 
     testCompile project(':micrometer-test')
+    testCompile 'org.mockito:mockito-core:latest.release' lock '2.15.0'
     testCompile 'io.projectreactor.ipc:reactor-netty:latest.release' lock '0.7.4.RELEASE'
 }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogNamingConvention.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogNamingConvention.java
@@ -21,7 +21,10 @@ import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
 
 /**
+ * {@link NamingConvention} for Datadog.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class DatadogNamingConvention implements NamingConvention {
     private final NamingConvention delegate;
@@ -45,7 +48,7 @@ public class DatadogNamingConvention implements NamingConvention {
         String sanitized = StringEscapeUtils.escapeJson(delegate.name(name, type, baseUnit));
 
         // Metrics that don't start with a letter get dropped on the floor by the Datadog publish API,
-        // so we will prepend them with 'm_'.
+        // so we will prepend them with 'm.'.
         if(!Character.isLetter(sanitized.charAt(0))) {
             sanitized = "m." + sanitized;
         }
@@ -57,13 +60,13 @@ public class DatadogNamingConvention implements NamingConvention {
 
     /**
      * Some set of non-alphanumeric characters will be replaced with '_', but not all (e.g. '/' is OK, but '{' is replaced).
-     * Tag keys that begin with a number show up as an empty string, so we prepend them with 'm_'.
+     * Tag keys that begin with a number show up as an empty string, so we prepend them with 'm.'.
      */
     @Override
     public String tagKey(String key) {
         String sanitized = StringEscapeUtils.escapeJson(delegate.tagKey(key));
-        if(Character.isDigit(key.charAt(0))) {
-            sanitized = "m." + key;
+        if(Character.isDigit(sanitized.charAt(0))) {
+            sanitized = "m." + sanitized;
         }
         return sanitized;
     }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogNamingConventionTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogNamingConventionTest.java
@@ -17,10 +17,20 @@ package io.micrometer.datadog;
 
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
 
+/**
+ * Tests for {@link DatadogNamingConvention}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class DatadogNamingConventionTest {
     private DatadogNamingConvention convention = new DatadogNamingConvention();
 
@@ -32,6 +42,18 @@ class DatadogNamingConventionTest {
     @Test
     void tagKeyStartsWithLetter() {
         assertThat(convention.tagKey("123")).isEqualTo("m.123");
+    }
+
+    @Test
+    void tagKeyWhenStartsWithNumberShouldRespectDelegateNamingConvention() {
+        String tagKey = "123";
+
+        NamingConvention delegate = mock(NamingConvention.class);
+        given(delegate.tagKey(eq(tagKey))).willReturn("123456");
+
+        DatadogNamingConvention convention = new DatadogNamingConvention(delegate);
+
+        assertThat(convention.tagKey(tagKey)).isEqualTo("m.123456");
     }
 
     @Test


### PR DESCRIPTION
This PR changes `DatadogNamingConvention.tagKey()` to respect its
`delegate` when a tag key starts with a number.