### PR TITLE
Allow tag values when they are in allowable tag values

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
@@ -249,23 +249,31 @@ public interface MeterFilter {
 
             @Override
             public MeterFilterReply accept(Meter.Id id) {
-                if (id.getName().equals(meterNamePrefix)) {
-                    String value = id.getTag(tagKey);
-                    if (value != null) {
-                        observedTagValues.add(value);
-                        if (observedTagValues.size() > maximumTagValues) {
+                String value = getTagValue(id);
+                if (value != null) {
+                    if (!observedTagValues.contains(value)) {
+                        if (observedTagValues.size() >= maximumTagValues) {
                             return onMaxReached.accept(id);
                         }
+                        observedTagValues.add(value);
                     }
                 }
-
                 return MeterFilterReply.NEUTRAL;
+            }
+
+            private String getTagValue(Meter.Id id) {
+                return (id.getName().equals(meterNamePrefix) ? id.getTag(tagKey) : null);
             }
 
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-                if (observedTagValues.size() > maximumTagValues) {
-                    return onMaxReached.configure(id, config);
+                String value = getTagValue(id);
+                if (value != null) {
+                    if (!observedTagValues.contains(value)) {
+                        if (observedTagValues.size() >= maximumTagValues) {
+                            return onMaxReached.configure(id, config);
+                        }
+                    }
                 }
                 return config;
             }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -162,6 +162,28 @@ class MeterFilterTest {
     }
 
     @Test
+    void maximumAllowableTagsWhenAlreadyInAllowableTagValuesShouldNotAffect() {
+        MeterFilter onMaxReached = mock(MeterFilter.class);
+        MeterFilter filter = MeterFilter.maximumAllowableTags("name1", "key1", 3, onMaxReached);
+
+        Meter.Id id1 = new Meter.Id("name1", Tags.of("key1", "value1"), null, null, Meter.Type.COUNTER);
+        Meter.Id id2 = new Meter.Id("name1", Tags.of("key1", "value2"), null, null, Meter.Type.COUNTER);
+        Meter.Id id3 = new Meter.Id("name1", Tags.of("key1", "value3"), null, null, Meter.Type.COUNTER);
+        Meter.Id id4 = new Meter.Id("name1", Tags.of("key1", "value4"), null, null, Meter.Type.COUNTER);
+
+        filter.accept(id1);
+        filter.accept(id2);
+        filter.accept(id3);
+        verifyZeroInteractions(onMaxReached);
+
+        filter.accept(id4);
+        verify(onMaxReached).accept(id4);
+
+        filter.accept(id1);
+        verifyNoMoreInteractions(onMaxReached);
+    }
+
+    @Test
     void minExpectedOnSummary() {
         MeterFilter filter = MeterFilter.minExpected("name", 100);
         Meter.Id timer = new Meter.Id("name", emptyList(), null, null, Meter.Type.DISTRIBUTION_SUMMARY);


### PR DESCRIPTION
When it has reached its maximum allowable tag values, the tag values in its maximum allowable tag values are affected too. This PR makes them continue to be allowed.

As a side effect (in a good way), `observedTagValues` no longer grows infinitely.