### PR TITLE
Add a switch to disable ScheduledMethodMetrics

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -92,14 +92,6 @@ public class MetricsAutoConfiguration {
         return new PropertiesMeterFilter(properties);
     }
 
-    // If AOP is not enabled, scheduled interception will not work.
-    @Bean
-    @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
-    @ConditionalOnProperty(value = "spring.aop.enabled", havingValue = "true", matchIfMissing = true)
-    public ScheduledMethodMetrics metricsSchedulingAspect(MeterRegistry registry) {
-        return new ScheduledMethodMetrics(registry);
-    }
-
     @Bean
     @ConditionalOnClass(name = "com.netflix.hystrix.strategy.HystrixPlugins")
     @ConditionalOnProperty(value = "management.metrics.binders.hystrix.enabled", matchIfMissing = true)
@@ -129,4 +121,20 @@ public class MetricsAutoConfiguration {
             return new SpringIntegrationMetrics(configurer);
         }
     }
+
+    @Configuration
+    @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
+    @ConditionalOnProperty(value = "spring.aop.enabled", havingValue = "true", matchIfMissing = true)
+    static class AopRequiredConfiguration {
+
+        // If AOP is not enabled, scheduled interception will not work.
+        @Bean
+        @ConditionalOnProperty(value = "management.metrics.binders.scheduled.enabled", matchIfMissing = true)
+        @ConditionalOnMissingBean
+        public ScheduledMethodMetrics metricsSchedulingAspect(MeterRegistry registry) {
+            return new ScheduledMethodMetrics(registry);
+        }
+
+    }
+
 }


### PR DESCRIPTION
This PR changes the configuration for the `ScheduledMethodMetrics` to align with the other binders like the `JvmGcMetrics` by:

- Adding a switch to disable it.
- Making it back off when a custom one has been defined.

For easy review, the previous `MetricsAutoConfigurationTest` has been renamed to `MetricsAutoConfigurationIntegrationTest` as a new `MetricsAutoConfigurationTest` has been added as unit tests. It seems that Git fails to be aware of the rename although there's no change in the previous one.