### PR TITLE
Fix ElasticMeterRegistryTest.writeMeter()

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -100,8 +100,8 @@ class ElasticMeterRegistryTest {
     @Test
     void writeMeter() {
         Timer timer = Timer.builder("myTimer").register(registry);
-        assertThat(registry.writeTimer(timer))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":0.0}");
+        assertThat(registry.writeMeter(timer))
+                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":\"0.0\",\"total\":\"0.0\",\"max\":\"0.0\"}");
     }
 
     @Test


### PR DESCRIPTION
This PR changes `ElasticMeterRegistryTest.writeMeter()` which is a duplicate of `ElasticMeterRegistryTest.writeTimer()` to test `ElasticMeterRegistry.writeMeter()` as its name suggests.