### PR TITLE
Polish AbstractTimeWindowHistogram.takeValueSnapshot()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
@@ -175,11 +175,8 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
     }
 
     private ValueAtPercentile[] takeValueSnapshot() {
-        if (distributionStatisticConfig.getPercentiles() == null)
-            return new ValueAtPercentile[0];
-
-        final double[] monitoredPercentiles = distributionStatisticConfig.getPercentiles();
-        if (monitoredPercentiles.length == 0) {
+        double[] monitoredPercentiles = distributionStatisticConfig.getPercentiles();
+        if (monitoredPercentiles == null || monitoredPercentiles.length == 0) {
             return null;
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSnapshot.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSnapshot.java
@@ -27,7 +27,6 @@ public final class HistogramSnapshot {
     private static final ValueAtPercentile[] EMPTY_VALUES = new ValueAtPercentile[0];
     private static final CountAtBucket[] EMPTY_COUNTS = new CountAtBucket[0];
 
-    private static final HistogramSnapshot EMPTY = new HistogramSnapshot(0, 0, 0, null, null, null);
     private final ValueAtPercentile[] percentileValues;
     private final CountAtBucket[] histogramCounts;
 


### PR DESCRIPTION
This commit merges two `if` statements which target the same purpose in the end but return different values, which is a bit confusing. Decided to use `null` over zero-sized array to avoid object creation.

Along the way, this commit also removes an unused private constant.