### PR TITLE
Support management.metrics.tags.*

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/PropertiesMeterFilter.java
@@ -16,6 +16,7 @@
 package io.micrometer.spring;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -27,24 +28,52 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+/**
+ * {@link MeterFilter} to apply settings from {@link MetricsProperties}.
+ *
+ * @author Jon Schneider
+ * @author Phillip Webb
+ * @author Stephane Nicoll
+ */
 @NonNullApi
 public class PropertiesMeterFilter implements MeterFilter {
     private static final ServiceLevelAgreementBoundary[] EMPTY_SLA = {};
 
-    private MetricsProperties properties;
+    private final MetricsProperties properties;
+
+    private final MeterFilter mapFilter;
 
     public PropertiesMeterFilter(MetricsProperties properties) {
         Assert.notNull(properties, "Properties must not be null");
         this.properties = properties;
+        this.mapFilter = createMapFilter(properties.getTags());
+    }
+
+    private static MeterFilter createMapFilter(Map<String, String> tags) {
+        if (tags.isEmpty()) {
+            return new MeterFilter() {
+            };
+        }
+        List<Tag> commonTags = tags.entrySet().stream()
+                .map((entry) -> Tag.of(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
+        return MeterFilter.commonTags(commonTags);
     }
 
     @Override
     public MeterFilterReply accept(Meter.Id id) {
         boolean enabled = lookup(this.properties.getEnable(), id, true);
         return (enabled ? MeterFilterReply.NEUTRAL : MeterFilterReply.DENY);
+    }
+
+    @Override
+    public Meter.Id map(Meter.Id id) {
+        return this.mapFilter.map(id);
     }
 
     @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
@@ -38,6 +38,11 @@ public class MetricsProperties {
     private final Map<String, Boolean> enable = new HashMap<>();
 
     /**
+     * Common tags that are applied to every meter.
+     */
+    private final Map<String, String> tags = new LinkedHashMap<>();
+
+    /**
      * Whether or not auto-configured MeterRegistry implementations should be bound to the
      * global static registry on Metrics. For testing, set this to 'false' to maximize
      * test independence.
@@ -58,6 +63,10 @@ public class MetricsProperties {
 
     public Map<String, Boolean> getEnable() {
         return enable;
+    }
+
+    public Map<String, String> getTags() {
+        return this.tags;
     }
 
     public Distribution getDistribution() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationIntegrationTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link MetricsAutoConfiguration}.
+ *
+ * @author Stephane Nicoll
+ * @author Johnny Lim
+ */
+class MetricsAutoConfigurationIntegrationTest {
+
+    private AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    void definesTagsProviderAndFilterWhenMeterRegistryIsPresent() {
+        prepareEnvironment("management.metrics.tags.region=test",
+                "management.metrics.tags.origin=local");
+        registerAndRefresh(MetricsAutoConfiguration.class,
+                CompositeMeterRegistryAutoConfiguration.class);
+
+        MeterRegistry registry = this.context.getBean(MeterRegistry.class);
+        registry.counter("my.counter", "env", "qa");
+        assertThat(registry.find("my.counter").tags("env", "qa")
+                .tags("region", "test").tags("origin", "local").counter())
+                .isNotNull();
+    }
+
+    private void prepareEnvironment(String... properties) {
+        EnvironmentTestUtils.addEnvironment(this.context, properties);
+    }
+
+    private void registerAndRefresh(Class<?>... configurationClasses) {
+        this.context.register(configurationClasses);
+        this.context.refresh();
+    }
+
+}


### PR DESCRIPTION
This PR adds support for `management.metrics.tags.*` by almost just synching from https://github.com/spring-projects/spring-boot/commit/602f52fffc63d71e4ab16e3da11c17e24aa4df69.

Closes gh-646

/cc @snicoll 