### PR TITLE
Metric name placeholders

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -143,6 +143,9 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
      */
     protected abstract Double nullGaugeValue();
 
+    /**
+     * @return A configuration object used to change the additional behavior of this registry.
+     */
     public MoreConfig moreConfig() {
         return moreConfig;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -37,9 +37,11 @@ import java.util.function.ToLongFunction;
  */
 public abstract class DropwizardMeterRegistry extends MeterRegistry {
     private final MetricRegistry registry;
-    private final HierarchicalNameMapper nameMapper;
+    private final MoreConfig moreConfig = new MoreConfig();
     private final DropwizardClock dropwizardClock;
     private final DropwizardConfig dropwizardConfig;
+
+    private HierarchicalNameMapper nameMapper;
 
     public DropwizardMeterRegistry(DropwizardConfig config, MetricRegistry registry, HierarchicalNameMapper nameMapper, Clock clock) {
         super(clock);
@@ -140,4 +142,23 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
      * @return Value to report when {@link io.micrometer.core.instrument.Gauge#value()} returns {@code null}.
      */
     protected abstract Double nullGaugeValue();
+
+    public MoreConfig moreConfig() {
+        return moreConfig;
+    }
+
+    /**
+     * Access to additional configuration options.
+     */
+    public class MoreConfig {
+
+        public MoreConfig nameMapper(HierarchicalNameMapper mapper) {
+            nameMapper = mapper;
+            return this;
+        }
+
+        public HierarchicalNameMapper nameMapper() {
+            return nameMapper;
+        }
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/NameMappingFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/NameMappingFilter.java
@@ -1,0 +1,26 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+
+import java.util.Map;
+
+class NameMappingFilter implements MeterFilter {
+
+    private final Map<String, String> mappings;
+
+    NameMappingFilter(Map<String, String> mappings) {
+        this.mappings = mappings;
+    }
+
+    @Override
+    public Meter.Id map(Meter.Id id) {
+        String mappedName = mappings.get(id.getName());
+
+        if (mappedName == null) {
+            return id;
+        }
+
+        return id.withName(mappedName);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/NameMappingFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/NameMappingFilter.java
@@ -5,6 +5,12 @@ import io.micrometer.core.instrument.config.MeterFilter;
 
 import java.util.Map;
 
+/**
+ * A filter that renames given metrics. Used in the placeholders mechanism in order to
+ * adjust metrics that are outside of user's control, e.g. standard memory metrics.
+ *
+ * @author Piotr Betkier
+ */
 class NameMappingFilter implements MeterFilter {
 
     private final Map<String, String> mappings;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
@@ -3,10 +3,33 @@ package io.micrometer.core.instrument.placeholder;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 
-public interface Placeholders {
+import java.util.HashMap;
+import java.util.Map;
 
-    static void bindTo(MeterRegistry... registries) {
+public class Placeholders {
+
+    private final Map<String, String> metricNameMappings = new HashMap<>();
+
+    private Placeholders() {
+    }
+
+    public static Placeholders withoutMappings() {
+        return new Placeholders();
+    }
+
+    public Placeholders addMapping(String from, String to) {
+        metricNameMappings.put(from, to);
+        return this;
+    }
+
+    public Placeholders extendWith(Placeholders others) {
+        metricNameMappings.putAll(others.metricNameMappings);
+        return this;
+    }
+
+    public void bindTo(MeterRegistry... registries) {
         for (MeterRegistry registry : registries) {
+            registry.config().meterFilter(new NameMappingFilter(metricNameMappings));
             registry.config().namingConvention(
                     new RemovePlaceholdersNamingConvention(registry.config().namingConvention())
             );

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
@@ -1,0 +1,19 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
+
+public interface Placeholders {
+
+    static void bindTo(MeterRegistry... registries) {
+        for (MeterRegistry registry : registries) {
+            registry.config().namingConvention(
+                    new RemovePlaceholdersNamingConvention(registry.config().namingConvention())
+            );
+            if (registry instanceof DropwizardMeterRegistry) {
+                ((DropwizardMeterRegistry) registry).moreConfig()
+                        .nameMapper(new ResolvePlaceholdersNameMapper());
+            }
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/Placeholders.java
@@ -1,11 +1,27 @@
 package io.micrometer.core.instrument.placeholder;
 
+import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * An entry-point for the placeholders feature.
+ *
+ * Placeholders are an alternative way to build metric names from tags in hierarchical
+ * registries like Dropwizard (Graphite). Users may put placeholders in the metric name
+ * which define positions in which given tags should be encoded. When bound to a registry
+ * it replaces the default strategy of tag encoding by appending all tag keys and values to the
+ * metric name.
+ *
+ * By defining metric name mappings, users can define placeholders in metrics that are
+ * outside of their control, e.g. standard memory metrics.
+ *
+ * @author Piotr Betkier
+ */
+@Incubating(since = "1.1.0")
 public class Placeholders {
 
     private final Map<String, String> metricNameMappings = new HashMap<>();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConvention.java
@@ -9,6 +9,14 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * A naming convention that removes all placeholders from the metric name. Configured in
+ * non-hierarchical registries when using the placeholders mechanism. Metrics
+ * registered in non-hierarchical registries don't have tags encoded in their name, because
+ * they support tags explicitly.
+ *
+ * @author Piotr Betkier
+ */
 class RemovePlaceholdersNamingConvention implements NamingConvention {
 
     private static final Pattern PLACEHOLDER = Pattern.compile("\\{.*\\}");

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConvention.java
@@ -1,0 +1,30 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.StringUtils;
+import io.micrometer.core.lang.Nullable;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+class RemovePlaceholdersNamingConvention implements NamingConvention {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{.*\\}");
+
+    private final NamingConvention delegate;
+
+    RemovePlaceholdersNamingConvention(NamingConvention delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String name(String name, Meter.Type type, @Nullable String baseUnit) {
+        String noPlaceholders = PLACEHOLDER.matcher(name).replaceAll("");
+        String normalized = Arrays.stream(noPlaceholders.split("\\."))
+                .filter(s -> !StringUtils.isEmpty(s))
+                .collect(Collectors.joining("."));
+        return delegate.name(normalized, type, baseUnit);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapper.java
@@ -5,6 +5,13 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 
+/**
+ * A name mapper that encodes tags in positions specified by metric name placeholders.
+ * Configured in hierarchical registries when using the placeholders mechanism. All placeholders
+ * in the given metric name need to have matching tags or else an exception is thrown.
+ *
+ * @author Piotr Betkier
+ */
 class ResolvePlaceholdersNameMapper implements HierarchicalNameMapper {
 
     @Override
@@ -12,12 +19,14 @@ class ResolvePlaceholdersNameMapper implements HierarchicalNameMapper {
         String name = id.getName();
 
         for (Tag tag : id.getTags()) {
-            name = name.replace("{" + tag.getKey() + "}", tag.getValue());
+            name = name.replace("{" + tag.getKey() + "}", convention.tagValue(tag.getValue()));
         }
 
         if (name.contains("{") || name.contains("}")) {
-            throw new IllegalArgumentException("Some placeholders in the metric name do not have a matching tag! " +
-                    "Metric name: " + id.getName() + ", after resolving with tags provided: " + name );
+            throw new IllegalArgumentException(
+                    "Some placeholders in the metric name do not have a matching tag! " +
+                            "Metric name: " + id.getName() +
+                            ", after resolving with tags provided: " + name);
         }
 
         return name;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapper.java
@@ -1,0 +1,25 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+
+class ResolvePlaceholdersNameMapper implements HierarchicalNameMapper {
+
+    @Override
+    public String toHierarchicalName(Meter.Id id, NamingConvention convention) {
+        String name = id.getName();
+
+        for (Tag tag : id.getTags()) {
+            name = name.replace("{" + tag.getKey() + "}", tag.getValue());
+        }
+
+        if (name.contains("{") || name.contains("}")) {
+            throw new IllegalArgumentException("Some placeholders in the metric name do not have a matching tag! " +
+                    "Metric name: " + id.getName() + ", after resolving with tags provided: " + name );
+        }
+
+        return name;
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/MeterAssert.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/MeterAssert.java
@@ -1,0 +1,27 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+class MeterAssert extends AbstractAssert<MeterAssert, Meter> {
+
+    private MeterAssert(Meter meter, Class<?> selfType) {
+        super(meter, selfType);
+    }
+
+    static MeterAssert assertThat(Meter actual) {
+        return new MeterAssert(actual, MeterAssert.class);
+    }
+
+    MeterAssert hasName(String expected) {
+        Assertions.assertThat(actual.getId().getName()).isEqualTo(expected);
+        return myself;
+    }
+
+    MeterAssert hasExactTags(Tag... tags) {
+        Assertions.assertThat(actual.getId().getTags()).containsExactly(tags);
+        return myself;
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/NamingConventionMeterRegistry.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/NamingConventionMeterRegistry.java
@@ -1,0 +1,33 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.noop.NoopCounter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+class NamingConventionMeterRegistry extends SimpleMeterRegistry {
+
+    private final Map<Meter.Id, Counter> delegate = new HashMap<>();
+
+    NamingConventionMeterRegistry(NamingConvention convention) {
+        config().namingConvention(convention);
+    }
+
+    @Override
+    protected Counter newCounter(Meter.Id id) {
+        Counter counter = super.newCounter(id);
+        Meter.Id renamed = id.withName(getConventionName(id));
+        delegate.put(renamed, new NoopCounter(renamed));
+        return counter;
+    }
+
+    public Collection<Counter> countersInDelegateRegistry() {
+        return delegate.values();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/PlaceholdersTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/PlaceholdersTest.java
@@ -1,0 +1,170 @@
+package io.micrometer.core.instrument.placeholder;
+
+import com.codahale.metrics.MetricRegistry;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
+import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import io.micrometer.core.lang.Nullable;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static io.micrometer.core.instrument.placeholder.PlaceholdersTest.MeterAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlaceholdersTest {
+
+    private final DropwizardMeterRegistry hierarchicalRegistry = createDropwizardRegistry();
+
+    private final NamingConventionMeterRegistry nonHierarchicalRegistry =
+            new NamingConventionMeterRegistry(NamingConvention.snakeCase);
+
+    @Test
+    void placeholdersAreRemovedInNonHierarchicalDelegateRegistries() {
+        // given
+        Placeholders.bindTo(nonHierarchicalRegistry);
+
+        // when
+        nonHierarchicalRegistry.counter("metric.{db}.{op}.count", "db", "mongo", "op", "save");
+
+        // then
+        assertThat(any(nonHierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(any(nonHierarchicalRegistry.countersInDelegateRegistry()))
+                .hasName("metric_count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+    }
+
+    @Test
+    void placeholdersAreResolvedWithTagsInHierarchicalDelegateRegistries() {
+        // given
+        Placeholders.bindTo(hierarchicalRegistry);
+
+        // when
+        hierarchicalRegistry.counter("metric.{db}.{op}.count", "db", "mongo", "op", "save");
+
+        // then
+        assertThat(any(hierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(hierarchicalRegistry.getDropwizardRegistry().getMetrics())
+                .containsKey("metric.mongo.save.count");
+    }
+
+    @Test
+    void placeholdersAreNotResolvedIfBoundToCompositeRegistryButNotToChildRegistries() {
+        // given
+        CompositeMeterRegistry composite = new CompositeMeterRegistry();
+        composite.add(hierarchicalRegistry);
+        composite.add(nonHierarchicalRegistry);
+
+        Placeholders.bindTo(composite);
+
+        // when
+        composite.counter("metric.{db}.{op}.count", "db", "mongo", "op", "save");
+
+        // then
+        assertThat(any(hierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(hierarchicalRegistry.getDropwizardRegistry().getMetrics())
+                .doesNotContainKeys("metric.mongo.save.count")
+                .containsKey("metric{db}{op}Count.db.mongo.op.save");
+
+        assertThat(any(nonHierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(any(nonHierarchicalRegistry.countersInDelegateRegistry()))
+                .hasName("metric_{db}_{op}_count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+    }
+
+    @Test
+    void placeholdersAreResolvedIfBoundToCompositeRegistryAndChildRegistries() {
+        // given
+        CompositeMeterRegistry composite = new CompositeMeterRegistry();
+        composite.add(hierarchicalRegistry);
+        composite.add(nonHierarchicalRegistry);
+
+        Placeholders.bindTo(composite, hierarchicalRegistry, nonHierarchicalRegistry);
+
+        // when
+        composite.counter("metric.{db}.{op}.count", "db", "mongo", "op", "save");
+
+        // then
+        assertThat(any(hierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(hierarchicalRegistry.getDropwizardRegistry().getMetrics())
+                .containsKey("metric.mongo.save.count");
+
+        assertThat(any(nonHierarchicalRegistry.getMeters()))
+                .hasName("metric.{db}.{op}.count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+
+        assertThat(any(nonHierarchicalRegistry.countersInDelegateRegistry()))
+                .hasName("metric_count")
+                .hasExactTags(Tag.of("db", "mongo"), Tag.of("op", "save"));
+    }
+
+    private <T> T any(Collection<T> meters) {
+        return meters.iterator().next();
+    }
+
+    private DropwizardMeterRegistry createDropwizardRegistry() {
+        DropwizardConfig config = new DropwizardConfig() {
+            @Override
+            public String prefix() {
+                return "dropwizard";
+            }
+
+            @Override
+            @Nullable
+            public String get(String key) {
+                return null;
+            }
+        };
+
+        return new DropwizardMeterRegistry(
+                config, new MetricRegistry(), HierarchicalNameMapper.DEFAULT, new MockClock()) {
+            @Override
+            protected Double nullGaugeValue() {
+                return Double.NaN;
+            }
+        };
+    }
+
+    static class MeterAssert extends AbstractAssert<MeterAssert, Meter> {
+
+        private MeterAssert(Meter meter, Class<?> selfType) {
+            super(meter, selfType);
+        }
+
+        static MeterAssert assertThat(Meter actual) {
+            return new MeterAssert(actual, MeterAssert.class);
+        }
+
+        MeterAssert hasName(String expected) {
+            Assertions.assertThat(actual.getId().getName()).isEqualTo(expected);
+            return myself;
+        }
+
+        MeterAssert hasExactTags(Tag... tags) {
+            Assertions.assertThat(actual.getId().getTags()).containsExactly(tags);
+            return myself;
+        }
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConventionTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConventionTest.java
@@ -1,0 +1,33 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RemovePlaceholdersNamingConventionTest {
+
+    private RemovePlaceholdersNamingConvention namingConvention =
+            new RemovePlaceholdersNamingConvention(NamingConvention.snakeCase);
+
+    @ParameterizedTest
+    @CsvSource(delimiter = '|', value = {
+            "a.{b}.c | a_c",
+            "{a}.b | b",
+            "a.{b} | a",
+            "{a} | ''",
+            "{a}.{b} | ''",
+            "a.{spe-cial_char.s}.c | a_c",
+            "a.{numb3r5}.c | a_c"
+    })
+    void removesPlaceholdersFromName(String name, String expectedName) {
+        // when
+        String renamed = namingConvention.name(name, Meter.Type.COUNTER, null);
+
+        // then
+        assertThat(renamed).isEqualTo(expectedName);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConventionTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/RemovePlaceholdersNamingConventionTest.java
@@ -20,7 +20,8 @@ class RemovePlaceholdersNamingConventionTest {
             "{a} | ''",
             "{a}.{b} | ''",
             "a.{spe-cial_char.s}.c | a_c",
-            "a.{numb3r5}.c | a_c"
+            "a.{numb3r5}.c | a_c",
+            "a.b | a_b"
     })
     void removesPlaceholdersFromName(String name, String expectedName) {
         // when

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapperTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/placeholder/ResolvePlaceholdersNameMapperTest.java
@@ -1,0 +1,81 @@
+package io.micrometer.core.instrument.placeholder;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.config.NamingConvention;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ResolvePlaceholdersNameMapperTest {
+
+    private static final NamingConvention UNUSED = NamingConvention.dot;
+
+    private ResolvePlaceholdersNameMapper mapper = new ResolvePlaceholdersNameMapper();
+
+    @ParameterizedTest
+    @MethodSource("dataForSubstitutions")
+    void placeholdersAreSubstitutedWithTagValues(String name, Tags tags, String expectedName) {
+        // given
+        Meter.Id id = createMeterId(name, tags);
+
+        // when
+        String hierarchicalName = mapper.toHierarchicalName(id, UNUSED);
+
+        // then
+        assertThat(hierarchicalName).isEqualTo(expectedName);
+    }
+
+    private static Stream<Arguments> dataForSubstitutions() {
+        return Stream.of(
+                Arguments.of("a.{p1}.c", Tags.of("p1", "xyz"), "a.xyz.c"),
+                Arguments.of("{p1}.c", Tags.of("p1", "xyz"), "xyz.c"),
+                Arguments.of("a.{p1}", Tags.of("p1", "xyz"), "a.xyz"),
+                Arguments.of("a.{p1}.{p2}.c", Tags.of("p1", "abc").and("p2", "xyz"), "a.abc.xyz.c"),
+                Arguments.of("a.{p2}.{p1}.c", Tags.of("p1", "abc").and("p2", "xyz"), "a.xyz.abc.c"),
+                Arguments.of("a.{w1thNumb3r5}.c", Tags.of("w1thNumb3r5", "123"), "a.123.c"),
+                Arguments.of("a.{_spe.cial-chars}.c", Tags.of("_spe.cial-chars", "abc"), "a.abc.c"),
+                Arguments.of("a.b.c", Tags.empty(), "a.b.c"),
+                Arguments.of("a.b.c", Tags.of("p1", "xyz"), "a.b.c")
+        );
+    }
+
+    @Test
+    void throwsExceptionIfAnyPlaceholderDoesntHaveAMatchingTag() {
+        // given
+        Meter.Id id = createMeterId("{missing}.{present}", Tags.of("present", "x"));
+
+        // expect
+        IllegalArgumentException e = assertThrows(
+                IllegalArgumentException.class,
+                () -> mapper.toHierarchicalName(id, UNUSED)
+        );
+        assertThat(e.getMessage()).contains("after resolving with tags provided: {missing}.x");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a.{whoops.b", "a.{{wow}.x}y"})
+    void throwsExceptionIfMetricNameHasMalformedPlaceholders(String name) {
+        // given
+        Meter.Id id = createMeterId(name, Tags.empty());
+
+        // expect
+        assertThrows(IllegalArgumentException.class, () -> mapper.toHierarchicalName(id, UNUSED));
+    }
+
+    @Test
+    void dotInTagValue() {
+
+    }
+
+    private Meter.Id createMeterId(String name, Tags tags) {
+        return new Meter.Id(name, tags, null, "", Meter.Type.TIMER);
+    }
+}


### PR DESCRIPTION
Support for placeholders in metric names as an alternative way of encoding tags in hierarchical registries like Dropwizard. The feature is described in detail in #620.

This PR is a first iteration, without standard placeholder mappings, e.g. for Graphite and missing docs.