### PR TITLE
Use local variables for counter.count() in AzureMonitorMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
+++ b/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
@@ -141,15 +141,17 @@ public class AzureMonitorMeterRegistry extends StepMeterRegistry {
 
     private Stream<MetricTelemetry> trackCounter(Counter counter) {
         MetricTelemetry mt = createMetricTelemetry(counter, null);
-        mt.setValue(counter.count());
-        mt.setCount((int) Math.round(counter.count()));
+        double count = counter.count();
+        mt.setValue(count);
+        mt.setCount((int) Math.round(count));
         return Stream.of(mt);
     }
 
     private Stream<MetricTelemetry> trackFunctionCounter(FunctionCounter counter) {
         MetricTelemetry mt = createMetricTelemetry(counter, null);
-        mt.setValue(counter.count());
-        mt.setCount((int) Math.round(counter.count()));
+        double count = counter.count();
+        mt.setValue(count);
+        mt.setCount((int) Math.round(count));
         return Stream.of(mt);
     }
 


### PR DESCRIPTION
This PR changes to use local variables for `counter.count()` in `AzureMonitorMeterRegistry` as it could have a different return value on each invocation.