### PR TITLE
Limit metrics collection of incoming requests for Servlet

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
@@ -123,6 +123,13 @@ public class MetricsProperties {
              */
             private String requestsMetricName = "http.server.requests";
 
+            /**
+             * Maximum number of unique URI tag values allowed. After the max number of
+             * tag values is reached, metrics with additional tag values are denied by
+             * filter.
+             */
+            private int maxUriTags = 100;
+
             public boolean isAutoTimeRequests() {
                 return this.autoTimeRequests;
             }
@@ -138,6 +145,15 @@ public class MetricsProperties {
             public void setRequestsMetricName(String requestsMetricName) {
                 this.requestsMetricName = requestsMetricName;
             }
+
+            public int getMaxUriTags() {
+                return this.maxUriTags;
+            }
+
+            public void setMaxUriTags(int maxUriTags) {
+                this.maxUriTags = maxUriTags;
+            }
+
         }
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/OnlyOnceLoggingDenyMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/OnlyOnceLoggingDenyMeterFilter.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import org.springframework.util.Assert;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * {@link MeterFilter} to log only once a warning message and deny a {@link Meter}
+ * {@link Meter.Id}.
+ *
+ * @author Jon Schneider
+ * @author Dmytro Nosan
+ */
+public final class OnlyOnceLoggingDenyMeterFilter implements MeterFilter {
+
+    private static final Log logger = LogFactory
+            .getLog(OnlyOnceLoggingDenyMeterFilter.class);
+
+    private final AtomicBoolean alreadyWarned = new AtomicBoolean(false);
+
+    private final Supplier<String> message;
+
+    public OnlyOnceLoggingDenyMeterFilter(Supplier<String> message) {
+        Assert.notNull(message, "Message must not be null");
+        this.message = message;
+    }
+
+    @Override
+    public MeterFilterReply accept(Meter.Id id) {
+        if (logger.isWarnEnabled()
+                && this.alreadyWarned.compareAndSet(false, true)) {
+            logger.warn(this.message.get());
+        }
+        return MeterFilterReply.DENY;
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/TestController.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/TestController.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test controller used by metrics tests.
+ *
+ * @author Dmytro Nosan
+ * @author Stephane Nicoll
+ */
+@RestController
+public class TestController {
+
+    @GetMapping("test0")
+    public String test0() {
+        return "test0";
+    }
+
+    @GetMapping("test1")
+    public String test1() {
+        return "test1";
+    }
+
+    @GetMapping("test2")
+    public String test2() {
+        return "test2";
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfiguration.java
@@ -15,20 +15,15 @@
  */
 package io.micrometer.spring.autoconfigure.web.client;
 
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.micrometer.core.instrument.config.MeterFilterReply;
-import io.micrometer.core.lang.NonNull;
-import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
 import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.MetricsProperties;
+import io.micrometer.spring.autoconfigure.OnlyOnceLoggingDenyMeterFilter;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import io.micrometer.spring.web.client.DefaultRestTemplateExchangeTagsProvider;
 import io.micrometer.spring.web.client.MetricsRestTemplateCustomizer;
 import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -43,7 +38,6 @@ import org.springframework.web.client.AsyncRestTemplate;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Configuration for {@link RestTemplate}- and {@link AsyncRestTemplate}-related metrics.
@@ -60,7 +54,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 })
 @ConditionalOnBean(MeterRegistry.class)
 public class RestTemplateMetricsAutoConfiguration {
-    private final Logger logger = LoggerFactory.getLogger(RestTemplateMetricsAutoConfiguration.class);
+
+    private final MetricsProperties properties;
+
+    public RestTemplateMetricsAutoConfiguration(MetricsProperties properties) {
+        this.properties = properties;
+    }
 
     @Bean
     @ConditionalOnMissingBean(RestTemplateExchangeTagsProvider.class)
@@ -70,8 +69,7 @@ public class RestTemplateMetricsAutoConfiguration {
 
     @Bean
     public MetricsRestTemplateCustomizer metricsRestTemplateCustomizer(MeterRegistry meterRegistry,
-                                                                       RestTemplateExchangeTagsProvider restTemplateTagConfigurer,
-                                                                       MetricsProperties properties) {
+                                                                       RestTemplateExchangeTagsProvider restTemplateTagConfigurer) {
         return new MetricsRestTemplateCustomizer(meterRegistry, restTemplateTagConfigurer,
             properties.getWeb().getClient().getRequestsMetricName());
     }
@@ -89,21 +87,13 @@ public class RestTemplateMetricsAutoConfiguration {
 
     @Bean
     @Order(0)
-    public MeterRegistryCustomizer limitCardinalityOfUriTag(MetricsProperties properties) {
-        String metricName = properties.getWeb().getClient().getRequestsMetricName();
-        return r -> r.config().meterFilter(MeterFilter.maximumAllowableTags(metricName,
-            "uri", properties.getWeb().getClient().getMaxUriTags(), new MeterFilter() {
-                private AtomicBoolean alreadyWarned = new AtomicBoolean(false);
-
-                @Override
-                @NonNull
-                public MeterFilterReply accept(@NonNull Meter.Id id) {
-                    if (alreadyWarned.compareAndSet(false, true)) {
-                        logger.warn("Reached the maximum number of URI tags for '" + metricName + "'. Are you using uriVariables on RestTemplate calls?");
-                    }
-                    return MeterFilterReply.DENY;
-                }
-            })
-        );
+    public MeterFilter metricsHttpClientUriTagFilter() {
+        String metricName = this.properties.getWeb().getClient().getRequestsMetricName();
+        MeterFilter denyFilter = new OnlyOnceLoggingDenyMeterFilter(() -> String
+                .format("Reached the maximum number of URI tags for '%s'. Are you using "
+                        + "'uriVariables'?", metricName));
+        return MeterFilter.maximumAllowableTags(metricName, "uri",
+                this.properties.getWeb().getClient().getMaxUriTags(), denyFilter);
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfiguration.java
@@ -16,8 +16,10 @@
 package io.micrometer.spring.autoconfigure.web.servlet;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.MetricsProperties;
+import io.micrometer.spring.autoconfigure.OnlyOnceLoggingDenyMeterFilter;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import io.micrometer.spring.web.servlet.DefaultWebMvcTagsProvider;
 import io.micrometer.spring.web.servlet.WebMvcMetricsFilter;
@@ -32,6 +34,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
@@ -41,6 +44,7 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
  * MVC servlet-based request mappings.
  *
  * @author Jon Schneider
+ * @author Dmytro Nosan
  */
 @Configuration
 @AutoConfigureAfter({ MetricsAutoConfiguration.class,
@@ -51,6 +55,12 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 @EnableConfigurationProperties(MetricsProperties.class)
 public class WebMvcMetricsAutoConfiguration {
 
+    private final MetricsProperties properties;
+
+    public WebMvcMetricsAutoConfiguration(MetricsProperties properties) {
+        this.properties = properties;
+    }
+
     @Bean
     @ConditionalOnMissingBean(WebMvcTagsProvider.class)
     public DefaultWebMvcTagsProvider servletTagsProvider() {
@@ -59,7 +69,7 @@ public class WebMvcMetricsAutoConfiguration {
 
     @SuppressWarnings("deprecation")
     @Bean
-    public WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry, MetricsProperties properties,
+    public WebMvcMetricsFilter webMetricsFilter(MeterRegistry registry,
                                                 WebMvcTagsProvider tagsProvider,
                                                 WebApplicationContext ctx) {
         return new WebMvcMetricsFilter(registry, tagsProvider,
@@ -67,4 +77,15 @@ public class WebMvcMetricsAutoConfiguration {
                 properties.getWeb().getServer().isAutoTimeRequests(),
                 new HandlerMappingIntrospector(ctx));
     }
+
+    @Bean
+    @Order(0)
+    public MeterFilter metricsHttpServerUriTagFilter() {
+        String metricName = this.properties.getWeb().getServer().getRequestsMetricName();
+        MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(() -> String
+                .format("Reached the maximum number of URI tags for '%s'.", metricName));
+        return MeterFilter.maximumAllowableTags(metricName, "uri",
+                this.properties.getWeb().getServer().getMaxUriTags(), filter);
+    }
+
 }


### PR DESCRIPTION
This PR limits metrics collection of incoming requests for Servlet by porting partially from https://github.com/spring-projects/spring-boot/pull/14173.