### PR TITLE
Reduce String object creation in Datadog and New Relic registries

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -105,8 +105,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                     }"
                     */
 
-                    String body = "{\"series\":[" +
-                            batch.stream().flatMap(m -> {
+                    String body = batch.stream().flatMap(m -> {
                                 if (m instanceof Timer) {
                                     return writeTimer((Timer) m, metadataToSend);
                                 }
@@ -117,8 +116,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                                     return writeTimer((FunctionTimer) m, metadataToSend);
                                 }
                                 return writeMeter(m, metadataToSend);
-                            }).collect(joining(",")) +
-                            "]}";
+                            }).collect(joining(",", "{\"series\":[", "]}"));
 
                     logger.debug(body);
 
@@ -250,11 +248,11 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                 .map(t -> ",\"host\":\"" + t.getValue() + "\"")
                 .orElse("");
 
-        String tagsArray = tags.iterator().hasNext() ?
-                ",\"tags\":[" +
-                        stream(tags.spliterator(), false)
-                                .map(t -> "\"" + t.getKey() + ":" + t.getValue() + "\"")
-                                .collect(joining(",")) + "]" : "";
+        String tagsArray = tags.iterator().hasNext()
+            	? stream(tags.spliterator(), false)
+                        .map(t -> "\"" + t.getKey() + ":" + t.getValue() + "\"")
+                        .collect(joining(",", ",\"tags\":[", "]"))
+            	: "";
 
         return "{\"metric\":\"" + getConventionName(fullId) + "\"," +
                 "\"points\":[[" + (wallTime / 1000) + ", " + value + "]]" + host + tagsArray + "}";

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 /**
  * @author Jon Schneider
@@ -119,7 +118,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
                     authenticateRequest(con);
 
-                    List<String> bodyLines = batch.stream()
+                    String body = batch.stream()
                             .flatMap(m -> {
                                 if (m instanceof Timer) {
                                     return writeTimer((Timer) m);
@@ -147,9 +146,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                                 }
                                 return writeMeter(m);
                             })
-                            .collect(toList());
-
-                    String body = String.join("\n", bodyLines);
+                            .collect(joining("\n"));
 
                     if (config.compressed())
                         con.setRequestProperty("Content-Encoding", "gzip");

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -200,9 +200,9 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             tagsJson.append(",\"").append(convention.tagKey(tag.getKey())).append("\":\"").append(convention.tagValue(tag.getValue())).append("\"");
         }
 
-        return "{\"eventType\":\"" + getConventionName(id) + "\"" +
-                Arrays.stream(attributes).map(attr -> ",\"" + attr.getName() + "\":" + DoubleFormat.decimalOrWhole(attr.getValue().doubleValue()))
-                        .collect(Collectors.joining("")) + tagsJson.toString() + "}";
+        return Arrays.stream(attributes)
+                .map(attr -> ",\"" + attr.getName() + "\":" + DoubleFormat.decimalOrWhole(attr.getValue().doubleValue()))
+                .collect(Collectors.joining("", "{\"eventType\":\"" + getConventionName(id) + "\"", tagsJson + "}"));
     }
 
     private void sendEvents(URL insightsEndpoint, List<String> events) {
@@ -219,7 +219,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
             con.setDoOutput(true);
 
-            String body = "[" + events.stream().collect(Collectors.joining(",")) + "]";
+            String body = events.stream().collect(Collectors.joining(",", "[", "]"));
 
             logger.trace("Sending payload to New Relic:");
             logger.trace(body);


### PR DESCRIPTION
This PR changes to reduce `String` object creation in `DatadogMeterRegistry`.