### PR TITLE
Drop NaN metric values in CloudWatchMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+import java.util.stream.Stream;
+
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MockClock;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link CloudWatchMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class CloudWatchMeterRegistryTest {
+
+    private final CloudWatchConfig config = new CloudWatchConfig() {
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public String namespace() {
+            return "namespace";
+        }
+    };
+
+    private CloudWatchMeterRegistry registry = new CloudWatchMeterRegistry(config, new MockClock(), null);
+
+    @Test
+    void metricData() {
+        registry.gauge("test", 1d);
+        Gauge gauge = registry.find("test").gauge();
+        Stream<MetricDatum> metricDatumStream = registry.metricData(gauge);
+        assertThat(metricDatumStream.count()).isEqualTo(1);
+    }
+
+    @Test
+    void metricDataWhenNaNShouldNotAdd() {
+        registry.gauge("test", Double.NaN);
+        Gauge gauge = registry.find("test").gauge();
+        Stream<MetricDatum> metricDatumStream = registry.metricData(gauge);
+        assertThat(metricDatumStream.count()).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION
This PR changes to drop NaN metric values in `CloudWatchMeterRegistry`.

Closes gh-899