### PR TITLE
Make ServletMetricsConfiguration auto-configuration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.hystrix.HystrixMetricsBinder;
 import io.micrometer.spring.PropertiesMeterFilter;
 import io.micrometer.spring.autoconfigure.jersey2.server.JerseyServerMetricsConfiguration;
-import io.micrometer.spring.autoconfigure.web.servlet.ServletMetricsConfiguration;
 import io.micrometer.spring.autoconfigure.web.tomcat.TomcatMetricsConfiguration;
 import io.micrometer.spring.integration.SpringIntegrationMetrics;
 import io.micrometer.spring.scheduling.ScheduledMethodMetrics;
@@ -57,7 +56,7 @@ import org.springframework.integration.support.management.IntegrationManagementC
         MeterBindersConfiguration.class,
 
         // default instrumentation
-        ServletMetricsConfiguration.class, TomcatMetricsConfiguration.class,
+        TomcatMetricsConfiguration.class,
         JerseyServerMetricsConfiguration.class,
 })
 @AutoConfigureAfter({

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfiguration.java
@@ -16,10 +16,16 @@
 package io.micrometer.spring.autoconfigure.web.servlet;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.MetricsProperties;
+import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import io.micrometer.spring.web.servlet.DefaultWebMvcTagsProvider;
 import io.micrometer.spring.web.servlet.WebMvcMetricsFilter;
 import io.micrometer.spring.web.servlet.WebMvcTagsProvider;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -31,15 +37,19 @@ import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 /**
- * Configures instrumentation of Spring Web MVC servlet-based request mappings.
+ * {@link EnableAutoConfiguration Auto-configuration} for instrumentation of Spring Web
+ * MVC servlet-based request mappings.
  *
  * @author Jon Schneider
  */
 @Configuration
-@ConditionalOnClass(DispatcherServlet.class)
+@AutoConfigureAfter({ MetricsAutoConfiguration.class,
+        SimpleMetricsExportAutoConfiguration.class })
 @ConditionalOnWebApplication
+@ConditionalOnClass(DispatcherServlet.class)
+@ConditionalOnBean(MeterRegistry.class)
 @EnableConfigurationProperties(MetricsProperties.class)
-public class ServletMetricsConfiguration {
+public class WebMvcMetricsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(WebMvcTagsProvider.class)

--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -16,4 +16,5 @@ io.micrometer.spring.autoconfigure.export.signalfx.SignalFxMetricsExportAutoConf
 io.micrometer.spring.autoconfigure.export.statsd.StatsdMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.wavefront.WavefrontMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.web.client.RestTemplateMetricsAutoConfiguration,\
+io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration,\
 io.micrometer.spring.jdbc.DataSourcePoolMetricsAutoConfiguration

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfigurationTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.web.servlet;
+
+import java.util.Collections;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.spring.web.servlet.DefaultWebMvcTagsProvider;
+import io.micrometer.spring.web.servlet.WebMvcMetricsFilter;
+import io.micrometer.spring.web.servlet.WebMvcTagsProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link WebMvcMetricsAutoConfiguration}.
+ *
+ * @author Andy Wilkinson
+ * @author Johnny Lim
+ */
+class WebMvcMetricsAutoConfigurationTest {
+
+    private AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    void backsOffWhenMeterRegistryIsMissing() {
+        registerAndRefresh(WebMvcMetricsAutoConfiguration.class);
+
+        assertThatThrownBy(() -> this.context.getBean(WebMvcMetricsAutoConfiguration.class))
+            .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+
+    @Test
+    public void definesTagsProviderAndFilterWhenMeterRegistryIsPresent() {
+        registerAndRefresh(MeterRegistryConfiguration.class, WebMvcMetricsAutoConfiguration.class);
+
+        assertThat(this.context.getBean(DefaultWebMvcTagsProvider.class)).isNotNull();
+        assertThat(this.context.getBean(WebMvcMetricsFilter.class)).isNotNull();
+    }
+
+    @Test
+    public void tagsProviderBacksOff() {
+        registerAndRefresh(MeterRegistryConfiguration.class, TagsProviderConfiguration.class,
+                WebMvcMetricsAutoConfiguration.class);
+
+        assertThatThrownBy(() -> this.context.getBean(DefaultWebMvcTagsProvider.class))
+            .isInstanceOf(NoSuchBeanDefinitionException.class);
+        assertThat(this.context.getBean(TestWebMvcTagsProvider.class)).isNotNull();
+    }
+
+    private void registerAndRefresh(Class<?>... configurationClasses) {
+        this.context.register(configurationClasses);
+        this.context.refresh();
+    }
+
+    @Configuration
+    static class MeterRegistryConfiguration {
+
+        @Bean
+        public MeterRegistry meterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+    }
+
+    @Configuration
+    static class TagsProviderConfiguration {
+
+        @Bean
+        public TestWebMvcTagsProvider tagsProvider() {
+            return new TestWebMvcTagsProvider();
+        }
+
+    }
+
+    private static final class TestWebMvcTagsProvider implements WebMvcTagsProvider {
+
+        @Override
+        public Iterable<Tag> httpLongRequestTags(HttpServletRequest request, Object handler) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Iterable<Tag> httpRequestTags(HttpServletRequest request, HttpServletResponse response, Object handler, Throwable ex) {
+            return Collections.emptyList();
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
@@ -20,10 +20,11 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.spring.autoconfigure.web.servlet.ServletMetricsConfiguration;
+import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,7 +70,8 @@ public class WebMvcMetricsFilterAutoTimedTest {
 
     @Configuration
     @EnableWebMvc
-    @Import({Controller.class, ServletMetricsConfiguration.class})
+    @Import(Controller.class)
+    @ImportAutoConfiguration(WebMvcMetricsAutoConfiguration.class)
     static class TestConfiguration {
         @Bean
         MockClock clock() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
@@ -21,14 +21,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.spring.autoconfigure.web.servlet.ServletMetricsConfiguration;
+import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -83,7 +83,7 @@ public class WebMvcMetricsFilterCustomExceptionHandlerTest {
 
     @Configuration
     @EnableWebMvc
-    @Import(ServletMetricsConfiguration.class)
+    @ImportAutoConfiguration(WebMvcMetricsAutoConfiguration.class)
     static class TestConfiguration {
         @Bean
         MockClock clock() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
@@ -26,12 +26,13 @@ import io.micrometer.core.lang.NonNull;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.micrometer.spring.autoconfigure.web.servlet.ServletMetricsConfiguration;
+import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
 import io.prometheus.client.CollectorRegistry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -220,7 +221,8 @@ public class WebMvcMetricsFilterTest {
 
     @Configuration
     @EnableWebMvc
-    @Import({ServletMetricsConfiguration.class, Controller1.class, Controller2.class})
+    @Import({Controller1.class, Controller2.class})
+    @ImportAutoConfiguration(WebMvcMetricsAutoConfiguration.class)
     static class MetricsFilterApp {
         @Bean
         Clock micrometerClock() {


### PR DESCRIPTION
This PR changes `ServletMetricsConfiguration` to auto-configuration, so it can be disabled separately now.

This PR also changes its name to align with Spring Boot 2.x.