### PR TITLE
Add a leading slash for a publishing URI in ElasticMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -134,9 +134,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         }
 
         for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-            ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(config().clock().wallTime()), ZoneOffset.UTC);
-            String indexName = config.index() + "-" + DateTimeFormatter.ofPattern(config.indexDateFormat()).format(dt);
-            HttpURLConnection connection = openConnection(indexName + "/doc/_bulk", HttpMethod.POST);
+            String publishingUri = getPublishingUri();
+            HttpURLConnection connection = openConnection(publishingUri, HttpMethod.POST);
 
             if (connection == null) {
                 if (logger.isErrorEnabled()) {
@@ -193,6 +192,13 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                 connection.disconnect();
             }
         }
+    }
+
+    // VisibleForTesting
+     String getPublishingUri() {
+        ZonedDateTime dt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(config().clock().wallTime()), ZoneOffset.UTC);
+        String indexName = config.index() + "-" + DateTimeFormatter.ofPattern(config.indexDateFormat()).format(dt);
+        return "/" + indexName + "/doc/_bulk";
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -131,4 +131,11 @@ class ElasticMeterRegistryTest {
         assertThat(registry.writeCounter(c)).contains("{ \"index\" : {} }\n" +
                 "{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"counter\",\"type\":\"counter\",\"count\":0.0}");
     }
+
+    @Issue("#896")
+    @Test
+    void getPublishingUriShouldHaveALeadingSlash() {
+        assertThat(registry.getPublishingUri()).isEqualTo("/metrics-1970-01/doc/_bulk");
+    }
+
 }


### PR DESCRIPTION
This PR adds a leading slash for a publishing URI in `ElasticMeterRegistry`.

Closes gh-896