### PR TITLE
Move registry properties base classes to properties package

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsProperties.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.appoptics;
 
 import java.time.Duration;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.appoptics;
 
 import io.micrometer.appoptics.AppOpticsConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link AppOpticsProperties} to an {@link AppOpticsConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.atlas;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/atlas/AtlasPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.atlas;
 
 import com.netflix.spectator.atlas.AtlasConfig;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.azuremonitor;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/azuremonitor/AzureMonitorPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.azuremonitor;
 
 import io.micrometer.azuremonitor.AzureMonitorConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link AzureMonitorProperties} to a {@link AzureMonitorConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.datadog;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/datadog/DatadogPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.datadog;
 
 import io.micrometer.datadog.DatadogConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link DatadogProperties} to a {@link DatadogConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.dynatrace;
 
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatracePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatracePropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.dynatrace;
 
 import io.micrometer.dynatrace.DynatraceConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link DynatraceProperties} to a {@link io.micrometer.dynatrace.DynatraceConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.elastic;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.elastic;
 
 import io.micrometer.elastic.ElasticConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link ElasticProperties} to an {@link ElasticConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/ganglia/GangliaPropertiesConfigAdapter.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.ganglia;
 
 import info.ganglia.gmetric4j.gmetric.GMetric;
 import io.micrometer.ganglia.GangliaConfig;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphitePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/graphite/GraphitePropertiesConfigAdapter.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.graphite;
 
 import io.micrometer.graphite.GraphiteConfig;
 import io.micrometer.graphite.GraphiteProtocol;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.humio;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.humio;
 
 import io.micrometer.humio.HumioConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 import java.util.Map;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxProperties.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.influx;
 
 import io.micrometer.influx.InfluxConsistency;
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/influx/InfluxPropertiesConfigAdapter.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.influx;
 
 import io.micrometer.influx.InfluxConfig;
 import io.micrometer.influx.InfluxConsistency;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link InfluxProperties} to an {@link InfluxConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/jmx/JmxPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.jmx;
 
 import io.micrometer.jmx.JmxConfig;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.kairos;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/kairos/KairosPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.kairos;
 
 import io.micrometer.kairos.KairosConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link KairosProperties} to an {@link KairosConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.newrelic;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.newrelic;
 
 import io.micrometer.newrelic.NewRelicConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link NewRelicProperties} to a {@link NewRelicConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/prometheus/PrometheusPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.prometheus;
 
 import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/PropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/PropertiesConfigAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.autoconfigure.export;
+package io.micrometer.spring.autoconfigure.export.properties;
 
 import org.springframework.util.Assert;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryProperties.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.autoconfigure.export;
+package io.micrometer.spring.autoconfigure.export.properties;
 
 import java.time.Duration;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.spring.autoconfigure.export;
+package io.micrometer.spring.autoconfigure.export.properties;
 
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxProperties.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.signalfx;
 
 import java.time.Duration;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
@@ -16,7 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.signalfx;
 
 import io.micrometer.signalfx.SignalFxConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 
 /**
  * Adapter to convert {@link SignalFxProperties} to a {@link SignalFxConfig}.

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimplePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimplePropertiesConfigAdapter.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.simple;
 
 import io.micrometer.core.instrument.simple.CountingMode;
 import io.micrometer.core.instrument.simple.SimpleConfig;
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 
 import java.time.Duration;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.statsd;
 
-import io.micrometer.spring.autoconfigure.export.PropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdFlavor;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
@@ -18,7 +18,7 @@ package io.micrometer.spring.autoconfigure.export.wavefront;
 import java.net.URI;
 import java.time.Duration;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.spring.autoconfigure.export.wavefront;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
+import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapter;
 import io.micrometer.wavefront.WavefrontConfig;
 
 /**

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
@@ -17,8 +17,6 @@ package io.micrometer.spring.autoconfigure.export.properties;
 
 import java.time.Duration;
 
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
-import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAdapter;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
@@ -16,7 +16,6 @@
 package io.micrometer.spring.autoconfigure.export.properties;
 
 import io.micrometer.core.instrument.step.StepRegistryConfig;
-import io.micrometer.spring.autoconfigure.export.StepRegistryProperties;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This PR moves registry properties base classes to `properties` package to align with Spring Boot 2.x support.