### PR TITLE
Make meterNamePrefix work as a prefix in maximumAllowableTags()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
@@ -262,7 +262,7 @@ public interface MeterFilter {
             }
 
             private String getTagValue(Meter.Id id) {
-                return (id.getName().equals(meterNamePrefix) ? id.getTag(tagKey) : null);
+                return (id.getName().startsWith(meterNamePrefix) ? id.getTag(tagKey) : null);
             }
 
             @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -184,6 +184,25 @@ class MeterFilterTest {
     }
 
     @Test
+    void maximumAllowableTagsWhenPrefixMatchedShouldAffect() {
+        MeterFilter onMaxReached = mock(MeterFilter.class);
+        MeterFilter filter = MeterFilter.maximumAllowableTags("name", "key1", 3, onMaxReached);
+
+        Meter.Id id1 = new Meter.Id("name", Tags.of("key1", "value1"), null, null, Meter.Type.COUNTER);
+        Meter.Id id2 = new Meter.Id("name", Tags.of("key1", "value2"), null, null, Meter.Type.COUNTER);
+        Meter.Id id3 = new Meter.Id("name1", Tags.of("key1", "value3"), null, null, Meter.Type.COUNTER);
+        Meter.Id id4 = new Meter.Id("name1", Tags.of("key1", "value4"), null, null, Meter.Type.COUNTER);
+
+        filter.accept(id1);
+        filter.accept(id2);
+        filter.accept(id3);
+        verifyZeroInteractions(onMaxReached);
+
+        filter.accept(id4);
+        verify(onMaxReached).accept(id4);
+    }
+
+    @Test
     void minExpectedOnSummary() {
         MeterFilter filter = MeterFilter.minExpected("name", 100);
         Meter.Id timer = new Meter.Id("name", emptyList(), null, null, Meter.Type.DISTRIBUTION_SUMMARY);


### PR DESCRIPTION
This PR makes `meterNamePrefix` work as a prefix as its name and Javadoc claim.