### PR TITLE
Avoid duplicate calculation in AbstractDistributionSummary.record()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -44,8 +44,9 @@ public abstract class AbstractDistributionSummary extends AbstractMeter implemen
     @Override
     public final void record(double amount) {
         if (amount >= 0) {
-            histogram.recordDouble(scale * amount);
-            recordNonNegative(scale * amount);
+            double scaledAmount = this.scale * amount;
+            histogram.recordDouble(scaledAmount);
+            recordNonNegative(scaledAmount);
         }
     }
 


### PR DESCRIPTION
This PR changes to avoid duplicate calculation in `AbstractDistributionSummary.record()` as it doesn't seem to be necessary.