### PR TITLE
Structural pattern matching for meters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/MeterVisitor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/MeterVisitor.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Base meter visitor. By default it does nothing if the method for the type that's being visited was not overrided.
+ */
+public interface MeterVisitor {
+
+    default void defaultVisit(Meter meter) {
+    }
+
+    default void visitTimer(Timer timer) {
+        defaultVisit(timer);
+    }
+
+    default void visitCounter(Counter counter) {
+        defaultVisit(counter);
+    }
+
+    default void visitGauge(Gauge gauge) {
+        defaultVisit(gauge);
+    }
+
+    default void visitLongTaskTimer(LongTaskTimer longTaskTimer) {
+        defaultVisit(longTaskTimer);
+    }
+
+    default void visitTimeGauge(TimeGauge timeGauge) {
+        visitGauge(timeGauge);
+    }
+
+    default void visitDistributionSummary(DistributionSummary distributionSummary) {
+        defaultVisit(distributionSummary);
+    }
+
+    default void visitFunctionTimer(FunctionCounter functionCounter) {
+        defaultVisit(functionCounter);
+    }
+
+    default void visitFunctionCounter(FunctionTimer functionTimer) {
+        defaultVisit(functionTimer);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.lang.Nullable;
 
 import java.util.ArrayList;
@@ -130,4 +131,10 @@ public interface Counter extends Meter {
             return registry.counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER));
         }
     }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitCounter(this);
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
@@ -315,6 +316,11 @@ public interface DistributionSummary extends Meter, HistogramSupport {
         public DistributionSummary register(MeterRegistry registry) {
             return registry.summary(new Meter.Id(name, tags, baseUnit, description, Type.DISTRIBUTION_SUMMARY), distributionConfigBuilder.build(), scale);
         }
+    }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitDistributionSummary(this);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.lang.Nullable;
 
 import java.util.ArrayList;
@@ -124,4 +125,10 @@ public interface FunctionCounter extends Meter {
             return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
         }
     }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitFunctionTimer(this);
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.lang.Nullable;
 
 import java.util.ArrayList;
@@ -147,4 +148,10 @@ public interface FunctionTimer extends Meter {
                     totalTimeFunctionUnit);
         }
     }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitFunctionCounter(this);
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
 import io.micrometer.core.lang.Nullable;
@@ -146,5 +147,10 @@ public interface Gauge extends Meter {
         public Gauge register(MeterRegistry registry) {
             return registry.gauge(new Meter.Id(name, tags, baseUnit, description, Type.GAUGE, synthetic), obj, f);
         }
+    }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitGauge(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.lang.Nullable;
 
@@ -246,5 +247,10 @@ public interface LongTaskTimer extends Meter {
         public LongTaskTimer register(MeterRegistry registry) {
             return registry.more().longTaskTimer(new Meter.Id(name, tags, null, description, Type.LONG_TASK_TIMER));
         }
+    }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitLongTaskTimer(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
@@ -47,6 +48,11 @@ public interface Meter extends AutoCloseable {
      * @return The set of measurements that represents the instantaneous value of this meter.
      */
     Iterable<Measurement> measure();
+
+    /**
+     * Accepts a {@link MeterVisitor}.
+     */
+    void accept(MeterVisitor visitor);
 
     /**
      * Custom meters may emit metrics like one of these types without implementing

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.lang.Nullable;
 
@@ -119,5 +120,10 @@ public interface TimeGauge extends Gauge {
             return registry.more().timeGauge(new Meter.Id(name, tags, null, description, Type.GAUGE),
                     obj, fUnits, f);
         }
+    }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitTimeGauge(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -447,5 +448,10 @@ public interface Timer extends Meter, HistogramSupport {
             return registry.timer(new Meter.Id(name, tags, null, description, Type.TIMER), distributionConfigBuilder.build(),
                     pauseDetector == null ? registry.config().pauseDetector() : pauseDetector);
         }
+    }
+
+    @Override
+    default void accept(MeterVisitor visitor) {
+        visitor.visitTimer(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.composite;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -102,5 +103,10 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
                 }
             }
         }
+    }
+
+    @Override
+    public void accept(MeterVisitor visitor) {
+        forEachChild(child -> child.accept(visitor));
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultMeter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.internal;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
@@ -36,5 +37,11 @@ public class DefaultMeter extends AbstractMeter {
 
     public Type getType() {
         return type;
+    }
+
+
+    @Override
+    public void accept(MeterVisitor visitor) {
+        visitor.defaultVisit(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopMeter.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.noop;
 
+import io.micrometer.core.MeterVisitor;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Measurement;
 
@@ -30,5 +31,10 @@ public class NoopMeter extends AbstractMeter {
     @Override
     public List<Measurement> measure() {
         return emptyList();
+    }
+
+    @Override
+    public void accept(MeterVisitor visitor) {
+        // do nothing
     }
 }


### PR DESCRIPTION
Hi 👋 , I've seen an anti-pattern across all the registries which is the use of the following construction `if (meter instanceof XXX)`.


That's why  I want to propose a small enhancement to the current codebase by using a visitor to execute custom logic depending on the object type. Moreover, we can execute the same code for classes that belong to the same hierarchy if needed.

This visitor could be used in all the registries but before implementing such change I wanted to check what you think about this idea 🤓 