### PR TITLE
Avoid String reallocation in WavefrontMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -67,7 +67,7 @@ public class GangliaMeterRegistry extends DropwizardMeterRegistry {
 
     @Override
     public void close() {
-        if(config.enabled()) {
+        if (config.enabled()) {
             reporter.report();
         }
         stop();

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
@@ -87,7 +87,7 @@ public class GraphiteMeterRegistry extends DropwizardMeterRegistry {
 
     @Override
     public void close() {
-        if(config.enabled()) {
+        if (config.enabled()) {
             reporter.report();
         }
         stop();

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -96,7 +96,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
 
                         try (OutputStream os = con.getOutputStream();
                              OutputStreamWriter writer = new OutputStreamWriter(os, "UTF-8")) {
-                            writer.write("{" + stream.collect(joining(",")) + "}");
+                            writer.write(stream.collect(joining(",", "{", "}")));
                             writer.flush();
                         }
 
@@ -121,7 +121,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                     try (Socket socket = new Socket()) {
                         socket.connect(endpoint, timeout);
                         try (OutputStreamWriter writer = new OutputStreamWriter(socket.getOutputStream(), "UTF-8")) {
-                          writer.write(stream.collect(joining("\n")) + "\n");
+                          writer.write(stream.collect(joining("\n", "", "\n")));
                           writer.flush();
                         }
                     }


### PR DESCRIPTION
This PR also fixes Checkstyle violations in `GangliaMeterRegistry` and `GraphiteMeterRegistry`.