### PR TITLE
Polish UptimeMetrics.bindTo()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
@@ -56,12 +56,12 @@ public class UptimeMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        TimeGauge.builder("process.uptime", runtimeMXBean, TimeUnit.MILLISECONDS, x -> Long.valueOf(x.getUptime()).doubleValue())
+        TimeGauge.builder("process.uptime", runtimeMXBean, TimeUnit.MILLISECONDS, RuntimeMXBean::getUptime)
             .tags(tags)
             .description("The uptime of the Java virtual machine")
             .register(registry);
 
-        TimeGauge.builder("process.start.time", runtimeMXBean, TimeUnit.SECONDS, x -> Long.valueOf(x.getStartTime()).doubleValue() / 1000.0)
+        TimeGauge.builder("process.start.time", runtimeMXBean, TimeUnit.SECONDS, x -> TimeUnit.MILLISECONDS.toSeconds(x.getStartTime()))
             .tags(tags)
             .description("Start time of the process since unix epoch in seconds.")
             .register(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/UptimeMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/UptimeMetricsTest.java
@@ -53,6 +53,6 @@ class UptimeMetricsTest {
         new UptimeMetrics(runtimeMXBean, emptyList()).bindTo(registry);
 
         assertThat(registry.get("process.uptime").timeGauge().value()).isEqualTo(1.337);
-        assertThat(registry.get("process.start.time").timeGauge().value()).isEqualTo(4.711);
+        assertThat(registry.get("process.start.time").timeGauge().value()).isEqualTo(4);
     }
 }


### PR DESCRIPTION
This PR polishes `UptimeMetrics.bindTo()`.

As a side effect, `process.start.time` has been rounded down but IMHO it looks better as its time unit is seconds.