### PR TITLE
Restore updateLoggers() in Log4j2Metrics.updateLoggers()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -68,6 +68,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         Configuration configuration = loggerContext.getConfiguration();
         configuration.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).addFilter(metricsFilter);
+        loggerContext.updateLoggers(configuration);
     }
 
     @Override
@@ -75,6 +76,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         if (metricsFilter != null) {
             Configuration configuration = loggerContext.getConfiguration();
             configuration.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).removeFilter(metricsFilter);
+            loggerContext.updateLoggers(configuration);
             metricsFilter.stop();
         }
     }


### PR DESCRIPTION
This PR also adds `updateLoggers()` after the filter has been removed in `Log4j2Metrics.close()`.

See gh-867