### PR TITLE
Update Wavefront integration

### DIFF
--- a/benchmarks/benchmarks-core/gradle/dependency-locks/compile.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/compile.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/compile.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/compile.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/default.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/default.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/default.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/default.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/runtime.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/runtime.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/runtime.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/runtime.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testCompile.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testCompile.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testCompile.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testCompile.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntime.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntime.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/compile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/compileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/default.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/runtime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompile.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntime.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/compile.lockfile
@@ -22,7 +22,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/compileClasspath.lockfile
@@ -22,7 +22,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/default.lockfile
@@ -22,7 +22,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/runtime.lockfile
@@ -22,7 +22,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -22,7 +22,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompile.lockfile
@@ -31,7 +31,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -31,7 +31,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntime.lockfile
@@ -31,7 +31,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -31,7 +31,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/compile.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/compileClasspath.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/default.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/runtime.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompile.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntime.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -30,7 +30,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/compile.lockfile
@@ -20,7 +20,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,7 +20,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/default.lockfile
@@ -20,7 +20,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/runtime.lockfile
@@ -20,7 +20,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -20,7 +20,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompile.lockfile
@@ -27,7 +27,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -27,7 +27,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntime.lockfile
@@ -27,7 +27,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -27,7 +27,7 @@ commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/build.gradle
+++ b/implementations/micrometer-registry-graphite/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-graphite:3.+'
+    compile 'io.dropwizard.metrics:metrics-graphite:4.0.+'
 
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor.netty:reactor-netty:latest.release'

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/compile.lockfile
@@ -13,14 +13,15 @@ com.google.j2objc:j2objc-annotations:1.1
 com.hazelcast:hazelcast:3.8.9
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,14 +13,15 @@ com.google.j2objc:j2objc-annotations:1.1
 com.hazelcast:hazelcast:3.8.9
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/default.lockfile
@@ -13,14 +13,15 @@ com.google.j2objc:j2objc-annotations:1.1
 com.hazelcast:hazelcast:3.8.9
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/runtime.lockfile
@@ -13,14 +13,15 @@ com.google.j2objc:j2objc-annotations:1.1
 com.hazelcast:hazelcast:3.8.9
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,14 +13,15 @@ com.google.j2objc:j2objc-annotations:1.1
 com.hazelcast:hazelcast:3.8.9
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompile.lockfile
@@ -19,6 +19,7 @@ com.hazelcast:hazelcast:3.8.9
 com.jayway.jsonpath:json-path:2.4.0
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-codec:commons-codec:1.10
@@ -26,8 +27,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -19,6 +19,7 @@ com.hazelcast:hazelcast:3.8.9
 com.jayway.jsonpath:json-path:2.4.0
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-codec:commons-codec:1.10
@@ -26,8 +27,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntime.lockfile
@@ -19,6 +19,7 @@ com.hazelcast:hazelcast:3.8.9
 com.jayway.jsonpath:json-path:2.4.0
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-codec:commons-codec:1.10
@@ -26,8 +27,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -19,6 +19,7 @@ com.hazelcast:hazelcast:3.8.9
 com.jayway.jsonpath:json-path:2.4.0
 com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
+com.rabbitmq:amqp-client:4.4.1
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 commons-codec:commons-codec:1.10
@@ -26,8 +27,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-graphite:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/build.gradle
+++ b/implementations/micrometer-registry-jmx/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-core:3.+'
+    compile 'io.dropwizard.metrics:metrics-jmx:4.0.+'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,8 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxMeterRegistry.java
+++ b/implementations/micrometer-registry-jmx/src/main/java/io/micrometer/jmx/JmxMeterRegistry.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.jmx;
 
-import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.dropwizard.DropwizardMeterRegistry;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/compile.lockfile
@@ -20,7 +20,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,7 +20,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/default.lockfile
@@ -20,7 +20,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/runtime.lockfile
@@ -20,7 +20,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -20,7 +20,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompile.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntime.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -27,7 +27,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/build.gradle
+++ b/implementations/micrometer-registry-wavefront/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'org.junit.platform.gradle.plugin'
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'com.wavefront:wavefront-sdk-java:0.9.0'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compile.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compile.lockfile
@@ -15,6 +15,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/compileClasspath.lockfile
@@ -15,6 +15,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/default.lockfile
@@ -15,6 +15,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtime.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtime.lockfile
@@ -15,6 +15,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -15,6 +15,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompile.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompile.lockfile
@@ -21,6 +21,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -21,6 +21,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntime.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntime.lockfile
@@ -21,6 +21,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -21,6 +21,7 @@ com.netflix.archaius:archaius-core:0.4.1
 com.netflix.hystrix:hystrix-core:1.5.12
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/DeltaCounter.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/DeltaCounter.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.wavefront;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.step.StepCounter;
+import io.micrometer.core.lang.Nullable;
+
+import static io.micrometer.wavefront.WavefrontConstants.WAVEFRONT_METRIC_TYPE_TAG_KEY;
+import static io.micrometer.wavefront.WavefrontConstants.isWavefrontMetricType;
+
+/**
+ * Wavefront delta counter which has the ability to report delta values aggregated on Wavefront
+ * server side. Extends StepCounter so that the value is reset every time it is reported.
+ *
+ * @author Han Zhang
+ */
+public class DeltaCounter extends StepCounter {
+    /**
+     * The tag value that is used to identify DeltaCounters.
+     */
+    private static final String WAVEFRONT_METRIC_TYPE_TAG_VALUE = "deltaCounter";
+
+    static Builder builder(String name) { return new Builder(name); }
+
+    /**
+     * @param id    The identifier for a metric.
+     * @return {@code true} if the id identifies a DeltaCounter, {@code false} otherwise.
+     */
+    static boolean isDeltaCounter(Id id) {
+        return isWavefrontMetricType(id, WAVEFRONT_METRIC_TYPE_TAG_VALUE);
+    }
+
+    DeltaCounter(Id id, Clock clock, long stepMillis) {
+        super(id, clock, stepMillis);
+    }
+
+    /**
+     * Fluent builder for delta counters.
+     */
+    static class Builder {
+        private final Counter.Builder builder;
+
+        private Builder(String name) {
+            builder = Counter
+                .builder(name)
+                .tag(WAVEFRONT_METRIC_TYPE_TAG_KEY, WAVEFRONT_METRIC_TYPE_TAG_VALUE);
+        }
+
+        /**
+         * @param tags Must be an even number of arguments representing key/value pairs of tags.
+         * @return The delta counter builder with added tags.
+         */
+        public Builder tags(String... tags) {
+            builder.tags(tags);
+            return this;
+        }
+
+        /**
+         * @param tags Tags to add to the eventual counter.
+         * @return The delta counter builder with added tags.
+         */
+        public Builder tags(Iterable<Tag> tags) {
+            builder.tags(tags);
+            return this;
+        }
+
+        /**
+         * @param key   The tag key.
+         * @param value The tag value.
+         * @return The delta counter builder with a single added tag.
+         */
+        public Builder tag(String key, String value) {
+            builder.tag(key, value);
+            return this;
+        }
+
+        /**
+         * @param description Description text of the eventual counter.
+         * @return The delta counter builder with added description.
+         */
+        public Builder description(@Nullable String description) {
+            builder.description(description);
+            return this;
+        }
+
+        /**
+         * @param unit Base unit of the eventual counter.
+         * @return The delta counter builder with added base unit.
+         */
+        public Builder baseUnit(@Nullable String unit) {
+            builder.baseUnit(unit);
+            return this;
+        }
+
+        /**
+         * Add the delta counter to a single registry, or return an existing delta counter
+         * in that registry. The returned counter will be unique for each registry, but each
+         * registry is guaranteed to only create one counter for the same combination of
+         * name and tags. If an existing counter is found but it is not a delta counter,
+         * an IllegalStateException is thrown.
+         *
+         * @param registry A registry to add the delta counter to, if it doesn't already exist.
+         * @return A new or existing delta counter.
+         */
+        public DeltaCounter register(MeterRegistry registry) {
+            Counter counter = builder.register(registry);
+            if (counter instanceof DeltaCounter) {
+                return (DeltaCounter) counter;
+            } else {
+                throw new IllegalStateException("Found existing non-DeltaCounter: " + counter);
+            }
+        }
+    }
+}

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConstants.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConstants.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.wavefront;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+
+/**
+ * Class containing Wavefront-specific constants and related static methods.
+ *
+ * @author Han Zhang
+ */
+public class WavefrontConstants {
+    /**
+     * The tag key that is used to identify Wavefront-specific metric types.
+     */
+    public static final String WAVEFRONT_METRIC_TYPE_TAG_KEY = "wavefrontMetricType";
+
+    /**
+     * @param id                            The identifier for a metric.
+     * @param wavefrontMetricTypeTagValue   The tag value that identifies a particular
+     *                                      Wavefront-specific metric type.
+     * @return {@code true} if the id identifies the metric type, {@code false} otherwise.
+     */
+    static boolean isWavefrontMetricType(Meter.Id id, String wavefrontMetricTypeTagValue) {
+        Tag wavefrontMetricTypeTag = Tag.of(WAVEFRONT_METRIC_TYPE_TAG_KEY, wavefrontMetricTypeTagValue);
+        for (Tag tag : id.getTags()) {
+            if (tag.equals(wavefrontMetricTypeTag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontHistogram.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontHistogram.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.wavefront;
+
+import com.wavefront.sdk.entities.histograms.WavefrontHistogramImpl;
+import io.micrometer.core.instrument.AbstractDistributionSummary;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.lang.Nullable;
+
+import java.util.List;
+
+import static io.micrometer.wavefront.WavefrontConstants.WAVEFRONT_METRIC_TYPE_TAG_KEY;
+import static io.micrometer.wavefront.WavefrontConstants.isWavefrontMetricType;
+
+/**
+ * Wavefront's implementation of a DistributionSummary based off of WavefrontHistogramImpl.
+ *
+ * @author Han Zhang
+ */
+public class WavefrontHistogram extends AbstractDistributionSummary {
+    /**
+     * The tag value that is used to identify WavefrontHistograms.
+     */
+    private static final String WAVEFRONT_METRIC_TYPE_TAG_VALUE = "wavefrontHistogram";
+
+    private final WavefrontHistogramImpl delegate;
+
+    static Builder builder(String name) {
+        return new Builder(name);
+    }
+
+    /**
+     * @param id    The identifier for a metric.
+     * @return {@code true} if the id identifies a WavefrontHistogram, {@code false} otherwise.
+     */
+    static boolean isWavefrontHistogram(Id id) {
+        return isWavefrontMetricType(id, WAVEFRONT_METRIC_TYPE_TAG_VALUE);
+    }
+
+    WavefrontHistogram(Id id, Clock clock,
+                       DistributionStatisticConfig distributionStatisticConfig,
+                       double scale) {
+        super(id, clock, distributionStatisticConfig, scale, false);
+        delegate = new WavefrontHistogramImpl(clock::wallTime);
+    }
+
+    @Override
+    protected void recordNonNegative(double amount) {
+        delegate.update(amount);
+    }
+
+    @Override
+    public long count() {
+        return delegate.getCount();
+    }
+
+    @Override
+    public double totalAmount() {
+        return delegate.getSum();
+    }
+
+    @Override
+    public double mean() {
+        return delegate.getMean();
+    }
+
+    @Override
+    public double max() {
+        return delegate.getMax();
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        throw new UnsupportedOperationException(
+            "takeSnapshot() is not supported by WavefrontHistogram");
+    }
+
+    public List<WavefrontHistogramImpl.Distribution> flushDistributions() {
+        return delegate.flushDistributions();
+    }
+
+    /**
+     * Fluent builder for Wavefront histograms.
+     */
+    static class Builder {
+        private final DistributionSummary.Builder builder;
+
+        private Builder(String name) {
+            builder = DistributionSummary
+                .builder(name)
+                .tag(WAVEFRONT_METRIC_TYPE_TAG_KEY, WAVEFRONT_METRIC_TYPE_TAG_VALUE);
+        }
+
+        /**
+         * @param tags Must be an even number of arguments representing key/value pairs of tags.
+         * @return The Wavefront histogram builder with added tags.
+         */
+        public Builder tags(String... tags) {
+            builder.tags(tags);
+            return this;
+        }
+
+        /**
+         * @param tags Tags to add to the eventual distribution summary.
+         * @return The Wavefront histogram builder with added tags.
+         */
+        public Builder tags(Iterable<Tag> tags) {
+            builder.tags(tags);
+            return this;
+        }
+
+        /**
+         * @param key   The tag key.
+         * @param value The tag value.
+         * @return The Wavefront histogram builder with a single added tag.
+         */
+        public Builder tag(String key, String value) {
+            builder.tag(key, value);
+            return this;
+        }
+
+        /**
+         * @param description Description text of the eventual distribution summary.
+         * @return The Wavefront histogram builder with added description.
+         */
+        public Builder description(@Nullable String description) {
+            builder.description(description);
+            return this;
+        }
+
+        /**
+         * @param unit Base unit of the eventual distribution summary.
+         * @return The Wavefront histogram builder with added base unit.
+         */
+        public Builder baseUnit(@Nullable String unit) {
+            builder.baseUnit(unit);
+            return this;
+        }
+
+        /**
+         * Add the Wavefront histogram to a single registry, or return an existing
+         * Wavefront histogram in that registry. The returned distribution summary
+         * will be unique for each registry, but each registry is guaranteed to only
+         * create one distribution summary for the same combination of name and tags.
+         * If an existing distribution summary is found but it is not a Wavefront histogram,
+         * an IllegalStateException is thrown.
+         *
+         * @param registry A registry to add the Wavefront histogram to, if it doesn't already exist.
+         * @return A new or existing Wavefront histogram.
+         */
+        public WavefrontHistogram register(MeterRegistry registry) {
+            DistributionSummary summary = builder.register(registry);
+            if (summary instanceof WavefrontHistogram) {
+                return (WavefrontHistogram) summary;
+            } else {
+                throw new IllegalStateException("Found existing non-WavefrontHistogram: " + summary);
+            }
+        }
+    }
+}

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -15,55 +15,115 @@
  */
 package io.micrometer.wavefront;
 
-import io.micrometer.core.instrument.*;
+import com.wavefront.sdk.common.WavefrontSender;
+import com.wavefront.sdk.direct_ingestion.WavefrontDirectIngestionClient;
+import com.wavefront.sdk.entities.histograms.HistogramGranularity;
+import com.wavefront.sdk.entities.histograms.WavefrontHistogramImpl;
+import com.wavefront.sdk.proxy.WavefrontProxyClient;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
-import io.micrometer.core.instrument.util.DoubleFormat;
 import io.micrometer.core.instrument.util.MeterPartition;
-import io.micrometer.core.ipc.http.HttpClient;
-import io.micrometer.core.ipc.http.HttpUrlConnectionClient;
 import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.net.*;
-import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.Meter.Type.match;
-import static java.util.stream.Collectors.joining;
+import static io.micrometer.wavefront.DeltaCounter.isDeltaCounter;
+import static io.micrometer.wavefront.WavefrontConstants.WAVEFRONT_METRIC_TYPE_TAG_KEY;
+import static io.micrometer.wavefront.WavefrontHistogram.isWavefrontHistogram;
 import static java.util.stream.StreamSupport.stream;
 
 /**
+ * Registry that builds a WavefrontSender from WavefrontConfig to handle the reporting of data
+ * (e.g., metrics, DeltaCounters, WavefrontHistograms) to Wavefront.
+ *
  * @author Jon Schneider
  * @author Howard Yoo
  */
 public class WavefrontMeterRegistry extends StepMeterRegistry {
     private final Logger logger = LoggerFactory.getLogger(WavefrontMeterRegistry.class);
     private final WavefrontConfig config;
-    private final HttpClient httpClient;
+    private final WavefrontSender wavefrontSender;
+    private Set<HistogramGranularity> histogramGranularities;
 
     public WavefrontMeterRegistry(WavefrontConfig config, Clock clock) {
         this(config, clock, Executors.defaultThreadFactory());
     }
 
     public WavefrontMeterRegistry(WavefrontConfig config, Clock clock, ThreadFactory threadFactory) {
-        this(config, clock, threadFactory, new HttpUrlConnectionClient(config.connectTimeout(), config.readTimeout()));
-    }
-
-    private WavefrontMeterRegistry(WavefrontConfig config, Clock clock, ThreadFactory threadFactory, HttpClient httpClient) {
         super(config, clock);
         this.config = config;
-        this.httpClient = httpClient;
-        if (directToApi() && config.apiToken() == null) {
-            throw new MissingRequiredConfigurationException("apiToken must be set whenever publishing directly to the Wavefront API");
+
+        /**
+         * Build a WavefrontProxyClient to handle the sending of data to a Wavefront proxy,
+         * or a WavefrontDirectIngestionClient to handle the sending of data directly
+         * to a Wavefront API server.
+         *
+         * See https://github.com/wavefrontHQ/wavefront-java-sdk/blob/master/README.md for reference.
+         */
+        if (config.sendToProxy()) {
+            WavefrontConfig.ProxyConfig proxyConfig = config.proxyConfig();
+            WavefrontProxyClient.Builder proxyBuilder =
+                new WavefrontProxyClient.Builder(proxyConfig.hostName());
+
+            Integer metricsPort = proxyConfig.metricsPort();
+            if (metricsPort != null) proxyBuilder.metricsPort(metricsPort);
+
+            Integer distributionPort = proxyConfig.distributionPort();
+            if (distributionPort != null) proxyBuilder.distributionPort(distributionPort);
+
+            Integer flushIntervalSeconds = config.flushIntervalSeconds();
+            if (flushIntervalSeconds != null) proxyBuilder.flushIntervalSeconds(flushIntervalSeconds);
+
+            wavefrontSender = proxyBuilder.build();
+        } else {
+            WavefrontConfig.DirectIngestionConfig directIngestionConfig =
+                config.directIngestionConfig();
+            if (directIngestionConfig.apiToken() == null) {
+                throw new MissingRequiredConfigurationException(
+                    "apiToken must be set whenever publishing directly to the Wavefront API");
+            }
+            WavefrontDirectIngestionClient.Builder directIngestionBuilder =
+                new WavefrontDirectIngestionClient
+                    .Builder(directIngestionConfig.uri(), directIngestionConfig.apiToken());
+
+            Integer maxQueueSize = directIngestionConfig.maxQueueSize();
+            if (maxQueueSize != null) directIngestionBuilder.maxQueueSize(maxQueueSize);
+
+            Integer batchSize = directIngestionConfig.batchSize();
+            if (batchSize != null) directIngestionBuilder.batchSize(batchSize);
+
+            wavefrontSender = directIngestionBuilder.build();
+        }
+
+        histogramGranularities = new HashSet<>();
+        WavefrontConfig.WavefrontHistogramConfig wavefrontHistogramConfig =
+            config.wavefrontHistogramConfig();
+        if (wavefrontHistogramConfig.reportMinuteDistribution()) {
+            histogramGranularities.add(HistogramGranularity.MINUTE);
+        }
+        if (wavefrontHistogramConfig.reportHourDistribution()) {
+            histogramGranularities.add(HistogramGranularity.HOUR);
+        }
+        if (wavefrontHistogramConfig.reportDayDistribution()) {
+            histogramGranularities.add(HistogramGranularity.DAY);
         }
 
         config().namingConvention(new WavefrontNamingConvention(config.globalPrefix()));
@@ -72,175 +132,176 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
     }
 
     @Override
-    protected void publish() {
-        for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-            Stream<String> stream = batch.stream().flatMap(m -> match(m,
-                    this::writeMeter,
-                    this::writeMeter,
-                    this::writeTimer,
-                    this::writeSummary,
-                    this::writeMeter,
-                    this::writeMeter,
-                    this::writeMeter,
-                    this::writeFunctionTimer,
-                    this::writeMeter));
-
-            if (directToApi()) {
-                try {
-                    httpClient.post(config.uri() + "/report/metrics?t=" + config.apiToken() + "&h=" + config.source())
-                            .acceptJson()
-                            .withJsonContent("{" + stream.collect(joining(",")) + "}")
-                            .send()
-                            .onSuccess(response -> logSuccessfulMetricsSent(batch))
-                            .onError(response -> logger.error("failed to send metrics to wavefront: {}", response.body()));
-                } catch (Throwable e) {
-                    logger.error("failed to send metrics to wavefront", e);
-                }
-            } else {
-                URI uri = URI.create(config.uri());
-                try {
-                    SocketAddress endpoint = uri.getHost() != null ? new InetSocketAddress(uri.getHost(), uri.getPort()) :
-                            new InetSocketAddress(InetAddress.getByName(null), uri.getPort());
-                    try (Socket socket = new Socket()) {
-                        socket.connect(endpoint, (int) this.config.connectTimeout().toMillis());
-                        try (OutputStreamWriter writer = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8)) {
-                            writer.write(stream.collect(joining("\n")) + "\n");
-                            writer.flush();
-                        }
-                        logSuccessfulMetricsSent(batch);
-                    } catch (IOException e) {
-                        logger.error("failed to send metrics to wavefront", e);
-                    }
-                } catch (UnknownHostException e) {
-                    logger.error("failed to send metrics to wavefront: unknown host + " + uri.getHost());
-                }
-            }
+    protected Counter newCounter(Meter.Id id) {
+        if (isDeltaCounter(id)) {
+            // If the metric id belongs to a delta counter, create a DeltaCounter
+            return new DeltaCounter(id, clock, config.step().toMillis());
+        } else {
+            return super.newCounter(id);
         }
     }
 
-    private void logSuccessfulMetricsSent(List<Meter> batch) {
-        logger.debug("Successfully sent {} metrics to Wavefront.", batch.size());
+    @Override
+    protected DistributionSummary newDistributionSummary(
+        Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        if (isWavefrontHistogram(id)) {
+            // If the metric id belongs to a Wavefront histogram, create a WavefrontHistogram
+            return new WavefrontHistogram(id, clock, distributionStatisticConfig, scale);
+        } else {
+            return super.newDistributionSummary(id, distributionStatisticConfig, scale);
+        }
     }
 
-    private boolean directToApi() {
-        return !"proxy".equals(URI.create(config.uri()).getScheme());
+    @Override
+    protected void publish() {
+        for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
+            batch.stream().forEach(m -> match(m,
+                this::writeMeter,
+                this::writeCounter,
+                this::writeTimer,
+                this::writeSummary,
+                this::writeMeter,
+                this::writeMeter,
+                this::writeMeter,
+                this::writeFunctionTimer,
+                this::writeMeter));
+        }
     }
 
-    private Stream<String> writeFunctionTimer(FunctionTimer timer) {
+    private boolean writeFunctionTimer(FunctionTimer timer) {
         long wallTime = clock.wallTime();
-        Stream.Builder<String> metrics = Stream.builder();
 
         Meter.Id id = timer.getId();
 
         // we can't know anything about max and percentiles originating from a function timer
-        addMetric(metrics, id, "count", wallTime, timer.count());
-        addMetric(metrics, id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
-        addMetric(metrics, id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
+        reportMetric(id, "count", wallTime, timer.count());
+        reportMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
+        reportMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
 
-        return metrics.build();
+        return true;
     }
 
-    private Stream<String> writeTimer(Timer timer) {
+    private boolean writeTimer(Timer timer) {
         final long wallTime = clock.wallTime();
-        final Stream.Builder<String> metrics = Stream.builder();
 
         Meter.Id id = timer.getId();
-        addMetric(metrics, id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
-        addMetric(metrics, id, "count", wallTime, timer.count());
-        addMetric(metrics, id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
-        addMetric(metrics, id, "max", wallTime, timer.max(getBaseTimeUnit()));
+        reportMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
+        reportMetric(id, "count", wallTime, timer.count());
+        reportMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
+        reportMetric(id, "max", wallTime, timer.max(getBaseTimeUnit()));
 
-        return metrics.build();
+        return true;
     }
 
-    private Stream<String> writeSummary(DistributionSummary summary) {
-        final long wallTime = clock.wallTime();
-        final Stream.Builder<String> metrics = Stream.builder();
-
+    private boolean writeSummary(DistributionSummary summary) {
         Meter.Id id = summary.getId();
-        addMetric(metrics, id, "sum", wallTime, summary.totalAmount());
-        addMetric(metrics, id, "count", wallTime, summary.count());
-        addMetric(metrics, id, "avg", wallTime, summary.mean());
-        addMetric(metrics, id, "max", wallTime, summary.max());
 
-        return metrics.build();
+        if (summary instanceof WavefrontHistogram) {
+            reportWavefrontHistogram(id, ((WavefrontHistogram) summary).flushDistributions());
+        } else {
+            final long wallTime = clock.wallTime();
+
+            reportMetric(id, "sum", wallTime, summary.totalAmount());
+            reportMetric(id, "count", wallTime, summary.count());
+            reportMetric(id, "avg", wallTime, summary.mean());
+            reportMetric(id, "max", wallTime, summary.max());
+        }
+
+        return true;
     }
 
-    private Stream<String> writeMeter(Meter meter) {
-        long wallTime = clock.wallTime();
-        Stream.Builder<String> metrics = Stream.builder();
+    private boolean writeCounter(Counter counter) {
+        final long wallTime = clock.wallTime();
+
+        stream(counter.measure().spliterator(), false)
+            .forEach(measurement -> {
+                Meter.Id id = counter.getId().withTag(measurement.getStatistic());
+                if (counter instanceof DeltaCounter) {
+                    reportDeltaCounter(id, measurement.getValue());
+                } else {
+                    reportMetric(id, null, wallTime, measurement.getValue());
+                }
+            });
+
+        return true;
+    }
+
+    private boolean writeMeter(Meter meter) {
+        final long wallTime = clock.wallTime();
 
         stream(meter.measure().spliterator(), false)
                 .forEach(measurement -> {
                     Meter.Id id = meter.getId().withTag(measurement.getStatistic());
-                    addMetric(metrics, id, null, wallTime, measurement.getValue());
+                    reportMetric(id, null, wallTime, measurement.getValue());
                 });
 
-        return metrics.build();
+        return true;
     }
 
-    private void addMetric(Stream.Builder<String> metrics, Meter.Id id, @Nullable String suffix, long wallTime, double value) {
-        if (value != Double.NaN) {
-            metrics.add(writeMetric(id, suffix, wallTime, value));
+    private void reportMetric(Meter.Id id, @Nullable String suffix, long wallTime, double value) {
+        if (value == Double.NaN) {
+            return;
+        }
+
+        Meter.Id fullId = id;
+        if (suffix != null) {
+            fullId = idWithSuffix(id, suffix);
+        }
+
+        try {
+            wavefrontSender.sendMetric(
+                getConventionName(fullId), value, wallTime, config.source(), getTagsAsMap(id)
+            );
+        } catch (Exception e) {
+            logger.error("failed to send metric: " + getConventionName(fullId), e);
         }
     }
 
-    /**
-     * The metric format is a little different depending on whether you are going straight to the
-     * Wavefront API server or through a sidecar proxy.
-     * <p>
-     * https://docs.wavefront.com/wavefront_data_format.html#wavefront-data-format-syntax
-     */
-    private String writeMetric(Meter.Id id, @Nullable String suffix, long wallTime, double value) {
-        return directToApi() ?
-                writeMetricDirect(id, suffix, value) :
-                writeMetricProxy(id, suffix, wallTime, value);
+    private void reportDeltaCounter(Meter.Id id, double value) {
+        if (value == Double.NaN) {
+            return;
+        }
+
+        try {
+            wavefrontSender.sendDeltaCounter(
+                getConventionName(id), value, config.source(), getTagsAsMap(id)
+            );
+        } catch (Exception e) {
+            logger.error("failed to send delta counter: " + getConventionName(id), e);
+        }
     }
 
-    private String writeMetricProxy(Meter.Id id, @Nullable String suffix, long wallTime, double value) {
-        Meter.Id fullId = id;
-        if (suffix != null)
-            fullId = idWithSuffix(id, suffix);
+    private void reportWavefrontHistogram(Meter.Id id,
+                                          List<WavefrontHistogramImpl.Distribution> distributions) {
+        String name = getConventionName(id);
+        String source = config.source();
+        Map<String, String> tags = getTagsAsMap(id);
 
-        // surrounding the name with double quotes allows for / and , in names
-        return "\"" + getConventionName(fullId) + "\" " + DoubleFormat.decimalOrNan(value) + " " + (wallTime / 1000) +
-                " source=" + config.source() + " " +
-                getConventionTags(fullId)
-                        .stream()
-                        .map(t -> t.getKey() + "=\"" + t.getValue() + "\"")
-                        .collect(joining(" "));
+        for (WavefrontHistogramImpl.Distribution distribution : distributions) {
+            try {
+                wavefrontSender.sendDistribution(
+                    name, distribution.centroids, histogramGranularities,
+                    distribution.timestamp, source, tags
+                );
+            } catch (Exception e) {
+                logger.error("failed to send Wavefront histogram: " + name, e);
+            }
+        }
     }
 
-    private String writeMetricDirect(Meter.Id id, @Nullable String suffix, double value) {
-        Meter.Id fullId = id;
-        if (suffix != null)
-            fullId = idWithSuffix(id, suffix);
-
-        List<Tag> conventionTags = getConventionTags(fullId);
-
-        String tags = conventionTags
-                .stream()
-                .map(t -> "\"" + t.getKey() + "\": \"" + t.getValue() + "\"")
-                .collect(joining(","));
-
-        UUID uuid = UUID.randomUUID();
-        String uniqueNameSuffix = ((Long) uuid.getMostSignificantBits()).toString() + uuid.getLeastSignificantBits();
-
-        // To be valid JSON, the metric name must be unique. Since the same name can occur in multiple entries because of
-        // variance in tag values, we need to append a suffix to the name. The suffix must be numeric, or Wavefront interprets
-        // it as part of the name. Wavefront strips a $<NUMERIC> suffix from the name at parsing time.
-        return "\"" + getConventionName(fullId) + "$" + uniqueNameSuffix + "\"" +
-                ": {" +
-                "\"value\": " + DoubleFormat.decimalOrNan(value) + "," +
-                "\"tags\": {" + tags + "}" +
-                "}";
+    private Map<String, String> getTagsAsMap(Meter.Id id) {
+        return getConventionTags(id)
+            .stream()
+            .filter(tag -> !tag.getKey().equals(WAVEFRONT_METRIC_TYPE_TAG_KEY))
+            .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (tag1, tag2) -> tag2));
     }
 
     /**
      * Copy tags, unit, and description from an existing id, but change the name.
      */
     private Meter.Id idWithSuffix(Meter.Id id, String suffix) {
-        return new Meter.Id(id.getName() + "." + suffix, id.getTags(), id.getBaseUnit(), id.getDescription(), id.getType());
+        return new Meter.Id(
+            id.getName() + "." + suffix, id.getTags(), id.getBaseUnit(), id.getDescription(), id.getType());
     }
 
     @Override
@@ -253,11 +314,9 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
 
         private Clock clock = Clock.SYSTEM;
         private ThreadFactory threadFactory = Executors.defaultThreadFactory();
-        private HttpClient httpClient;
 
         public Builder(WavefrontConfig config) {
             this.config = config;
-            this.httpClient = new HttpUrlConnectionClient(config.connectTimeout(), config.readTimeout());
         }
 
         public Builder clock(Clock clock) {
@@ -270,13 +329,8 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
             return this;
         }
 
-        public Builder httpClient(HttpClient httpClient) {
-            this.httpClient = httpClient;
-            return this;
-        }
-
         public WavefrontMeterRegistry build() {
-            return new WavefrontMeterRegistry(config, clock, threadFactory, httpClient);
+            return new WavefrontMeterRegistry(config, clock, threadFactory);
         }
     }
 }

--- a/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryCompatibilityTest.java
@@ -27,9 +27,7 @@ class WavefrontMeterRegistryCompatibilityTest extends MeterRegistryCompatibility
     public MeterRegistry registry() {
         return new WavefrontMeterRegistry(new WavefrontConfig() {
             @Override
-            public boolean enabled() {
-                return false;
-            }
+            public boolean enabled() { return false; }
 
             @Override
             @Nullable
@@ -38,8 +36,11 @@ class WavefrontMeterRegistryCompatibilityTest extends MeterRegistryCompatibility
             }
 
             @Override
-            public String uri() {
-                return WavefrontConfig.DEFAULT_PROXY.uri();
+            public boolean sendToProxy() { return true; }
+
+            @Override
+            public ProxyConfig proxyConfig() {
+                return WavefrontConfig.DEFAULT_PROXY.proxyConfig();
             }
         }, new MockClock());
     }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     }
 
     // instrumentation options
-    compile 'io.dropwizard.metrics:metrics-core:3.+', optional
+    compile 'io.dropwizard.metrics:metrics-core:4.0.+', optional
 
     // cache monitoring
     compile 'com.google.guava:guava:latest.release', optional

--- a/micrometer-core/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-core/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/default.lockfile
+++ b/micrometer-core/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-core/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testCompile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testRuntime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/compile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/compileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/default.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/default.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/runtime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testCompile.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testRuntime.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-jersey2/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -19,7 +19,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.1.1
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
@@ -38,6 +38,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -29,6 +29,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
@@ -38,6 +38,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -29,6 +29,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
@@ -38,6 +38,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -29,6 +29,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
@@ -38,6 +38,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -29,6 +29,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -38,6 +38,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -14,7 +14,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
 com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -29,6 +29,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/micrometer-spring-legacy/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testCompile.lockfile
@@ -51,6 +51,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.github.resilience4j:resilience4j-core:0.13.1
 io.github.resilience4j:resilience4j-retry:0.13.1
 io.grpc:grpc-context:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testCompile.lockfile
@@ -23,7 +23,7 @@ com.github.jknack:handlebars-helpers:4.0.7
 com.github.jknack:handlebars:4.0.7
 com.github.tomakehurst:wiremock:2.19.0
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -41,6 +41,7 @@ com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+com.wavefront:wavefront-sdk-java:0.9.0
 com.zaxxer:HikariCP:2.5.1
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8

--- a/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -51,6 +51,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.github.resilience4j:resilience4j-core:0.13.1
 io.github.resilience4j:resilience4j-retry:0.13.1
 io.grpc:grpc-context:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -23,7 +23,7 @@ com.github.jknack:handlebars-helpers:4.0.7
 com.github.jknack:handlebars:4.0.7
 com.github.tomakehurst:wiremock:2.19.0
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -41,6 +41,7 @@ com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+com.wavefront:wavefront-sdk-java:0.9.0
 com.zaxxer:HikariCP:2.5.1
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntime.lockfile
@@ -52,6 +52,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.github.resilience4j:resilience4j-core:0.13.1
 io.github.resilience4j:resilience4j-retry:0.13.1
 io.grpc:grpc-context:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntime.lockfile
@@ -23,7 +23,7 @@ com.github.jknack:handlebars-helpers:4.0.7
 com.github.jknack:handlebars:4.0.7
 com.github.tomakehurst:wiremock:2.19.0
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -42,6 +42,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.sun.xml.messaging.saaj:saaj-impl:1.4.0
 com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+com.wavefront:wavefront-sdk-java:0.9.0
 com.zaxxer:HikariCP:2.5.1
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -52,6 +52,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.github.resilience4j:resilience4j-core:0.13.1
 io.github.resilience4j:resilience4j-retry:0.13.1
 io.grpc:grpc-context:1.14.0

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -23,7 +23,7 @@ com.github.jknack:handlebars-helpers:4.0.7
 com.github.jknack:handlebars:4.0.7
 com.github.tomakehurst:wiremock:2.19.0
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -42,6 +42,7 @@ com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
 com.sun.xml.messaging.saaj:saaj-impl:1.4.0
 com.vaadin.external.google:android-json:0.0.20131108.vaadin1
+com.wavefront:wavefront-sdk-java:0.9.0
 com.zaxxer:HikariCP:2.5.1
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
@@ -26,24 +26,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("management.metrics.export.wavefront")
 public class WavefrontProperties extends StepRegistryProperties {
     /**
-     * The URI to publish metrics to. The URI could represent a Wavefront sidecar or the
-     * Wavefront API host. This host could also represent an internal proxy set up in your environment
-     * that forwards metrics data to the Wavefront API host.
-     *
-     * If publishing metrics to a Wavefront proxy (as described in https://docs.wavefront.com/proxies_installing.html),
-     * the host must be in the proxy://HOST:PORT format.
+     * {@code true} to publish to the Wavefront proxy,
+     * {@code false} to publish directly to the Wavefront API.
      */
-    private String uri;
+    private Boolean sendToProxy;
 
     /**
-     * Uniquely identifies the app instance that is publishing metrics to Wavefront. Defaults to the local host name.
+     * Required when publishing to the Wavefront proxy.
+     */
+    private ProxyProperties proxy;
+
+    /**
+     * Required when publishing directly the Wavefront API.
+     */
+    private DirectIngestionProperties directIngestion;
+
+    /**
+     * At least one of reportMinuteDistribution, reportHourDistribution, and reportDayDistribution
+     * must be {@code true} for WavefrontHistograms to be published to Wavefront.
+     */
+    private WavefrontHistogramProperties wavefrontHistogram;
+
+    /**
+     * Uniquely identifies the app instance that is publishing metrics to Wavefront.
+     * Defaults to the local host name.
      */
     private String source;
-
-    /**
-     * Required when publishing directly to the Wavefront API host, otherwise does nothing.
-     */
-    private String apiToken;
 
     /**
      * Wavefront metrics are grouped hierarchically by name in the UI. Setting a global prefix separates
@@ -52,12 +60,29 @@ public class WavefrontProperties extends StepRegistryProperties {
      */
     private String globalPrefix;
 
-    public String getUri() {
-        return uri;
+    /**
+     * Interval at which to flush points to Wavefront, in seconds.
+     */
+    private Integer flushIntervalSeconds;
+
+    public Boolean getSendToProxy() { return sendToProxy; }
+
+    public void setSendToProxy(Boolean sendToProxy) { this.sendToProxy = sendToProxy; }
+
+    public ProxyProperties getProxy() { return proxy; }
+
+    public void setProxy(ProxyProperties proxy) { this.proxy = proxy; }
+
+    public DirectIngestionProperties getDirectIngestion() { return directIngestion; }
+
+    public void setDirectIngestion(DirectIngestionProperties directIngestion) {
+        this.directIngestion = directIngestion;
     }
 
-    public void setUri(String uri) {
-        this.uri = uri;
+    public WavefrontHistogramProperties getWavefrontHistogram() { return wavefrontHistogram; }
+
+    public void setWavefrontHistogram(WavefrontHistogramProperties wavefrontHistogram) {
+        this.wavefrontHistogram = wavefrontHistogram;
     }
 
     public String getSource() {
@@ -68,19 +93,141 @@ public class WavefrontProperties extends StepRegistryProperties {
         this.source = source;
     }
 
-    public String getApiToken() {
-        return apiToken;
-    }
-
-    public void setApiToken(String apiToken) {
-        this.apiToken = apiToken;
-    }
-
     public String getGlobalPrefix() {
         return globalPrefix;
     }
 
     public void setGlobalPrefix(String globalPrefix) {
         this.globalPrefix = globalPrefix;
+    }
+
+    public Integer getFlushIntervalSeconds() { return flushIntervalSeconds; }
+
+    public void setFlushIntervalSeconds(Integer flushIntervalSeconds) {
+        this.flushIntervalSeconds = flushIntervalSeconds;
+    }
+
+    public static class ProxyProperties {
+        /**
+         * Required when publishing to the Wavefront proxy.
+         *
+         * Host name of the Wavefront proxy to publish to.
+         */
+        private String hostName;
+
+        /**
+         * Required when publishing metrics to the Wavefront proxy.
+         *
+         * Port on which the Wavefront proxy is listening to metrics.
+         */
+        private Integer metricsPort;
+
+        /**
+         * Required when publishing WavefrontHistograms to the Wavefront proxy.
+         *
+         * Port on which the Wavefront proxy is listening to WavefrontHistogram distributions.
+         */
+        private Integer distributionPort;
+
+        public String getHostName() {
+            return hostName;
+        }
+
+        public void setHostName(String hostName) {
+            this.hostName = hostName;
+        }
+
+        public Integer getMetricsPort() {
+            return metricsPort;
+        }
+
+        public void setMetricsPort(Integer metricsPort) {
+            this.metricsPort = metricsPort;
+        }
+
+        public Integer getDistributionPort() {
+            return distributionPort;
+        }
+
+        public void setDistributionPort(Integer distributionPort) {
+            this.distributionPort = distributionPort;
+        }
+    }
+
+    public static class DirectIngestionProperties {
+        /**
+         * Required when publishing directly to the Wavefront API host.
+         *
+         * URI of the Wavefront API host to publish to.
+         */
+        private String uri;
+
+        /**
+         * Required when publishing directly to the Wavefront API host.
+         *
+         * The Wavefront API token.
+         */
+        private String apiToken;
+
+        /**
+         * Max queue size of the in-memory buffer when publishing directly to the Wavefront API host.
+         */
+        private Integer maxQueueSize;
+
+        /**
+         * Size of the batch to be reported during every flush when publishing directly to the Wavefront API host.
+         */
+        private Integer batchSize;
+
+        public String getUri() { return uri; }
+
+        public void setUri(String uri) { this.uri = uri; }
+
+        public String getApiToken() { return apiToken; }
+
+        public void setApiToken(String apiToken) { this.apiToken = apiToken; }
+
+        public Integer getMaxQueueSize() { return maxQueueSize; }
+
+        public void setMaxQueueSize(Integer maxQueueSize) { this.maxQueueSize = maxQueueSize; }
+
+        public Integer getBatchSize() { return batchSize; }
+
+        public void setBatchSize(Integer batchSize) { this.batchSize = batchSize; }
+    }
+
+    public static class WavefrontHistogramProperties {
+        /**
+         * {@code true} to report WavefrontHistogram distributions aggregated into minute intervals.
+         */
+        private Boolean reportMinuteDistribution;
+
+        /**
+         * {@code true} to report WavefrontHistogram distributions aggregated into hour intervals.
+         */
+        private Boolean reportHourDistribution;
+
+        /**
+         * {@code true} to report WavefrontHistogram distributions aggregated into day intervals.
+         */
+        private Boolean reportDayDistribution;
+
+        public Boolean getReportMinuteDistribution() { return reportMinuteDistribution; }
+
+        public void setReportMinuteDistribution(Boolean reportMinuteDistribution) {
+            this.reportMinuteDistribution = reportMinuteDistribution;
+        }
+
+        public Boolean getReportHourDistribution() { return reportHourDistribution; }
+
+        public void setReportHourDistribution(Boolean reportHourDistribution) {
+            this.reportHourDistribution = reportHourDistribution;
+        }
+
+        public Boolean getReportDayDistribution() { return reportDayDistribution; }
+
+        public void setReportDayDistribution(Boolean reportDayDistribution) {
+            this.reportDayDistribution = reportDayDistribution;
+        }
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -23,21 +23,42 @@ import io.micrometer.wavefront.WavefrontConfig;
  *
  * @author Jon Schneider
  */
-public class WavefrontPropertiesConfigAdapter extends PropertiesConfigAdapter<WavefrontProperties> implements WavefrontConfig {
+public class WavefrontPropertiesConfigAdapter
+    extends PropertiesConfigAdapter<WavefrontProperties> implements WavefrontConfig {
+
+    private final ProxyConfig proxyConfig;
+    private final DirectIngestionConfig directIngestionConfig;
+    private final WavefrontHistogramConfig wavefrontHistogramConfig;
 
     public WavefrontPropertiesConfigAdapter(WavefrontProperties properties) {
         super(properties);
+        proxyConfig = new ProxyPropertiesConfigAdapter(properties.getProxy());
+        directIngestionConfig =
+            new DirectIngestionPropertiesConfigAdapter(properties.getDirectIngestion());
+        wavefrontHistogramConfig =
+            new WavefrontHistogramPropertiesConfigAdapter(properties.getWavefrontHistogram());
     }
 
     @Override
-    public String get(String k) {
-        return null;
+    public String get(String k) { return null; }
+
+    @Override
+    public boolean sendToProxy() {
+        return get(WavefrontProperties::getSendToProxy, WavefrontConfig.DEFAULT_DIRECT::sendToProxy);
     }
 
     @Override
-    public String uri() {
-        return get(WavefrontProperties::getUri, WavefrontConfig.DEFAULT_DIRECT::uri);
+    public ProxyConfig proxyConfig() {
+        return proxyConfig;
     }
+
+    @Override
+    public DirectIngestionConfig directIngestionConfig() {
+        return directIngestionConfig;
+    }
+
+    @Override
+    public WavefrontHistogramConfig wavefrontHistogramConfig() { return wavefrontHistogramConfig; }
 
     @Override
     public String source() {
@@ -45,12 +66,110 @@ public class WavefrontPropertiesConfigAdapter extends PropertiesConfigAdapter<Wa
     }
 
     @Override
-    public String apiToken() {
-        return get(WavefrontProperties::getApiToken, WavefrontConfig.super::apiToken);
+    public String globalPrefix() {
+        return get(WavefrontProperties::getGlobalPrefix, WavefrontConfig.super::globalPrefix);
     }
 
     @Override
-    public String globalPrefix() {
-        return get(WavefrontProperties::getGlobalPrefix, WavefrontConfig.super::globalPrefix);
+    public Integer flushIntervalSeconds() {
+        return get(WavefrontProperties::getFlushIntervalSeconds, WavefrontConfig.super::flushIntervalSeconds);
+    }
+
+    public static class ProxyPropertiesConfigAdapter
+        extends PropertiesConfigAdapter<WavefrontProperties.ProxyProperties>
+        implements WavefrontConfig.ProxyConfig {
+
+        public ProxyPropertiesConfigAdapter(WavefrontProperties.ProxyProperties proxyProperties) {
+            super(proxyProperties);
+        }
+
+        @Override
+        public String get(String k) { return null; }
+
+        @Override
+        public String hostName() {
+            return get(WavefrontProperties.ProxyProperties::getHostName,
+                WavefrontConfig.DEFAULT_PROXY_CONFIG::hostName);
+        }
+
+        @Override
+        public Integer metricsPort() {
+            return get(WavefrontProperties.ProxyProperties::getMetricsPort,
+                WavefrontConfig.DEFAULT_PROXY_CONFIG::metricsPort);
+        }
+
+        @Override
+        public Integer distributionPort() {
+            return get(WavefrontProperties.ProxyProperties::getDistributionPort,
+                WavefrontConfig.DEFAULT_PROXY_CONFIG::distributionPort);
+        }
+    }
+
+    public static class DirectIngestionPropertiesConfigAdapter
+        extends PropertiesConfigAdapter<WavefrontProperties.DirectIngestionProperties>
+        implements WavefrontConfig.DirectIngestionConfig {
+
+        public DirectIngestionPropertiesConfigAdapter(
+            WavefrontProperties.DirectIngestionProperties proxyProperties) {
+            super(proxyProperties);
+        }
+
+        @Override
+        public String get(String k) { return null; }
+
+        @Override
+        public String uri() {
+            return get(WavefrontProperties.DirectIngestionProperties::getUri,
+                WavefrontConfig.DEFAULT_DIRECT_CONFIG::uri);
+        }
+
+        @Override
+        public String apiToken() {
+            return get(WavefrontProperties.DirectIngestionProperties::getApiToken,
+                WavefrontConfig.DEFAULT_DIRECT_CONFIG::apiToken);
+        }
+
+        @Override
+        public Integer maxQueueSize() {
+            return get(WavefrontProperties.DirectIngestionProperties::getMaxQueueSize,
+                WavefrontConfig.DEFAULT_DIRECT_CONFIG::maxQueueSize);
+        }
+
+        @Override
+        public Integer batchSize() {
+            return get(WavefrontProperties.DirectIngestionProperties::getBatchSize,
+                WavefrontConfig.DEFAULT_DIRECT_CONFIG::batchSize);
+        }
+    }
+
+    public static class WavefrontHistogramPropertiesConfigAdapter
+        extends PropertiesConfigAdapter<WavefrontProperties.WavefrontHistogramProperties>
+        implements WavefrontConfig.WavefrontHistogramConfig {
+
+        public WavefrontHistogramPropertiesConfigAdapter(
+            WavefrontProperties.WavefrontHistogramProperties wavefrontHistogramProperties) {
+            super(wavefrontHistogramProperties);
+        }
+
+        @Override
+        public String get(String k) { return null; }
+
+        @Override
+        public boolean reportMinuteDistribution() {
+            return get(WavefrontProperties.WavefrontHistogramProperties::getReportMinuteDistribution,
+                WavefrontConfig.DEFAULT_WAVEFRONT_HISTOGRAM_CONFIG::reportMinuteDistribution);
+        }
+
+        @Override
+        public boolean reportHourDistribution() {
+            return get(WavefrontProperties.WavefrontHistogramProperties::getReportHourDistribution,
+                WavefrontConfig.DEFAULT_WAVEFRONT_HISTOGRAM_CONFIG::reportHourDistribution);
+        }
+
+        @Override
+        public boolean reportDayDistribution() {
+            return get(WavefrontProperties.WavefrontHistogramProperties::getReportDayDistribution,
+                WavefrontConfig.DEFAULT_WAVEFRONT_HISTOGRAM_CONFIG::reportDayDistribution);
+        }
     }
 }

--- a/micrometer-test/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-test/gradle/dependency-locks/compile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/compileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/default.lockfile
+++ b/micrometer-test/gradle/dependency-locks/default.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-test/gradle/dependency-locks/runtime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testCompile.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testRuntime.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/micrometer-test/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -26,7 +26,7 @@ commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6
 commons-logging:commons-logging:1.2
 dom4j:dom4j:1.6.1
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.netty:netty-buffer:4.1.29.Final
 io.netty:netty-codec-http2:4.1.29.Final
 io.netty:netty-codec-http:4.1.29.Final

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compile.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compile.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compile.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compile.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/default.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/default.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/default.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/default.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/runtime.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/runtime.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/runtime.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/runtime.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompile.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompile.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompile.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompile.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntime.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntime.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntime.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntime.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -15,7 +15,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 com.fasterxml:classmate:1.3.4
 com.github.ben-manes.caffeine:caffeine:2.3.5
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.5
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -30,6 +30,7 @@ com.netflix.spectator:spectator-reg-atlas:0.77.0
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -39,6 +39,7 @@ info.ganglia.gmetric4j:gmetric4j:1.0.7
 io.dropwizard.metrics:metrics-core:3.1.5
 io.dropwizard.metrics:metrics-ganglia:3.1.5
 io.dropwizard.metrics:metrics-graphite:3.1.5
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/GangliaSample.java
+++ b/samples/micrometer-samples-boot1/src/main/java/io/micrometer/boot1/samples/GangliaSample.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.boot1.samples;
+
+import io.micrometer.boot1.samples.components.PersonController;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication(scanBasePackageClasses = PersonController.class)
+@EnableScheduling
+public class GangliaSample {
+    public static void main(String[] args) {
+        new SpringApplicationBuilder(GangliaSample.class).profiles("ganglia").run(args);
+    }
+}

--- a/samples/micrometer-samples-boot1/src/main/resources/application-ganglia.yml
+++ b/samples/micrometer-samples-boot1/src/main/resources/application-ganglia.yml
@@ -1,0 +1,17 @@
+#
+# Copyright 2017 Pivotal Software, Inc.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# http://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+management.metrics.export.ganglia.enabled: true

--- a/samples/micrometer-samples-boot1/src/main/resources/application-wavefront.yml
+++ b/samples/micrometer-samples-boot1/src/main/resources/application-wavefront.yml
@@ -16,4 +16,5 @@
 
 management.metrics.export.wavefront:
   enabled: true
-  apiToken: fake
+  directionIngestion:
+    apiToken: fake

--- a/samples/micrometer-samples-core/gradle/dependency-locks/compile.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/compile.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/compile.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/compile.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/compileClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/default.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/default.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/default.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/default.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/runtime.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/runtime.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/runtime.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/runtime.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testCompile.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testCompile.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testCompile.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testCompile.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testRuntime.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testRuntime.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -28,6 +28,7 @@ com.netflix.hystrix:hystrix-core:1.5.12
 com.netflix.spectator:spectator-api:0.77.0
 com.netflix.spectator:spectator-ext-ipc:0.77.0
 com.netflix.spectator:spectator-reg-atlas:0.77.0
+com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
@@ -38,9 +39,10 @@ commons-logging:commons-logging:1.2
 concurrent:concurrent:1.3.4
 dom4j:dom4j:1.6.1
 info.ganglia.gmetric4j:gmetric4j:1.0.7
-io.dropwizard.metrics:metrics-core:3.2.6
+io.dropwizard.metrics:metrics-core:4.0.3
 io.dropwizard.metrics:metrics-ganglia:3.2.6
-io.dropwizard.metrics:metrics-graphite:3.2.6
+io.dropwizard.metrics:metrics-graphite:4.0.3
+io.dropwizard.metrics:metrics-jmx:4.0.3
 io.grpc:grpc-context:1.14.0
 io.grpc:grpc-core:1.14.0
 io.grpc:grpc-netty-shaded:1.14.0

--- a/samples/micrometer-samples-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -16,7 +16,7 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.9.6
 com.fasterxml:classmate:1.3.0
 com.github.ben-manes.caffeine:caffeine:2.6.2
 com.google.api.grpc:proto-google-common-protos:1.0.0
-com.google.code.findbugs:jsr305:3.0.0
+com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.7
 com.google.errorprone:error_prone_annotations:2.1.2
 com.google.guava:guava:20.0
@@ -32,6 +32,7 @@ com.rabbitmq:amqp-client:4.4.1
 com.signalfx.public:signalfx-java:0.0.48
 com.squareup.okhttp3:okhttp:3.11.0
 com.squareup.okio:okio:1.14.0
+com.wavefront:wavefront-sdk-java:0.9.0
 commons-codec:commons-codec:1.10
 commons-configuration:commons-configuration:1.8
 commons-lang:commons-lang:2.6

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
@@ -335,6 +335,21 @@ public class SampleRegistries {
     }
 
     public static WavefrontMeterRegistry wavefrontDirect(String apiToken) {
+        WavefrontConfig.DirectIngestionConfig directIngestionConfig = new WavefrontConfig.DirectIngestionConfig() {
+            @Override
+            public String get(String key) { return null; }
+
+            @Override
+            public String uri() {
+                return "https://longboard.wavefront.com";
+            }
+
+            @Override
+            public String apiToken() {
+                return apiToken;
+            }
+        };
+
         return new WavefrontMeterRegistry(new WavefrontConfig() {
             @Override
             public String get(String key) {
@@ -342,13 +357,11 @@ public class SampleRegistries {
             }
 
             @Override
-            public String apiToken() {
-                return apiToken;
-            }
+            public boolean sendToProxy() { return false; }
 
             @Override
-            public String uri() {
-                return "https://longboard.wavefront.com";
+            public DirectIngestionConfig directIngestionConfig() {
+                return directIngestionConfig;
             }
         }, Clock.SYSTEM);
     }

--- a/scripts/ganglia.sh
+++ b/scripts/ganglia.sh
@@ -6,10 +6,9 @@ if [ ! -f .ganglia ]; then
 fi
 
 docker run \
-  -d \
   -v $(pwd)/.ganglia/etc:/etc/ganglia \
   -v $(pwd)/.ganglia/data:/var/lib/ganglia \
-  -p 127.0.0.1:80:80 \
+  -p 8089:80 \
   -p 8649:8649 \
   -p 8649:8649/udp \
   kurthuwig/ganglia:latest


### PR DESCRIPTION
Updates to the Wavefront reporter:

- Added a dependency on `wavefront-sdk-java` to abstract away the sending-to-Wavefront logic and use the latest Wavefront API.
- Added support for Wavefront-specific metric types: Delta Counters and Wavefront Histograms.
- Updated Wavefront properties and config to support the latest Wavefront API and proxy configuration options.

We'll also need to update the following docs due to the updated configuration options: 

- https://micrometer.io/docs/registry/wavefront
- https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metrics-export-wavefront

