### PR TITLE
Add Content-Encoding header for gzip

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpRequest.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpRequest.java
@@ -32,6 +32,12 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
+/**
+ * HTTP request.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public class HttpRequest {
     private final byte[] entity;
     private final HttpMethod method;
@@ -182,6 +188,7 @@ public class HttpRequest {
         }
 
         public final Builder compress() throws IOException {
+            withHeader("Content-Encoding", "gzip");
             this.entity = gzip(entity);
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpRequest.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpRequest.java
@@ -37,6 +37,7 @@ import java.util.zip.GZIPOutputStream;
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @since 1.1.0
  */
 public class HttpRequest {
     private final byte[] entity;

--- a/micrometer-core/src/test/java/io/micrometer/core/ipc/http/HttpRequestTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/ipc/http/HttpRequestTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.ipc.http;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link HttpRequest}.
+ *
+ * @author Johnny Lim
+ */
+class HttpRequestTest {
+
+    @Test
+    void compressShouldAddContentEncodingHeader() throws IOException, NoSuchFieldException, IllegalAccessException {
+        HttpRequest.Builder builder = HttpRequest.build("https://micrometer.io/", mock(HttpClient.class)).compress();
+        Field requestHeadersField = HttpRequest.Builder.class.getDeclaredField("requestHeaders");
+        requestHeadersField.setAccessible(true);
+        Map<String, String> requestHeaders = (Map<String, String>) requestHeadersField.get(builder);
+        assertThat(requestHeaders).containsEntry("Content-Encoding", "gzip");
+    }
+
+}


### PR DESCRIPTION
This PR adds `Content-Encoding` header for gzip.

Fixes gh-948