### PR TITLE
Handle reporter with config.enabled() consistently

### DIFF
--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -44,25 +44,28 @@ public class GangliaMeterRegistry extends DropwizardMeterRegistry {
         this.config = config;
 
         try {
-            final GMetric ganglia = new GMetric(config.host(), config.port(), config.addressingMode(), config.ttl());
-            this.reporter = GangliaReporter.forRegistry(getDropwizardRegistry())
+            GMetric ganglia = new GMetric(config.host(), config.port(), config.addressingMode(), config.ttl());
+            reporter = GangliaReporter.forRegistry(getDropwizardRegistry())
                     .convertRatesTo(config.rateUnits())
                     .convertDurationsTo(config.durationUnits())
                     .build(ganglia);
 
-            if (config.enabled())
-                start();
+            start();
         } catch (IOException e) {
             throw new RuntimeException("Failed to configure Ganglia metrics reporting", e);
         }
     }
 
     public void stop() {
-        this.reporter.stop();
+        if (config.enabled()) {
+            reporter.stop();
+        }
     }
 
     public void start() {
-        this.reporter.start(config.step().getSeconds(), TimeUnit.SECONDS);
+        if (config.enabled()) {
+            reporter.start(config.step().getSeconds(), TimeUnit.SECONDS);
+        }
     }
 
     @Override
@@ -71,7 +74,9 @@ public class GangliaMeterRegistry extends DropwizardMeterRegistry {
             reporter.report();
         }
         stop();
-        this.reporter.close();
+        if (config.enabled()) {
+            reporter.close();
+        }
         super.close();
     }
 


### PR DESCRIPTION
This PR does a similar change to gh-863 but for `GangliaMeterRegistry`.