### PR TITLE
Close all registries when closing CompositeMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -35,6 +35,7 @@ import java.util.function.ToLongFunction;
  * be overridden.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class CompositeMeterRegistry extends MeterRegistry {
     private final AtomicBoolean registriesLock = new AtomicBoolean(false);
@@ -218,4 +219,11 @@ public class CompositeMeterRegistry extends MeterRegistry {
     public Set<MeterRegistry> getRegistries() {
         return unmodifiableRegistries;
     }
+
+    @Override
+    public void close() {
+        this.registries.forEach(MeterRegistry::close);
+        super.close();
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -35,9 +35,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
+ * Tests for {@link CompositeMeterRegistry}.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 class CompositeMeterRegistryTest {
     private MockClock clock = new MockClock();
@@ -298,4 +303,20 @@ class CompositeMeterRegistryTest {
         latch.await(10, TimeUnit.SECONDS);
         assertThat(latch.getCount()).isZero();
     }
+
+    @Issue("#838")
+    @Test
+    void closeShouldCloseAllMeterRegistries() {
+        MeterRegistry registry1 = mock(MeterRegistry.class);
+        MeterRegistry registry2 = mock(MeterRegistry.class);
+
+        CompositeMeterRegistry compositeMeterRegistry = new CompositeMeterRegistry();
+        compositeMeterRegistry.add(registry1);
+        compositeMeterRegistry.add(registry2);
+
+        compositeMeterRegistry.close();
+        verify(registry1).close();
+        verify(registry2).close();
+    }
+
 }


### PR DESCRIPTION
This PR closes all registries when closing `CompositeMeterRegistry`.

Closes gh-838