### PR TITLE
Restore double quotes for database name in InfluxDB database creation

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
  */
 class CreateDatabaseQueryBuilder {
 
-    private static final String QUERY_MANDATORY_TEMPLATE = "CREATE DATABASE %s";
+    private static final String QUERY_MANDATORY_TEMPLATE = "CREATE DATABASE \"%s\"";
     private static final String RETENTION_POLICY_INTRODUCTION = " WITH";
     private static final String DURATION_CLAUSE_TEMPLATE = " DURATION %s";
     private static final String REPLICATION_FACTOR_CLAUSE_TEMPLATE = " REPLICATION %d";

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
@@ -44,13 +44,13 @@ class CreateDatabaseQueryBuilderTest {
     @Test
     void noRetentionPolicy() {
         String query = createDatabaseQueryBuilder.build();
-        assertEquals("CREATE DATABASE dummy_database_0", query);
+        assertEquals("CREATE DATABASE \"dummy_database_0\"", query);
     }
 
     @Test
     void oneClauseInRetentionPolicy() {
         String query = createDatabaseQueryBuilder.setRetentionPolicyName("dummy_policy").build();
-        assertEquals("CREATE DATABASE dummy_database_0 WITH NAME dummy_policy", query);
+        assertEquals("CREATE DATABASE \"dummy_database_0\" WITH NAME dummy_policy", query);
     }
 
     @Test
@@ -60,7 +60,7 @@ class CreateDatabaseQueryBuilderTest {
                 .setRetentionReplicationFactor(1)
                 .setRetentionShardDuration("3")
                 .build();
-        assertEquals("CREATE DATABASE dummy_database_0 WITH DURATION 2d REPLICATION 1 SHARD DURATION 3 NAME dummy_policy", query);
+        assertEquals("CREATE DATABASE \"dummy_database_0\" WITH DURATION 2d REPLICATION 1 SHARD DURATION 3 NAME dummy_policy", query);
     }
 
 }


### PR DESCRIPTION
This PR restores double quotes for database name when creating databases in InfluxDB as it looks removed accidentally in 5d5db2e63b180c2e1bb89f3d1785894e400753b3.

See https://docs.influxdata.com/influxdb/v1.6/introduction/getting-started/#creating-a-database

Closes gh-776