### PR TITLE
Add a utility for JSON String builder

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/test/java/io/micrometer/appoptics/AppOpticsMeterRegistryTest.java
+++ b/implementations/micrometer-registry-appoptics/src/test/java/io/micrometer/appoptics/AppOpticsMeterRegistryTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.appoptics;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AppOpticsMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class AppOpticsMeterRegistryTest {
+
+    private final AppOpticsMeterRegistry registry = new AppOpticsMeterRegistry(key -> null, Clock.SYSTEM);
+
+    @Test
+    void write() {
+        String name = "name";
+        Tags tags = Tags.of("key1", "value1", "key2", "value2");
+        String baseUnit = "baseUnit";
+        String description = "description";
+        Meter.Type meterType = Meter.Type.COUNTER;
+        Meter.Id id = new Meter.Id(name, tags, baseUnit, description, meterType);
+
+        String json = registry.write(id, "counter", "statistic1", 1, "statistic2", 2);
+        assertThat(json).isEqualTo("{\"name\":\"name\",\"period\":60,\"attributes\":{\"aggregate\":false},\"statistic1\":1,\"statistic2\":2,\"tags\":{\"_type\":\"counter\",\"key1\":\"value1\",\"key2\":\"value2\"}}");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/JsonUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/JsonUtils.java
@@ -15,7 +15,15 @@
  */
 package io.micrometer.core.instrument.util;
 
-public class JsonUtils {
+import java.util.Map;
+
+/**
+ * Utilities for JSON.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
+public final class JsonUtils {
     /**
      * Based on https://stackoverflow.com/a/49564514/510017
      */
@@ -77,4 +85,58 @@ public class JsonUtils {
             stringBuilder.append("  ");
         }
     }
+
+    /**
+     * Convert an object to JSON.
+     *
+     * This method supports only the following types:
+     *
+     * <ul>
+     *   <li><code>Map</code></li>
+     *   <li><code>Boolean</code></li>
+     *   <li><code>Number</code></li>
+     *   <li><code>String</code></li>
+     * </ul>
+     *
+     * @param o object to convert JSON
+     * @return JSON
+     * @throws UnsupportedOperationException if the type of the object is an unlisted type.
+     */
+    public static String toJson(Object o) {
+        return toJson(o, new StringBuilder()).toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static StringBuilder toJson(Object o, StringBuilder collector) {
+        if (o == null) {
+            return collector.append("null");
+        }
+        if (o instanceof Boolean || o instanceof Number) {
+            return collector.append(o);
+        }
+        if (o instanceof Number) {
+            return collector.append(DoubleFormat.decimal(((Number) o).doubleValue()));
+        }
+        if (o instanceof String) {
+            return collector.append('"').append(o).append('"');
+        }
+        if (o instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) o;
+            collector.append('{');
+            if (!map.isEmpty()) {
+                map.forEach((key, value) -> {
+                    collector.append('"').append(key).append("\":");
+                    toJson(value, collector);
+                    collector.append(',');
+                });
+                collector.deleteCharAt(collector.length() - 1);
+            }
+            return collector.append('}');
+        }
+        throw new UnsupportedOperationException("Unsupported class: " + o.getClass());
+    }
+
+    private JsonUtils() {
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/JsonUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/JsonUtilsTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link JsonUtils}.
+ *
+ * @author Johnny Lim
+ */
+class JsonUtilsTest {
+
+    @Test
+    void toJsonWithUnsupportedClass() {
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+                .isThrownBy(() -> JsonUtils.toJson(new Person("Johnny", "Lim")))
+                .withMessageStartingWith("Unsupported class: ");
+    }
+
+    @Test
+    void toJsonWithEmptyMap() {
+        assertThat(JsonUtils.toJson(Collections.emptyMap())).isEqualTo("{}");
+    }
+
+    @Test
+    void toJsonWithMap() {
+        assertThat( JsonUtils.toJson(createTestMap()))
+                .isEqualTo("{\"null\":null,\"boolean\":true,\"integer\":1,\"long\":1,\"float\":3.5,\"double\":4.5,\"string\":\"Hello, world!\"}");
+    }
+
+    private Map<String, Object> createTestMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("null", null);
+        map.put("boolean", Boolean.TRUE);
+        map.put("integer", Integer.valueOf(1));
+        map.put("long", Long.valueOf(1L));
+        map.put("float", Float.valueOf(3.5f));
+        map.put("double", Double.valueOf(4.5d));
+        map.put("string", "Hello, world!");
+        return map;
+    }
+
+    private static class Person {
+
+        private final String firstName;
+        private final String lastName;
+
+        Person(String firstName, String lastName) {
+            this.firstName = firstName;
+            this.lastName = lastName;
+        }
+
+        public String getFirstName() {
+            return this.firstName;
+        }
+
+        public String getLastName() {
+            return this.lastName;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR adds a utility for JSON `String` builder and also applies it to `AppOpticsMeterRegistry` as an example.

I was writing a generalized version for this but it seems to make things complicated more than necessary, so I just focused only on `AppOpticsMeterRegistry` for brevity by leaving out other primitive types, escaping, and formatting. We can augment this when necessary.