### PR TITLE
Align AppOptics auto-configuration with Spring Boot 2.x support

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfiguration.java
@@ -24,6 +24,7 @@ import io.micrometer.spring.autoconfigure.export.StringToDurationConverter;
 import io.micrometer.spring.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -34,13 +35,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 /**
- * Configuration for exporting metrics to AppOptics.
+ * {@link EnableAutoConfiguration Auto-configuration} for exporting metrics to AppOptics.
  *
  * @author Hunter Sherman
+ * @author Stephane Nicoll
+ * @since 1.1.0
  */
 @Configuration
-@AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,
-    SimpleMetricsExportAutoConfiguration.class})
+@AutoConfigureBefore({ CompositeMeterRegistryAutoConfiguration.class,
+        SimpleMetricsExportAutoConfiguration.class })
 @AutoConfigureAfter(MetricsAutoConfiguration.class)
 @ConditionalOnBean(Clock.class)
 @ConditionalOnClass(AppOpticsMeterRegistry.class)
@@ -50,14 +53,16 @@ import org.springframework.context.annotation.Import;
 public class AppOpticsMetricsExportAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(AppOpticsConfig.class)
+    @ConditionalOnMissingBean
     public AppOpticsConfig appOpticsConfig(AppOpticsProperties appOpticsProperties) {
         return new AppOpticsPropertiesConfigAdapter(appOpticsProperties);
     }
 
     @Bean
     @ConditionalOnMissingBean
-    public AppOpticsMeterRegistry appOpticsMeterRegistry(AppOpticsConfig config, Clock clock) {
+    public AppOpticsMeterRegistry appOpticsMeterRegistry(AppOpticsConfig config,
+            Clock clock) {
         return new AppOpticsMeterRegistry(config, clock);
     }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.spring.autoconfigure.export.appoptics;
 
+import java.time.Duration;
+
 import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -22,9 +24,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * {@link ConfigurationProperties} for configuring AppOptics metrics export.
  *
  * @author Hunter Sherman
+ * @author Stephane Nicoll
+ * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "management.metrics.export.appoptics")
 public class AppOpticsProperties extends StepRegistryProperties {
+
+    /**
+     * URI to ship metrics to.
+     */
+    private String uri = "https://api.appoptics.com/v1/measurements";
 
     /**
      * AppOptics API token.
@@ -32,28 +41,63 @@ public class AppOpticsProperties extends StepRegistryProperties {
     private String apiToken;
 
     /**
-     * The tag that will be mapped to "@host" when shipping metrics to AppOptics.
+     * Tag that will be mapped to "@host" when shipping metrics to AppOptics.
      */
     private String hostTag = "instance";
 
     /**
-     * The URI to ship metrics to.
+     * Number of measurements per request to use for this backend. If more measurements
+     * are found, then multiple requests will be made.
      */
-    private String uri;
+    private Integer batchSize = 500;
 
-    public String getApiToken() { return apiToken; }
+    /**
+     * Connection timeout for requests to this backend.
+     */
+    private Duration connectTimeout = Duration.ofSeconds(5);
 
-    public void setApiToken(String apiToken) { this.apiToken = apiToken; }
+    public String getUri() {
+        return this.uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getApiToken() {
+        return this.apiToken;
+    }
+
+    public void setApiToken(String apiToken) {
+        this.apiToken = apiToken;
+    }
 
     public String getHostTag() {
-        return hostTag;
+        return this.hostTag;
     }
 
     public void setHostTag(String hostTag) {
         this.hostTag = hostTag;
     }
 
-    public String getUri() { return uri; }
+    @Override
+    public Integer getBatchSize() {
+        return this.batchSize;
+    }
 
-    public void setUri(String uri) { this.uri = uri; }
+    @Override
+    public void setBatchSize(Integer batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public Duration getConnectTimeout() {
+        return this.connectTimeout;
+    }
+
+    @Override
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
@@ -19,18 +19,32 @@ import io.micrometer.appoptics.AppOpticsConfig;
 import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
 
 /**
- * Adapter to convert {@link AppOpticsProperties} to a {@link io.micrometer.appoptics.AppOpticsConfig}.
+ * Adapter to convert {@link AppOpticsProperties} to an {@link AppOpticsConfig}.
  *
  * @author Hunter Sherman
+ * @author Stephane Nicoll
  */
-public class AppOpticsPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<AppOpticsProperties>
-    implements AppOpticsConfig {
+class AppOpticsPropertiesConfigAdapter
+        extends StepRegistryPropertiesConfigAdapter<AppOpticsProperties>
+        implements AppOpticsConfig {
 
-    public AppOpticsPropertiesConfigAdapter(AppOpticsProperties properties) { super(properties); }
+    AppOpticsPropertiesConfigAdapter(AppOpticsProperties properties) {
+        super(properties);
+    }
 
-    public String apiToken() { return get(AppOpticsProperties::getApiToken, AppOpticsConfig.super::apiToken); }
+    @Override
+    public String uri() {
+        return get(AppOpticsProperties::getUri, AppOpticsConfig.super::uri);
+    }
 
-    public String hostTag() { return get(AppOpticsProperties::getHostTag, AppOpticsConfig.super::hostTag); }
+    @Override
+    public String apiToken() {
+        return get(AppOpticsProperties::getApiToken, AppOpticsConfig.super::apiToken);
+    }
 
-    public String uri() { return get(AppOpticsProperties::getUri, AppOpticsConfig.super::uri); }
+    @Override
+    public String hostTag() {
+        return get(AppOpticsProperties::getHostTag, AppOpticsConfig.super::hostTag);
+    }
+
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfigurationTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.export.appoptics;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.micrometer.appoptics.AppOpticsConfig;
+import io.micrometer.appoptics.AppOpticsMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link AppOpticsMetricsExportAutoConfiguration}.
+ *
+ * @author Stephane Nicoll
+ * @author Johnny Lim
+ */
+class AppOpticsMetricsExportAutoConfigurationTest {
+
+    private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Test
+    void backsOffWithoutAClock() {
+        registerAndRefresh();
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+                .isThrownBy(() -> context.getBean(AppOpticsMeterRegistry.class));
+    }
+
+    @Test
+    void autoConfiguresItsConfigAndMeterRegistry() {
+        registerAndRefresh(BaseConfiguration.class);
+        assertThat(context.getBean(AppOpticsMeterRegistry.class)).isNotNull();
+        assertThat(context.getBean(AppOpticsConfig.class)).isNotNull();
+    }
+
+    @Test
+    void autoConfigurationCanBeDisabled() {
+        EnvironmentTestUtils.addEnvironment(context, "management.metrics.export.appoptics.enabled=false");
+        registerAndRefresh(BaseConfiguration.class);
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+                .isThrownBy(() -> context.getBean(AppOpticsMeterRegistry.class));
+        assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+                .isThrownBy(() -> context.getBean(AppOpticsConfig.class));
+    }
+
+    @Test
+    void allowsCustomConfigToBeUsed() {
+        registerAndRefresh(CustomConfigConfiguration.class);
+        assertThat(context.getBean(AppOpticsMeterRegistry.class)).isNotNull();
+        assertThat(context.getBean(AppOpticsConfig.class)).isEqualTo(context.getBean("customConfig"));
+    }
+
+    @Test
+    void allowsCustomRegistryToBeUsed() {
+        registerAndRefresh(CustomRegistryConfiguration.class);
+        assertThat(context.getBean(AppOpticsMeterRegistry.class)).isEqualTo(context.getBean("customRegistry"));
+        assertThat(context.getBean(AppOpticsConfig.class)).isNotNull();
+    }
+
+    @Test
+    public void stopsMeterRegistryWhenContextIsClosed() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        registerAndRefresh(context, BaseConfiguration.class);
+        AppOpticsMeterRegistry registry = spyOnDisposableBean(AppOpticsMeterRegistry.class, context);
+        context.close();
+        verify(registry).stop();
+    }
+
+    private void registerAndRefresh(AnnotationConfigApplicationContext context,
+            Class<?>... configurationClasses) {
+        if (configurationClasses.length > 0) {
+            context.register(configurationClasses);
+        }
+        context.register(AppOpticsMetricsExportAutoConfiguration.class);
+        context.refresh();
+    }
+
+    private void registerAndRefresh(Class<?>... configurationClasses) {
+        registerAndRefresh(context, configurationClasses);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T spyOnDisposableBean(Class<T> type, AnnotationConfigApplicationContext context) {
+        String[] names = context.getBeanNamesForType(type);
+        assertThat(names).hasSize(1);
+        String registryBeanName = names[0];
+        Map<String, Object> disposableBeans = (Map<String, Object>) ReflectionTestUtils
+                .getField(context.getAutowireCapableBeanFactory(), "disposableBeans");
+        Object registryAdapter = disposableBeans.get(registryBeanName);
+        T registry = (T) spy(ReflectionTestUtils.getField(registryAdapter, "bean"));
+        ReflectionTestUtils.setField(registryAdapter, "bean", registry);
+        return registry;
+    }
+
+    @Configuration
+    static class BaseConfiguration {
+
+        @Bean
+        public Clock clock() {
+            return Clock.SYSTEM;
+        }
+
+    }
+
+    @Configuration
+    @Import(BaseConfiguration.class)
+    static class CustomConfigConfiguration {
+
+        @Bean
+        public AppOpticsConfig customConfig() {
+            return (key) -> null;
+        }
+
+    }
+
+    @Configuration
+    @Import(BaseConfiguration.class)
+    static class CustomRegistryConfiguration {
+
+        @Bean
+        public AppOpticsMeterRegistry customRegistry(AppOpticsConfig config,
+                Clock clock) {
+            return new AppOpticsMeterRegistry(config, clock);
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.export.appoptics;
+
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapterTest;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AppOpticsPropertiesConfigAdapter}.
+ *
+ * @author Stephane Nicoll
+ */
+public class AppOpticsPropertiesConfigAdapterTest extends
+        StepRegistryPropertiesConfigAdapterTest<AppOpticsProperties, AppOpticsPropertiesConfigAdapter> {
+
+    @Override
+    protected AppOpticsProperties createProperties() {
+        return new AppOpticsProperties();
+    }
+
+    @Override
+    protected AppOpticsPropertiesConfigAdapter createConfigAdapter(
+        AppOpticsProperties properties) {
+        return new AppOpticsPropertiesConfigAdapter(properties);
+    }
+
+    @Test
+    public void whenPropertiesUrisIsSetAdapterUriReturnsIt() {
+        AppOpticsProperties properties = createProperties();
+        properties.setUri("https://appoptics.example.com/v1/measurements");
+        assertThat(createConfigAdapter(properties).uri())
+                .isEqualTo("https://appoptics.example.com/v1/measurements");
+    }
+
+    @Test
+    public void whenPropertiesApiTokenIsSetAdapterApiTokenReturnsIt() {
+        AppOpticsProperties properties = createProperties();
+        properties.setApiToken("ABC123");
+        assertThat(createConfigAdapter(properties).apiToken()).isEqualTo("ABC123");
+    }
+
+    @Test
+    public void whenPropertiesHostTagIsSetAdapterHostTagReturnsIt() {
+        AppOpticsProperties properties = createProperties();
+        properties.setHostTag("node");
+        assertThat(createConfigAdapter(properties).hostTag()).isEqualTo("node");
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.export.appoptics;
+
+import io.micrometer.appoptics.AppOpticsConfig;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AppOpticsProperties}.
+ *
+ * @author Stephane Nicoll
+ */
+public class AppOpticsPropertiesTest extends StepRegistryPropertiesTest {
+
+    @Override
+    public void defaultValuesAreConsistent() {
+        AppOpticsProperties properties = new AppOpticsProperties();
+        AppOpticsConfig config = (key) -> null;
+        assertStepRegistryDefaultValues(properties, config);
+        assertThat(properties.getUri()).isEqualToIgnoringWhitespace(config.uri());
+        assertThat(properties.getHostTag()).isEqualToIgnoringWhitespace(config.hostTag());
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.export.properties;
+
+import java.time.Duration;
+
+import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base test for {@link StepRegistryPropertiesConfigAdapter} implementations.
+ *
+ * @param <P> properties used by the tests
+ * @param <A> adapter used by the tests
+ * @author Stephane Nicoll
+ */
+public abstract class StepRegistryPropertiesConfigAdapterTest<P extends StepRegistryProperties, A extends StepRegistryPropertiesConfigAdapter<P>> {
+
+    protected abstract P createProperties();
+
+    protected abstract A createConfigAdapter(P properties);
+
+    @Test
+    public void whenPropertiesStepIsSetAdapterStepReturnsIt() {
+        P properties = createProperties();
+        properties.setStep(Duration.ofSeconds(42));
+        assertThat(createConfigAdapter(properties).step())
+                .isEqualTo(Duration.ofSeconds(42));
+    }
+
+    @Test
+    public void whenPropertiesEnabledIsSetAdapterEnabledReturnsIt() {
+        P properties = createProperties();
+        properties.setEnabled(false);
+        assertThat(createConfigAdapter(properties).enabled()).isFalse();
+    }
+
+    @Test
+    public void whenPropertiesConnectTimeoutIsSetAdapterConnectTimeoutReturnsIt() {
+        P properties = createProperties();
+        properties.setConnectTimeout(Duration.ofMinutes(42));
+        assertThat(createConfigAdapter(properties).connectTimeout())
+                .isEqualTo(Duration.ofMinutes(42));
+    }
+
+    @Test
+    public void whenPropertiesReadTimeoutIsSetAdapterReadTimeoutReturnsIt() {
+        P properties = createProperties();
+        properties.setReadTimeout(Duration.ofMillis(42));
+        assertThat(createConfigAdapter(properties).readTimeout())
+                .isEqualTo(Duration.ofMillis(42));
+    }
+
+    @Test
+    public void whenPropertiesNumThreadsIsSetAdapterNumThreadsReturnsIt() {
+        P properties = createProperties();
+        properties.setNumThreads(42);
+        assertThat(createConfigAdapter(properties).numThreads()).isEqualTo(42);
+    }
+
+    @Test
+    public void whenPropertiesBatchSizeIsSetAdapterBatchSizeReturnsIt() {
+        P properties = createProperties();
+        properties.setBatchSize(10042);
+        assertThat(createConfigAdapter(properties).batchSize()).isEqualTo(10042);
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.export.properties;
+
+import io.micrometer.core.instrument.step.StepRegistryConfig;
+import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base tests for {@link StepRegistryProperties} implementation.
+ *
+ * @author Stephane Nicoll
+ */
+public abstract class StepRegistryPropertiesTest {
+
+    protected void assertStepRegistryDefaultValues(StepRegistryProperties properties,
+            StepRegistryConfig config) {
+        assertThat(properties.getStep()).isEqualTo(config.step());
+        assertThat(properties.isEnabled()).isEqualTo(config.enabled());
+        assertThat(properties.getConnectTimeout()).isEqualTo(config.connectTimeout());
+        assertThat(properties.getReadTimeout()).isEqualTo(config.readTimeout());
+        assertThat(properties.getNumThreads()).isEqualTo(config.numThreads());
+        assertThat(properties.getBatchSize()).isEqualTo(config.batchSize());
+    }
+
+    @Test
+    public abstract void defaultValuesAreConsistent();
+
+}


### PR DESCRIPTION
This PR aligns AppOptics auto-configuration with Spring Boot 2.x support.

See https://github.com/spring-projects/spring-boot/issues/14819