### PR TITLE
Fix Jersey status and outcome tags on unmapped exceptions

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.util.StringUtils;
@@ -46,7 +47,7 @@ public final class JerseyTags {
 
     private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
 
-    private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+    private static final Tag STATUS_SERVER_ERROR = Tag.of("status", String.valueOf(Status.INTERNAL_SERVER_ERROR.getStatusCode()));
 
     private static final Tag OUTCOME_UNKNOWN = Tag.of("outcome", "UNKNOWN");
 
@@ -85,9 +86,10 @@ public final class JerseyTags {
      * @return the status tag derived from the status of the response
      */
     public static Tag status(ContainerResponse response) {
+        /* In case there is no response we are dealing with an unmapped exception. */
         return (response != null)
                 ? Tag.of("status", Integer.toString(response.getStatus()))
-                : STATUS_UNKNOWN;
+                : STATUS_SERVER_ERROR;
     }
 
     /**
@@ -189,7 +191,8 @@ public final class JerseyTags {
                     return OUTCOME_UNKNOWN;
             }
         }
-        return OUTCOME_UNKNOWN;
+        /* In case there is no response we are dealing with an unmapped exception. */
+        return OUTCOME_SERVER_ERROR;
     }
 
 }

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
@@ -72,19 +72,19 @@ public class MetricsRequestEventListenerTest extends JerseyTest {
         target("sub-resource/sub-hello/peter").request().get();
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("root", "200", null)).timer().count())
+            .tags(tagsFrom("root", "200", "SUCCESS", null)).timer().count())
             .isEqualTo(1);
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("/hello", "200", null)).timer().count())
+            .tags(tagsFrom("/hello", "200", "SUCCESS", null)).timer().count())
             .isEqualTo(2);
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("/hello/{name}", "200", null)).timer().count())
+            .tags(tagsFrom("/hello/{name}", "200", "SUCCESS", null)).timer().count())
             .isEqualTo(1);
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("/sub-resource/sub-hello/{name}", "200", null)).timer().count())
+            .tags(tagsFrom("/sub-resource/sub-hello/{name}", "200", "SUCCESS", null)).timer().count())
             .isEqualTo(1);
 
         // assert we are not auto-timing long task @Timed
@@ -103,7 +103,7 @@ public class MetricsRequestEventListenerTest extends JerseyTest {
         }
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("NOT_FOUND", "404", null)).timer().count())
+            .tags(tagsFrom("NOT_FOUND", "404", "CLIENT_ERROR", null)).timer().count())
             .isEqualTo(2);
     }
 
@@ -113,11 +113,11 @@ public class MetricsRequestEventListenerTest extends JerseyTest {
         target("redirect/307").request().get();
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("REDIRECTION", "302", null)).timer().count())
+            .tags(tagsFrom("REDIRECTION", "302", "REDIRECTION", null)).timer().count())
             .isEqualTo(1);
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("REDIRECTION", "307", null)).timer().count())
+            .tags(tagsFrom("REDIRECTION", "307", "REDIRECTION", null)).timer().count())
             .isEqualTo(1);
     }
 
@@ -137,23 +137,23 @@ public class MetricsRequestEventListenerTest extends JerseyTest {
         }
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("/throws-exception", "UNKNOWN", "IllegalArgumentException"))
+            .tags(tagsFrom("/throws-exception", "500", "SERVER_ERROR", "IllegalArgumentException"))
             .timer().count())
             .isEqualTo(1);
 
         assertThat(registry.get(METRIC_NAME).tags(
-            tagsFrom("/throws-webapplication-exception", "401", "NotAuthorizedException"))
+            tagsFrom("/throws-webapplication-exception", "401", "CLIENT_ERROR", "NotAuthorizedException"))
             .timer().count())
             .isEqualTo(1);
 
         assertThat(registry.get(METRIC_NAME).tags(
-            tagsFrom("/throws-mappable-exception", "410", "ResourceGoneException"))
+            tagsFrom("/throws-mappable-exception", "410", "CLIENT_ERROR", "ResourceGoneException"))
             .timer().count())
             .isEqualTo(1);
     }
 
-    private static Iterable<Tag> tagsFrom(String uri, String status, String exception) {
-        return Tags.of("method", "GET", "uri", uri, "status", status,
+    private static Iterable<Tag> tagsFrom(String uri, String status, String outcome, String exception) {
+        return Tags.of("method", "GET", "uri", uri, "status", status, "outcome", outcome,
                 "exception", exception == null ? "None" : exception);
     }
 }


### PR DESCRIPTION
In case unmapped exceptions are thrown from resources there
is no response object.

This one slipped in with #907.

//cc @izeye (Thank you very much for taking care of this! My review on a mobile screen missed this one.)