### PR TITLE
Use pre-compiled patterns in WavefrontNamingConvention

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
@@ -15,12 +15,18 @@
  */
 package io.micrometer.wavefront;
 
+import java.util.regex.Pattern;
+
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
 
 public class WavefrontNamingConvention implements NamingConvention {
+
+    private static final Pattern PATTERN_NAME_TO_SANITIZE = Pattern.compile("[^a-zA-Z0-9\\-_\\./,]");
+    private static final Pattern PATTERN_TAG_KEY_TO_SANITIZE = Pattern.compile("[^a-zA-Z0-9\\-_\\.]");
+
     private final NamingConvention delegate;
 
     @Nullable
@@ -41,7 +47,8 @@ public class WavefrontNamingConvention implements NamingConvention {
      */
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        String sanitizedName = delegate.name(name, type, baseUnit).replaceAll("[^a-zA-Z0-9\\-_\\./,]", "_");
+        String delegatedName = this.delegate.name(name, type, baseUnit);
+        String sanitizedName = PATTERN_NAME_TO_SANITIZE.matcher(delegatedName).replaceAll("_");
 
         // add name prefix if prefix exists
         if (namePrefix != null) {
@@ -55,7 +62,8 @@ public class WavefrontNamingConvention implements NamingConvention {
      */
     @Override
     public String tagKey(String key) {
-        return delegate.tagKey(key).replaceAll("[^a-zA-Z0-9\\-_\\.]", "_");
+        String delegatedTagKey = this.delegate.tagKey(key);
+        return PATTERN_TAG_KEY_TO_SANITIZE.matcher(delegatedTagKey).replaceAll("_");
     }
 
     /**


### PR DESCRIPTION
This PR changes to use pre-compiled patterns in `WavefrontNamingConvention`.