### PR TITLE
Remove this keyword on method of superclass

### DIFF
--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -69,7 +69,7 @@ public class AtlasMeterRegistry extends MeterRegistry {
 
         // invalid character replacement happens in the spectator-reg-atlas module, so doesn't need
         // to be duplicated here.
-        this.config().namingConvention(new AtlasNamingConvention());
+        config().namingConvention(new AtlasNamingConvention());
 
         start();
     }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -56,7 +56,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         this.amazonCloudWatchAsync = amazonCloudWatchAsync;
         this.config = config;
-        this.config().namingConvention(NamingConvention.identity);
+        config().namingConvention(NamingConvention.identity);
         start(threadFactory);
     }
 

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -58,7 +58,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         super(config, clock);
         requireNonNull(config.apiKey());
 
-        this.config().namingConvention(new DatadogNamingConvention());
+        config().namingConvention(new DatadogNamingConvention());
 
         this.config = config;
 

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -50,7 +50,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
     public InfluxMeterRegistry(InfluxConfig config, Clock clock, ThreadFactory threadFactory) {
         super(config, clock);
-        this.config().namingConvention(new InfluxNamingConvention());
+        config().namingConvention(new InfluxNamingConvention());
         this.config = config;
         start(threadFactory);
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -61,7 +61,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     public PrometheusMeterRegistry(PrometheusConfig config, CollectorRegistry registry, Clock clock) {
         super(clock);
         this.registry = registry;
-        this.config().namingConvention(new PrometheusNamingConvention());
+        config().namingConvention(new PrometheusNamingConvention());
         this.prometheusConfig = config;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -47,7 +47,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
         this.dropwizardClock = new DropwizardClock(clock);
         this.registry = registry;
         this.nameMapper = nameMapper;
-        this.config().namingConvention(NamingConvention.camelCase);
+        config().namingConvention(NamingConvention.camelCase);
     }
 
     public MetricRegistry getDropwizardRegistry() {


### PR DESCRIPTION
This PR removes `this` keyword in `this.config()` as `this` keyword on methods is unusual and furthermore it comes from its superclass, not itself.