### PR TITLE
Change fields' scope to private in AppOpticsProperties

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
@@ -29,17 +29,17 @@ public class AppOpticsProperties extends StepRegistryProperties {
     /**
      * AppOptics API token.
      */
-    public String apiToken;
+    private String apiToken;
 
     /**
      * The tag that will be mapped to "@host" when shipping metrics to AppOptics.
      */
-    public String hostTag = "instance";
+    private String hostTag = "instance";
 
     /**
      * The URI to ship metrics to.
      */
-    public String uri;
+    private String uri;
 
     public String getApiToken() { return apiToken; }
 


### PR DESCRIPTION
This PR changes fields' scope to `private` in `AppOpticsProperties` as it seems exposed unintentionally.