### PR TITLE
Align configuration properties for meter registries with Spring Boot 2.x

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/StepRegistryProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/StepRegistryProperties.java
@@ -34,28 +34,28 @@ public abstract class StepRegistryProperties {
     /**
      * Whether exporting of metrics to this backend is enabled.
      */
-    private Boolean enabled;
+    private boolean enabled = true;
 
     /**
      * Connection timeout for requests to this backend.
      */
-    private Duration connectTimeout;
+    private Duration connectTimeout = Duration.ofSeconds(1);
 
     /**
      * Read timeout for requests to this backend.
      */
-    private Duration readTimeout;
+    private Duration readTimeout = Duration.ofSeconds(10);
 
     /**
      * Number of threads to use with the metrics publishing scheduler.
      */
-    private Integer numThreads;
+    private Integer numThreads = 2;
 
     /**
      * Number of measurements per request to use for this backend. If more measurements
      * are found, then multiple requests will be made.
      */
-    private Integer batchSize;
+    private Integer batchSize = 10000;
 
     public Duration getStep() {
         return this.step;
@@ -65,11 +65,11 @@ public abstract class StepRegistryProperties {
         this.step = step;
     }
 
-    public Boolean getEnabled() {
+    public boolean isEnabled() {
         return this.enabled;
     }
 
-    public void setEnabled(Boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/StepRegistryPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/StepRegistryPropertiesConfigAdapter.java
@@ -50,7 +50,7 @@ public abstract class StepRegistryPropertiesConfigAdapter<T extends StepRegistry
 
     @Override
     public boolean enabled() {
-        return get(T::getEnabled, StepRegistryConfig.super::enabled);
+        return get(T::isEnabled, StepRegistryConfig.super::enabled);
     }
 
     @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
@@ -31,38 +31,38 @@ public class AtlasProperties extends StepRegistryProperties {
     /**
      * URI of the Atlas server.
      */
-    private String uri;
+    private String uri = "http://localhost:7101/api/v1/publish";
 
     /**
      * Time to live for meters that do not have any activity. After this period the meter
      * will be considered expired and will not get reported.
      */
-    private Duration meterTimeToLive;
+    private Duration meterTimeToLive = Duration.ofMinutes(15);
 
     /**
-     * Enable streaming to Atlas LWC.
+     * Whether to enable streaming to Atlas LWC.
      */
-    private Boolean lwcEnabled;
+    private boolean lwcEnabled;
 
     /**
      * Frequency for refreshing config settings from the LWC service.
      */
-    private Duration configRefreshFrequency;
+    private Duration configRefreshFrequency = Duration.ofSeconds(10);
 
     /**
      * Time to live for subscriptions from the LWC service.
      */
-    private Duration configTimeToLive;
+    private Duration configTimeToLive = Duration.ofSeconds(150);
 
     /**
      * URI for the Atlas LWC endpoint to retrieve current subscriptions.
      */
-    private String configUri;
+    private String configUri = "http://localhost:7101/lwc/api/v1/expressions/local-dev";
 
     /**
      * URI for the Atlas LWC endpoint to evaluate the data for a subscription.
      */
-    private String evalUri;
+    private String evalUri = "http://localhost:7101/lwc/api/v1/evaluate";
 
     public String getUri() {
         return this.uri;
@@ -80,11 +80,11 @@ public class AtlasProperties extends StepRegistryProperties {
         this.meterTimeToLive = meterTimeToLive;
     }
 
-    public Boolean getLwcEnabled() {
+    public boolean isLwcEnabled() {
         return this.lwcEnabled;
     }
 
-    public void setLwcEnabled(Boolean lwcEnabled) {
+    public void setLwcEnabled(boolean lwcEnabled) {
         this.lwcEnabled = lwcEnabled;
     }
 
@@ -119,4 +119,5 @@ public class AtlasProperties extends StepRegistryProperties {
     public void setEvalUri(String evalUri) {
         this.evalUri = evalUri;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasPropertiesConfigAdapter.java
@@ -45,7 +45,7 @@ class AtlasPropertiesConfigAdapter extends PropertiesConfigAdapter<AtlasProperti
 
     @Override
     public boolean enabled() {
-        return get(AtlasProperties::getEnabled, AtlasConfig.super::enabled);
+        return get(AtlasProperties::isEnabled, AtlasConfig.super::enabled);
     }
 
     @Override
@@ -80,7 +80,7 @@ class AtlasPropertiesConfigAdapter extends PropertiesConfigAdapter<AtlasProperti
 
     @Override
     public boolean lwcEnabled() {
-        return get(AtlasProperties::getLwcEnabled, AtlasConfig.super::lwcEnabled);
+        return get(AtlasProperties::isLwcEnabled, AtlasConfig.super::lwcEnabled);
     }
 
     @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorProperties.java
@@ -26,6 +26,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "management.metrics.export.azuremonitor")
 public class AzureMonitorProperties extends StepRegistryProperties {
 
+    /**
+     * Instrumentation key.
+     */
     private String instrumentationKey;
 
     public String getInstrumentationKey() {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
@@ -32,8 +32,8 @@ public class DatadogProperties extends StepRegistryProperties {
     private String apiKey;
 
     /**
-     * Datadog application key. Not strictly required, but improves the Datadog
-     * experience by sending meter descriptions, types, and base units to Datadog.
+     * Datadog application key. Not strictly required, but improves the Datadog experience
+     * by sending meter descriptions, types, and base units to Datadog.
      */
     private String applicationKey;
 
@@ -41,11 +41,10 @@ public class DatadogProperties extends StepRegistryProperties {
      * Whether to publish descriptions metadata to Datadog. Turn this off to minimize the
      * amount of metadata sent.
      */
-    private Boolean descriptions;
+    private boolean descriptions = true;
 
     /**
-     * Tag that will be mapped to "host" when shipping metrics to Datadog. Can be
-     * omitted if host should be omitted on publishing.
+     * Tag that will be mapped to "host" when shipping metrics to Datadog.
      */
     private String hostTag = "instance";
 
@@ -53,7 +52,7 @@ public class DatadogProperties extends StepRegistryProperties {
      * URI to ship metrics to. If you need to publish metrics to an internal proxy
      * en-route to Datadog, you can define the location of the proxy with this.
      */
-    private String uri;
+    private String uri = "https://app.datadoghq.com";
 
     public String getApiKey() {
         return this.apiKey;
@@ -71,11 +70,11 @@ public class DatadogProperties extends StepRegistryProperties {
         this.applicationKey = applicationKey;
     }
 
-    public Boolean getDescriptions() {
+    public boolean isDescriptions() {
         return this.descriptions;
     }
 
-    public void setDescriptions(Boolean descriptions) {
+    public void setDescriptions(boolean descriptions) {
         this.descriptions = descriptions;
     }
 
@@ -94,4 +93,5 @@ public class DatadogProperties extends StepRegistryProperties {
     public void setUri(String uri) {
         this.uri = uri;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogPropertiesConfigAdapter.java
@@ -52,7 +52,7 @@ class DatadogPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
 
     @Override
     public boolean descriptions() {
-        return get(DatadogProperties::getDescriptions, DatadogConfig.super::descriptions);
+        return get(DatadogProperties::isDescriptions, DatadogConfig.super::descriptions);
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
@@ -25,47 +25,40 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Oriol Barcelona
  */
 @ConfigurationProperties(prefix = "management.metrics.export.dynatrace")
-public class DynatraceProperties  extends StepRegistryProperties {
+public class DynatraceProperties extends StepRegistryProperties {
 
     /**
-     * Dynatrace API token
+     * Dynatrace authentication token.
      */
     private String apiToken;
 
     /**
-     * URI to ship metrics to. Should be used for SaaS, self managed
-     * instances or to en-route through an internal proxy
-     */
-    private String uri;
-
-    /**
-     * The custom device used to identify the sender into Dynatrace
+     * ID of the custom device that is exporting metrics to Dynatrace.
      */
     private String deviceId;
 
     /**
-     * The type of technology used to create the custom device and its metrics
+     * Technology type for exported metrics. Used to group metrics under a logical
+     * technology name in the Dynatrace UI.
      */
-    private String technologyType;
+    private String technologyType = "java";
+
+    /**
+     * URI to ship metrics to. Should be used for SaaS, self managed instances or to
+     * en-route through an internal proxy.
+     */
+    private String uri;
 
     public String getApiToken() {
-        return apiToken;
+        return this.apiToken;
     }
 
     public void setApiToken(String apiToken) {
         this.apiToken = apiToken;
     }
 
-    public String getUri() {
-        return uri;
-    }
-
-    public void setUri(String uri) {
-        this.uri = uri;
-    }
-
     public String getDeviceId() {
-        return deviceId;
+        return this.deviceId;
     }
 
     public void setDeviceId(String deviceId) {
@@ -73,10 +66,19 @@ public class DynatraceProperties  extends StepRegistryProperties {
     }
 
     public String getTechnologyType() {
-        return technologyType;
+        return this.technologyType;
     }
 
     public void setTechnologyType(String technologyType) {
         this.technologyType = technologyType;
     }
+
+    public String getUri() {
+        return this.uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -27,48 +27,43 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ElasticProperties extends StepRegistryProperties {
 
     /**
-     * The hosts to send the metrics to
+     * Host to export metrics to.
      */
-    private String host;
+    private String host = "http://localhost:9200";
 
     /**
-     * The index name to write metrics to.
+     * Index to export metrics to.
      */
-    private String index;
+    private String index = "metrics";
 
     /**
-     * The index date format used for rolling indices.
-     * This is appended to the index name, split by a '-'.
+     * Index date format used for rolling indices. Appended to the index name, preceded by
+     * a '-'.
      */
-    private String indexDateFormat;
+    private String indexDateFormat = "yyyy-MM";
 
     /**
-     * The bulk size per request.
+     * Name of the timestamp field.
      */
-    private int bulkSize;
+    private String timestampFieldName = "@timestamp";
 
     /**
-     * The name of the timestamp field.
+     * Whether to create the index automatically if it does not exist.
      */
-    private String timestampFieldName;
+    private boolean autoCreateIndex = true;
 
     /**
-     * Whether to create the index automatically if it doesn't exist.
+     * Login user of the Elastic server.
      */
-    private boolean autoCreateIndex;
+    private String userName = "";
 
     /**
-     * The Basic Authentication username.
+     * Login password of the Elastic server.
      */
-    private String userName;
-
-    /**
-     * The Basic Authentication password.
-     */
-    private String password;
+    private String password = "";
 
     public String getHost() {
-        return host;
+        return this.host;
     }
 
     public void setHost(String host) {
@@ -76,7 +71,7 @@ public class ElasticProperties extends StepRegistryProperties {
     }
 
     public String getIndex() {
-        return index;
+        return this.index;
     }
 
     public void setIndex(String index) {
@@ -84,23 +79,15 @@ public class ElasticProperties extends StepRegistryProperties {
     }
 
     public String getIndexDateFormat() {
-        return indexDateFormat;
+        return this.indexDateFormat;
     }
 
     public void setIndexDateFormat(String indexDateFormat) {
         this.indexDateFormat = indexDateFormat;
     }
 
-    public int getBulkSize() {
-        return bulkSize;
-    }
-
-    public void setBulkSize(int bulkSize) {
-        this.bulkSize = bulkSize;
-    }
-
     public String getTimestampFieldName() {
-        return timestampFieldName;
+        return this.timestampFieldName;
     }
 
     public void setTimestampFieldName(String timestampFieldName) {
@@ -108,7 +95,7 @@ public class ElasticProperties extends StepRegistryProperties {
     }
 
     public boolean isAutoCreateIndex() {
-        return autoCreateIndex;
+        return this.autoCreateIndex;
     }
 
     public void setAutoCreateIndex(boolean autoCreateIndex) {
@@ -116,7 +103,7 @@ public class ElasticProperties extends StepRegistryProperties {
     }
 
     public String getUserName() {
-        return userName;
+        return this.userName;
     }
 
     public void setUserName(String userName) {
@@ -124,10 +111,11 @@ public class ElasticProperties extends StepRegistryProperties {
     }
 
     public String getPassword() {
-        return password;
+        return this.password;
     }
 
     public void setPassword(String password) {
         this.password = password;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaProperties.java
@@ -30,55 +30,56 @@ import java.util.concurrent.TimeUnit;
 public class GangliaProperties {
 
     /**
-     * Enable publishing to Ganglia.
+     * Whether exporting of metrics to Ganglia is enabled.
      */
-    private Boolean enabled;
+    private boolean enabled = true;
 
     /**
      * Step size (i.e. reporting frequency) to use.
      */
-    private Duration step;
+    private Duration step = Duration.ofMinutes(1);
 
     /**
      * Base time unit used to report rates.
      */
-    private TimeUnit rateUnits;
+    private TimeUnit rateUnits = TimeUnit.SECONDS;
 
     /**
      * Base time unit used to report durations.
      */
-    private TimeUnit durationUnits;
+    private TimeUnit durationUnits = TimeUnit.MILLISECONDS;
 
     /**
      * Ganglia protocol version. Must be either 3.1 or 3.0.
      */
-    private String protocolVersion;
+    private String protocolVersion = "3.1";
 
     /**
      * UDP addressing mode, either unicast or multicast.
      */
-    private GMetric.UDPAddressingMode addressingMode;
+    private GMetric.UDPAddressingMode addressingMode = GMetric.UDPAddressingMode.MULTICAST;
 
     /**
-     * Time to live for metrics on Ganglia.
+     * Time to live for metrics on Ganglia. Set the multi-cast Time-To-Live to be one
+     * greater than the number of hops (routers) between the hosts.
      */
-    private Integer timeToLive;
+    private Integer timeToLive = 1;
 
     /**
      * Host of the Ganglia server to receive exported metrics.
      */
-    private String host;
+    private String host = "localhost";
 
     /**
      * Port of the Ganglia server to receive exported metrics.
      */
-    private Integer port;
+    private Integer port = 8649;
 
-    public Boolean getEnabled() {
+    public boolean isEnabled() {
         return this.enabled;
     }
 
-    public void setEnabled(Boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaPropertiesConfigAdapter.java
@@ -42,7 +42,7 @@ class GangliaPropertiesConfigAdapter extends PropertiesConfigAdapter<GangliaProp
 
     @Override
     public boolean enabled() {
-        return get(GangliaProperties::getEnabled, GangliaConfig.super::enabled);
+        return get(GangliaProperties::isEnabled, GangliaConfig.super::enabled);
     }
 
     @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphiteProperties.java
@@ -30,51 +30,51 @@ import java.util.concurrent.TimeUnit;
 public class GraphiteProperties {
 
     /**
-     * Enable publishing to Graphite.
+     * Whether exporting of metrics to Graphite is enabled.
      */
-    private Boolean enabled;
+    private boolean enabled = true;
 
     /**
      * Step size (i.e. reporting frequency) to use.
      */
-    private Duration step;
+    private Duration step = Duration.ofMinutes(1);
 
     /**
      * Base time unit used to report rates.
      */
-    private TimeUnit rateUnits;
+    private TimeUnit rateUnits = TimeUnit.SECONDS;
 
     /**
      * Base time unit used to report durations.
      */
-    private TimeUnit durationUnits;
+    private TimeUnit durationUnits = TimeUnit.MILLISECONDS;
 
     /**
      * Host of the Graphite server to receive exported metrics.
      */
-    private String host;
+    private String host = "localhost";
 
     /**
      * Port of the Graphite server to receive exported metrics.
      */
-    private Integer port;
-
-    /**
-     * For the default naming convention, turn the specified tag keys into
-     * part of the metric prefix.
-     */
-    private String[] tagsAsPrefix;
+    private Integer port = 2004;
 
     /**
      * Protocol to use while shipping data to Graphite.
      */
-    private GraphiteProtocol protocol;
+    private GraphiteProtocol protocol = GraphiteProtocol.PICKLED;
 
-    public Boolean getEnabled() {
+    /**
+     * For the default naming convention, turn the specified tag keys into part of the
+     * metric prefix.
+     */
+    private String[] tagsAsPrefix = new String[0];
+
+    public boolean isEnabled() {
         return this.enabled;
     }
 
-    public void setEnabled(Boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 
@@ -127,10 +127,11 @@ public class GraphiteProperties {
     }
 
     public String[] getTagsAsPrefix() {
-        return tagsAsPrefix;
+        return this.tagsAsPrefix;
     }
 
     public void setTagsAsPrefix(String[] tagsAsPrefix) {
         this.tagsAsPrefix = tagsAsPrefix;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphitePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphitePropertiesConfigAdapter.java
@@ -42,7 +42,7 @@ class GraphitePropertiesConfigAdapter extends PropertiesConfigAdapter<GraphitePr
 
     @Override
     public boolean enabled() {
-        return get(GraphiteProperties::getEnabled, GraphiteConfig.super::enabled);
+        return get(GraphiteProperties::isEnabled, GraphiteConfig.super::enabled);
     }
 
     @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
@@ -18,6 +18,8 @@ package io.micrometer.spring.autoconfigure.export.humio;
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -27,58 +29,75 @@ import java.util.Map;
  */
 @ConfigurationProperties(prefix = "management.metrics.export.humio")
 public class HumioProperties extends StepRegistryProperties {
+
     /**
      * Humio API token.
      */
     private String apiToken;
 
     /**
-     * The repository name to write metrics to.
+     * Connection timeout for requests to Humio.
      */
-    private String repository;
+    private Duration connectTimeout = Duration.ofSeconds(5);
+
+    /**
+     * Name of the repository to publish metrics to.
+     */
+    private String repository = "sandbox";
+
+    /**
+     * Humio tags describing the data source in which metrics will be stored. Humio tags
+     * are a distinct concept from Micrometer's tags. Micrometer's tags are used to divide
+     * metrics along dimensional boundaries.
+     */
+    private Map<String, String> tags = new HashMap<>();
 
     /**
      * URI to ship metrics to. If you need to publish metrics to an internal proxy
      * en-route to Humio, you can define the location of the proxy with this.
      */
-    private String uri;
-
-    /**
-     * Humio uses a concept called "tags" to decide which datasource to store metrics in. This concept
-     * is distinct from Micrometer's notion of tags, which divides a metric along dimensional boundaries.
-     * All metrics from this registry will be stored under a datasource defined by these tags.
-     */
-    private Map<String, String> tags;
+    private String uri = "https://cloud.humio.com";
 
     public String getApiToken() {
-        return apiToken;
+        return this.apiToken;
     }
 
     public void setApiToken(String apiToken) {
         this.apiToken = apiToken;
     }
 
+    @Override
+    public Duration getConnectTimeout() {
+        return this.connectTimeout;
+    }
+
+    @Override
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
     public String getRepository() {
-        return repository;
+        return this.repository;
     }
 
     public void setRepository(String repository) {
         this.repository = repository;
     }
 
+    public Map<String, String> getTags() {
+        return this.tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
     public String getUri() {
-        return uri;
+        return this.uri;
     }
 
     public void setUri(String uri) {
         this.uri = uri;
     }
 
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Map<String, String> tags) {
-        this.tags = tags;
-    }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
@@ -28,15 +28,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class InfluxProperties extends StepRegistryProperties {
 
     /**
-     * Tag that will be mapped to "host" when shipping metrics to Influx. Can be
-     * omitted if host should be omitted on publishing.
+     * Tag that will be mapped to "host" when shipping metrics to Influx.
      */
-    private String db;
+    private String db = "mydb";
 
     /**
      * Write consistency for each point.
      */
-    private InfluxConsistency consistency;
+    private InfluxConsistency consistency = InfluxConsistency.ONE;
 
     /**
      * Login user of the Influx server.
@@ -55,34 +54,39 @@ public class InfluxProperties extends StepRegistryProperties {
     private String retentionPolicy;
 
     /**
-     * URI of the Influx server.
-     */
-    private String uri;
-
-    /**
-     * Enable GZIP compression of metrics batches published to Influx.
-     */
-    private Boolean compressed;
-
-    /**
-     * Check if Influx database exists before attempting to publish metrics to it, creating it if it does not exist.
-     */
-    private Boolean autoCreateDb;
-
-    /**
-     * Time period for which influx should retain data in the current database (e.g. 2h, 52w)
+     * Time period for which Influx should retain data in the current database. For
+     * instance 7d, check the influx documentation for more details on the duration
+     * format.
      */
     private String retentionDuration;
 
     /**
-     * How many copies of the data are stored in the cluster. Must be 1 for a single node instance.
+     * How many copies of the data are stored in the cluster. Must be 1 for a single node
+     * instance.
      */
     private Integer retentionReplicationFactor;
 
     /**
-     * The time range covered by a shard group (e.g. 2h, 52w).
+     * Time range covered by a shard group. For instance 2w, check the influx
+     * documentation for more details on the duration format.
      */
     private String retentionShardDuration;
+
+    /**
+     * URI of the Influx server.
+     */
+    private String uri = "http://localhost:8086";
+
+    /**
+     * Whether to enable GZIP compression of metrics batches published to Influx.
+     */
+    private boolean compressed = true;
+
+    /**
+     * Whether to create the Influx database if it does not exist before attempting to
+     * publish metrics to it.
+     */
+    private boolean autoCreateDb = true;
 
     public String getDb() {
         return this.db;
@@ -124,6 +128,30 @@ public class InfluxProperties extends StepRegistryProperties {
         this.retentionPolicy = retentionPolicy;
     }
 
+    public String getRetentionDuration() {
+        return this.retentionDuration;
+    }
+
+    public void setRetentionDuration(String retentionDuration) {
+        this.retentionDuration = retentionDuration;
+    }
+
+    public Integer getRetentionReplicationFactor() {
+        return this.retentionReplicationFactor;
+    }
+
+    public void setRetentionReplicationFactor(Integer retentionReplicationFactor) {
+        this.retentionReplicationFactor = retentionReplicationFactor;
+    }
+
+    public String getRetentionShardDuration() {
+        return this.retentionShardDuration;
+    }
+
+    public void setRetentionShardDuration(String retentionShardDuration) {
+        this.retentionShardDuration = retentionShardDuration;
+    }
+
     public String getUri() {
         return this.uri;
     }
@@ -132,43 +160,20 @@ public class InfluxProperties extends StepRegistryProperties {
         this.uri = uri;
     }
 
-    public Boolean getCompressed() {
+    public boolean isCompressed() {
         return this.compressed;
     }
 
-    public void setCompressed(Boolean compressed) {
+    public void setCompressed(boolean compressed) {
         this.compressed = compressed;
     }
 
-    public Boolean getAutoCreateDb() {
-        return autoCreateDb;
+    public boolean isAutoCreateDb() {
+        return this.autoCreateDb;
     }
 
-    public void setAutoCreateDb(Boolean autoCreateDb) {
+    public void setAutoCreateDb(boolean autoCreateDb) {
         this.autoCreateDb = autoCreateDb;
     }
 
-    public String getRetentionDuration() {
-        return retentionDuration;
-    }
-
-    public void setRetentionDuration(String retentionDuration) {
-        this.retentionDuration = retentionDuration;
-    }
-
-    public Integer getRetentionReplicationFactor() {
-        return retentionReplicationFactor;
-    }
-
-    public void setRetentionReplicationFactor(Integer retentionReplicationFactor) {
-        this.retentionReplicationFactor = retentionReplicationFactor;
-    }
-
-    public String getRetentionShardDuration() {
-        return retentionShardDuration;
-    }
-
-    public void setRetentionShardDuration(String retentionShardDuration) {
-        this.retentionShardDuration = retentionShardDuration;
-    }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxPropertiesConfigAdapter.java
@@ -78,11 +78,11 @@ class InfluxPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<
 
     @Override
     public boolean compressed() {
-        return get(InfluxProperties::getCompressed, InfluxConfig.super::compressed);
+        return get(InfluxProperties::isCompressed, InfluxConfig.super::compressed);
     }
 
     @Override
     public boolean autoCreateDb() {
-        return get(InfluxProperties::getAutoCreateDb, InfluxConfig.super::autoCreateDb);
+        return get(InfluxProperties::isAutoCreateDb, InfluxConfig.super::autoCreateDb);
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxProperties.java
@@ -26,10 +26,6 @@ import java.time.Duration;
  */
 @ConfigurationProperties(prefix = "management.metrics.export.jmx")
 public class JmxProperties {
-    /**
-     * Whether exporting of metrics to JMX is enabled.
-     */
-    private Boolean enabled;
 
     /**
      * Metrics JMX domain name.
@@ -39,10 +35,10 @@ public class JmxProperties {
     /**
      * Step size (i.e. reporting frequency) to use.
      */
-    private Duration step;
+    private Duration step = Duration.ofMinutes(1);
 
     public String getDomain() {
-        return domain;
+        return this.domain;
     }
 
     public void setDomain(String domain) {
@@ -57,11 +53,4 @@ public class JmxProperties {
         this.step = step;
     }
 
-    public Boolean getEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosProperties.java
@@ -42,7 +42,7 @@ public class KairosProperties extends StepRegistryProperties {
     private String password;
 
     public String getUri() {
-        return uri;
+        return this.uri;
     }
 
     public void setUri(String uri) {
@@ -50,7 +50,7 @@ public class KairosProperties extends StepRegistryProperties {
     }
 
     public String getUserName() {
-        return userName;
+        return this.userName;
     }
 
     public void setUserName(String userName) {
@@ -58,10 +58,11 @@ public class KairosProperties extends StepRegistryProperties {
     }
 
     public String getPassword() {
-        return password;
+        return this.password;
     }
 
     public void setPassword(String password) {
         this.password = password;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
@@ -25,17 +25,24 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "management.metrics.export.newrelic")
 public class NewRelicProperties extends StepRegistryProperties {
+
     /**
-     * Your API key, found in your account settings at New Relic. This property is required.
+     * New Relic API key.
      */
     private String apiKey;
 
+    /**
+     * New Relic account ID.
+     */
     private String accountId;
 
-    private String uri;
+    /**
+     * URI to ship metrics to.
+     */
+    private String uri = "https://insights-collector.newrelic.com";
 
     public String getApiKey() {
-        return apiKey;
+        return this.apiKey;
     }
 
     public void setApiKey(String apiKey) {
@@ -43,7 +50,7 @@ public class NewRelicProperties extends StepRegistryProperties {
     }
 
     public String getAccountId() {
-        return accountId;
+        return this.accountId;
     }
 
     public void setAccountId(String accountId) {
@@ -51,10 +58,11 @@ public class NewRelicProperties extends StepRegistryProperties {
     }
 
     public String getUri() {
-        return uri;
+        return this.uri;
     }
 
     public void setUri(String uri) {
         this.uri = uri;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.spring.autoconfigure.export.prometheus;
 
-import io.micrometer.core.annotation.Incubating;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
@@ -31,40 +30,27 @@ import java.util.Map;
 public class PrometheusProperties {
 
     /**
-     * Enable publishing to Prometheus.
+     * Whether to enable publishing descriptions as part of the scrape payload to
+     * Prometheus. Turn this off to minimize the amount of data sent on each scrape.
      */
-    private Boolean enabled;
+    private boolean descriptions = true;
 
     /**
-     * Enable publishing descriptions as part of the scrape payload to Prometheus. Turn
-     * this off to minimize the amount of data sent on each scrape.
+     * Configuration options for using Prometheus Pushgateway, allowing metrics to be
+     * pushed when they cannot be scraped.
      */
-    private Boolean descriptions;
+    private PushgatewayProperties pushgateway = new PushgatewayProperties();
 
     /**
      * Step size (i.e. reporting frequency) to use.
      */
     private Duration step = Duration.ofMinutes(1);
 
-    /**
-     * Configuration options for using Prometheus Pushgateway, allowing metrics to be pushed
-     * when they cannot be scraped.
-     */
-    private PushgatewayProperties pushgateway = new PushgatewayProperties();
-
-    public Boolean getEnabled() {
-        return this.enabled;
-    }
-
-    public void setEnabled(Boolean enabled) {
-        this.enabled = enabled;
-    }
-
-    public Boolean getDescriptions() {
+    public boolean isDescriptions() {
         return this.descriptions;
     }
 
-    public void setDescriptions(Boolean descriptions) {
+    public void setDescriptions(boolean descriptions) {
         this.descriptions = descriptions;
     }
 
@@ -77,7 +63,7 @@ public class PrometheusProperties {
     }
 
     public PushgatewayProperties getPushgateway() {
-        return pushgateway;
+        return this.pushgateway;
     }
 
     public void setPushgateway(PushgatewayProperties pushgateway) {
@@ -87,27 +73,32 @@ public class PrometheusProperties {
     /**
      * Configuration options for push-based interaction with Prometheus.
      */
-    @Incubating(since = "1.0.0")
     public static class PushgatewayProperties {
+
         /**
          * Enable publishing via a Prometheus Pushgateway.
          */
         private Boolean enabled = false;
 
         /**
-         * Required host:port or ip:port of the Pushgateway.
+         * Base URL for the Pushgateway.
          */
         private String baseUrl = "localhost:9091";
 
         /**
-         * Required identifier for this application instance.
+         * Frequency with which to push metrics.
+         */
+        private Duration pushRate = Duration.ofMinutes(1);
+
+        /**
+         * Job identifier for this application instance.
          */
         private String job;
 
         /**
-         * Frequency with which to push metrics to Pushgateway.
+         * Grouping key for the pushed metrics.
          */
-        private Duration pushRate = Duration.ofMinutes(1);
+        private Map<String, String> groupingKeys = new HashMap<>();
 
         /**
          * Push metrics right before shut-down. Mostly useful for batch jobs.
@@ -115,17 +106,13 @@ public class PrometheusProperties {
         private boolean pushOnShutdown = true;
 
         /**
-         * Delete metrics from Pushgateway when application is shut-down
+         * Delete metrics from Pushgateway when application is shut-down.
          */
         private boolean deleteOnShutdown = true;
 
-        /**
-         * Used to group metrics in pushgateway. A common example is setting
-         */
-        private Map<String, String> groupingKeys = new HashMap<>();
 
         public Boolean getEnabled() {
-            return enabled;
+            return this.enabled;
         }
 
         public void setEnabled(Boolean enabled) {
@@ -133,33 +120,41 @@ public class PrometheusProperties {
         }
 
         public String getBaseUrl() {
-            return baseUrl;
+            return this.baseUrl;
         }
 
         public void setBaseUrl(String baseUrl) {
             this.baseUrl = baseUrl;
         }
 
+        public Duration getPushRate() {
+            return this.pushRate;
+        }
+
+        public void setPushRate(Duration pushRate) {
+            this.pushRate = pushRate;
+        }
+
         public String getJob() {
-            return job;
+            return this.job;
         }
 
         public void setJob(String job) {
             this.job = job;
         }
 
-        public Duration getPushRate() {
-            return pushRate;
+        public Map<String, String> getGroupingKeys() {
+            return this.groupingKeys;
         }
 
-        public void setPushRate(Duration pushRate) {
-            this.pushRate = pushRate;
+        public void setGroupingKeys(Map<String, String> groupingKeys) {
+            this.groupingKeys = groupingKeys;
         }
-        
+
         public boolean isPushOnShutdown() {
             return pushOnShutdown;
         }
-        
+
         public void setPushOnShutdown(boolean pushOnShutdown) {
             this.pushOnShutdown = pushOnShutdown;
         }
@@ -172,12 +167,6 @@ public class PrometheusProperties {
             this.deleteOnShutdown = deleteOnShutdown;
         }
 
-        public Map<String, String> getGroupingKeys() {
-            return groupingKeys;
-        }
-
-        public void setGroupingKeys(Map<String, String> groupingKeys) {
-            this.groupingKeys = groupingKeys;
-        }
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusPropertiesConfigAdapter.java
@@ -39,7 +39,7 @@ class PrometheusPropertiesConfigAdapter extends PropertiesConfigAdapter<Promethe
 
     @Override
     public boolean descriptions() {
-        return get(PrometheusProperties::getDescriptions,
+        return get(PrometheusProperties::isDescriptions,
             PrometheusConfig.super::descriptions);
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxProperties.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.spring.autoconfigure.export.signalfx;
 
+import java.time.Duration;
+
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -25,24 +27,40 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "management.metrics.export.signalfx")
 public class SignalFxProperties extends StepRegistryProperties {
+
     /**
-     * Your access token, found in your account settings at SignalFX. This property is required.
+     * Step size (i.e. reporting frequency) to use.
+     */
+    private Duration step = Duration.ofSeconds(10);
+
+    /**
+     * SignalFX access token.
      */
     private String accessToken;
 
     /**
-     * Uniquely identifies the app instance that is publishing metrics to SignalFx. Defaults to the local host name.
+     * URI to ship metrics to.
+     */
+    private String uri = "https://ingest.signalfx.com";
+
+    /**
+     * Uniquely identifies the app instance that is publishing metrics to SignalFx.
+     * Defaults to the local host name.
      */
     private String source;
 
-    /**
-     * The URI to ship metrics to. If you need to publish metrics to an internal proxy en route to
-     * SignalFx, you can define the location of the proxy with this.
-     */
-    private String uri;
+    @Override
+    public Duration getStep() {
+        return this.step;
+    }
+
+    @Override
+    public void setStep(Duration step) {
+        this.step = step;
+    }
 
     public String getAccessToken() {
-        return accessToken;
+        return this.accessToken;
     }
 
     public void setAccessToken(String accessToken) {
@@ -50,7 +68,7 @@ public class SignalFxProperties extends StepRegistryProperties {
     }
 
     public String getUri() {
-        return uri;
+        return this.uri;
     }
 
     public void setUri(String uri) {
@@ -58,10 +76,11 @@ public class SignalFxProperties extends StepRegistryProperties {
     }
 
     public String getSource() {
-        return source;
+        return this.source;
     }
 
     public void setSource(String source) {
         this.source = source;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimpleProperties.java
@@ -31,28 +31,14 @@ import java.time.Duration;
 public class SimpleProperties {
 
     /**
-     * Enable in-memory metrics that aren't published anywhere (allows you to see
-     * what metrics are collected in the metrics actuator endpoint).
-     */
-    private boolean enabled;
-
-    /**
      * Step size (i.e. reporting frequency) to use.
      */
-    private Duration step = Duration.ofSeconds(10);
+    private Duration step = Duration.ofMinutes(1);
 
     /**
      * Counting mode.
      */
     private CountingMode mode = CountingMode.CUMULATIVE;
-
-    public boolean getEnabled() {
-        return this.enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
 
     public Duration getStep() {
         return this.step;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
@@ -30,9 +30,9 @@ import java.time.Duration;
 public class StatsdProperties {
 
     /**
-     * Export metrics to StatsD.
+     * Whether exporting of metrics to StatsD is enabled.
      */
-    private Boolean enabled;
+    private boolean enabled = true;
 
     /**
      * StatsD line protocol to use.
@@ -55,27 +55,22 @@ public class StatsdProperties {
     private Integer maxPacketLength = 1400;
 
     /**
-     * How often gauges will be polled. When a gauge is polled, its value is
-     * recalculated and if the value has changed, it is sent to the StatsD server.
+     * How often gauges will be polled. When a gauge is polled, its value is recalculated
+     * and if the value has changed (or publishUnchangedMeters is true), it is sent to the
+     * StatsD server.
      */
     private Duration pollingFrequency = Duration.ofSeconds(10);
 
     /**
-     * Maximum size of the queue of items waiting to be sent to the StatsD server.
+     * Whether to send unchanged meters to the StatsD server.
      */
-    @Deprecated
-    private Integer queueSize = Integer.MAX_VALUE;
+    private boolean publishUnchangedMeters = true;
 
-    /**
-     * Enables or disables sending of unchanged meters to StatsD server
-     */
-    private Boolean publishUnchangedMeters = true;
-
-    public Boolean getEnabled() {
+    public boolean isEnabled() {
         return this.enabled;
     }
 
-    public void setEnabled(Boolean enabled) {
+    public void setEnabled(boolean enabled) {
         this.enabled = enabled;
     }
 
@@ -119,21 +114,11 @@ public class StatsdProperties {
         this.pollingFrequency = pollingFrequency;
     }
 
-    @Deprecated
-    public Integer getQueueSize() {
-        return this.queueSize;
+    public boolean isPublishUnchangedMeters() {
+        return this.publishUnchangedMeters;
     }
 
-    @Deprecated
-    public void setQueueSize(Integer queueSize) {
-        this.queueSize = queueSize;
-    }
-
-    public Boolean getPublishUnchangedMeters() {
-        return publishUnchangedMeters;
-    }
-
-    public void setPublishUnchangedMeters(Boolean publishUnchangedMeters) {
+    public void setPublishUnchangedMeters(boolean publishUnchangedMeters) {
         this.publishUnchangedMeters = publishUnchangedMeters;
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -44,7 +44,7 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
 
     @Override
     public boolean enabled() {
-        return get(StatsdProperties::getEnabled, StatsdConfig.super::enabled);
+        return get(StatsdProperties::isEnabled, StatsdConfig.super::enabled);
     }
 
     @Override
@@ -69,15 +69,9 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
             StatsdConfig.super::pollingFrequency);
     }
 
-    @Deprecated
-    @Override
-    public int queueSize() {
-        return get(StatsdProperties::getQueueSize, StatsdConfig.super::queueSize);
-    }
-
     @Override
     public boolean publishUnchangedMeters() {
-        return get(StatsdProperties::getPublishUnchangedMeters, StatsdConfig.super::publishUnchangedMeters);
+        return get(StatsdProperties::isPublishUnchangedMeters, StatsdConfig.super::publishUnchangedMeters);
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
@@ -15,6 +15,9 @@
  */
 package io.micrometer.spring.autoconfigure.export.wavefront;
 
+import java.net.URI;
+import java.time.Duration;
+
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -25,43 +28,55 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("management.metrics.export.wavefront")
 public class WavefrontProperties extends StepRegistryProperties {
-    /**
-     * The URI to publish metrics to. The URI could represent a Wavefront sidecar or the
-     * Wavefront API host. This host could also represent an internal proxy set up in your environment
-     * that forwards metrics data to the Wavefront API host.
-     *
-     * If publishing metrics to a Wavefront proxy (as described in https://docs.wavefront.com/proxies_installing.html),
-     * the host must be in the proxy://HOST:PORT format.
-     */
-    private String uri;
 
     /**
-     * Uniquely identifies the app instance that is publishing metrics to Wavefront. Defaults to the local host name.
+     * Step size (i.e. reporting frequency) to use.
+     */
+    private Duration step = Duration.ofSeconds(10);
+
+    /**
+     * URI to ship metrics to.
+     */
+    private URI uri = URI.create("https://longboard.wavefront.com");
+
+    /**
+     * Unique identifier for the app instance that is the source of metrics being
+     * published to Wavefront. Defaults to the local host name.
      */
     private String source;
 
     /**
-     * Required when publishing directly to the Wavefront API host, otherwise does nothing.
+     * API token used when publishing metrics directly to the Wavefront API host.
      */
     private String apiToken;
 
     /**
-     * Wavefront metrics are grouped hierarchically by name in the UI. Setting a global prefix separates
-     * metrics originating from this app's whitebox instrumentation from those originating from other Wavefront
-     * integrations.
+     * Global prefix to separate metrics originating from this app's white box
+     * instrumentation from those originating from other Wavefront integrations when
+     * viewed in the Wavefront UI.
      */
     private String globalPrefix;
 
-    public String getUri() {
-        return uri;
+    public URI getUri() {
+        return this.uri;
     }
 
-    public void setUri(String uri) {
+    public void setUri(URI uri) {
         this.uri = uri;
     }
 
+    @Override
+    public Duration getStep() {
+        return this.step;
+    }
+
+    @Override
+    public void setStep(Duration step) {
+        this.step = step;
+    }
+
     public String getSource() {
-        return source;
+        return this.source;
     }
 
     public void setSource(String source) {
@@ -69,7 +84,7 @@ public class WavefrontProperties extends StepRegistryProperties {
     }
 
     public String getApiToken() {
-        return apiToken;
+        return this.apiToken;
     }
 
     public void setApiToken(String apiToken) {
@@ -77,10 +92,11 @@ public class WavefrontProperties extends StepRegistryProperties {
     }
 
     public String getGlobalPrefix() {
-        return globalPrefix;
+        return this.globalPrefix;
     }
 
     public void setGlobalPrefix(String globalPrefix) {
         this.globalPrefix = globalPrefix;
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -36,7 +36,7 @@ public class WavefrontPropertiesConfigAdapter extends StepRegistryPropertiesConf
 
     @Override
     public String uri() {
-        return get(WavefrontProperties::getUri, WavefrontConfig.DEFAULT_DIRECT::uri);
+        return get(this::getUriAsString, WavefrontConfig.DEFAULT_DIRECT::uri);
     }
 
     @Override
@@ -53,4 +53,9 @@ public class WavefrontPropertiesConfigAdapter extends StepRegistryPropertiesConf
     public String globalPrefix() {
         return get(WavefrontProperties::getGlobalPrefix, WavefrontConfig.super::globalPrefix);
     }
+
+    private String getUriAsString(WavefrontProperties properties) {
+        return (properties.getUri() != null) ? properties.getUri().toString() : null;
+    }
+
 }


### PR DESCRIPTION
This PR aligns configuration properties for meter registries with Spring Boot 2.x.

Closes gh-932