### PR TITLE
Ensure that CharacterEncodingFilter is ordered first

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilter.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
  * @author Jon Schneider
  */
 @NonNullApi
-@Order(Ordered.HIGHEST_PRECEDENCE)
+@Order(Ordered.HIGHEST_PRECEDENCE + 1)
 public class WebMvcMetricsFilter extends OncePerRequestFilter {
     private static final String TIMING_SAMPLE = "micrometer.timingSample";
 


### PR DESCRIPTION
This PR ensures that `CharacterEncodingFilter` is ordered first. https://github.com/spring-projects/spring-boot/commit/a8baf42f2fa986d632f7b507b8c774771fb4f523 from Spring Boot hasn't been ported to the Spring Boot legacy support somehow.

Closes gh-802
See https://github.com/spring-projects/spring-boot/issues/11607