### PR TITLE
Measurement buffering for Statsd

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -199,11 +199,14 @@ public class StatsdMeterRegistry extends MeterRegistry {
     }
 
     public void start() {
+        final Flux<String> bufferingPublisher = BufferingFlux.create(Flux.from(processor), "\n", statsdConfig.maxPacketLength(), statsdConfig.pollingFrequency().toMillis())
+            .onBackpressureLatest();
+
         if (started.compareAndSet(false, true) && lineSink == null) {
             UdpClient.create(statsdConfig.host(), statsdConfig.port())
                     .newHandler((in, out) -> out
                             .options(NettyPipeline.SendOptions::flushOnEach)
-                            .sendString(processor)
+                            .sendString(bufferingPublisher)
                             .neverComplete()
                     )
                     .subscribe(client -> {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.statsd.internal;
+
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class BufferingFlux {
+
+    private BufferingFlux() {
+    }
+
+    /**
+     * Creates a Flux that implements Nagle's algorithm to buffer messages -- joined by a delimiter string -- to up a
+     * maximum number of bytes, or a maximum duration of time. This avoids sending many small packets in favor of fewer
+     * larger ones.
+     *
+     * Also see: https://en.wikipedia.org/wiki/Nagle%27s_algorithm
+     */
+    public static Flux<String> create(final Flux<String> source, final String delimiter, final int maxByteArraySize, final long maxMillisecondsBetweenEmits) {
+        return Flux.defer(() -> {
+            final int delimiterSize = delimiter.getBytes().length;
+            final AtomicInteger byteSize = new AtomicInteger(0);
+            final AtomicLong lastTime = new AtomicLong(0);
+
+            final DirectProcessor<Void> intervalEnd = DirectProcessor.create();
+
+            final Flux<String> hearbeat = Flux.interval(Duration.ofMillis(maxMillisecondsBetweenEmits))
+                .map(l -> "")
+                .takeUntilOther(intervalEnd);
+
+            // Create a stream that emits at least once every $maxMillisecondsBetweenEmits, to avoid long pauses between
+            // buffer flushes when the source doesn't emit for a while.
+            final Flux<String> sourceWithEmptyStringKeepAlive = source
+                .doOnTerminate(intervalEnd::onComplete)
+                .mergeWith(hearbeat);
+
+            return sourceWithEmptyStringKeepAlive
+                .bufferUntil(line -> {
+                    final int bytesLength = line.getBytes().length;
+                    final long now = System.currentTimeMillis();
+                    final long last = lastTime.getAndSet(now);
+                    long diff;
+                    if (last != 0L) {
+                        diff = now - last;
+                        if (diff > maxMillisecondsBetweenEmits && byteSize.get() > 0) {
+                            // This creates a buffer, reset size
+                            byteSize.set(bytesLength);
+                            return true;
+                        }
+                    }
+
+                    int additionalBytes = bytesLength;
+                    if (additionalBytes > 0 && byteSize.get() > 0) {
+                        additionalBytes += delimiterSize;  // Make up for the delimiter that's added when joining the strings
+                    }
+
+                    final int projectedBytes = byteSize.addAndGet(additionalBytes);
+
+                    if (projectedBytes > maxByteArraySize) {
+                        // This creates a buffer, reset size
+                        byteSize.set(bytesLength);
+                        return true;
+                    }
+
+                    return false;
+                }, true)
+                .map(lines -> {
+                    lines.removeIf(String::isEmpty); // Ignore empty messages
+                    return String.join(delimiter, lines);
+                });
+        });
+    }
+}

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/BufferingFluxTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/BufferingFluxTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.statsd.internal;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+@Disabled
+class BufferingFluxTest {
+
+    @Test
+    void bufferSingleStrings() {
+        final Flux<String> source = Flux.just(
+            "twelve bytes",
+            "fourteen bytes",
+            "twelve bytes",
+            "fourteen bytes"
+        ).delayElements(Duration.ofMillis(50));
+
+        final Flux<String> buffered = BufferingFlux.create(source, "\n", 14, 200);
+
+        StepVerifier.create(buffered)
+            .expectNext("twelve bytes")
+            .expectNext("fourteen bytes")
+            .expectNext("twelve bytes")
+            .expectNext("fourteen bytes")
+            .verifyComplete();
+    }
+
+    @Test
+    void bufferMultipleStrings() {
+        final Flux<String> source = Flux.just(
+            "twelve bytes",
+            "fourteen bytes",
+            "twelve bytes",
+            "fourteen bytes"
+        );
+
+        final Flux<String> buffered = BufferingFlux.create(source, "\n", 27, Long.MAX_VALUE);
+
+        StepVerifier.create(buffered)
+            .expectNext("twelve bytes\nfourteen bytes")
+            .expectNext("twelve bytes\nfourteen bytes")
+            .verifyComplete();
+    }
+
+    @Test
+    void bufferUntilTimeout() {
+        final Flux<String> source = Flux.concat(
+            Mono.just("twelve bytes"),
+            Mono.just("fourteen bytes"),
+            Mono.just("twelve bytes"),
+            Mono.just("fourteen bytes").delayElement(Duration.ofMillis(500))
+        );
+
+        final Flux<String> buffered = BufferingFlux.create(source, "\n", Integer.MAX_VALUE, 100);
+
+        StepVerifier.create(buffered)
+            .expectNext("twelve bytes\nfourteen bytes\ntwelve bytes")
+            .expectNext("fourteen bytes")
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
The Statsd implementation sends out every individual measurement via UDP. In my company this causes loadbalancers to get flooded with UDP packets. To reduce the load on our Statsd infrastructure I have implemented buffering for Statsd, so multiple measurements can be sent in a single UDP packet. Depending on the maximum packet size used this can result in a very significant reduction of the number of UDP packets sent.