### PR TITLE
Add outcome tag to Servlet metrics

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/DefaultWebMvcTagsProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/DefaultWebMvcTagsProvider.java
@@ -57,7 +57,7 @@ public class DefaultWebMvcTagsProvider implements WebMvcTagsProvider {
                                          @Nullable Object handler,
                                          @Nullable Throwable ex) {
         return Arrays.asList(WebMvcTags.method(request), WebMvcTags.uri(request, response),
-            WebMvcTags.exception(ex), WebMvcTags.status(response));
+            WebMvcTags.exception(ex), WebMvcTags.status(response), WebMvcTags.outcome(response));
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTags.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @author Jon Schneider
  * @author Andy Wilkinson
+ * @author Michael McFadyen
  */
 @NonNullApi
 public final class WebMvcTags {
@@ -46,6 +47,18 @@ public final class WebMvcTags {
     private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
 
     private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+
+    private static final Tag OUTCOME_UNKNOWN = Tag.of("outcome", "UNKNOWN");
+
+    private static final Tag OUTCOME_INFORMATIONAL = Tag.of("outcome", "INFORMATIONAL");
+
+    private static final Tag OUTCOME_SUCCESS = Tag.of("outcome", "SUCCESS");
+
+    private static final Tag OUTCOME_REDIRECTION = Tag.of("outcome", "REDIRECTION");
+
+    private static final Tag OUTCOME_CLIENT_ERROR = Tag.of("outcome", "CLIENT_ERROR");
+
+    private static final Tag OUTCOME_SERVER_ERROR = Tag.of("outcome", "SERVER_ERROR");
 
     private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
 
@@ -142,4 +155,31 @@ public final class WebMvcTags {
         String simpleName = exception.getClass().getSimpleName();
         return Tag.of("exception", simpleName.isEmpty() ? exception.getClass().getName() : simpleName);
     }
+
+    /**
+     * Creates an {@code outcome} tag based on the status of the given {@code response}.
+     * @param response the HTTP response
+     * @return the outcome tag derived from the status of the response
+     * @since 1.1.0
+     */
+    public static Tag outcome(HttpServletResponse response) {
+        if (response != null) {
+            int status = response.getStatus();
+            if (status < 200) {
+                return OUTCOME_INFORMATIONAL;
+            }
+            if (status < 300) {
+                return OUTCOME_SUCCESS;
+            }
+            if (status < 400) {
+                return OUTCOME_REDIRECTION;
+            }
+            if (status < 500) {
+                return OUTCOME_CLIENT_ERROR;
+            }
+            return OUTCOME_SERVER_ERROR;
+        }
+        return OUTCOME_UNKNOWN;
+    }
+
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
@@ -23,6 +23,13 @@ import org.springframework.web.servlet.HandlerMapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link WebMvcTags}.
+ *
+ * @author Andy Wilkinson
+ * @author Brian Clozel
+ * @author Michael McFadyen
+ */
 public class WebMvcTagsTest {
     private final MockHttpServletRequest request = new MockHttpServletRequest();
 
@@ -80,4 +87,46 @@ public class WebMvcTagsTest {
         Tag tag = WebMvcTags.uri(null, null);
         assertThat(tag.getValue()).isEqualTo("UNKNOWN");
     }
+
+    @Test
+    public void outcomeTagIsUnknownWhenResponseIsNull() {
+        Tag tag = WebMvcTags.outcome(null);
+        assertThat(tag.getValue()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    public void outcomeTagIsInformationalWhenResponseIs1xx() {
+        this.response.setStatus(100);
+        Tag tag = WebMvcTags.outcome(this.response);
+        assertThat(tag.getValue()).isEqualTo("INFORMATIONAL");
+    }
+
+    @Test
+    public void outcomeTagIsSuccessWhenResponseIs2xx() {
+        this.response.setStatus(200);
+        Tag tag = WebMvcTags.outcome(this.response);
+        assertThat(tag.getValue()).isEqualTo("SUCCESS");
+    }
+
+    @Test
+    public void outcomeTagIsRedirectionWhenResponseIs3xx() {
+        this.response.setStatus(301);
+        Tag tag = WebMvcTags.outcome(this.response);
+        assertThat(tag.getValue()).isEqualTo("REDIRECTION");
+    }
+
+    @Test
+    public void outcomeTagIsClientErrorWhenResponseIs4xx() {
+        this.response.setStatus(400);
+        Tag tag = WebMvcTags.outcome(this.response);
+        assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
+    }
+
+    @Test
+    public void outcomeTagIsServerErrorWhenResponseIs5xx() {
+        this.response.setStatus(500);
+        Tag tag = WebMvcTags.outcome(this.response);
+        assertThat(tag.getValue()).isEqualTo("SERVER_ERROR");
+    }
+
 }


### PR DESCRIPTION
This PR adds `outcome` tag to Servlet metrics by porting partially from https://github.com/spring-projects/spring-boot/pull/14486.