### PR TITLE
Align Prometheus Pushgateway support with Spring Boot 2.x

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfiguration.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.spring.autoconfigure.export.prometheus;
 
-import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
@@ -23,10 +22,9 @@ import io.micrometer.spring.autoconfigure.CompositeMeterRegistryAutoConfiguratio
 import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
+import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration;
 import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -38,16 +36,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 
-import javax.annotation.PreDestroy;
-import java.net.UnknownHostException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.util.Map;
 
 /**
  * Configuration for exporting metrics to Prometheus.
  *
  * @author Jon Schneider
+ * @author David J. M. Karlsen
  */
 @Configuration
 @AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,
@@ -94,88 +90,43 @@ public class PrometheusMetricsExportAutoConfiguration {
     }
 
     /**
-     * Configuration for <a href="https://github.com/prometheus/pushgateway">Prometheus Pushgateway</a>.
-     *
-     * @author David J. M. Karlsen
+     * Configuration for <a href="https://github.com/prometheus/pushgateway">Prometheus
+     * Pushgateway</a>.
      */
     @Configuration
     @ConditionalOnClass(PushGateway.class)
-    @ConditionalOnProperty(prefix = "management.metrics.export.prometheus.pushgateway", name = "enabled", havingValue = "true", matchIfMissing = false)
-    @Incubating(since = "1.0.0")
+    @ConditionalOnProperty(prefix = "management.metrics.export.prometheus.pushgateway", name = "enabled")
     public static class PrometheusPushGatewayConfiguration {
 
+        /**
+         * The fallback job name. We use 'spring' since there's a history of Prometheus
+         * spring integration defaulting to that name from when Prometheus integration
+         * didn't exist in Spring itself.
+         */
+        private static final String FALLBACK_JOB = "spring";
+
         @Bean
-        public PushGatewayHandler pushGatewayHandler(CollectorRegistry collectorRegistry,
+        @ConditionalOnMissingBean
+        public PrometheusPushGatewayManager prometheusPushGatewayManager(
+                CollectorRegistry collectorRegistry,
                 PrometheusProperties prometheusProperties, Environment environment) {
-            return new PushGatewayHandler(collectorRegistry, prometheusProperties, environment);
+            PrometheusProperties.Pushgateway properties = prometheusProperties
+                    .getPushgateway();
+            PushGateway pushGateway = new PushGateway(properties.getBaseUrl());
+            Duration pushRate = properties.getPushRate();
+            String job = getJob(properties, environment);
+            Map<String, String> groupingKey = properties.getGroupingKey();
+            PrometheusPushGatewayManager.ShutdownOperation shutdownOperation = properties.getShutdownOperation();
+            return new PrometheusPushGatewayManager(pushGateway, collectorRegistry,
+                    pushRate, job, groupingKey, shutdownOperation);
         }
 
-        public static class PushGatewayHandler {
-
-            private final Logger logger = LoggerFactory.getLogger(PrometheusPushGatewayConfiguration.class);
-            private final CollectorRegistry collectorRegistry;
-            private final PrometheusProperties.PushgatewayProperties pushgatewayProperties;
-            private final PushGateway pushGateway;
-            private final Environment environment;
-            private final ScheduledExecutorService executorService;
-
-            public PushGatewayHandler(CollectorRegistry collectorRegistry, PrometheusProperties prometheusProperties,
-                    Environment environment) {
-                this.collectorRegistry = collectorRegistry;
-                this.pushgatewayProperties = prometheusProperties.getPushgateway();
-                this.pushGateway = new PushGateway(pushgatewayProperties.getBaseUrl());
-                this.environment = environment;
-                this.executorService = Executors.newSingleThreadScheduledExecutor(
-                    (r) -> {
-                        final Thread thread = new Thread(r);
-                        thread.setDaemon(true);
-                        thread.setName("micrometer-pushgateway");
-                        return thread;
-                    }
-                );
-                executorService.scheduleAtFixedRate(this::push, 0, pushgatewayProperties.getPushRate().toMillis(),
-                    TimeUnit.MILLISECONDS);
-            }
-
-            void push() {
-                try {
-                    pushGateway.pushAdd(collectorRegistry, job(), pushgatewayProperties.getGroupingKeys());
-                } catch (UnknownHostException e) {
-                    logger.error("Unable to locate host '" + pushgatewayProperties.getBaseUrl() + "'. No longer attempting metrics publication to this host");
-                    executorService.shutdown();
-                } catch (Throwable t) {
-                    logger.error("Unable to push metrics to Prometheus Pushgateway", t);
-                }
-            }
-
-            @PreDestroy
-            void shutdown() {
-                executorService.shutdown();
-                if (pushgatewayProperties.isPushOnShutdown()) {
-                    push();
-                }
-                if (pushgatewayProperties.isDeleteOnShutdown()) {
-                    try {
-                        pushGateway.delete(job(), pushgatewayProperties.getGroupingKeys());
-                    } catch (Throwable t) {
-                        logger.error("Unable to delete metrics from Prometheus Pushgateway", t);
-                    }
-                }
-            }
-
-            private String job() {
-                String job = pushgatewayProperties.getJob();
-                if (job == null) {
-                    job = environment.getProperty("spring.application.name");
-                }
-                if (job == null) {
-                    // There's a history of Prometheus spring integration defaulting the job name to "spring" from when
-                    // Prometheus integration didn't exist in Spring itself.
-                    job = "spring";
-                }
-                return job;
-            }
-
+        private String getJob(PrometheusProperties.Pushgateway properties,
+                Environment environment) {
+            String job = properties.getJob();
+            job = (job != null) ? job
+                    : environment.getProperty("spring.application.name");
+            return (job != null) ? job : FALLBACK_JOB;
         }
 
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusProperties.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager.ShutdownOperation;
+
 /**
  * {@link ConfigurationProperties} for configuring metrics export to Prometheus.
  *
@@ -39,7 +41,7 @@ public class PrometheusProperties {
      * Configuration options for using Prometheus Pushgateway, allowing metrics to be
      * pushed when they cannot be scraped.
      */
-    private PushgatewayProperties pushgateway = new PushgatewayProperties();
+    private Pushgateway pushgateway = new Pushgateway();
 
     /**
      * Step size (i.e. reporting frequency) to use.
@@ -62,18 +64,18 @@ public class PrometheusProperties {
         this.step = step;
     }
 
-    public PushgatewayProperties getPushgateway() {
+    public Pushgateway getPushgateway() {
         return this.pushgateway;
     }
 
-    public void setPushgateway(PushgatewayProperties pushgateway) {
+    public void setPushgateway(Pushgateway pushgateway) {
         this.pushgateway = pushgateway;
     }
 
     /**
      * Configuration options for push-based interaction with Prometheus.
      */
-    public static class PushgatewayProperties {
+    public static class Pushgateway {
 
         /**
          * Enable publishing via a Prometheus Pushgateway.
@@ -98,18 +100,12 @@ public class PrometheusProperties {
         /**
          * Grouping key for the pushed metrics.
          */
-        private Map<String, String> groupingKeys = new HashMap<>();
+        private Map<String, String> groupingKey = new HashMap<>();
 
         /**
-         * Push metrics right before shut-down. Mostly useful for batch jobs.
+         * Operation that should be performed on shutdown.
          */
-        private boolean pushOnShutdown = true;
-
-        /**
-         * Delete metrics from Pushgateway when application is shut-down.
-         */
-        private boolean deleteOnShutdown = true;
-
+        private ShutdownOperation shutdownOperation = ShutdownOperation.NONE;
 
         public Boolean getEnabled() {
             return this.enabled;
@@ -143,28 +139,20 @@ public class PrometheusProperties {
             this.job = job;
         }
 
-        public Map<String, String> getGroupingKeys() {
-            return this.groupingKeys;
+        public Map<String, String> getGroupingKey() {
+            return this.groupingKey;
         }
 
-        public void setGroupingKeys(Map<String, String> groupingKeys) {
-            this.groupingKeys = groupingKeys;
+        public void setGroupingKey(Map<String, String> groupingKey) {
+            this.groupingKey = groupingKey;
         }
 
-        public boolean isPushOnShutdown() {
-            return pushOnShutdown;
+        public ShutdownOperation getShutdownOperation() {
+            return this.shutdownOperation;
         }
 
-        public void setPushOnShutdown(boolean pushOnShutdown) {
-            this.pushOnShutdown = pushOnShutdown;
-        }
-
-        public boolean isDeleteOnShutdown() {
-            return deleteOnShutdown;
-        }
-
-        public void setDeleteOnShutdown(boolean deleteOnShutdown) {
-            this.deleteOnShutdown = deleteOnShutdown;
+        public void setShutdownOperation(ShutdownOperation shutdownOperation) {
+            this.shutdownOperation = shutdownOperation;
         }
 
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManager.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManager.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.export.prometheus;
+
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.PushGateway;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Class that can be used to manage the pushing of metrics to a {@link PushGateway
+ * Prometheus PushGateway}. Handles the scheduling of push operations, error handling and
+ * shutdown operations.
+ *
+ * @author David J. M. Karlsen
+ * @author Phillip Webb
+ * @since 1.1.0
+ */
+public class PrometheusPushGatewayManager {
+
+    private static final Log logger = LogFactory
+            .getLog(PrometheusPushGatewayManager.class);
+
+    private final PushGateway pushGateway;
+
+    private final CollectorRegistry registry;
+
+    private final String job;
+
+    private final Map<String, String> groupingKey;
+
+    private final ShutdownOperation shutdownOperation;
+
+    private final TaskScheduler scheduler;
+
+    private ScheduledFuture<?> scheduled;
+
+    /**
+     * Create a new {@link PrometheusPushGatewayManager} instance using a single threaded
+     * {@link TaskScheduler}.
+     * @param pushGateway the source push gateway
+     * @param registry the collector registry to push
+     * @param pushRate the rate at which push operations occur
+     * @param job the job ID for the operation
+     * @param groupingKey an optional set of grouping keys for the operation
+     * @param shutdownOperation the shutdown operation that should be performed when
+     * context is closed.
+     */
+    public PrometheusPushGatewayManager(PushGateway pushGateway,
+            CollectorRegistry registry, Duration pushRate, String job,
+            Map<String, String> groupingKey, ShutdownOperation shutdownOperation) {
+        this(pushGateway, registry, new PushGatewayTaskScheduler(), pushRate, job,
+                groupingKey, shutdownOperation);
+    }
+
+    /**
+     * Create a new {@link PrometheusPushGatewayManager} instance.
+     * @param pushGateway the source push gateway
+     * @param registry the collector registry to push
+     * @param scheduler the scheduler used for operations
+     * @param pushRate the rate at which push operations occur
+     * @param job the job ID for the operation
+     * @param groupingKey an optional set of grouping keys for the operation
+     * @param shutdownOperation the shutdown operation that should be performed when
+     * context is closed.
+     */
+    public PrometheusPushGatewayManager(PushGateway pushGateway,
+            CollectorRegistry registry, TaskScheduler scheduler, Duration pushRate,
+            String job, Map<String, String> groupingKey,
+            ShutdownOperation shutdownOperation) {
+        Assert.notNull(pushGateway, "PushGateway must not be null");
+        Assert.notNull(registry, "Registry must not be null");
+        Assert.notNull(scheduler, "Scheduler must not be null");
+        Assert.notNull(pushRate, "PushRate must not be null");
+        Assert.hasLength(job, "Job must not be empty");
+        this.pushGateway = pushGateway;
+        this.registry = registry;
+        this.job = job;
+        this.groupingKey = groupingKey;
+        this.shutdownOperation = (shutdownOperation != null) ? shutdownOperation
+                : ShutdownOperation.NONE;
+        this.scheduler = scheduler;
+        this.scheduled = this.scheduler.scheduleAtFixedRate(this::push, pushRate.toMillis());
+    }
+
+    private void push() {
+        try {
+            this.pushGateway.pushAdd(this.registry, this.job, this.groupingKey);
+        }
+        catch (UnknownHostException ex) {
+            String host = ex.getMessage();
+            String message = "Unable to locate prometheus push gateway host"
+                    + (StringUtils.hasLength(host) ? " '" + host + "'" : "")
+                    + ". No longer attempting metrics publication to this host";
+            logger.error(message, ex);
+            shutdown(ShutdownOperation.NONE);
+        }
+        catch (Throwable ex) {
+            logger.error("Unable to push metrics to Prometheus Pushgateway", ex);
+        }
+    }
+
+    private void delete() {
+        try {
+            this.pushGateway.delete(this.job, this.groupingKey);
+        }
+        catch (Throwable ex) {
+            logger.error("Unable to delete metrics from Prometheus Pushgateway", ex);
+        }
+    }
+
+    /**
+     * Shutdown the manager, running any {@link ShutdownOperation}.
+     */
+    public void shutdown() {
+        shutdown(this.shutdownOperation);
+    }
+
+    private void shutdown(ShutdownOperation shutdownOperation) {
+        if (this.scheduler instanceof PushGatewayTaskScheduler) {
+            ((PushGatewayTaskScheduler) this.scheduler).shutdown();
+        }
+        this.scheduled.cancel(false);
+        switch (shutdownOperation) {
+            case PUSH:
+                push();
+                break;
+            case DELETE:
+                delete();
+                break;
+        }
+    }
+
+    /**
+     * The operation that should be performed on shutdown.
+     */
+    public enum ShutdownOperation {
+
+        /**
+         * Don't perform any shutdown operation.
+         */
+        NONE,
+
+        /**
+         * Perform a 'push' before shutdown.
+         */
+        PUSH,
+
+        /**
+         * Perform a 'delete' before shutdown.
+         */
+        DELETE
+
+    }
+
+    /**
+     * {@link TaskScheduler} used when the user doesn't specify one.
+     */
+    static class PushGatewayTaskScheduler extends ThreadPoolTaskScheduler {
+
+        PushGatewayTaskScheduler() {
+            setPoolSize(1);
+            setDaemon(true);
+            setThreadGroupName("prometheus-push-gateway");
+        }
+
+        @Override
+        public ScheduledExecutorService getScheduledExecutor()
+                throws IllegalStateException {
+            return Executors.newSingleThreadScheduledExecutor(this::newThread);
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfigurationTest.java
@@ -23,6 +23,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,62 +38,74 @@ import static org.mockito.Mockito.mock;
  */
 class PrometheusMetricsExportAutoConfigurationTest {
 
-    private AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+    private final AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (context != null) {
+            context.close();
+        }
+    }
 
     @Test
     void autoConfigureByDefault() {
-        registerAndRefresh(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        registerAndRefresh();
 
-        assertThat(this.context.getBean(PrometheusMeterRegistry.class)).isNotNull();
+        assertThat(context.getBean(PrometheusMeterRegistry.class)).isNotNull();
     }
 
     @Test
     void autoConfigureDisabledByProperty() {
-        EnvironmentTestUtils.addEnvironment(this.context, "management.metrics.export.prometheus.enabled=false");
+        EnvironmentTestUtils.addEnvironment(context, "management.metrics.export.prometheus.enabled=false");
 
-        registerAndRefresh(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        registerAndRefresh();
 
-        assertThatThrownBy(() -> this.context.getBean(PrometheusMeterRegistry.class))
+        assertThatThrownBy(() -> context.getBean(PrometheusMeterRegistry.class))
             .isInstanceOf(NoSuchBeanDefinitionException.class);
     }
 
     @Test
     void autoConfigurePrometheusPushGatewayDisabledByDefault() {
-        registerAndRefresh(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        registerAndRefresh();
 
-        assertThatThrownBy(() -> this.context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class))
+        assertThatThrownBy(() -> context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class))
             .isInstanceOf(NoSuchBeanDefinitionException.class);
     }
 
     @Test
     void autoConfigurePrometheusPushGatewayEnabledByProperty() {
-        EnvironmentTestUtils.addEnvironment(this.context, "management.metrics.export.prometheus.pushgateway.enabled=true");
+        EnvironmentTestUtils.addEnvironment(context, "management.metrics.export.prometheus.pushgateway.enabled=true");
 
-        registerAndRefresh(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        registerAndRefresh();
 
-        assertThat(this.context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class)).isNotNull();
+        assertThat(context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class)).isNotNull();
     }
 
     @Test
     void autoConfigurePrometheusPushGatewayDisabledByPrometheusEnabledProperty() {
-        EnvironmentTestUtils.addEnvironment(this.context, "management.metrics.export.prometheus.enabled=false", "management.metrics.export.prometheus.pushgateway.enabled=true");
+        EnvironmentTestUtils.addEnvironment(context, "management.metrics.export.prometheus.enabled=false", "management.metrics.export.prometheus.pushgateway.enabled=true");
 
-        registerAndRefresh(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        registerAndRefresh();
 
-        assertThatThrownBy(() -> this.context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class))
+        assertThatThrownBy(() -> context.getBean(PrometheusMetricsExportAutoConfiguration.PrometheusPushGatewayConfiguration.class))
             .isInstanceOf(NoSuchBeanDefinitionException.class);
     }
 
-    @AfterEach
-    void cleanUp() {
-        if (this.context != null) {
-            this.context.close();
-        }
+    @Test
+    public void withPushGatewayEnabled() {
+        EnvironmentTestUtils.addEnvironment(context, "management.metrics.export.prometheus.pushgateway.enabled=true");
+
+        registerAndRefresh();
+
+        assertThat(context.getBean(PrometheusPushGatewayManager.class)).isNotNull();
     }
 
     private void registerAndRefresh(Class<?>... configurationClasses) {
-        this.context.register(configurationClasses);
-        this.context.refresh();
+        if (configurationClasses.length > 0) {
+            context.register(configurationClasses);
+        }
+        context.register(ClockConfiguration.class, PrometheusMetricsExportAutoConfiguration.class);
+        context.refresh();
     }
 
     @Configuration

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManagerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManagerTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.export.prometheus;
+
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager.PushGatewayTaskScheduler;
+import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager.ShutdownOperation;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.PushGateway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Tests for {@link PrometheusPushGatewayManager}.
+ *
+ * @author Phillip Webb
+ */
+class PrometheusPushGatewayManagerTest {
+
+    @Mock
+    private PushGateway pushGateway;
+
+    @Mock
+    private CollectorRegistry registry;
+
+    private TaskScheduler scheduler;
+
+    private Duration pushRate = Duration.ofSeconds(1);
+
+    private Map<String, String> groupingKey = Collections.singletonMap("foo", "bar");
+
+    @Captor
+    private ArgumentCaptor<Runnable> task;
+
+    @Mock
+    private ScheduledFuture<Object> future;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        this.scheduler = mockScheduler(TaskScheduler.class);
+    }
+
+    @Test
+    void createWhenPushGatewayIsNullThrowsException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new PrometheusPushGatewayManager(null, this.registry,
+                        this.scheduler, this.pushRate, "job", this.groupingKey, null))
+                .withMessage("PushGateway must not be null");
+    }
+
+    @Test
+    void createWhenCollectorRegistryIsNullThrowsException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new PrometheusPushGatewayManager(this.pushGateway, null,
+                        this.scheduler, this.pushRate, "job", this.groupingKey, null))
+                .withMessage("Registry must not be null");
+    }
+
+    @Test
+    void createWhenSchedulerIsNullThrowsException() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new PrometheusPushGatewayManager(this.pushGateway, this.registry,
+                        null, this.pushRate, "job", this.groupingKey, null))
+                .withMessage("Scheduler must not be null");
+    }
+
+    @Test
+    void createWhenPushRateIsNullThrowsException() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new PrometheusPushGatewayManager(this.pushGateway, this.registry,
+                        this.scheduler, null, "job", this.groupingKey, null))
+                .withMessage("PushRate must not be null");
+    }
+
+    @Test
+    void createWhenJobIsEmptyThrowsException() {
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> new PrometheusPushGatewayManager(this.pushGateway, this.registry,
+                        this.scheduler, this.pushRate, "", this.groupingKey, null))
+                .withMessage("Job must not be empty");
+    }
+
+    @Test
+    void createShouldSchedulePushAsFixedRate() throws Exception {
+        new PrometheusPushGatewayManager(this.pushGateway, this.registry, this.scheduler,
+                this.pushRate, "job", this.groupingKey, null);
+        verify(this.scheduler).scheduleAtFixedRate(this.task.capture(),
+                eq(this.pushRate.toMillis()));
+        this.task.getValue().run();
+        verify(this.pushGateway).pushAdd(this.registry, "job", this.groupingKey);
+    }
+
+    @Test
+    void shutdownWhenOwnsSchedulerDoesShutdownScheduler() {
+        PushGatewayTaskScheduler ownedScheduler = mockScheduler(
+                PushGatewayTaskScheduler.class);
+        PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(
+                this.pushGateway, this.registry, ownedScheduler, this.pushRate, "job",
+                this.groupingKey, null);
+        manager.shutdown();
+        verify(ownedScheduler).shutdown();
+    }
+
+    @Test
+    void shutdownWhenDoesNotOwnSchedulerDoesNotShutdownScheduler() {
+        ThreadPoolTaskScheduler otherScheduler = mockScheduler(
+                ThreadPoolTaskScheduler.class);
+        PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(
+                this.pushGateway, this.registry, otherScheduler, this.pushRate, "job",
+                this.groupingKey, null);
+        manager.shutdown();
+        verify(otherScheduler, never()).shutdown();
+    }
+
+    @Test
+    void shutdownWhenShutdownOperationIsPushPerformsPushOnShutdown()
+            throws Exception {
+        PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(
+                this.pushGateway, this.registry, this.scheduler, this.pushRate, "job",
+                this.groupingKey, ShutdownOperation.PUSH);
+        manager.shutdown();
+        verify(this.future).cancel(false);
+        verify(this.pushGateway).pushAdd(this.registry, "job", this.groupingKey);
+    }
+
+    @Test
+    void shutdownWhenShutdownOperationIsDeletePerformsDeleteOnShutdown()
+            throws Exception {
+        PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(
+                this.pushGateway, this.registry, this.scheduler, this.pushRate, "job",
+                this.groupingKey, ShutdownOperation.DELETE);
+        manager.shutdown();
+        verify(this.future).cancel(false);
+        verify(this.pushGateway).delete("job", this.groupingKey);
+    }
+
+    @Test
+    void shutdownWhenShutdownOperationIsNoneDoesNothing() {
+        PrometheusPushGatewayManager manager = new PrometheusPushGatewayManager(
+                this.pushGateway, this.registry, this.scheduler, this.pushRate, "job",
+                this.groupingKey, PrometheusPushGatewayManager.ShutdownOperation.NONE);
+        manager.shutdown();
+        verify(this.future).cancel(false);
+        verifyZeroInteractions(this.pushGateway);
+    }
+
+    @Test
+    void pushWhenUnknownHostExceptionIsThrownDoesShutdown() throws Exception {
+        new PrometheusPushGatewayManager(this.pushGateway, this.registry, this.scheduler,
+                this.pushRate, "job", this.groupingKey, null);
+        verify(this.scheduler).scheduleAtFixedRate(this.task.capture(),
+                eq(this.pushRate.toMillis()));
+        willThrow(new UnknownHostException("foo")).given(this.pushGateway)
+                .pushAdd(this.registry, "job", this.groupingKey);
+        this.task.getValue().run();
+        verify(this.future).cancel(false);
+    }
+
+    @Test
+    void pushDoesNotThrowException() throws Exception {
+        new PrometheusPushGatewayManager(this.pushGateway, this.registry, this.scheduler,
+                this.pushRate, "job", this.groupingKey, null);
+        verify(this.scheduler).scheduleAtFixedRate(this.task.capture(),
+                eq(this.pushRate.toMillis()));
+        willThrow(RuntimeException.class).given(this.pushGateway).pushAdd(this.registry,
+                "job", this.groupingKey);
+        this.task.getValue().run();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private <T extends TaskScheduler> T mockScheduler(Class<T> type) {
+        T scheduler = mock(type);
+        given(scheduler.scheduleAtFixedRate(isA(Runnable.class), isA(Long.class)))
+                .willReturn((ScheduledFuture) this.future);
+        return scheduler;
+    }
+
+}


### PR DESCRIPTION
This PR aligns Prometheus Pushgateway support with Spring Boot 2.x by porting from https://github.com/spring-projects/spring-boot/issues/14346.