### PR TITLE
Add spring-boot-autoconfigure-processor

### DIFF
--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
     compile 'org.springframework.integration:spring-integration-core', optional
 
+    annotationProcessor 'org.springframework.boot:spring-boot-autoconfigure-processor'
+
     // to validate auto-completion on configuration properties
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 


### PR DESCRIPTION
This PR adds `spring-boot-autoconfigure-processor` to improve startup time with auto-configurations.

I confirmed a `spring-autoconfigure-metadata.properties` file has been created as follows:

```
$ find . -name spring-autoconfigure-metadata.properties
./micrometer-spring-legacy/build/classes/java/main/META-INF/spring-autoconfigure-metadata.properties
$ 
```