### PR TITLE
Switch to CircleCI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,34 @@ jobs:
           path: ~/micrometer/test-results/
 
       - store_artifacts:
-          path: build/libs
+          path: ~/micrometer/test-results/
 
+  deploy:
+    working_directory: ~/micrometer
+    environment:
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - checkout
+      - restore_cache:
+          key: gradle-dependencies-{{ checksum "build.gradle" }}
       - deploy:
           name: Deployment
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ] || [ "$CIRCLE_BRANCH" = "1.0.x" ]; then
-              sh ./gradle/deploy.sh
-            else
-              echo "SKIPPED publishing artifacts for non-integration branch."
-            fi
+          command: sh ./gradle/deploy.sh
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - /\d+\.\d+\.x/
+            tags:
+              only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/


### PR DESCRIPTION
Separates build step and deploy step, so that the deploy step is only conditionally run on integration branches and version tags.