### PR TITLE
Polish KafkaConsumerMetrics

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetricsTest.java
@@ -70,6 +70,6 @@ class KafkaConsumerMetricsTest {
     void kafkaMajorVersion() {
         createConsumer();
 
-        assertThat(kafkaConsumerMetrics.kafkaMajorVersion(Tags.of("client.id", "consumer-1"))).isGreaterThanOrEqualTo(2);
+        assertThat(kafkaConsumerMetrics.getKafkaMajorVersion(Tags.of("client.id", "consumer-1"))).isGreaterThanOrEqualTo(2);
     }
 }


### PR DESCRIPTION
This PR polishes the `KafkaConsumerMetrics` by:

- Adding missing `@since` tag.
- Changing `KafkaConsumerMetrics()` to use `KafkaConsumerMetrics(Iterable<Tag> tags)`, not directly `KafkaConsumerMetrics(MBeanServer mBeanServer, Iterable<Tag> tags)`.
- Reordering assignments to align with parameters in `KafkaConsumerMetrics(MBeanServer mBeanServer, Iterable<Tag> tags)`.
- Introducing constants for repeated literals.
- Introducing `kafkaMajorVersion` field to cache its result.
- Replacing duplicate invocations with an extracted method.
- Replacing duplicate invocations with local variables.
- Fixing typos.
- Removing `NotificationListener` like `TomcatMetrics`.
- Using `null` value for missing `baseUnit` consistently.

They are mostly cosmetic changes but there are some functional changes, so they need to be double-checked as I might miss some intentions.