### PR TITLE
Adjust naming of Subscriber and Processor fields in StatsD classes

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
@@ -28,19 +28,19 @@ import java.util.concurrent.atomic.DoubleAdder;
 public class StatsdCounter extends AbstractMeter implements Counter {
     private DoubleAdder count = new DoubleAdder();
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
 
-    StatsdCounter(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher) {
+    StatsdCounter(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber) {
         super(id);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
     }
 
     @Override
     public void increment(double amount) {
         if (amount > 0) {
             count.add(amount);
-            publisher.onNext(lineBuilder.count((long) amount));
+            subscriber.onNext(lineBuilder.count((long) amount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
@@ -33,14 +33,14 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
     private final TimeWindowMax max;
 
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
 
-    StatsdDistributionSummary(Meter.Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, Clock clock,
+    StatsdDistributionSummary(Meter.Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber, Clock clock,
                               DistributionStatisticConfig distributionStatisticConfig, double scale) {
         super(id, clock, distributionStatisticConfig, scale, false);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
             count.increment();
             this.amount.add(amount);
             max.record(amount);
-            publisher.onNext(lineBuilder.histogram(amount));
+            subscriber.onNext(lineBuilder.histogram(amount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionCounter.java
@@ -23,20 +23,20 @@ import java.util.function.ToDoubleFunction;
 
 public class StatsdFunctionCounter<T> extends CumulativeFunctionCounter<T> implements StatsdPollable {
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
     private final AtomicReference<Long> lastValue = new AtomicReference<>(0L);
 
-    StatsdFunctionCounter(Id id, T obj, ToDoubleFunction<T> f, StatsdLineBuilder lineBuilder, Subscriber<String> publisher) {
+    StatsdFunctionCounter(Id id, T obj, ToDoubleFunction<T> f, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber) {
         super(id, obj, f);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
     }
 
     @Override
     public void poll() {
         lastValue.updateAndGet(prev -> {
             long count = (long) count();
-            publisher.onNext(lineBuilder.count(count - prev));
+            subscriber.onNext(lineBuilder.count(count - prev));
             return count;
         });
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
@@ -25,16 +25,16 @@ import java.util.function.ToLongFunction;
 
 public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implements StatsdPollable {
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
     private final AtomicReference<Long> lastCount = new AtomicReference<>(0L);
     private final AtomicReference<Double> lastTime = new AtomicReference<>(0.0);
 
     StatsdFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction,
                         TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit,
-                        StatsdLineBuilder lineBuilder, Subscriber<String> publisher) {
+                        StatsdLineBuilder lineBuilder, Subscriber<String> subscriber) {
         super(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, baseTimeUnit);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
     }
 
     @Override
@@ -53,7 +53,7 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
                     // occurrences.
                     double timingAverage = newTimingsSum / newTimingsCount;
                     for (int i = 0; i < newTimingsCount; i++) {
-                        publisher.onNext(lineBuilder.timing(timingAverage));
+                        subscriber.onNext(lineBuilder.timing(timingAverage));
                     }
 
                     return totalTime;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
@@ -27,17 +27,17 @@ import java.util.function.ToDoubleFunction;
 
 public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollable {
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
 
     private final WeakReference<T> ref;
     private final ToDoubleFunction<T> value;
     private final AtomicReference<Double> lastValue = new AtomicReference<>(Double.NaN);
     private final boolean alwaysPublish;
 
-    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, @Nullable T obj, ToDoubleFunction<T> value, boolean alwaysPublish) {
+    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber, @Nullable T obj, ToDoubleFunction<T> value, boolean alwaysPublish) {
         super(id);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
         this.ref = new WeakReference<>(obj);
         this.value = value;
         this.alwaysPublish = alwaysPublish;
@@ -53,7 +53,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
     public void poll() {
         double val = value();
         if (alwaysPublish || lastValue.getAndSet(val) != val) {
-            publisher.onNext(lineBuilder.gauge(val));
+            subscriber.onNext(lineBuilder.gauge(val));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
@@ -25,17 +25,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdPollable {
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
 
     private final AtomicReference<Long> lastActive = new AtomicReference<>(Long.MIN_VALUE);
     private final AtomicReference<Double> lastDuration = new AtomicReference<>(Double.NEGATIVE_INFINITY);
 
     private final boolean alwaysPublish;
 
-    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, Clock clock, boolean alwaysPublish) {
+    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber, Clock clock, boolean alwaysPublish) {
         super(id, clock);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
         this.alwaysPublish = alwaysPublish;
     }
 
@@ -43,12 +43,12 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
     public void poll() {
         long active = activeTasks();
         if (alwaysPublish || lastActive.getAndSet(active) != active) {
-            publisher.onNext(lineBuilder.gauge(active, Statistic.ACTIVE_TASKS));
+            subscriber.onNext(lineBuilder.gauge(active, Statistic.ACTIVE_TASKS));
         }
 
         double duration = duration(TimeUnit.MILLISECONDS);
         if (alwaysPublish || lastDuration.getAndSet(duration) != duration) {
-            publisher.onNext(lineBuilder.gauge(duration, Statistic.DURATION));
+            subscriber.onNext(lineBuilder.gauge(duration, Statistic.DURATION));
         }
     }
 }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
@@ -33,14 +33,14 @@ public class StatsdTimer extends AbstractTimer {
     private StepDouble max;
 
     private final StatsdLineBuilder lineBuilder;
-    private final Subscriber<String> publisher;
+    private final Subscriber<String> subscriber;
 
-    StatsdTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> publisher, Clock clock,
+    StatsdTimer(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber, Clock clock,
                 DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepMillis) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, false);
         this.max = new StepDouble(clock, stepMillis);
         this.lineBuilder = lineBuilder;
-        this.publisher = publisher;
+        this.subscriber = subscriber;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class StatsdTimer extends AbstractTimer {
             // not necessary to ship max, as most StatsD agents calculate this themselves
             max.getCurrent().add(Math.max(msAmount - max.getCurrent().doubleValue(), 0));
 
-            publisher.onNext(lineBuilder.timing(msAmount));
+            subscriber.onNext(lineBuilder.timing(msAmount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
@@ -32,7 +32,7 @@ class StatsdGaugeTest {
     private StatsdLineBuilder lineBuilder = mock(StatsdLineBuilder.class);
 
     @SuppressWarnings("unchecked")
-    private Subscriber<String> publisher = mock(Subscriber.class);
+    private Subscriber<String> subscriber = mock(Subscriber.class);
 
     @Test
     void shouldAlwaysPublishValue() {
@@ -41,7 +41,7 @@ class StatsdGaugeTest {
         alwaysPublishingGauge.poll();
         alwaysPublishingGauge.poll();
 
-        verify(publisher, times(2)).onNext(any());
+        verify(subscriber, times(2)).onNext(any());
     }
 
     @Test
@@ -51,20 +51,20 @@ class StatsdGaugeTest {
         gaugePublishingOnChange.poll();
         gaugePublishingOnChange.poll();
 
-        verify(publisher, times(1)).onNext(any());
+        verify(subscriber, times(1)).onNext(any());
 
         //update value and expect the publisher to be called again
         value.incrementAndGet();
         gaugePublishingOnChange.poll();
 
 
-        verify(publisher, times(2)).onNext(any());
+        verify(subscriber, times(2)).onNext(any());
     }
 
 
     private StatsdGauge<?> gauge(boolean alwaysPublish) {
         Meter.Id meterId = new Meter.Id("test", Collections.emptyList(), null, null, Meter.Type.GAUGE);
-        return new StatsdGauge<>(meterId, lineBuilder, publisher, value, AtomicInteger::get, alwaysPublish);
+        return new StatsdGauge<>(meterId, lineBuilder, subscriber, value, AtomicInteger::get, alwaysPublish);
     }
 
 }

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -273,9 +273,9 @@ class StatsdMeterRegistryTest {
         StatsdMeterRegistry registry = new StatsdMeterRegistry(configWithFlavor(StatsdFlavor.ETSY), clock);
         new LogbackMetrics().bindTo(registry);
 
-        // Cause the publisher to get into a state that would make it perform logging at DEBUG level.
+        // Cause the processor to get into a state that would make it perform logging at DEBUG level.
         ((Logger) LoggerFactory.getLogger(Operators.class)).setLevel(Level.DEBUG);
-        registry.publisher.onComplete();
+        registry.processor.onComplete();
 
         registry.counter("my.counter").increment();
     }


### PR DESCRIPTION
Going through the Micrometer StatsD code I got confused a bit. `Subscriber` and `Publisher` are opposite concepts, but a lot of subscribers are named `publisher`. A `Processor` is both a `Subscriber` and `Publisher`, so I've also changed the `Processor` names to indicate they are a `Processor` and not just a `Publisher`.