### PR TITLE
Add tests for match() and consume() in Meter.Type

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link Meter}.
+ *
+ * @author Johnny Lim
+ */
+class MeterTest {
+
+    @Test
+    void matchWhenTimeGaugeShouldUseFunctionForTimeGauge() {
+        String matched = Meter.Type.match(
+                mock(TimeGauge.class),
+                (gauge) -> "gauge",
+                (counter) -> "counter",
+                (timer) -> "timer",
+                (distributionSummary) -> "distributionSummary",
+                (longTaskTimer) -> "longTaskTimer",
+                (timeGauge) -> "timeGauge",
+                (functionCounter) -> "functionCounter",
+                (functionTimer) -> "functionTimer",
+                (meter) -> "meter");
+        assertThat(matched).isEqualTo("timeGauge");
+    }
+
+    @Test
+    void consumeWhenTimeGaugeShouldUseConsumerForTimeGauge() {
+        StringBuilder consumed = new StringBuilder();
+        Meter.Type.consume(
+                mock(TimeGauge.class),
+                (gauge) -> consumed.append("gauge"),
+                (counter) -> consumed.append("counter"),
+                (timer) -> consumed.append("timer"),
+                (distributionSummary) -> consumed.append("distributionSummary"),
+                (longTaskTimer) -> consumed.append("longTaskTimer"),
+                (timeGauge) -> consumed.append("timeGauge"),
+                (functionCounter) -> consumed.append("functionCounter"),
+                (functionTimer) -> consumed.append("functionTimer"),
+                (meter) -> consumed.append("meter"));
+        assertThat(consumed.toString()).isEqualTo("timeGauge");
+    }
+
+}


### PR DESCRIPTION
I saw [the fix](https://github.com/micrometer-metrics/micrometer/commit/80978cebedfb33fec3c37262cb05d5a85fd40aa8) from @jkschneider (Thanks!) for [the bug which I have introduced](https://github.com/micrometer-metrics/micrometer/commit/1399b07d78d5a599bb945ec7332dd791bf7cc612) carelessly. I'd be good to have tests for it and the similar method, `consume()` to prevent it from sneaking into them again somehow.