### PR TITLE
Add TagsProvider as a marker interface

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/TagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/TagsProvider.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+/**
+ * Marker interface for tags provider.
+ *
+ * @author Johnny Lim
+ * @since 1.1.0
+ */
+public interface TagsProvider {
+}

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTagsProvider.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTagsProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.jersey2.server;
 
+import io.micrometer.core.instrument.TagsProvider;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 
 import io.micrometer.core.instrument.Tag;
@@ -24,7 +25,7 @@ import io.micrometer.core.instrument.Tag;
  * 
  * @author Michael Weirauch
  */
-public interface JerseyTagsProvider {
+public interface JerseyTagsProvider extends TagsProvider {
 
     /**
      * Provides tags to be associated with metrics for the given {@code event}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTagsProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTagsProvider.java
@@ -16,6 +16,7 @@
 package io.micrometer.spring.web.client;
 
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 import io.micrometer.core.lang.Nullable;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
@@ -28,7 +29,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Andy Wilkinson
  */
 @FunctionalInterface
-public interface RestTemplateExchangeTagsProvider {
+public interface RestTemplateExchangeTagsProvider extends TagsProvider {
 
     /**
      * Provides the tags to be associated with metrics that are recorded for the given

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTagsProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcTagsProvider.java
@@ -17,6 +17,7 @@ package io.micrometer.spring.web.servlet;
 
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TagsProvider;
 import io.micrometer.core.lang.NonNull;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.Nullable;
@@ -31,7 +32,7 @@ import javax.servlet.http.HttpServletResponse;
  * @author Andy Wilkinson
  */
 @NonNullApi
-public interface WebMvcTagsProvider {
+public interface WebMvcTagsProvider extends TagsProvider {
 
     /**
      * Provides tags to be used by {@link LongTaskTimer long task timers}.


### PR DESCRIPTION
This PR adds `TagsProvider` as a marker interface and changes tags provider interfaces to extend it.

Closes gh-542