### PR TITLE
Log an error with invalid URI string in DatadogMeterRegistry.publish()

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -70,12 +70,16 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
     protected void publish() {
         Map<String, DatadogMetricMetadata> metadataToSend = new HashMap<>();
 
+        String uriString = config.uri() + "/api/v1/series?api_key=" + config.apiKey();
         URL postTimeSeriesEndpoint;
         try {
-            postTimeSeriesEndpoint = URI.create(config.uri() + "/api/v1/series?api_key=" + config.apiKey()).toURL();
+            postTimeSeriesEndpoint = URI.create(uriString).toURL();
         } catch (MalformedURLException e) {
             // not possible
             throw new RuntimeException(e);
+        } catch (IllegalArgumentException e) {
+            logger.error("Invalid URI string for an endpoint to send time series: " + uriString);
+            return;
         }
 
         try {


### PR DESCRIPTION
This PR logs an error with an invalid URI string in `DatadogMeterRegistry.publish()` as the current code silently ignores `IllegalArgumentException` which could be thrown by illegal character(s) like `{` in `config.uri()` or `config.apiKey()` due to user's mistake.