### PR TITLE
Make RestTemplateMetricsConfiguration auto-configuration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.hystrix.HystrixMetricsBinder;
 import io.micrometer.spring.PropertiesMeterFilter;
 import io.micrometer.spring.autoconfigure.jersey2.server.JerseyServerMetricsConfiguration;
-import io.micrometer.spring.autoconfigure.web.client.RestTemplateMetricsConfiguration;
 import io.micrometer.spring.autoconfigure.web.servlet.ServletMetricsConfiguration;
 import io.micrometer.spring.autoconfigure.web.tomcat.TomcatMetricsConfiguration;
 import io.micrometer.spring.integration.SpringIntegrationMetrics;
@@ -58,8 +57,8 @@ import org.springframework.integration.support.management.IntegrationManagementC
         MeterBindersConfiguration.class,
 
         // default instrumentation
-        ServletMetricsConfiguration.class, RestTemplateMetricsConfiguration.class,
-        TomcatMetricsConfiguration.class, JerseyServerMetricsConfiguration.class,
+        ServletMetricsConfiguration.class, TomcatMetricsConfiguration.class,
+        JerseyServerMetricsConfiguration.class,
 })
 @AutoConfigureAfter({
         DataSourceAutoConfiguration.class,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfiguration.java
@@ -21,7 +21,9 @@ import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.lang.NonNull;
 import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
+import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.MetricsProperties;
+import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import io.micrometer.spring.web.client.DefaultRestTemplateExchangeTagsProvider;
 import io.micrometer.spring.web.client.MetricsRestTemplateCustomizer;
 import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider;
@@ -29,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -48,13 +52,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Phillip Webb
  */
 @Configuration
+@AutoConfigureAfter({ MetricsAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class })
 @ConditionalOnClass(name = {
     "org.springframework.web.client.RestTemplate",
     "org.springframework.web.client.AsyncRestTemplate",
     "org.springframework.boot.web.client.RestTemplateCustomizer" // didn't exist until Boot 1.4
 })
-public class RestTemplateMetricsConfiguration {
-    private final Logger logger = LoggerFactory.getLogger(RestTemplateMetricsConfiguration.class);
+@ConditionalOnBean(MeterRegistry.class)
+public class RestTemplateMetricsAutoConfiguration {
+    private final Logger logger = LoggerFactory.getLogger(RestTemplateMetricsAutoConfiguration.class);
 
     @Bean
     @ConditionalOnMissingBean(RestTemplateExchangeTagsProvider.class)

--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -15,4 +15,5 @@ io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfigur
 io.micrometer.spring.autoconfigure.export.signalfx.SignalFxMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.statsd.StatsdMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
+io.micrometer.spring.autoconfigure.web.client.RestTemplateMetricsAutoConfiguration,\
 io.micrometer.spring.jdbc.DataSourcePoolMetricsAutoConfiguration

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfigurationTest.java
@@ -49,13 +49,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = RestTemplateMetricsConfigurationTest.ClientApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(classes = RestTemplateMetricsAutoConfigurationTest.ClientApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
         "management.port=-1", // Disable the entire Spring Boot actuator, so that it does not get needlessly instrumented
         "security.ignored=/**",
 })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-public class RestTemplateMetricsConfigurationTest {
+public class RestTemplateMetricsAutoConfigurationTest {
     @Autowired
     private MeterRegistry registry;
 


### PR DESCRIPTION
This PR makes `RestTemplateMetricsConfiguration` auto-configuration and also renames to `RestTemplateMetricsAutoConfiguration` to align with other auto-configuration classes.

Closes gh-722