### PR TITLE
Checks config.enabled() do publish metrics on close

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -71,7 +71,9 @@ public abstract class StepMeterRegistry extends MeterRegistry {
 
     @Override
     public void close() {
-        publish();
+        if (config.enabled()) {
+            publish();
+        }
         stop();
         super.close();
     }


### PR DESCRIPTION
If config.enabled() is false, the scheduled executor is not activated, so it must not publish on close too.