### PR TITLE
Support distribution's min/max expected values via properties

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterValue.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterValue.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
+
+/**
+ * A meter value that is used when configuring micrometer. Can be a String representation
+ * of either a {@link Long} (applicable to timers and distribution summaries) or a
+ * {@link Duration} (applicable to only timers).
+ *
+ * @author Phillip Webb
+ */
+final class MeterValue {
+
+    private static final StringToDurationConverter durationConverter = new StringToDurationConverter();
+
+    private final Object value;
+
+    MeterValue(long value) {
+        this.value = value;
+    }
+
+    MeterValue(Duration value) {
+        this.value = value;
+    }
+
+    /**
+     * Return the underlying value of the SLA in form suitable to apply to the given meter
+     * type.
+     * @param meterType the meter type
+     * @return the value or {@code null} if the value cannot be applied
+     */
+    public Long getValue(Meter.Type meterType) {
+        if (meterType == Meter.Type.DISTRIBUTION_SUMMARY) {
+            return getDistributionSummaryValue();
+        }
+        if (meterType == Meter.Type.TIMER) {
+            return getTimerValue();
+        }
+        return null;
+    }
+
+    private Long getDistributionSummaryValue() {
+        if (this.value instanceof Long) {
+            return (Long) this.value;
+        }
+        return null;
+    }
+
+    private Long getTimerValue() {
+        if (this.value instanceof Long) {
+            return TimeUnit.MILLISECONDS.toNanos((long) this.value);
+        }
+        if (this.value instanceof Duration) {
+            return ((Duration) this.value).toNanos();
+        }
+        return null;
+    }
+
+    /**
+     * Return a new {@link MeterValue} instance for the given String value. The value may
+     * contain a simple number, or a {@link Duration duration string}.
+     * @param value the source value
+     * @return a {@link MeterValue} instance
+     */
+    public static MeterValue valueOf(String value) {
+        if (isNumber(value)) {
+            return new MeterValue(Long.parseLong(value));
+        }
+        return new MeterValue(durationConverter.convert(value));
+    }
+
+    /**
+     * Return a new {@link MeterValue} instance for the given long value.
+     * @param value the source value
+     * @return a {@link MeterValue} instance
+     */
+    public static MeterValue valueOf(long value) {
+        return new MeterValue(value);
+    }
+
+    private static boolean isNumber(String value) {
+        return value.chars().allMatch(Character::isDigit);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
@@ -25,6 +25,7 @@ import java.util.Map;
  * {@link ConfigurationProperties} for configuring Micrometer-based metrics.
  *
  * @author Jon Schneider
+ * @author Alexander Abramov
  */
 @ConfigurationProperties("management.metrics")
 public class MetricsProperties {
@@ -191,6 +192,20 @@ public class MetricsProperties {
          */
         private final Map<String, ServiceLevelAgreementBoundary[]> sla = new LinkedHashMap<>();
 
+        /**
+         * Minimum value that meter IDs starting-with the specified name are expected to
+         * observe. The longest match wins. Values can be specified as a long or as a
+         * Duration value (for timer meters, defaulting to ms if no unit specified).
+         */
+        private final Map<String, String> minimumExpectedValue = new LinkedHashMap<>();
+
+        /**
+         * Maximum value that meter IDs starting-with the specified name are expected to
+         * observe. The longest match wins. Values can be specified as a long or as a
+         * Duration value (for timer meters, defaulting to ms if no unit specified).
+         */
+        private final Map<String, String> maximumExpectedValue = new LinkedHashMap<>();
+
         public Map<String, Boolean> getPercentilesHistogram() {
             return this.percentilesHistogram;
         }
@@ -201,6 +216,14 @@ public class MetricsProperties {
 
         public Map<String, ServiceLevelAgreementBoundary[]> getSla() {
             return this.sla;
+        }
+
+        public Map<String, String> getMinimumExpectedValue() {
+            return this.minimumExpectedValue;
+        }
+
+        public Map<String, String> getMaximumExpectedValue() {
+            return this.maximumExpectedValue;
         }
 
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
  * @author Jon Schneider
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Alexander Abramov
  */
 @NonNullApi
 public class PropertiesMeterFilter implements MeterFilter {
@@ -80,6 +81,10 @@ public class PropertiesMeterFilter implements MeterFilter {
                 .percentilesHistogram(lookup(distribution.getPercentilesHistogram(), id, null))
                 .percentiles(lookup(distribution.getPercentiles(), id, null))
                 .sla(convertSla(id.getType(), lookup(distribution.getSla(), id, null)))
+                .minimumExpectedValue(convertMeterValue(id.getType(),
+                        lookup(distribution.getMinimumExpectedValue(), id, null)))
+                .maximumExpectedValue(convertMeterValue(id.getType(),
+                        lookup(distribution.getMaximumExpectedValue(), id, null)))
                 .build()
                 .merge(config);
     }
@@ -93,6 +98,10 @@ public class PropertiesMeterFilter implements MeterFilter {
                 .map((candidate) -> candidate.getValue(meterType))
                 .filter(Objects::nonNull).mapToLong(Long::longValue).toArray();
         return converted.length == 0 ? null : converted;
+    }
+
+    private Long convertMeterValue(Meter.Type meterType, String value) {
+        return (value != null) ? MeterValue.valueOf(value).getValue(meterType) : null;
     }
 
     private <T> T lookup(Map<String, T> values, Meter.Id id, @Nullable T defaultValue) {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundary.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundary.java
@@ -16,94 +16,52 @@
 package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Meter.Type;
-import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 /**
- * A service level agreement boundary. Can be specified as either a {@link Long}
- * (applicable to timers and distribution summaries) or a {@link Duration}
- * (applicable to only timers).
+ * A service level agreement boundary for use when configuring Micrometer. Can be
+ * specified as either a {@link Long} (applicable to timers and distribution summaries) or
+ * a {@link Duration} (applicable to only timers).
  *
  * @author Phillip Webb
  */
 public final class ServiceLevelAgreementBoundary {
-    private static final StringToDurationConverter durationConverter = new StringToDurationConverter();
-    private final Object value;
 
-    ServiceLevelAgreementBoundary(long value) {
-        this.value = value;
-    }
+    private final MeterValue value;
 
-    ServiceLevelAgreementBoundary(Duration value) {
+    ServiceLevelAgreementBoundary(MeterValue value) {
         this.value = value;
     }
 
     /**
      * Return the underlying value of the SLA in form suitable to apply to the given meter
      * type.
-     *
      * @param meterType the meter type
      * @return the value or {@code null} if the value cannot be applied
      */
     public Long getValue(Meter.Type meterType) {
-        if (meterType == Type.DISTRIBUTION_SUMMARY) {
-            return getDistributionSummaryValue();
-        }
-        if (meterType == Type.TIMER) {
-            return getTimerValue();
-        }
-        return null;
-    }
-
-    private Long getDistributionSummaryValue() {
-        if (this.value instanceof Long) {
-            return (Long) this.value;
-        }
-        return null;
-    }
-
-    private Long getTimerValue() {
-        if (this.value instanceof Long) {
-            return TimeUnit.MILLISECONDS.toNanos((long) this.value);
-        }
-        if (this.value instanceof Duration) {
-            return ((Duration) this.value).toNanos();
-        }
-        return null;
-    }
-
-    public static ServiceLevelAgreementBoundary valueOf(String value) {
-        if (isNumber(value)) {
-            return new ServiceLevelAgreementBoundary(Long.parseLong(value));
-        }
-        return new ServiceLevelAgreementBoundary(
-                durationConverter.convert(value));
+        return this.value.getValue(meterType);
     }
 
     /**
      * Return a new {@link ServiceLevelAgreementBoundary} instance for the given long
      * value.
-     *
      * @param value the source value
      * @return a {@link ServiceLevelAgreementBoundary} instance
      */
     public static ServiceLevelAgreementBoundary valueOf(long value) {
-        return new ServiceLevelAgreementBoundary(value);
+        return new ServiceLevelAgreementBoundary(MeterValue.valueOf(value));
     }
 
     /**
-     * Return a new {@link ServiceLevelAgreementBoundary} instance for the given String
-     * value. The value may contain a simple number, or a {@link StringToDurationConverter}
-     * duration formatted value.
-     *
+     * Return a new {@link ServiceLevelAgreementBoundary} instance for the given long
+     * value.
      * @param value the source value
      * @return a {@link ServiceLevelAgreementBoundary} instance
      */
-    private static boolean isNumber(String value) {
-        return value.chars().allMatch(Character::isDigit);
+    public static ServiceLevelAgreementBoundary valueOf(String value) {
+        return new ServiceLevelAgreementBoundary(MeterValue.valueOf(value));
     }
 
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterValueTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterValueTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import io.micrometer.core.instrument.Meter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MeterValue}.
+ *
+ * @author Phillip Webb
+ */
+class MeterValueTest {
+
+    @Test
+    void getValueForDistributionSummaryWhenFromLongShouldReturnLongValue() {
+        MeterValue meterValue = MeterValue.valueOf(123L);
+        assertThat(meterValue.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isEqualTo(123);
+    }
+
+    @Test
+    void getValueForDistributionSummaryWhenFromNumberStringShouldReturnLongValue() {
+        MeterValue meterValue = MeterValue.valueOf("123");
+        assertThat(meterValue.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isEqualTo(123);
+    }
+
+    @Test
+    void getValueForDistributionSummaryWhenFromDurationStringShouldReturnNull() {
+        MeterValue meterValue = MeterValue.valueOf("123ms");
+        assertThat(meterValue.getValue(Meter.Type.DISTRIBUTION_SUMMARY)).isNull();
+    }
+
+    @Test
+    void getValueForTimerWhenFromLongShouldReturnMsToNanosValue() {
+        MeterValue meterValue = MeterValue.valueOf(123L);
+        assertThat(meterValue.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+    @Test
+    void getValueForTimerWhenFromNumberStringShouldMsToNanosValue() {
+        MeterValue meterValue = MeterValue.valueOf("123");
+        assertThat(meterValue.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+    @Test
+    void getValueForTimerWhenFromDurationStringShouldReturnDurationNanos() {
+        MeterValue meterValue = MeterValue.valueOf("123ms");
+        assertThat(meterValue.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+    @Test
+    void getValueForOthersShouldReturnNull() {
+        MeterValue meterValue = MeterValue.valueOf("123");
+        assertThat(meterValue.getValue(Meter.Type.COUNTER)).isNull();
+        assertThat(meterValue.getValue(Meter.Type.GAUGE)).isNull();
+        assertThat(meterValue.getValue(Meter.Type.LONG_TASK_TIMER)).isNull();
+        assertThat(meterValue.getValue(Meter.Type.OTHER)).isNull();
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundaryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/ServiceLevelAgreementBoundaryTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import io.micrometer.core.instrument.Meter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ServiceLevelAgreementBoundary}.
+ *
+ * @author Phillip Webb
+ */
+class ServiceLevelAgreementBoundaryTest {
+
+    @Test
+    void getValueForTimerWhenFromLongShouldReturnMsToNanosValue() {
+        ServiceLevelAgreementBoundary sla = ServiceLevelAgreementBoundary.valueOf(123L);
+        assertThat(sla.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+    @Test
+    void getValueForTimerWhenFromNumberStringShouldMsToNanosValue() {
+        ServiceLevelAgreementBoundary sla = ServiceLevelAgreementBoundary.valueOf("123");
+        assertThat(sla.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+    @Test
+    void getValueForTimerWhenFromDurationStringShouldReturnDurationNanos() {
+        ServiceLevelAgreementBoundary sla = ServiceLevelAgreementBoundary.valueOf("123ms");
+        assertThat(sla.getValue(Meter.Type.TIMER)).isEqualTo(123000000);
+    }
+
+}


### PR DESCRIPTION
This PR adds support for distribution's min/max expected values via properties by porting from Spring Boot 2.x support.

See https://github.com/spring-projects/spring-boot/pull/14139