### PR TITLE
Fix spring.aop.auto property reference

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -124,7 +124,7 @@ public class MetricsAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(name = "org.aspectj.lang.ProceedingJoinPoint")
-    @ConditionalOnProperty(value = "spring.aop.enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(value = "spring.aop.auto", havingValue = "true", matchIfMissing = true)
     static class AopRequiredConfiguration {
 
         // If AOP is not enabled, scheduled interception will not work.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -89,7 +89,7 @@ class MetricsAutoConfigurationTest {
 
     @Test
     void backsOffWhenSpringAopEnabledIsFalse() {
-        EnvironmentTestUtils.addEnvironment(context, "spring.aop.enabled=false");
+        EnvironmentTestUtils.addEnvironment(context, "spring.aop.auto=false");
 
         registerAndRefresh(BaseMeterRegistryConfiguration.class);
 


### PR DESCRIPTION
This PR fixes the `spring.aop.auto` property reference as it seems incorrect based on [the Spring Boot reference](https://docs.spring.io/spring-boot/docs/1.5.x/reference/htmlsingle/#common-application-properties) as follows:

```
spring.aop.auto=true # Add @EnableAspectJAutoProxy.
```