### PR TITLE
jersey-server: handle anonymous exceptions correctly

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/DefaultJerseyTagsProvider.java
@@ -86,7 +86,8 @@ public final class DefaultJerseyTagsProvider implements JerseyTagsProvider {
         final Throwable exception = event.getException();
         if (exception != null && statusCode != 404 && !isRedirect(statusCode)) {
             final Throwable cause = exception.getCause() != null ? exception.getCause() : exception;
-            return Tag.of(TAG_EXCEPTION, cause.getClass().getSimpleName());
+            final String simpleName = cause.getClass().getSimpleName();
+            return Tag.of(TAG_EXCEPTION, simpleName.isEmpty() ? cause.getClass().getName() : simpleName);
         }
         return Tag.of(TAG_EXCEPTION, "None");
     }

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java
@@ -82,6 +82,7 @@ public class DefaultJerseyTagsProviderTest {
     }
 
     @Test
+    @SuppressWarnings("serial")
     public void exceptionsAreMappedCorrectly() {
         assertThat(uut.httpRequestTags(
             event(500, new IllegalArgumentException(), "/app", (String[]) null)))
@@ -92,6 +93,9 @@ public class DefaultJerseyTagsProviderTest {
         assertThat(uut.httpRequestTags(
             event(406, new NotAcceptableException(), "/app", (String[]) null)))
             .containsExactlyInAnyOrder(tagsFrom("/app", 406, "NotAcceptableException"));
+        assertThat(uut.httpRequestTags(
+            event(500, new Exception("anonymous") { }, "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("/app", 500, "io.micrometer.jersey2.server.DefaultJerseyTagsProviderTest$1"));
     }
 
     @Test


### PR DESCRIPTION
Aligns the handling with the WebMVC implementation.

I am so deliberate to add it to the `1.0.7` milestone.