### PR TITLE
Use the provided tags for DiskSpaceMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/DiskSpaceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/DiskSpaceMetrics.java
@@ -31,6 +31,7 @@ import static java.util.Collections.emptyList;
  * Record metrics that report disk space usage.
  *
  * @author jmcshane
+ * @author Johnny Lim
  */
 @NonNullApi
 @NonNullFields
@@ -53,12 +54,12 @@ public class DiskSpaceMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Iterable<Tag> tagsWithPath = Tags.concat(tags, "path", absolutePath);
         Gauge.builder("disk.free", path, File::getUsableSpace)
-                .tags()
+                .tags(tagsWithPath)
                 .description("Usable space for path")
                 .baseUnit("bytes")
                 .register(registry);
         Gauge.builder("disk.total", path, File::getTotalSpace)
-                .tags()
+                .tags(tagsWithPath)
                 .description("Total space for path")
                 .baseUnit("bytes")
                 .register(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/DiskSpaceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/DiskSpaceMetricsTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.binder.jvm;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,12 @@ import java.io.File;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+/**
+ * Tests for {@link DiskSpaceMetrics}.
+ *
+ * @author jmcshane
+ * @author Johnny Lim
+ */
 class DiskSpaceMetricsTest {
     @Test
     void diskSpaceMetrics() {
@@ -32,4 +39,14 @@ class DiskSpaceMetricsTest {
         assertThat(registry.get("disk.free").gauge().value()).isGreaterThan(0);
         assertThat(registry.get("disk.total").gauge().value()).isGreaterThan(0);
     }
+
+    @Test
+    void diskSpaceMetricsWithTags() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        new DiskSpaceMetrics(new File(System.getProperty("user.dir")), Tags.of("key1", "value1")).bindTo(registry);
+
+        assertThat(registry.get("disk.free").tags("key1", "value1").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("disk.total").tags("key1", "value1").gauge().value()).isGreaterThan(0);
+    }
+
 }


### PR DESCRIPTION
The provided tags for `DiskSpaceMetrics` aren't used, so this PR changes to use them.