### PR TITLE
Rename token to apiToken in AppOptics

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
@@ -40,8 +40,8 @@ public interface AppOpticsConfig extends StepRegistryConfig {
     /**
      * @return AppOptics API token
      */
-    default String token() {
-        final String t = get(prefix() + ".token");
+    default String apiToken() {
+        final String t = get(prefix() + ".apiToken");
         if (null == t)
             throw new MissingRequiredConfigurationException("token must be set to report metrics to AppOptics");
         return t;

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -80,7 +80,7 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
         try {
             for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
                 httpClient.post(config.uri())
-                        .withBasicAuthentication(config.token(), "")
+                        .withBasicAuthentication(config.apiToken(), "")
                         .withJsonContent(
                                 batch.stream()
                                         .map(meter -> match(meter,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
@@ -29,7 +29,7 @@ public class AppOpticsProperties extends StepRegistryProperties {
     /**
      * AppOptics API token.
      */
-    public String token;
+    public String apiToken;
 
     /**
      * The tag that will be mapped to "@host" when shipping metrics to AppOptics, or {@code null} if
@@ -42,9 +42,9 @@ public class AppOpticsProperties extends StepRegistryProperties {
      */
     public String uri;
 
-    public String getToken() { return token; }
+    public String getApiToken() { return apiToken; }
 
-    public void setToken(String token) { this.token = token; }
+    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
 
     public String getHostTag() {
         return hostTag;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
@@ -28,7 +28,7 @@ public class AppOpticsPropertiesConfigAdapter extends StepRegistryPropertiesConf
 
     public AppOpticsPropertiesConfigAdapter(AppOpticsProperties properties) { super(properties); }
 
-    public String token() { return get(AppOpticsProperties::getToken, AppOpticsConfig.super::token); }
+    public String apiToken() { return get(AppOpticsProperties::getApiToken, AppOpticsConfig.super::apiToken); }
 
     public String hostTag() { return get(AppOpticsProperties::getHostTag, AppOpticsConfig.super::hostTag); }
 

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
@@ -68,7 +68,7 @@ public class SampleRegistries {
     public static AppOpticsMeterRegistry appOptics(String apiToken) {
         return new AppOpticsMeterRegistry(new AppOpticsConfig() {
             @Override
-            public String token() {
+            public String apiToken() {
                 return apiToken;
             }
 


### PR DESCRIPTION
This PR renames `token` to `apiToken` in AppOptics to align with Dynatrace, Humio, and Wavefront.

Closes gh-933