### PR TITLE
Polish Javadoc for WebMvcTags.uri()

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
@@ -76,10 +76,11 @@ public final class WebMvcTags {
     /**
      * Creates a {@code uri} tag based on the URI of the given {@code request}. Uses the
      * {@link HandlerMapping#BEST_MATCHING_PATTERN_ATTRIBUTE} best matching pattern if
-     * available, falling back to the request's {@link HttpServletRequest#getPathInfo()
-     * path info} if necessary.
+     * available. Falling back to {@code REDIRECTION} for 3xx responses, {@code NOT_FOUND}
+     * for 404 responses, {@code root} for requests with no path info, and {@code UNKNOWN}
+     * for all other requests.
      *
-     * @param request  the request
+     * @param request the request
      * @param response the response
      * @return the uri tag derived from the request
      */


### PR DESCRIPTION
This PR updates Javadoc for `WebMvcTags.uri()` to align with its logic by syncing from Spring Boot.

I guess https://github.com/micrometer-metrics/micrometer/issues/744 has been raised due to the outdated Javadoc.