### PR TITLE
Affect only to the specified tag key in maximumAllowableTags()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
@@ -39,6 +39,7 @@ import static java.util.stream.StreamSupport.stream;
  * All new metrics should pass through each {@link MeterFilter} in the order in which they were added.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public interface MeterFilter {
     /**
@@ -250,10 +251,11 @@ public interface MeterFilter {
             public MeterFilterReply accept(Meter.Id id) {
                 if (id.getName().equals(meterNamePrefix)) {
                     String value = id.getTag(tagKey);
-                    if (value != null)
+                    if (value != null) {
                         observedTagValues.add(value);
-                    if (observedTagValues.size() > maximumTagValues) {
-                        return onMaxReached.accept(id);
+                        if (observedTagValues.size() > maximumTagValues) {
+                            return onMaxReached.accept(id);
+                        }
                     }
                 }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -29,9 +29,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Collections.emptyList;
 import static java.util.stream.StreamSupport.stream;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 /**
+ * Tests for {@link MeterFilter}.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 class MeterFilterTest {
     private static Condition<Meter.Id> tag(String tagKey) {
@@ -129,6 +136,29 @@ class MeterFilterTest {
         
         filter.accept(id4);
         assertThat(n.get()).isEqualTo(1);
+    }
+
+    @Test
+    void maximumAllowableTagsWhenDifferentTagKeyShouldNotAffect() {
+        MeterFilter onMaxReached = mock(MeterFilter.class);
+        MeterFilter filter = MeterFilter.maximumAllowableTags("name1", "key1", 3, onMaxReached);
+
+        Meter.Id id1 = new Meter.Id("name1", Tags.of("key1", "value1"), null, null, Meter.Type.COUNTER);
+        Meter.Id id2 = new Meter.Id("name1", Tags.of("key1", "value2"), null, null, Meter.Type.COUNTER);
+        Meter.Id id3 = new Meter.Id("name1", Tags.of("key1", "value3"), null, null, Meter.Type.COUNTER);
+        Meter.Id id4 = new Meter.Id("name1", Tags.of("key1", "value4"), null, null, Meter.Type.COUNTER);
+        Meter.Id id5 = new Meter.Id("name1", Tags.of("key2", "value5"), null, null, Meter.Type.COUNTER);
+
+        filter.accept(id1);
+        filter.accept(id2);
+        filter.accept(id3);
+        verifyZeroInteractions(onMaxReached);
+
+        filter.accept(id4);
+        verify(onMaxReached).accept(id4);
+
+        filter.accept(id5);
+        verifyNoMoreInteractions(onMaxReached);
     }
 
     @Test


### PR DESCRIPTION
When the specified tag key has reached its maximum allowable tag values, other tag keys are affected too. This PR fixes to affect only to the specified tag key.