### PR TITLE
Remove an unused import in WavefrontPropertiesConfigAdapter

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.spring.autoconfigure.export.wavefront;
 
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
 import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
 import io.micrometer.wavefront.WavefrontConfig;
 


### PR DESCRIPTION
This PR removes an unused `import` in `WavefrontPropertiesConfigAdapter` to resolve a Checkstyle rule violation error.