### PR TITLE
Remove @Nullable on CreateDatabaseQueryBuilder

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/CreateDatabaseQueryBuilder.java
@@ -37,10 +37,10 @@ class CreateDatabaseQueryBuilder {
     private static final String SHARD_DURATION_CLAUSE_TEMPLATE = " SHARD DURATION %s";
     private static final String NAME_CLAUSE_TEMPLATE = " NAME %s";
 
-    private String databaseName;
-    private String[] retentionPolicyClauses = new String[4];
+    private final String databaseName;
+    private final String[] retentionPolicyClauses = new String[4];
 
-    CreateDatabaseQueryBuilder(@Nullable String databaseName) {
+    CreateDatabaseQueryBuilder(String databaseName) {
         if (isEmpty(databaseName)) {
             throw new IllegalArgumentException("The database name cannot be null or empty");
         }
@@ -77,7 +77,7 @@ class CreateDatabaseQueryBuilder {
 
     String build() {
         StringBuilder queryStringBuilder = new StringBuilder(String.format(QUERY_MANDATORY_TEMPLATE, databaseName));
-        if (toCreateRetentionPolicy()) {
+        if (hasAnyRetentionPolicy()) {
             String retentionPolicyClause = Stream.of(retentionPolicyClauses).filter(Objects::nonNull)
                     .reduce(RETENTION_POLICY_INTRODUCTION, String::concat);
             queryStringBuilder.append(retentionPolicyClause);
@@ -85,7 +85,7 @@ class CreateDatabaseQueryBuilder {
         return queryStringBuilder.toString();
     }
 
-    private boolean toCreateRetentionPolicy() {
+    private boolean hasAnyRetentionPolicy() {
         return Stream.of(retentionPolicyClauses).anyMatch(Objects::nonNull);
     }
 

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
@@ -93,7 +93,7 @@ public interface InfluxConfig extends StepRegistryConfig {
     @Nullable
     default Integer retentionReplicationFactor() {
         String v = get(prefix() + ".retentionReplicationFactor");
-        return v == null ? null : Integer.parseInt(v);
+        return v == null ? null : Integer.valueOf(v);
     }
 
     /**

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/CreateDatabaseQueryBuilderTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CreateDatabaseQueryBuilderTest {
 
-    private static String TEST_DB_NAME = "dummy_database_0";
+    private static final String TEST_DB_NAME = "dummy_database_0";
 
     /**
      * Class Parameters:


### PR DESCRIPTION
This PR removes `@Nullable` on `CreateDatabaseQueryBuilder` constructor as its internal doesn't allow `databaseName` to be `null`.
 
This PR also polishes some related parts along the way.