### PR TITLE
Split method "publishBatch" into smaller method

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -97,12 +97,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         createDatabaseIfNecessary();
 
         try {
-            String write = "/write?consistency=" + config.consistency().toString().toLowerCase() + "&precision=ms&db=" + config.db();
-            if (StringUtils.isNotBlank(config.retentionPolicy())) {
-                write += "&rp=" + config.retentionPolicy();
-            }
-            URL influxEndpoint = URI.create(config.uri() + write).toURL();
-
+            URL influxEndpoint = buildInfluxPublishUrl();
             for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
                 publishBatch(batch, influxEndpoint);
             }
@@ -111,6 +106,14 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         } catch (Throwable e) {
             logger.error("failed to send metrics", e);
         }
+    }
+
+    private URL buildInfluxPublishUrl() throws MalformedURLException {
+        String write = "/write?consistency=" + config.consistency().toString().toLowerCase() + "&precision=ms&db=" + config.db();
+        if (StringUtils.isNotBlank(config.retentionPolicy())) {
+            write += "&rp=" + config.retentionPolicy();
+        }
+        return URI.create(config.uri() + write).toURL();
     }
 
     private void publishBatch(List<Meter> batch, URL influxEndpoint) throws IOException {

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -22,6 +22,7 @@ import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
@@ -101,87 +102,91 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 write += "&rp=" + config.retentionPolicy();
             }
             URL influxEndpoint = URI.create(config.uri() + write).toURL();
-            HttpURLConnection con = null;
 
             for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-                try {
-                    con = (HttpURLConnection) influxEndpoint.openConnection();
-                    con.setConnectTimeout((int) config.connectTimeout().toMillis());
-                    con.setReadTimeout((int) config.readTimeout().toMillis());
-                    con.setRequestMethod(HttpMethod.POST);
-                    con.setRequestProperty(HttpHeader.CONTENT_TYPE, MediaType.PLAIN_TEXT);
-                    con.setDoOutput(true);
-
-                    authenticateRequest(con);
-
-                    List<String> bodyLines = batch.stream()
-                            .flatMap(m -> {
-                                if (m instanceof Timer) {
-                                    return writeTimer((Timer) m);
-                                }
-                                if (m instanceof DistributionSummary) {
-                                    return writeSummary((DistributionSummary) m);
-                                }
-                                if (m instanceof FunctionTimer) {
-                                    return writeTimer((FunctionTimer) m);
-                                }
-                                if (m instanceof TimeGauge) {
-                                    return writeGauge(m.getId(), ((TimeGauge) m).value(getBaseTimeUnit()));
-                                }
-                                if (m instanceof Gauge) {
-                                    return writeGauge(m.getId(), ((Gauge) m).value());
-                                }
-                                if (m instanceof FunctionCounter) {
-                                    return writeCounter(m.getId(), ((FunctionCounter) m).count());
-                                }
-                                if (m instanceof Counter) {
-                                    return writeCounter(m.getId(), ((Counter) m).count());
-                                }
-                                if (m instanceof LongTaskTimer) {
-                                    return writeLongTaskTimer((LongTaskTimer) m);
-                                }
-                                return writeMeter(m);
-                            })
-                            .collect(toList());
-
-                    String body = String.join("\n", bodyLines);
-
-                    if (config.compressed())
-                        con.setRequestProperty(HttpHeader.CONTENT_ENCODING, HttpContentCoding.GZIP);
-
-                    try (OutputStream os = con.getOutputStream()) {
-                        if (config.compressed()) {
-                            try (GZIPOutputStream gz = new GZIPOutputStream(os)) {
-                                gz.write(body.getBytes());
-                                gz.flush();
-                            }
-                        } else {
-                            os.write(body.getBytes());
-                        }
-                        os.flush();
-                    }
-
-                    int status = con.getResponseCode();
-
-                    if (status >= 200 && status < 300) {
-                        logger.info("successfully sent {} metrics to influx", batch.size());
-                        databaseExists = true;
-                    } else if (status >= 400) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error("failed to send metrics: {}", IOUtils.toString(con.getErrorStream()));
-                        }
-                    } else {
-                        logger.error("failed to send metrics: http {}", status);
-                    }
-
-                } finally {
-                    quietlyCloseUrlConnection(con);
-                }
+                publishBatch(batch, influxEndpoint);
             }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("Malformed InfluxDB publishing endpoint, see '" + config.prefix() + ".uri'", e);
         } catch (Throwable e) {
             logger.error("failed to send metrics", e);
+        }
+    }
+
+    private void publishBatch(List<Meter> batch, URL influxEndpoint) throws IOException {
+        HttpURLConnection con = null;
+        try {
+            con = (HttpURLConnection) influxEndpoint.openConnection();
+            con.setConnectTimeout((int) config.connectTimeout().toMillis());
+            con.setReadTimeout((int) config.readTimeout().toMillis());
+            con.setRequestMethod(HttpMethod.POST);
+            con.setRequestProperty(HttpHeader.CONTENT_TYPE, MediaType.PLAIN_TEXT);
+            con.setDoOutput(true);
+
+            authenticateRequest(con);
+
+            List<String> bodyLines = batch.stream()
+                    .flatMap(m -> {
+                        if (m instanceof Timer) {
+                            return writeTimer((Timer) m);
+                        }
+                        if (m instanceof DistributionSummary) {
+                            return writeSummary((DistributionSummary) m);
+                        }
+                        if (m instanceof FunctionTimer) {
+                            return writeTimer((FunctionTimer) m);
+                        }
+                        if (m instanceof TimeGauge) {
+                            return writeGauge(m.getId(), ((TimeGauge) m).value(getBaseTimeUnit()));
+                        }
+                        if (m instanceof Gauge) {
+                            return writeGauge(m.getId(), ((Gauge) m).value());
+                        }
+                        if (m instanceof FunctionCounter) {
+                            return writeCounter(m.getId(), ((FunctionCounter) m).count());
+                        }
+                        if (m instanceof Counter) {
+                            return writeCounter(m.getId(), ((Counter) m).count());
+                        }
+                        if (m instanceof LongTaskTimer) {
+                            return writeLongTaskTimer((LongTaskTimer) m);
+                        }
+                        return writeMeter(m);
+                    })
+                    .collect(toList());
+
+            String body = String.join("\n", bodyLines);
+
+            if (config.compressed())
+                con.setRequestProperty(HttpHeader.CONTENT_ENCODING, HttpContentCoding.GZIP);
+
+            try (OutputStream os = con.getOutputStream()) {
+                if (config.compressed()) {
+                    try (GZIPOutputStream gz = new GZIPOutputStream(os)) {
+                        gz.write(body.getBytes());
+                        gz.flush();
+                    }
+                } else {
+                    os.write(body.getBytes());
+                }
+                os.flush();
+            }
+
+            int status = con.getResponseCode();
+
+            if (status >= 200 && status < 300) {
+                logger.info("successfully sent {} metrics to influx", batch.size());
+                databaseExists = true;
+            } else if (status >= 400) {
+                if (logger.isErrorEnabled()) {
+                    logger.error("failed to send metrics: {}", IOUtils.toString(con.getErrorStream()));
+                }
+            } else {
+                logger.error("failed to send metrics: http {}", status);
+            }
+
+        } finally {
+            quietlyCloseUrlConnection(con);
         }
     }
 


### PR DESCRIPTION
Reduce size of method "publish". The reader of the method can now get an overview of what the method is doing very fast.