### PR TITLE
Fix ConditionalOnBean for DataSourcePoolMetricsAutoConfiguration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsAutoConfiguration.java
@@ -22,10 +22,12 @@ import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoC
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvider;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
@@ -39,12 +41,13 @@ import java.util.Map;
  * {@link DataSource datasources}.
  *
  * @author Stephane Nicoll
+ * @author Johnny Lim
  */
 @Configuration
 @AutoConfigureAfter({ MetricsAutoConfiguration.class, DataSourceAutoConfiguration.class,
     SimpleMetricsExportAutoConfiguration.class })
 @ConditionalOnClass({ DataSource.class, MeterRegistry.class })
-@ConditionalOnBean({ DataSource.class, MeterRegistry.class })
+@Conditional(DataSourcePoolMetricsAutoConfiguration.DataSourcePoolMetricsConditionalOnBeans.class)
 public class DataSourcePoolMetricsAutoConfiguration {
 
     @Configuration
@@ -86,6 +89,22 @@ public class DataSourcePoolMetricsAutoConfiguration {
                     beanName.length() - DATASOURCE_SUFFIX.length());
             }
             return beanName;
+        }
+
+    }
+
+    static class DataSourcePoolMetricsConditionalOnBeans extends AllNestedConditions {
+
+        DataSourcePoolMetricsConditionalOnBeans() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+
+        @ConditionalOnBean(DataSource.class)
+        static class ConditionalOnDataSourceBean {
+        }
+
+        @ConditionalOnBean(MeterRegistry.class)
+        static class ConditionalOnMeterRegistryBean {
         }
 
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsAutoConfigurationTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.jdbc;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link DataSourcePoolMetricsAutoConfiguration}.
+ *
+ * @author Johnny Lim
+ */
+class DataSourcePoolMetricsAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    void backsOffWhenMeterRegistryIsMissing() {
+        registerAndRefresh(DataSourceConfiguration.class,
+                DataSourcePoolMetricsAutoConfiguration.class);
+
+        assertThatThrownBy(() -> this.context.getBean(DataSourcePoolMetricsAutoConfiguration.class))
+            .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+
+    @Test
+    void backsOffWhenDataSourceIsMissing() {
+        registerAndRefresh(MeterRegistryConfiguration.class,
+                DataSourcePoolMetricsAutoConfiguration.class);
+
+        assertThatThrownBy(() -> this.context.getBean(DataSourcePoolMetricsAutoConfiguration.class))
+            .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+
+    @Test
+    void autoConfigurationKicksIn() {
+        registerAndRefresh(DataSourceConfiguration.class, MeterRegistryConfiguration.class,
+                DataSourcePoolMetricsAutoConfiguration.class);
+
+        assertThat(this.context.getBean(DataSourcePoolMetricsAutoConfiguration.class)).isNotNull();
+    }
+
+    private void registerAndRefresh(Class<?>... configurationClasses) {
+        this.context.register(configurationClasses);
+        this.context.refresh();
+    }
+
+    @Configuration
+    static class DataSourceConfiguration {
+
+        @Bean
+        public DataSource dataSource() {
+            return mock(DataSource.class);
+        }
+
+    }
+
+    @Configuration
+    static class MeterRegistryConfiguration {
+
+        @Bean
+        public MeterRegistry meterRegistry() {
+            return mock(MeterRegistry.class);
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes `@ConditionalOnBean` for `DataSourcePoolMetricsAutoConfiguration`.

Closes gh-753