### PR TITLE
Elastic reporter improvements

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -17,11 +17,18 @@ package io.micrometer.elastic;
 
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,36 +48,114 @@ class ElasticMeterRegistryTest {
     };
 
     private ElasticMeterRegistry registry = new ElasticMeterRegistry(config, clock);
+    private ByteArrayOutputStream bos = new ByteArrayOutputStream();
 
     @Test
     void timestampFormat() {
-        assertThat(ElasticMeterRegistry.IndexBuilder.timestamp(1)).isEqualTo("1970-01-01T00:00:00.001Z");
+        assertThat(ElasticMeterRegistry.FORMATTER.format(Instant.ofEpochMilli(1))).isEqualTo("1970-01-01T00:00:00.001Z");
     }
 
     @Test
-    void buildIndex() {
-        assertThat(registry.index("myTimer", "timer", 0)
-                .field("phi", "0.99").field("value", 1).build())
-                .isEqualTo("{\"index\":{\"_index\":\"metrics-1970-01\",\"_type\":\"doc\"}}\n" +
-                        "{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"phi\":\"0.99\",\"value\":1.0}");
+    void writeTimer() throws IOException {
+        Timer timer = Timer.builder("myTimer").register(registry);
+        registry.writeTimer(bos, timer, 0);
+        assertThat(bos.toString()).isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":0.0}\n");
+//        JSONAssert.assertEquals(expectedJSONString, actualJSON, strictMode);
+    }
+
+    @Test
+    void writeCounter() throws Exception {
+        Counter counter = Counter.builder("myCounter").register(registry);
+        counter.increment();
+        registry.writeCounter(bos, counter, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":0.0}\n");
+    }
+
+    @Test
+    void writeFunctionCounter() throws Exception {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", 123.0, Number::doubleValue).register(registry);
+        registry.writeCounter(bos, counter, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":0.0}\n");
+    }
+
+    @Test
+    void writeGauge() throws Exception {
+        Gauge gauge = Gauge.builder("myGauge", 123.0, Number::doubleValue).register(registry);
+        registry.writeGauge(bos, gauge, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}\n");
+    }
+
+    @Test
+    void writeTimeGauge() throws Exception {
+        TimeGauge gauge = TimeGauge.builder("myGauge", 123.0, TimeUnit.MILLISECONDS, Number::doubleValue).register(registry);
+        registry.writeGauge(bos, gauge, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}\n");
+    }
+
+    @Test
+    void writeLongTaskTimer() throws Exception {
+        LongTaskTimer timer = LongTaskTimer.builder("longTaskTimer").register(registry);
+        registry.writeLongTaskTimer(bos, timer, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"longTaskTimer\",\"type\":\"long_task_timer\",\"activeTasks\":0,\"duration\":0.0}\n");
+    }
+
+    @Test
+    void writeSummary() throws Exception {
+        DistributionSummary summary = DistributionSummary.builder("summary").register(registry);
+        summary.record(123);
+        summary.record(456);
+        registry.writeSummary(bos, summary, 0);
+        assertThat(bos.toString())
+            .isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"summary\",\"type\":\"distribution_summary\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":456.0}\n");
+    }
+
+    @Test
+    void writeMeter() throws Exception {
+        Timer timer = Timer.builder("myTimer").register(registry);
+        registry.writeTimer(bos, timer, 0);
+        assertThat(bos.toString()).isEqualTo("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":0.0}\n");
+    }
+
+    @Test
+    void writeTags() throws Exception {
+        Counter counter = Counter.builder("myCounter").tag("foo", "bar").tag("spam", "eggs").register(registry);
+        counter.increment();
+        registry.writeCounter(bos, counter, 0);
+        assertThat(bos.toString()).isEqualTo("{ \"index\" : {} }\n" +
+            "{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"foo\":\"bar\",\"spam\":\"eggs\",\"count\":0.0}\n");
     }
 
     @Issue("#497")
     @Test
-    void nullGauge() {
-        Gauge g = Gauge.builder("gauge", null, o -> 1).register(registry);
-        assertThat(registry.writeGauge(g, 0)).isEmpty();
+    void nullGauge() throws IOException {
+        {
+            Gauge g = Gauge.builder("gauge", null, o -> 1).register(registry);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            registry.writeGauge(bos, g, 0);
+            assertThat(bos.size()).isEqualTo(0);
+        }
 
-        TimeGauge tg = TimeGauge.builder("time.gauge", null, TimeUnit.MILLISECONDS, o -> 1).register(registry);
-        assertThat(registry.writeGauge(tg, 0)).isEmpty();
+        {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            TimeGauge tg = TimeGauge.builder("time.gauge", null, TimeUnit.MILLISECONDS, o -> 1).register(registry);
+            registry.writeGauge(bos, tg, 0);
+            assertThat(bos.size()).isEqualTo(0L);
+        }
     }
 
     @Issue("#498")
     @Test
-    void wholeCountIsReportedWithDecimal() {
+    void wholeCountIsReportedWithDecimal() throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
         Counter c = Counter.builder("counter").register(registry);
         c.increment(10);
-        assertThat(registry.writeCounter(c, 0)).containsExactly("{\"index\":{\"_index\":\"metrics-1970-01\",\"_type\":\"doc\"}}\n" +
-                "{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"counter\",\"type\":\"counter\",\"count\":0.0}");
+        registry.writeCounter(bos, c, 0);
+        assertThat(bos.toString()).isEqualTo("{ \"index\" : {} }\n" +
+                "{\"@timestamp\":\"1970-01-01T00:00:00Z\",\"name\":\"counter\",\"type\":\"counter\",\"count\":0.0}\n");
     }
 }


### PR DESCRIPTION
This commit improves the elastic reporter behaviour in a few ways:

First, it uses way less objects by removing the builder class and the
usage of streams. Second it does not generate one big in memory string
of the metrics, but rather writes the metrics directly to the output
stream - there is still a string builder per metric.

The first line of each of the bulk requests now does not include the index name
and the type as those can be specified in the URL, thus reducing the
size of the bulk request that needs to be sent over the wire.

The encoding of the basic auth data only needs to be done once in the
constructor instead of doing it in each request.

Lastly tests for each different kind of metric have been added.

Reviewers note: I would like to use ` JSONAssert.assertEquals();` but do not have any experience with locking dependencies and I tried and suddently tons of files were updated.  If you help me doing that I am happy to update this PR doing that as well, so we can ensure, the reporter is producing valid JSON per line.