### PR TITLE
Drop support for "all" from management.metrics.distribution.sla

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsProperties.java
@@ -169,10 +169,11 @@ public class MetricsProperties {
     public static class Distribution {
 
         /**
-         * Whether meter IDs starting-with the specified name should be publish percentile
-         * histograms. Monitoring systems that support aggregable percentile calculation
-         * based on a histogram be set to true. For other systems, this has no effect. The
-         * longest match wins, the key `all` can also be used to configure all meters.
+         * Whether meter IDs starting with the specified name should publish percentile
+         * histograms. For monitoring systems that support aggregable percentile
+         * calculation based on a histogram, this can be set to true. For other systems,
+         * this has no effect. The longest match wins, the key `all` can also be used to
+         * configure all meters.
          */
         private final Map<String, Boolean> percentilesHistogram = new LinkedHashMap<>();
 
@@ -185,10 +186,9 @@ public class MetricsProperties {
 
         /**
          * Specific SLA boundaries for meter IDs starting-with the specified name. The
-         * longest match wins, the key `all` can also be used to configure all meters.
-         * Counters will be published for each specified boundary. Values can be
-         * specified as a long or as a Duration value (for timer meters, defaulting to ms
-         * if no unit specified).
+         * longest match wins. Counters will be published for each specified boundary.
+         * Values can be specified as a long or as a Duration value (for timer meters,
+         * defaulting to ms if no unit specified).
          */
         private final Map<String, ServiceLevelAgreementBoundary[]> sla = new LinkedHashMap<>();
 
@@ -227,4 +227,5 @@ public class MetricsProperties {
         }
 
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilter.java
@@ -16,19 +16,20 @@
 package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.lang.NonNullApi;
-import io.micrometer.core.lang.Nullable;
+import io.micrometer.spring.autoconfigure.MetricsProperties.Distribution;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -37,9 +38,9 @@ import java.util.stream.Collectors;
  * @author Jon Schneider
  * @author Phillip Webb
  * @author Stephane Nicoll
+ * @author Artsiom Yudovin
  * @author Alexander Abramov
  */
-@NonNullApi
 public class PropertiesMeterFilter implements MeterFilter {
 
     private final MetricsProperties properties;
@@ -57,58 +58,69 @@ public class PropertiesMeterFilter implements MeterFilter {
             return new MeterFilter() {
             };
         }
-        List<Tag> commonTags = tags.entrySet().stream()
+        Tags commonTags = Tags.of(tags.entrySet().stream()
                 .map((entry) -> Tag.of(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
         return MeterFilter.commonTags(commonTags);
     }
 
     @Override
     public MeterFilterReply accept(Meter.Id id) {
-        boolean enabled = lookup(this.properties.getEnable(), id, true);
-        return (enabled ? MeterFilterReply.NEUTRAL : MeterFilterReply.DENY);
+        boolean enabled = lookupWithFallbackToAll(this.properties.getEnable(), id, true);
+        return enabled ? MeterFilterReply.NEUTRAL : MeterFilterReply.DENY;
     }
 
     @Override
-    public Meter.Id map(Meter.Id id) {
+    public Id map(Id id) {
         return this.mapFilter.map(id);
     }
 
     @Override
-    public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
-        MetricsProperties.Distribution distribution = this.properties.getDistribution();
+    public DistributionStatisticConfig configure(Meter.Id id,
+            DistributionStatisticConfig config) {
+        Distribution distribution = this.properties.getDistribution();
         return DistributionStatisticConfig.builder()
-                .percentilesHistogram(lookup(distribution.getPercentilesHistogram(), id, null))
-                .percentiles(lookup(distribution.getPercentiles(), id, null))
+                .percentilesHistogram(
+                        lookupWithFallbackToAll(distribution.getPercentilesHistogram(), id, null))
+                .percentiles(
+                        lookupWithFallbackToAll(distribution.getPercentiles(), id, null))
                 .sla(convertSla(id.getType(), lookup(distribution.getSla(), id, null)))
                 .minimumExpectedValue(convertMeterValue(id.getType(),
                         lookup(distribution.getMinimumExpectedValue(), id, null)))
                 .maximumExpectedValue(convertMeterValue(id.getType(),
                         lookup(distribution.getMaximumExpectedValue(), id, null)))
-                .build()
-                .merge(config);
+                .build().merge(config);
     }
 
-    @Nullable
-    private long[] convertSla(Meter.Type meterType, @Nullable ServiceLevelAgreementBoundary[] sla) {
+    private long[] convertSla(Meter.Type meterType, ServiceLevelAgreementBoundary[] sla) {
         if (sla == null) {
             return null;
         }
         long[] converted = Arrays.stream(sla)
                 .map((candidate) -> candidate.getValue(meterType))
                 .filter(Objects::nonNull).mapToLong(Long::longValue).toArray();
-        return converted.length == 0 ? null : converted;
+        return (converted.length != 0) ? converted : null;
     }
 
     private Long convertMeterValue(Meter.Type meterType, String value) {
         return (value != null) ? MeterValue.valueOf(value).getValue(meterType) : null;
     }
 
-    private <T> T lookup(Map<String, T> values, Meter.Id id, @Nullable T defaultValue) {
+    private <T> T lookup(Map<String, T> values, Id id, T defaultValue) {
         if (values.isEmpty()) {
             return defaultValue;
         }
+        return doLookup(values, id, () -> defaultValue);
+    }
 
+    private <T> T lookupWithFallbackToAll(Map<String, T> values, Id id, T defaultValue) {
+        if (values.isEmpty()) {
+            return defaultValue;
+        }
+        return doLookup(values, id, () -> values.getOrDefault("all", defaultValue));
+    }
+
+    private <T> T doLookup(Map<String, T> values, Id id, Supplier<T> defaultValue) {
         String name = id.getName();
         while (StringUtils.hasLength(name)) {
             T result = values.get(name);
@@ -116,8 +128,10 @@ public class PropertiesMeterFilter implements MeterFilter {
                 return result;
             }
             int lastDot = name.lastIndexOf('.');
-            name = lastDot == -1 ? "" : name.substring(0, lastDot);
+            name = (lastDot != -1) ? name.substring(0, lastDot) : "";
         }
-        return values.getOrDefault("all", defaultValue);
+
+        return defaultValue.get();
     }
+
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
@@ -62,6 +62,13 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
+    public void acceptWhenHasNoMatchingEnabledPropertyShouldReturnNeutral() {
+        properties.getEnable().put("something.else", false);
+        assertThat(filter.accept(createSpringBootMeter()))
+            .isEqualTo(MeterFilterReply.NEUTRAL);
+    }
+
+    @Test
     public void acceptWhenHasEnableFalseShouldReturnDeny() {
         enable("spring.boot", false);
         assertThat(filter.accept(createSpringBootMeter()))
@@ -220,41 +227,6 @@ public class PropertiesMeterFilterTest {
         slas("spring.boot", "4", "5", "6");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getSlaBoundaries()).containsExactly(4000000, 5000000, 6000000);
-    }
-
-    @Test
-    public void configureWhenAllSlaSetShouldSetSlaToValue() {
-        slas("all", "1", "2", "3");
-        assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
-                .getSlaBoundaries()).containsExactly(1000000, 2000000, 3000000);
-    }
-
-    @Test
-    public void configureWhenSlaDurationShouldOnlyApplyToTimer() {
-        slas("all", "1ms", "2ms", "3ms");
-        Meter.Id timer = createSpringBootMeter(Meter.Type.TIMER);
-        Meter.Id summary = createSpringBootMeter(Meter.Type.DISTRIBUTION_SUMMARY);
-        Meter.Id counter = createSpringBootMeter(Meter.Type.COUNTER);
-        assertThat(filter.configure(timer, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .containsExactly(1000000, 2000000, 3000000);
-        assertThat(filter.configure(summary, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .isNull();
-        assertThat(filter.configure(counter, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .isNull();
-    }
-
-    @Test
-    public void configureWhenSlaLongShouldOnlyApplyToTimerAndDistributionSummary() {
-        slas("all", "1", "2", "3");
-        Meter.Id timer = createSpringBootMeter(Meter.Type.TIMER);
-        Meter.Id summary = createSpringBootMeter(Meter.Type.DISTRIBUTION_SUMMARY);
-        Meter.Id counter = createSpringBootMeter(Meter.Type.COUNTER);
-        assertThat(filter.configure(timer, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .containsExactly(1000000, 2000000, 3000000);
-        assertThat(filter.configure(summary, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .containsExactly(1, 2, 3);
-        assertThat(filter.configure(counter, DistributionStatisticConfig.DEFAULT).getSlaBoundaries())
-                .isNull();
     }
 
     @Test


### PR DESCRIPTION
This PR drops support for "all" from `management.metrics.distribution.sla` by porting from https://github.com/spring-projects/spring-boot/issues/14678.

This PR also adds a test from https://github.com/spring-projects/spring-boot/issues/14689.