### PR TITLE
Make GraphiteNamingConvention respect its delegate NamingConvention

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
@@ -22,6 +22,12 @@ import io.micrometer.core.lang.Nullable;
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
+/**
+ * {@link NamingConvention} for Graphite.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public class GraphiteNamingConvention implements NamingConvention {
     private final NamingConvention delegate;
 
@@ -41,27 +47,29 @@ public class GraphiteNamingConvention implements NamingConvention {
 
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        return format(name);
+        return sanitize(this.delegate.name(normalize(name), type, baseUnit));
     }
 
     @Override
     public String tagKey(String key) {
-        return format(key);
+        return sanitize(this.delegate.tagKey(normalize(key)));
     }
 
     @Override
     public String tagValue(String value) {
-        return format(value);
+        return sanitize(this.delegate.tagValue(normalize(value)));
     }
 
     /**
      * Github Issue: https://github.com/graphite-project/graphite-web/issues/243
-
      * Unicode is not OK. Some special chars are not OK.
      */
-    private String format(String name) {
-        String sanitized = Normalizer.normalize(name, Normalizer.Form.NFKD);
-        sanitized = delegate.tagKey(sanitized);
-        return blacklistedChars.matcher(sanitized).replaceAll("_");
+    private String normalize(String name) {
+        return Normalizer.normalize(name, Normalizer.Form.NFKD);
     }
+
+    private String sanitize(String delegated) {
+        return blacklistedChars.matcher(delegated).replaceAll("_");
+    }
+
 }

--- a/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
+++ b/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
@@ -16,10 +16,17 @@
 package io.micrometer.graphite;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link GraphiteNamingConvention}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class GraphiteNamingConventionTest {
     private GraphiteNamingConvention convention = new GraphiteNamingConvention();
 
@@ -32,4 +39,35 @@ class GraphiteNamingConventionTest {
     void dotNotationIsConvertedToCamelCase() {
         assertThat(convention.name("gauge.size", Meter.Type.GAUGE)).isEqualTo("gaugeSize");
     }
+
+    @Test
+    void respectDelegateNamingConvention() {
+        CustomNamingConvention delegateNamingConvention = new CustomNamingConvention();
+
+        GraphiteNamingConvention convention = new GraphiteNamingConvention(delegateNamingConvention);
+
+        assertThat(convention.name("my.name", Meter.Type.TIMER)).isEqualTo("name: my.name");
+        assertThat(convention.tagKey("my.tag.key")).isEqualTo("key: my.tag.key");
+        assertThat(convention.tagValue("my.tag.value")).isEqualTo("value: my.tag.value");
+    }
+
+    private static class CustomNamingConvention implements NamingConvention {
+
+        @Override
+        public String name(String name, Meter.Type type, String baseUnit) {
+            return "name: " + name;
+        }
+
+        @Override
+        public String tagKey(String key) {
+            return "key: " + key;
+        }
+
+        @Override
+        public String tagValue(String value) {
+            return "value: " + value;
+        }
+
+    }
+
 }


### PR DESCRIPTION
This PR makes `GraphiteNamingConvention` respect its `delegate` `NamingConvention` as it delegates all to `tagKey()`.