### PR TITLE
Making sure TimedAspect does not disrupt the application flow when there is an exception recording a metric

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -78,14 +78,18 @@ public class TimedAspect {
             exceptionClass = ex.getClass().getSimpleName();
             throw ex;
         } finally {
-            sample.stop(Timer.builder(metricName)
-                    .description(timed.description().isEmpty() ? null : timed.description())
-                    .tags(timed.extraTags())
-                    .tags(EXCEPTION_TAG, exceptionClass)
-                    .tags(tagsBasedOnJoinPoint.apply(pjp))
-                    .publishPercentileHistogram(timed.histogram())
-                    .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
-                    .register(registry));
+            try {
+                sample.stop(Timer.builder(metricName)
+                        .description(timed.description().isEmpty() ? null : timed.description())
+                        .tags(timed.extraTags())
+                        .tags(EXCEPTION_TAG, exceptionClass)
+                        .tags(tagsBasedOnJoinPoint.apply(pjp))
+                        .publishPercentileHistogram(timed.histogram())
+                        .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
+                        .register(registry));
+            } catch (Exception e) {
+                // ignoring on purpose
+            }
         }
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -16,26 +16,13 @@
 package io.micrometer.core.aop;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.util.concurrent.TimeUnit;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToLongFunction;
-
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import io.micrometer.core.annotation.Timed;
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.FunctionCounter;
-import io.micrometer.core.instrument.FunctionTimer;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.LongTaskTimer;
-import io.micrometer.core.instrument.Measurement;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Id;
-import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -73,7 +60,7 @@ class TimedAspectTest {
         
         service.call();
         
-        Assertions.assertThatExceptionOfType(MeterNotFoundException.class).isThrownBy(() -> {
+        assertThatExceptionOfType(MeterNotFoundException.class).isThrownBy(() -> {
             failingRegistry.get("call")
                     .tag("class", "io.micrometer.core.aop.TimedAspectTest$TimedService")
                     .tag("method", "call")


### PR DESCRIPTION
I found that sometimes the monitoring backend can throw an Exception when recording a metric and the TimedAspect then breaks the application flow.
This happens, for instance, with prometheus when the metric has the wrong number of tags.
