### PR TITLE
Handle null ThreadInfo in JvmThreadMetrics.getThreadStateCount()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -75,9 +75,10 @@ public class JvmThreadMetrics implements MeterBinder {
         }
     }
 
-    private static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
+    // VisibleForTesting
+    static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state) {
         return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
-                .filter(threadInfo -> threadInfo.getThreadState() == state)
+                .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state)
                 .count();
     }
 


### PR DESCRIPTION
This PR changes to handle `null` `ThreadInfo` in `JvmThreadMetrics.getThreadStateCount()` as it's possible to be `null` based on [its Javadoc](https://docs.oracle.com/javase/8/docs/api/java/lang/management/ThreadMXBean.html#getThreadInfo-long:A-) as follows:

> If a thread of a given ID is not alive or does not exist, the corresponding element in the returned array will contain null.

This was originally reported via #956 (also #957 and #958 which are duplicates) by @benatportland but I can't find them any longer. I'm not sure they are deleted or missing by a GitHub issue.