### PR TITLE
Fail fast if any Dynatrace API mandatory property is missing

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -42,10 +42,14 @@ import java.util.stream.StreamSupport;
 
 import static io.micrometer.core.instrument.Meter.Type.match;
 import static io.micrometer.dynatrace.DynatraceMetricDefinition.DynatraceUnit;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 /**
+ * {@link StepMeterRegistry} for Dynatrace.
+ *
  * @author Oriol Barcelona
+ * @since 1.1.0
  */
 public class DynatraceMeterRegistry extends StepMeterRegistry {
 
@@ -64,6 +68,10 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     public DynatraceMeterRegistry(DynatraceConfig config, Clock clock, ThreadFactory threadFactory) {
         super(config, clock);
+        requireNonNull(config.uri());
+        requireNonNull(config.deviceId());
+        requireNonNull(config.apiToken());
+
         this.config = config;
 
         this.config().namingConvention(new DynatraceNamingConvention());

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link DynatraceMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class DynatraceMeterRegistryTest {
+
+    @Test
+    void constructorWhenUriIsMissingShouldThrowMissingRequiredConfigurationException() {
+        assertThatThrownBy(() -> new DynatraceMeterRegistry(new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String deviceId() {
+                return "deviceId";
+            }
+
+            @Override
+            public String apiToken() {
+                return "apiToken";
+            }
+        }, Clock.SYSTEM))
+            .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+            .hasMessage("uri must be set to report metrics to Dynatrace");
+    }
+
+    @Test
+    void constructorWhenDeviceIdIsMissingShouldThrowMissingRequiredConfigurationException() {
+        assertThatThrownBy(() -> new DynatraceMeterRegistry(new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String uri() {
+                return "uri";
+            }
+
+            @Override
+            public String apiToken() {
+                return "apiToken";
+            }
+        }, Clock.SYSTEM))
+            .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+            .hasMessage("deviceId must be set to report metrics to Dynatrace");
+    }
+
+    @Test
+    void constructorWhenApiTokenIsMissingShouldThrowMissingRequiredConfigurationException() {
+        assertThatThrownBy(() -> new DynatraceMeterRegistry(new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String uri() {
+                return "uri";
+            }
+
+            @Override
+            public String deviceId() {
+                return "deviceId";
+            }
+        }, Clock.SYSTEM))
+            .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+            .hasMessage("apiToken must be set to report metrics to Dynatrace");
+    }
+
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/MicrometerCollectorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.prometheus;
 
 import io.micrometer.core.Issue;


### PR DESCRIPTION
This PR changes to fail fast if any Dynatrace API mandatory property is missing.

Note that the first commit which is already in the 1.0.x branch is only for passing a PR build.

Closes gh-868