### PR TITLE
Fixed help message to conform to prometheus-pushgateway

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
@@ -61,9 +61,9 @@ public class UptimeMetrics implements MeterBinder {
             .description("The uptime of the Java virtual machine")
             .register(registry);
 
-        TimeGauge.builder("process.start.time", runtimeMXBean, TimeUnit.MILLISECONDS, x -> Long.valueOf(x.getStartTime()).doubleValue())
+        TimeGauge.builder("process.start.time", runtimeMXBean, TimeUnit.SECONDS, x -> Long.valueOf(x.getStartTime()).doubleValue() / 1000.0)
             .tags(tags)
-            .description("The start time of the Java virtual machine")
+            .description("Start time of the process since unix epoch in seconds.")
             .register(registry);
     }
 }


### PR DESCRIPTION
Because of https://github.com/micrometer-metrics/micrometer/issues/243, you'll get an error from prometheus-pushgateway:

```
An error has occurred during metrics collection:

gathered metric family process_start_time_seconds has help "The start time of the Java virtual machine" but should have "Start time of the process since unix epoch in seconds."
```

See https://github.com/micrometer-metrics/micrometer/issues/243