### PR TITLE
Deduplicate database tag in PostgreSQLDatabaseMetrics

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/db/PostgreSQLDatabaseMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/db/PostgreSQLDatabaseMetrics.java
@@ -33,7 +33,11 @@ import java.util.function.DoubleSupplier;
 
 
 /**
+ * {@link MeterBinder} for a PostgreSQL database.
+ *
  * @author Kristof Depypere
+ * @author Jon Schneider
+ * @author Johnny Lim
  */
 @NonNullApi
 @NonNullFields
@@ -49,7 +53,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
     private final Map<String, Double> previousValueCacheMap;
 
     public PostgreSQLDatabaseMetrics(DataSource postgresDataSource, String database) {
-        this(postgresDataSource, database, Tags.of(createDbTag(database)));
+        this(postgresDataSource, database, Tags.empty());
     }
 
     public PostgreSQLDatabaseMetrics(DataSource postgresDataSource, String database, Iterable<Tag> tags) {


### PR DESCRIPTION
This PR deduplicates "database" tag in `PostgreSQLDatabaseMetrics` as it looks accidentally added twice.