### PR TITLE
Remove invalid DEFAULT from some MeterRegistryConfig subclasses

### DIFF
--- a/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorConfig.java
+++ b/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorConfig.java
@@ -24,7 +24,6 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
  * @author Dhaval Doshi
  */
 public interface AzureMonitorConfig extends StepRegistryConfig {
-    AzureMonitorConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistryCompatibilityKit.java
+++ b/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistryCompatibilityKit.java
@@ -22,23 +22,26 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 public class AzureMonitorMeterRegistryCompatibilityKit extends MeterRegistryCompatibilityKit {
+
+    private final AzureMonitorConfig config = new AzureMonitorConfig() {
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
-        return new AzureMonitorMeterRegistry(new AzureMonitorConfig() {
-            @Override
-            public String get(String key) {
-                return null;
-            }
-
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-        }, new MockClock(), null);
+        return new AzureMonitorMeterRegistry(config, new MockClock(), null);
     }
 
     @Override
     public Duration step() {
-        return AzureMonitorConfig.DEFAULT.step();
+        return config.step();
     }
 }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
@@ -28,11 +28,6 @@ public interface CloudWatchConfig extends StepRegistryConfig {
 
     int MAX_BATCH_SIZE = 20;
 
-    /**
-     * Accept configuration defaults
-     */
-    CloudWatchConfig DEFAULT = k -> null;
-
     @Override
     default String prefix() {
         return "cloudwatch";

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryCompatibilityTest.java
@@ -23,30 +23,33 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 class CloudWatchMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final CloudWatchConfig config = new CloudWatchConfig() {
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String namespace() {
+            return "DOESNOTMATTER";
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
         //noinspection ConstantConditions
-        return new CloudWatchMeterRegistry(new CloudWatchConfig() {
-            @Override
-            @Nullable
-            public String get(String key) {
-                return null;
-            }
-
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-
-            @Override
-            public String namespace() {
-                return "DOESNOTMATTER";
-            }
-        }, new MockClock(), null);
+        return new CloudWatchMeterRegistry(config, new MockClock(), null);
     }
 
     @Override
     public Duration step() {
-        return CloudWatchConfig.DEFAULT.step();
+        return config.step();
     }
 }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java
@@ -25,10 +25,6 @@ import io.micrometer.core.lang.Nullable;
  * @author Jon Schneider
  */
 public interface DatadogConfig extends StepRegistryConfig {
-    /**
-     * Accept configuration defaults
-     */
-    DatadogConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryCompatibilityTest.java
@@ -23,29 +23,32 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 class DatadogMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final DatadogConfig config = new DatadogConfig() {
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String apiKey() {
+            return "DOESNOTMATTER";
+        }
+
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
-        return new DatadogMeterRegistry(new DatadogConfig() {
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-
-            @Override
-            public String apiKey() {
-                return "DOESNOTMATTER";
-            }
-
-            @Override
-            @Nullable
-            public String get(String key) {
-                return null;
-            }
-        }, new MockClock());
+        return new DatadogMeterRegistry(config, new MockClock());
     }
 
     @Override
     public Duration step() {
-        return DatadogConfig.DEFAULT.step();
+        return config.step();
     }
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -26,8 +26,6 @@ import io.micrometer.core.instrument.util.StringUtils;
  */
 public interface DynatraceConfig extends StepRegistryConfig {
 
-    DynatraceConfig DEFAULT = k -> null;
-
     @Override
     default String prefix() {
         return "dynatrace";

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryCompatibilityTest.java
@@ -22,38 +22,41 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 public class DynatraceMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final DynatraceConfig config = new DynatraceConfig() {
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String apiToken() {
+            return "DOESNOTMATTER";
+        }
+
+        @Override
+        public String uri() {
+            return "http://doesnotmatter.com";
+        }
+
+        @Override
+        public String deviceId() {
+            return "DOESNOTMATTER";
+        }
+
+        @Override
+        public String get(String key) {
+            return null;
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
-        return new DynatraceMeterRegistry(new DynatraceConfig() {
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-
-            @Override
-            public String apiToken() {
-                return "DOESNOTMATTER";
-            }
-
-            @Override
-            public String uri() {
-                return "http://doesnotmatter.com";
-            }
-
-            @Override
-            public String deviceId() {
-                return "DOESNOTMATTER";
-            }
-
-            @Override
-            public String get(String key) {
-                return null;
-            }
-        }, new MockClock());
+        return new DynatraceMeterRegistry(config, new MockClock());
     }
 
     @Override
     public Duration step() {
-        return DynatraceConfig.DEFAULT.step();
+        return config.step();
     }
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
@@ -24,10 +24,6 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
  * @author Jon Schneider
  */
 public interface NewRelicConfig extends StepRegistryConfig {
-    /**
-     * Accept configuration defaults
-     */
-    NewRelicConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryCompatibilityTest.java
@@ -23,34 +23,37 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 public class NewRelicMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final NewRelicConfig config = new NewRelicConfig() {
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String apiKey() {
+            return "DOESNOTMATTER";
+        }
+
+        @Override
+        public String accountId() {
+            return "DOESNOTMATTER";
+        }
+
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
-        return new NewRelicMeterRegistry(new NewRelicConfig() {
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-
-            @Override
-            public String apiKey() {
-                return "DOESNOTMATTER";
-            }
-
-            @Override
-            public String accountId() {
-                return "DOESNOTMATTER";
-            }
-
-            @Override
-            @Nullable
-            public String get(String key) {
-                return null;
-            }
-        }, new MockClock());
+        return new NewRelicMeterRegistry(config, new MockClock());
     }
 
     @Override
     public Duration step() {
-        return NewRelicConfig.DEFAULT.step();
+        return config.step();
     }
 }

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
@@ -28,7 +28,6 @@ import java.time.Duration;
  * @author Jon Schneider
  */
 public interface SignalFxConfig extends StepRegistryConfig {
-    SignalFxConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryCompatibilityTest.java
@@ -23,29 +23,32 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 import java.time.Duration;
 
 public class SignalFxMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final SignalFxConfig config = new SignalFxConfig() {
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String accessToken() {
+            return "fake";
+        }
+    };
+
     @Override
     public MeterRegistry registry() {
-        return new SignalFxMeterRegistry(new SignalFxConfig() {
-            @Override
-            @Nullable
-            public String get(String key) {
-                return null;
-            }
-
-            @Override
-            public boolean enabled() {
-                return false;
-            }
-
-            @Override
-            public String accessToken() {
-                return "fake";
-            }
-        }, new MockClock());
+        return new SignalFxMeterRegistry(config, new MockClock());
     }
 
     @Override
     public Duration step() {
-        return SignalFxConfig.DEFAULT.step();
+        return config.step();
     }
 }


### PR DESCRIPTION
This PR removes invalid `DEFAULT` constants from some `MeterRegistryConfig` subclasses as having the `DEFAULT` constant doesn't seem to make sense if any mandatory property exists.

This PR also updates tests accordingly.