### PR TITLE
Log4j2 metrics

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     // log monitoring
     compile 'ch.qos.logback:logback-classic:1.2.+', optional
+    compile 'org.apache.logging.log4j:log4j-core:2.+', optional
 
     // reactor
     compile 'io.projectreactor:reactor-core:latest.release', optional

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import static java.util.Collections.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Log4j2MetricsTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private final Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
+
+    @BeforeEach
+    void bindLog4j2Metrics() {
+        new Log4j2Metrics().bindTo(registry);
+    }
+
+    @Test
+    void log4j2LevelMetrics() {
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
+
+        Configurator.setLevel(Log4j2MetricsTest.class.getName(), Level.INFO);
+        logger.warn("warn");
+        logger.error("error");
+        logger.debug("debug"); // shouldn't record a metric
+
+        assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(0.0);
+    }
+
+    @Test
+    void isLevelEnabledDoesntContributeToCounts() {
+        logger.isErrorEnabled();
+
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(0.0);
+    }
+
+    @Test
+    void removeFilterFromLoggerContextOnClose() throws Exception {
+        LoggerContext loggerContext = new LoggerContext("test");
+        Log4j2Metrics log4j2Metrics = new Log4j2Metrics(emptyList(), loggerContext);
+        log4j2Metrics.bindTo(registry);
+
+        LoggerConfig loggerConfig = loggerContext.getConfiguration().getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
+        assertThat(loggerConfig.getFilter()).isNotNull();
+        log4j2Metrics.close();
+        assertThat(loggerConfig.getFilter()).isNull();
+    }
+}
+

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterBindersConfiguration.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.logging.Log4j2Metrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
@@ -64,6 +65,14 @@ class MeterBindersConfiguration {
     @ConditionalOnMissingBean
     public ClassLoaderMetrics classLoaderMetrics() {
         return new ClassLoaderMetrics();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(Log4j2Metrics.class)
+    @ConditionalOnProperty(value = "management.metrics.binders.log4j2.enabled", matchIfMissing = true)
+    @ConditionalOnClass(name = "org.apache.logging.log4j.Logger")
+    public Log4j2Metrics log4j2Metrics() {
+        return new Log4j2Metrics();
     }
 
     @Bean

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.logging.Log4j2Metrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
@@ -94,7 +95,7 @@ public class MetricsAutoConfigurationTest {
     @Test
     public void automaticallyRegisteredBinders() {
         assertThat(context.getBeansOfType(MeterBinder.class).values())
-            .hasAtLeastOneElementOfType(LogbackMetrics.class)
+            .hasAtLeastOneElementOfType(Log4j2Metrics.class)
             .hasAtLeastOneElementOfType(LogbackMetrics.class)
             .hasAtLeastOneElementOfType(JvmGcMetrics.class)
             .hasAtLeastOneElementOfType(JvmThreadMetrics.class)

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -95,6 +95,7 @@ public class MetricsAutoConfigurationTest {
     public void automaticallyRegisteredBinders() {
         assertThat(context.getBeansOfType(MeterBinder.class).values())
             .hasAtLeastOneElementOfType(LogbackMetrics.class)
+            .hasAtLeastOneElementOfType(LogbackMetrics.class)
             .hasAtLeastOneElementOfType(JvmGcMetrics.class)
             .hasAtLeastOneElementOfType(JvmThreadMetrics.class)
             .hasAtLeastOneElementOfType(ClassLoaderMetrics.class)


### PR DESCRIPTION
Issue #847. Adds Log4j2 metric support. I've patterned the implementation after the LogbackMetrics as much as possible. I had to update the lockfiles locally to add the log4j2 dependency, but I didn't check those in since I'm not sure how those are handled.