### PR TITLE
autocreating retention policy

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
@@ -1,0 +1,85 @@
+package io.micrometer.influx;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * Builds a create database query for influxdb. It is supposed to be of the following structure:
+ *
+ * CREATE DATABASE <database_name> [WITH [DURATION <duration>] [REPLICATION <n>] [SHARD DURATION <duration>] [NAME
+ * <retention-policy-name>]]
+ *
+ * @author Vladyslav Oleniuk (vlad.oleniuk@gmail.com)
+ */
+public class CreateDatabaseQueryBuilder {
+
+	private static String QUERY_MANDATORY_TEMPLATE = "CREATE DATABASE %s";
+
+	private static String RETENTION_POLICY_INTRODUCTION = " WITH";
+
+	private static String DURATION_CLAUSE_TEMPLATE = " DURATION %s";
+
+	private static String REPLICATION_FACTOR_CLAUSE_TEMPLATE = " REPLICATION %s";
+
+	private static String SHARD_DURATION_CLAUSE_TEMPLATE = " SHARD DURATION %s";
+
+	private static String NAME_CLAUSE_TEMPLATE = " NAME %s";
+
+	private String databaseName;
+
+	private String[] retentionPolicyClauses = new String[4];
+
+	public CreateDatabaseQueryBuilder(String databaseName) {
+		if (isEmpty(databaseName)) {
+			throw new IllegalArgumentException("The database name mustn't be empty");
+		}
+		this.databaseName = databaseName;
+	}
+
+	public CreateDatabaseQueryBuilder setRetentionDuration(String retentionDuration) {
+		if (!isEmpty(retentionDuration)) {
+			retentionPolicyClauses[0] = String.format(DURATION_CLAUSE_TEMPLATE, retentionDuration);
+		}
+		return this;
+	}
+
+	public CreateDatabaseQueryBuilder setRetentionReplicationFactor(String retentionReplicationFactor) {
+		if (!isEmpty(retentionReplicationFactor)) {
+			retentionPolicyClauses[1] = String.format(REPLICATION_FACTOR_CLAUSE_TEMPLATE, retentionReplicationFactor);
+		}
+		return this;
+	}
+
+	public CreateDatabaseQueryBuilder setRetentionShardDuration(String retentionShardDuration) {
+		if (!isEmpty(retentionShardDuration)) {
+			retentionPolicyClauses[2] = String.format(SHARD_DURATION_CLAUSE_TEMPLATE, retentionShardDuration);
+		}
+		return this;
+	}
+
+	public CreateDatabaseQueryBuilder setRetentionPolicyName(String retentionPolicyName) {
+		if (!isEmpty(retentionPolicyName)) {
+			retentionPolicyClauses[3] = String.format(NAME_CLAUSE_TEMPLATE, retentionPolicyName);
+		}
+		return this;
+	}
+
+	public String build() {
+		StringBuilder queryStringBuilder = new StringBuilder(String.format(QUERY_MANDATORY_TEMPLATE, databaseName));
+		if (toCreateRetentionPolicy()) {
+			String retentionPolicyClause = Stream.of(retentionPolicyClauses).filter(Objects::nonNull)
+					.reduce(RETENTION_POLICY_INTRODUCTION, String::concat);
+			queryStringBuilder.append(retentionPolicyClause);
+		}
+		return queryStringBuilder.toString();
+	}
+
+	private boolean toCreateRetentionPolicy() {
+		return Stream.of(retentionPolicyClauses).anyMatch(Objects::nonNull);
+	}
+
+	private boolean isEmpty(String string) {
+		return string == null || string.isEmpty();
+	}
+
+}

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
@@ -79,6 +79,31 @@ public interface InfluxConfig extends StepRegistryConfig {
         return get(prefix() + ".retentionPolicy");
     }
 
+	/**
+	 * @return time period for which influx should retain data in the current database (e.g. 2h, 52w)
+	 */
+	@Nullable
+	default String retentionDuration(){
+		return get(prefix() + ".retentionDuration");
+	}
+
+	/**
+	 * @return how many copies of the data are stored in the cluster. Must be 1 for a single node instance
+	 */
+	@Nullable
+	default String retentionReplicationFactor(){
+		return get(prefix() + ".retentionReplicationFactor");
+	}
+
+	/**
+	 * @return the time range covered by a shard group
+	 */
+	@Nullable
+	default String retentionShardDuration(){
+		return get(prefix() + ".retentionShardDuration");
+	}
+
+
     /**
      * @return The URI for the Influx backend. The default is {@code http://localhost:8086}.
      */

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -65,7 +65,12 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
         HttpURLConnection con = null;
         try {
-            URL queryEndpoint = URI.create(config.uri() + "/query?q=" + URLEncoder.encode("CREATE DATABASE \"" + config.db() + "\"", "UTF-8")).toURL();
+            String createDatabaseQuery = new CreateDatabaseQueryBuilder(config.db()).setRetentionDuration(config.retentionDuration())
+					.setRetentionPolicyName(config.retentionPolicy())
+					.setRetentionReplicationFactor(config.retentionReplicationFactor())
+					.setRetentionShardDuration(config.retentionShardDuration()).build();
+
+            URL queryEndpoint = URI.create(config.uri() + "/query?q=" + URLEncoder.encode(createDatabaseQuery, "UTF-8")).toURL();
 
             con = (HttpURLConnection) queryEndpoint.openConnection();
             con.setConnectTimeout((int) config.connectTimeout().toMillis());

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
@@ -52,7 +52,7 @@ public class CreateDatabaseQueryBuilderTest {
 	public void allClausesInRetentionPolicy() {
 		String query = createDatabaseQueryBuilder.setRetentionPolicyName("dummy_policy")
 				.setRetentionDuration("2d")
-				.setRetentionReplication("1")
+				.setRetentionReplicationFactor("1")
 				.setRetentionShardDuration("3")
 				.build();
 		assertEquals("CREATE DATABASE dummy_database_0 WITH DURATION 2d REPLICATION 1 SHARD DURATION 3 NAME dummy_policy", query);

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
@@ -7,6 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * Test for {@link CreateDatabaseQueryBuilder}
+ */
 public class CreateDatabaseQueryBuilderTest {
 
 	/**

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
@@ -1,0 +1,58 @@
+package io.micrometer.influx;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateDatabaseQueryBuilderTest {
+
+	/**
+	 * Class Parameters:
+	 *
+	 * - database name
+	 * - retention clauses
+	 *
+	 * Class Criteria
+	 * - database name is not null		->	true		false
+	 * - retention clauses			->	no		one		all
+	 */
+
+	private CreateDatabaseQueryBuilder createDatabaseQueryBuilder;
+	private static String TEST_DB_NAME = "dummy_database_0";
+
+	@BeforeEach
+	public void init() {
+		createDatabaseQueryBuilder = new CreateDatabaseQueryBuilder(TEST_DB_NAME);
+	}
+
+	@Test
+	public void noEmptyDatabaseName() {
+		assertThrows(IllegalArgumentException.class, () -> new CreateDatabaseQueryBuilder(null));
+	}
+
+	@Test
+	public void noRetentionPolicy() {
+		String query = createDatabaseQueryBuilder.build();
+		assertEquals("CREATE DATABASE dummy_database_0", query);
+	}
+
+	@Test
+	public void oneClauseInRetentionPolicy() {
+		String query = createDatabaseQueryBuilder.setRetentionPolicyName("dummy_policy").build();
+		assertEquals("CREATE DATABASE dummy_database_0 WITH NAME dummy_policy", query);
+	}
+
+	@Test
+	public void allClausesInRetentionPolicy() {
+		String query = createDatabaseQueryBuilder.setRetentionPolicyName("dummy_policy")
+				.setRetentionDuration("2d")
+				.setRetentionReplication("1")
+				.setRetentionShardDuration("3")
+				.build();
+		assertEquals("CREATE DATABASE dummy_database_0 WITH DURATION 2d REPLICATION 1 SHARD DURATION 3 NAME dummy_policy", query);
+	}
+
+}


### PR DESCRIPTION
While creating an influxdb database it is common to specify a retention policy for it.

Thus needed properties are added to InfluxConfig and  injected into the create database statement