### PR TITLE
Remove a wrong since tag in CompositeMeterRegistryAutoConfiguration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.context.annotation.Import;
  * {@link CompositeMeterRegistry}.
  *
  * @author Andy Wilkinson
- * @since 2.0.0
  */
 @Import({ NoOpMeterRegistryConfiguration.class,
 		CompositeMeterRegistryConfiguration.class })


### PR DESCRIPTION
It looks like a copy and paste error from Spring Boot 2.x support, so this PR removes the wrong `@since` tag on `CompositeMeterRegistryAutoConfiguration`.