### PR TITLE
Rename TimedAspect.DEFAULT_EXCEPTION_TAG to EXCEPTION_TAG

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -43,10 +43,14 @@ import java.util.function.Function;
 public class TimedAspect {
     public static final String DEFAULT_METRIC_NAME = "method.timed";
 
-    public static final String DEFAULT_EXCEPTION_TAG = "exception";
+    /**
+     * Tag key for an exception.
+     * @since 1.1.0
+     */
+    public static final String EXCEPTION_TAG = "exception";
 
     private final MeterRegistry registry;
-    private final Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinpoint;
+    private final Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint;
 
     public TimedAspect(MeterRegistry registry) {
         this(registry, pjp ->
@@ -55,9 +59,9 @@ public class TimedAspect {
         );
     }
 
-    public TimedAspect(MeterRegistry registry, Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinpoint) {
+    public TimedAspect(MeterRegistry registry, Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint) {
         this.registry = registry;
-        this.tagsBasedOnJoinpoint = tagsBasedOnJoinpoint;
+        this.tagsBasedOnJoinPoint = tagsBasedOnJoinPoint;
     }
 
     @Around("execution (@io.micrometer.core.annotation.Timed * *.*(..))")
@@ -77,8 +81,8 @@ public class TimedAspect {
             sample.stop(Timer.builder(metricName)
                     .description(timed.description().isEmpty() ? null : timed.description())
                     .tags(timed.extraTags())
-                    .tags(DEFAULT_EXCEPTION_TAG, exceptionClass)
-                    .tags(tagsBasedOnJoinpoint.apply(pjp))
+                    .tags(EXCEPTION_TAG, exceptionClass)
+                    .tags(tagsBasedOnJoinPoint.apply(pjp))
                     .publishPercentileHistogram(timed.histogram())
                     .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
                     .register(registry));

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedAspectTest.java
@@ -35,7 +35,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static io.micrometer.core.aop.TimedAspect.DEFAULT_EXCEPTION_TAG;
+import static io.micrometer.core.aop.TimedAspect.EXCEPTION_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -63,13 +63,13 @@ public class TimedAspectTest {
     @Test
     public void serviceIsTimedWhenThereIsAnException() {
         assertThrows(RuntimeException.class, () -> service.timeWithException());
-        assertThat(registry.get("somethingElse").tags(DEFAULT_EXCEPTION_TAG, "RuntimeException").timer().count()).isEqualTo(1);
+        assertThat(registry.get("somethingElse").tags(EXCEPTION_TAG, "RuntimeException").timer().count()).isEqualTo(1);
     }
 
     @Test
     public void serviceIsTimedWhenThereIsNoException() {
         service.timeWithoutException();
-        assertThat(registry.get("somethingElse").tags(DEFAULT_EXCEPTION_TAG, "none").timer().count()).isEqualTo(1);
+        assertThat(registry.get("somethingElse").tags(EXCEPTION_TAG, "none").timer().count()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
This PR renames `TimedAspect.DEFAULT_EXCEPTION_TAG` to `EXCEPTION_TAG` as it sounds customizable although it couldn't be.

This PR also polishes `TimedAspect` a bit along the way.