### PR TITLE
Add a missing @since tag to HistogramSupport.getId()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSupport.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSupport.java
@@ -39,5 +39,11 @@ public interface HistogramSupport {
         return takeSnapshot();
     }
 
+    /**
+     * Return the meter ID.
+     *
+     * @return the meter ID
+     * @since 1.0.7
+     */
     Meter.Id getId();
 }


### PR DESCRIPTION
This PR adds a missing `@since` tag to `HistogramSupport.getId()`.