### PR TITLE
Return null immediately when sla is null in convertSla()

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 
 @NonNullApi
 public class PropertiesMeterFilter implements MeterFilter {
-    private static final ServiceLevelAgreementBoundary[] EMPTY_SLA = {};
 
     private MetricsProperties properties;
 
@@ -60,7 +59,10 @@ public class PropertiesMeterFilter implements MeterFilter {
 
     @Nullable
     private long[] convertSla(Meter.Type meterType, @Nullable ServiceLevelAgreementBoundary[] sla) {
-        long[] converted = Arrays.stream(sla == null ? EMPTY_SLA : sla)
+        if (sla == null) {
+            return null;
+        }
+        long[] converted = Arrays.stream(sla)
                 .map((candidate) -> candidate.getValue(meterType))
                 .filter(Objects::nonNull).mapToLong(Long::longValue).toArray();
         return converted.length == 0 ? null : converted;


### PR DESCRIPTION
This PR changes to return `null` immediately when `sla` is `null` in `PropertiesMeterFilter.convertSla()` as passing through the stream pipeline isn't necessary.