### PR TITLE
Add thread state metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.binder.jvm;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
@@ -66,23 +67,23 @@ public class JvmThreadMetrics implements MeterBinder {
             .description("The current number of live threads including both daemon and non-daemon threads")
             .register(registry);
 
-        Gauge.builder("jvm.threads.runnable", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.RUNNABLE))
-            .tags(tags)
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.RUNNABLE))
+            .tags(Tags.concat(tags, "state", "runnable"))
             .description("The current number of threads having runnable state")
             .register(registry);
 
-        Gauge.builder("jvm.threads.blocked", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.BLOCKED))
-            .tags(tags)
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.BLOCKED))
+            .tags(Tags.concat(tags, "state", "blocked"))
             .description("The current number of threads having blocked state")
             .register(registry);
 
-        Gauge.builder("jvm.threads.waiting", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.WAITING))
-            .tags(tags)
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.WAITING))
+            .tags(Tags.concat(tags, "state", "waiting"))
             .description("The current number of threads having waiting state")
             .register(registry);
 
-        Gauge.builder("jvm.threads.timed-waiting", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TIMED_WAITING))
-            .tags(tags)
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TIMED_WAITING))
+            .tags(Tags.concat(tags, "state", "timed-waiting"))
             .description("The current number of threads having timed waiting state")
             .register(registry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -67,6 +67,11 @@ public class JvmThreadMetrics implements MeterBinder {
             .description("The current number of live threads including both daemon and non-daemon threads")
             .register(registry);
 
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.NEW))
+            .tags(Tags.concat(tags, "state", "new"))
+            .description("The current number of threads having new state")
+            .register(registry);
+
         Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.RUNNABLE))
             .tags(Tags.concat(tags, "state", "runnable"))
             .description("The current number of threads having runnable state")
@@ -85,6 +90,11 @@ public class JvmThreadMetrics implements MeterBinder {
         Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TIMED_WAITING))
             .tags(Tags.concat(tags, "state", "timed-waiting"))
             .description("The current number of threads having timed waiting state")
+            .register(registry);
+
+        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TERMINATED))
+            .tags(Tags.concat(tags, "state", "terminated"))
+            .description("The current number of threads having timed terminated state")
             .register(registry);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -67,41 +67,22 @@ public class JvmThreadMetrics implements MeterBinder {
             .description("The current number of live threads including both daemon and non-daemon threads")
             .register(registry);
 
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.NEW))
-            .tags(Tags.concat(tags, "state", "new"))
-            .description("The current number of threads having new state")
-            .register(registry);
-
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.RUNNABLE))
-            .tags(Tags.concat(tags, "state", "runnable"))
-            .description("The current number of threads having runnable state")
-            .register(registry);
-
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.BLOCKED))
-            .tags(Tags.concat(tags, "state", "blocked"))
-            .description("The current number of threads having blocked state")
-            .register(registry);
-
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.WAITING))
-            .tags(Tags.concat(tags, "state", "waiting"))
-            .description("The current number of threads having waiting state")
-            .register(registry);
-
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TIMED_WAITING))
-            .tags(Tags.concat(tags, "state", "timed-waiting"))
-            .description("The current number of threads having timed waiting state")
-            .register(registry);
-
-        Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, Thread.State.TERMINATED))
-            .tags(Tags.concat(tags, "state", "terminated"))
-            .description("The current number of threads having timed terminated state")
-            .register(registry);
+        for (Thread.State state : Thread.State.values()) {
+            Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, state))
+                .tags(Tags.concat(tags, "state", getStateTagValue(state)))
+                .description("The current number of threads having " + state + " state")
+                .register(registry);
+        }
     }
 
-    private long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
+    private static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
         return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
                 .filter(threadInfo -> threadInfo.getThreadState() == state)
                 .count();
+    }
+
+    private static String getStateTagValue(Thread.State state) {
+        return state.name().toLowerCase().replace("_", "-");
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -38,14 +38,14 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.live").gauge().value()).isGreaterThan(0);
         assertThat(registry.get("jvm.threads.daemon").gauge().value()).isGreaterThan(0);
         assertThat(registry.get("jvm.threads.peak").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.runnable").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.states").tag("state", "runnable").gauge().value()).isGreaterThan(0);
 
         createBlockedThread();
-        assertThat(registry.get("jvm.threads.blocked").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.waiting").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.states").tag("state", "blocked").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.states").tag("state", "waiting").gauge().value()).isGreaterThan(0);
 
         createTimedWaitingThread();
-        assertThat(registry.get("jvm.threads.timed-waiting").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.states").tag("state", "timed-waiting").gauge().value()).isGreaterThan(0);
     }
 
     private void createTimedWaitingThread() {


### PR DESCRIPTION
This PR adds thread state metrics.

Note that this could be enhanced if there's a way to reuse a result across gauges but I couldn't find an easy way yet. #807 might be helpful here.

Closes gh-543