### PR TITLE
Align package for Prometheus scrape endpoint with Spring Boot 2.x

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusMetricsExportAutoConfiguration.java
@@ -23,6 +23,8 @@ import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
 import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import io.micrometer.spring.export.prometheus.PrometheusPushGatewayManager;
+import io.micrometer.spring.export.prometheus.PrometheusScrapeEndpoint;
+import io.micrometer.spring.export.prometheus.PrometheusScrapeMvcEndpoint;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.PushGateway;
 import org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusScrapeEndpoint.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusScrapeEndpoint.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.autoconfigure.export.prometheus;
+package io.micrometer.spring.export.prometheus;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
@@ -38,7 +38,7 @@ public class PrometheusScrapeEndpoint extends AbstractEndpoint<ResponseEntity<St
 
     private final CollectorRegistry collectorRegistry;
 
-    PrometheusScrapeEndpoint(CollectorRegistry collectorRegistry) {
+    public PrometheusScrapeEndpoint(CollectorRegistry collectorRegistry) {
         super("prometheus");
         this.collectorRegistry = collectorRegistry;
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusScrapeMvcEndpoint.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/export/prometheus/PrometheusScrapeMvcEndpoint.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.autoconfigure.export.prometheus;
+package io.micrometer.spring.export.prometheus;
 
 import org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter;
 import org.springframework.web.bind.annotation.GetMapping;
 
 public class PrometheusScrapeMvcEndpoint extends EndpointMvcAdapter {
 
-    PrometheusScrapeMvcEndpoint(PrometheusScrapeEndpoint delegate) {
+    public PrometheusScrapeMvcEndpoint(PrometheusScrapeEndpoint delegate) {
         super(delegate);
     }
 


### PR DESCRIPTION
This PR moves Prometheus scrape endpoint classes to align its package with Spring Boot 2.x support.