### PR TITLE
Include useful percentiles for hystrix execution and total latency metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
@@ -47,6 +47,7 @@ public class MicrometerMetricsPublisherCommand implements HystrixMetricsPublishe
 
     private static final String DESCRIPTION_HYSTRIX_EXECUTION = "Execution results. See https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring#command-execution-event-types-comnetflixhystrixhystrixeventtype for type definitions";
     private static final String DESCRIPTION_HYSTRIX_EXECUTION_TERMINAL_TOTAL = "Sum of all terminal executions. Use this to derive percentages from hystrix.execution";
+    private static final double[] HYSTRIX_METRIC_PERCENTILES = {.05, .25, .50, .75, .90, .99, .995};
 
     private final MeterRegistry meterRegistry;
     private final HystrixCommandMetrics metrics;
@@ -82,8 +83,12 @@ public class MicrometerMetricsPublisherCommand implements HystrixMetricsPublishe
             .tags(Tags.concat(tags))
             .register(meterRegistry);
 
-        final Timer latencyExecution = Timer.builder(NAME_HYSTRIX_LATENCY_EXECUTION).tags(tags).register(meterRegistry);
-        final Timer latencyTotal = Timer.builder(NAME_HYSTRIX_LATENCY_TOTAL).tags(tags).register(meterRegistry);
+        final Timer latencyExecution = Timer.builder(NAME_HYSTRIX_LATENCY_EXECUTION).tags(tags)
+            .publishPercentiles(HYSTRIX_METRIC_PERCENTILES)
+            .register(meterRegistry);
+        final Timer latencyTotal = Timer.builder(NAME_HYSTRIX_LATENCY_TOTAL).tags(tags)
+            .publishPercentiles(HYSTRIX_METRIC_PERCENTILES)
+            .register(meterRegistry);
 
         HystrixCommandCompletionStream.getInstance(commandKey)
             .observe()


### PR DESCRIPTION
This PR is intented to solve the thread I opened a few days ago: https://github.com/micrometer-metrics/micrometer/issues/812

The idea is to publish the following percentiles for Hystrix total and execution latencies: https://github.com/Netflix/Hystrix/wiki/Metrics-and-Monitoring#latency-percentiles-hystrixcommandrun-execution-gauge