### PR TITLE
Change the return value of JCacheMetrics.lookupStatistic() to Long

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -130,13 +130,12 @@ public class JCacheMetrics extends CacheMeterBinder {
         }
     }
 
-    private long lookupStatistic(String name) {
+    private Long lookupStatistic(String name) {
         try {
             List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
             for (MBeanServer mBeanServer : mBeanServers) {
                 try {
-                    Object attribute = mBeanServer.getAttribute(objectName, name);
-                    return (Long) attribute;
+                    return (Long) mBeanServer.getAttribute(objectName, name);
                 } catch (AttributeNotFoundException | InstanceNotFoundException ex) {
                     // did not find MBean, try the next server
                 }
@@ -146,6 +145,6 @@ public class JCacheMetrics extends CacheMeterBinder {
         }
 
         // didn't find the MBean in any servers
-        return 0;
+        return 0L;
     }
 }


### PR DESCRIPTION
This PR changes the return value of `JCacheMetrics.lookupStatistic()` to `Long` to avoid unnecessary unboxing/boxing round trip.