### PR TITLE
Polish CompositeMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -53,6 +53,10 @@ public class CompositeMeterRegistry extends MeterRegistry {
     }
 
     public CompositeMeterRegistry(Clock clock) {
+        this(clock, Collections.emptySet());
+    }
+
+    public CompositeMeterRegistry(Clock clock, Iterable<MeterRegistry> registries) {
         super(clock);
         config().namingConvention(NamingConvention.identity);
         config().onMeterAdded(m -> {
@@ -60,10 +64,6 @@ public class CompositeMeterRegistry extends MeterRegistry {
                 lock(registriesLock, () -> nonCompositeDescendants.forEach(((CompositeMeter) m)::add));
             }
         });
-    }
-
-    public CompositeMeterRegistry(Clock clock, Iterable<MeterRegistry> registries) {
-        this(clock);
         registries.forEach(this::add);
     }
 


### PR DESCRIPTION
This PR polishes `CompositeMeterRegistry` by:

- Changing constructor having more parameters to be called by constructor having less parameters as we usually do.