### PR TITLE
Polish Log4j2Metrics

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/MicrometerCollectorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.prometheus;
 
 import io.micrometer.core.Issue;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -31,11 +31,16 @@ import org.apache.logging.log4j.core.filter.AbstractFilter;
 import static java.util.Collections.emptyList;
 
 /**
+ * {@link MeterBinder} for Apache Log4j 2.
+ *
  * @author Steven Sheehy
+ * @since 1.1.0
  */
 @NonNullApi
 @NonNullFields
 public class Log4j2Metrics implements MeterBinder, AutoCloseable {
+
+    private static final String METER_NAME = "log4j2.events";
 
     private final Iterable<Tag> tags;
     private final LoggerContext loggerContext;
@@ -63,7 +68,6 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         Configuration configuration = loggerContext.getConfiguration();
         configuration.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).addFilter(metricsFilter);
-        loggerContext.updateLoggers(configuration);
     }
 
     @Override
@@ -87,42 +91,42 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         private final Counter traceCounter;
 
         MetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
-            fatalCounter = Counter.builder("log4j2.events")
+            fatalCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "fatal")
                     .description("Number of fatal level log events")
                     .baseUnit("events")
                     .register(registry);
 
-            errorCounter = Counter.builder("log4j2.events")
+            errorCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "error")
                     .description("Number of error level log events")
                     .baseUnit("events")
                     .register(registry);
 
-            warnCounter = Counter.builder("log4j2.events")
+            warnCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "warn")
                     .description("Number of warn level log events")
                     .baseUnit("events")
                     .register(registry);
 
-            infoCounter = Counter.builder("log4j2.events")
+            infoCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "info")
                     .description("Number of info level log events")
                     .baseUnit("events")
                     .register(registry);
 
-            debugCounter = Counter.builder("log4j2.events")
+            debugCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "debug")
                     .description("Number of debug level log events")
                     .baseUnit("events")
                     .register(registry);
 
-            traceCounter = Counter.builder("log4j2.events")
+            traceCounter = Counter.builder(METER_NAME)
                     .tags(tags)
                     .tags("level", "trace")
                     .description("Number of trace level log events")


### PR DESCRIPTION
This PR polishes `Log4j2Metrics` by:

- Adding a missing `@since` tag.
- Extracting the meter name to a constant.
- Removing `loggerContext.updateLoggers(configuration);` in `bindTo()` as it doesn't seem to be necessary.

Note that the first commit which is already in the 1.0.x branch is only for passing a PR build.