### PR TITLE
Use debug log level for successful metrics sent events.

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -106,7 +106,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                                         m -> writeMeter(m, metadataToSend))
                                 ).collect(joining(",", "{\"series\":[", "]}")))
                         .send()
-                        .onSuccess(response -> logger.info("successfully sent {} metrics to datadog", batch.size()))
+                        .onSuccess(response -> logger.debug("Successfully sent {} metrics to Datadog.", batch.size()))
                         .onError(response -> logger.error("failed to send metrics to datadog: {}", response.body()));
             }
         } catch (Throwable e) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -219,7 +219,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                                     .collect(joining(",")) +
                             "]}")
                     .send()
-                    .onSuccess(response -> logger.info("successfully sent {} metrics to dynatrace", timeSeries.size()))
+                    .onSuccess(response -> logger.debug("Successfully sent {} metrics to Dynatrace.", timeSeries.size()))
                     .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
         } catch (Throwable e) {
             logger.error("failed to send metrics to dynatrace", e);

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -131,7 +131,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                             if (body.contains("\"errors\":true")) {
                                 logger.error("failed to send metrics to elastic: {}", response);
                             } else {
-                                logger.info("successfully sent {} metrics to elastic", batch.size());
+                                logger.debug("Successfully sent {} metrics to Elasticsearch.", batch.size());
                             }
                         })
                         .onError(response -> logger.error("failed to send metrics to elastic: {}", response.body()));

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -113,7 +113,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                         .compressWhen(config::compressed)
                         .send()
                         .onSuccess(response -> {
-                            logger.info("successfully sent {} metrics to influx", batch.size());
+                            logger.debug("Successfully sent {} metrics to InfluxDB.", batch.size());
                             databaseExists = true;
                         })
                         .onError(response -> logger.error("failed to send metrics to influx: {}", response.body()));

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -182,7 +182,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
                     .withHeader("X-Insert-Key", config.apiKey())
                     .withJsonContent(events.peek(ev -> totalEvents.incrementAndGet()).collect(Collectors.joining(",", "[", "]")))
                     .send()
-                    .onSuccess(response -> logger.info("successfully sent {} metrics to new relic", totalEvents.get()))
+                    .onSuccess(response -> logger.debug("Successfully sent {} metrics to New Relic.", totalEvents))
                     .onError(response -> logger.error("failed to send metrics to new relic: {}", response.body()));
         } catch (Throwable e) {
             logger.warn("failed to send metrics to new relic", e);

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -107,7 +107,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
                         .flatMap(builders -> builders.map(builder -> builder.setTimestamp(timestamp).build()))
                         .forEach(session::setDatapoint);
 
-                logger.info("successfully sent " + batch.size() + " metrics to SignalFx");
+                logger.debug("Successfully sent {} metrics to SignalFx.", batch.size());
             } catch (Throwable e) {
                 logger.warn("failed to send metrics", e);
             }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -91,7 +91,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                             .acceptJson()
                             .withJsonContent("{" + stream.collect(joining(",")) + "}")
                             .send()
-                            .onSuccess(response -> logger.info("successfully sent {} metrics to wavefront", batch.size()))
+                            .onSuccess(response -> logger.debug("Successfully sent {} metrics to Wavefront.", batch.size()))
                             .onError(response -> logger.error("failed to send metrics to wavefront: {}", response.body()));
                 } catch (Throwable e) {
                     logger.error("failed to send metrics to wavefront", e);

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -91,7 +91,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                             .acceptJson()
                             .withJsonContent("{" + stream.collect(joining(",")) + "}")
                             .send()
-                            .onSuccess(response -> logger.debug("Successfully sent {} metrics to Wavefront.", batch.size()))
+                            .onSuccess(response -> logSuccessfulMetricsSent(batch))
                             .onError(response -> logger.error("failed to send metrics to wavefront: {}", response.body()));
                 } catch (Throwable e) {
                     logger.error("failed to send metrics to wavefront", e);
@@ -107,6 +107,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                             writer.write(stream.collect(joining("\n")) + "\n");
                             writer.flush();
                         }
+                        logSuccessfulMetricsSent(batch);
                     } catch (IOException e) {
                         logger.error("failed to send metrics to wavefront", e);
                     }
@@ -115,6 +116,10 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                 }
             }
         }
+    }
+
+    private void logSuccessfulMetricsSent(List<Meter> batch) {
+        logger.debug("Successfully sent {} metrics to Wavefront.", batch.size());
     }
 
     private boolean directToApi() {


### PR DESCRIPTION
This PR changes the log level for successful metrics sent event to debug to lower verbosity by default.