### PR TITLE
Collapse nested try-resources statements into one

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/db/PostgreSQLDatabaseMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/db/PostgreSQLDatabaseMetrics.java
@@ -263,13 +263,11 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
         return correctedValue;
     }
 
-    private <T> Long runQuery(String query) {
-        try (Connection connection = postgresDataSource.getConnection()) {
-            try (Statement statement = connection.createStatement()) {
-                try (ResultSet resultSet = statement.executeQuery(query)) {
-                    return resultSet.getObject(1, Long.class);
-                }
-            }
+    private Long runQuery(String query) {
+        try (Connection connection = postgresDataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(query)) {
+            return resultSet.getObject(1, Long.class);
         } catch (SQLException e) {
             logger.error("Error getting statistic from postgreSQL database");
             return 0L;


### PR DESCRIPTION
This PR collapses nested try-resources statements into one as try-resources can handle multiple resources as the name suggests.

This PR also removes an unused type parameter.