### PR TITLE
Invoke ScheduledReporter.close() explicitly

### DIFF
--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -69,6 +69,7 @@ public class GangliaMeterRegistry extends DropwizardMeterRegistry {
     public void close() {
         reporter.report();
         stop();
+        this.reporter.close();
         super.close();
     }
 

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
@@ -89,6 +89,7 @@ public class GraphiteMeterRegistry extends DropwizardMeterRegistry {
     public void close() {
         reporter.report();
         stop();
+        this.reporter.close();
         super.close();
     }
 


### PR DESCRIPTION
This PR changes to invoke `ScheduledReporter.close()` explicitly. It's better to be safe to call `close()` explicitly for `Closeable` although the current implementation for the `close()` is just invoking `stop()` which has been invoked already.