### PR TITLE
Align PropertiesMeterFilter's package with Spring Boot 2.x support

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.hystrix.HystrixMetricsBinder;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.micrometer.spring.PropertiesMeterFilter;
 import io.micrometer.spring.integration.SpringIntegrationMetrics;
 import io.micrometer.spring.scheduling.ScheduledMethodMetrics;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring;
+package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -22,8 +22,6 @@ import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.Nullable;
-import io.micrometer.spring.autoconfigure.MetricsProperties;
-import io.micrometer.spring.autoconfigure.ServiceLevelAgreementBoundary;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -30,7 +30,6 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.spring.PropertiesMeterFilter;
 import io.micrometer.spring.scheduling.ScheduledMethodMetrics;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.filter;
+package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
-import io.micrometer.spring.autoconfigure.MeterRegistryCustomizer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.filter;
+package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
@@ -22,9 +22,6 @@ import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.spring.PropertiesMeterFilter;
-import io.micrometer.spring.autoconfigure.MetricsProperties;
-import io.micrometer.spring.autoconfigure.ServiceLevelAgreementBoundary;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;


### PR DESCRIPTION
This PR moves `PropertiesMeterFilter` to align its package with Spring Boot 2.x support.