### PR TITLE
Remove unrelated @see tags in Javadoc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -43,7 +43,6 @@ public class EhCache2Metrics extends CacheMeterBinder {
      * @param cache    The cache to instrument.
      * @param tags     Tags to apply to all recorded metrics. Must be an even number of arguments representing key/value pairs of tags.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static Ehcache monitor(MeterRegistry registry, Ehcache cache, String... tags) {
         return monitor(registry, cache, Tags.of(tags));
@@ -56,7 +55,6 @@ public class EhCache2Metrics extends CacheMeterBinder {
      * @param cache    The cache to instrument.
      * @param tags     Tags to apply to all recorded metrics.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static Ehcache monitor(MeterRegistry registry, Ehcache cache, Iterable<Tag> tags) {
         new EhCache2Metrics(cache, tags).bindTo(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
@@ -43,7 +43,6 @@ public class HazelcastCacheMetrics extends CacheMeterBinder {
      * @param <K>      The cache key type.
      * @param <V>      The cache value type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static <K, V, C extends IMap<K, V>> C monitor(MeterRegistry registry, C cache, String... tags) {
         return monitor(registry, cache, Tags.of(tags));
@@ -59,7 +58,6 @@ public class HazelcastCacheMetrics extends CacheMeterBinder {
      * @param <K>      The cache key type.
      * @param <V>      The cache value type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static <K, V, C extends IMap<K, V>> C monitor(MeterRegistry registry, C cache, Iterable<Tag> tags) {
         new HazelcastCacheMetrics(cache, tags).bindTo(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -54,7 +54,6 @@ public class JCacheMetrics extends CacheMeterBinder {
      * @param <K>      The cache key type.
      * @param <V>      The cache value type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, String... tags) {
         return monitor(registry, cache, Tags.of(tags));
@@ -70,7 +69,6 @@ public class JCacheMetrics extends CacheMeterBinder {
      * @param <K>      The cache key type.
      * @param <V>      The cache value type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, Iterable<Tag> tags) {
         new JCacheMetrics(cache, tags).bindTo(registry);

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/ConcurrentMapCacheMetrics.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/ConcurrentMapCacheMetrics.java
@@ -38,7 +38,6 @@ public class ConcurrentMapCacheMetrics extends CacheMeterBinder {
      * @param cache    The cache to instrument.
      * @param tags     Tags to apply to all recorded metrics. Must be an even number of arguments representing key/value pairs of tags.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static ConcurrentMapCache monitor(MeterRegistry registry, ConcurrentMapCache cache, String... tags) {
         return monitor(registry, cache, Tags.of(tags));
@@ -51,7 +50,6 @@ public class ConcurrentMapCacheMetrics extends CacheMeterBinder {
      * @param cache    The cache to instrument.
      * @param tags     Tags to apply to all recorded metrics.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
-     * @see com.google.common.cache.CacheStats
      */
     public static ConcurrentMapCache monitor(MeterRegistry registry, ConcurrentMapCache cache, Iterable<Tag> tags) {
         new ConcurrentMapCacheMetrics(cache, tags).bindTo(registry);


### PR DESCRIPTION
This PR removes unrelated `@see` tags in Javadoc which look accidentally copied from `GuavaCacheMetrics`.