### PR TITLE
Prevent null suffix in GangliaMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -36,7 +36,10 @@ import java.util.concurrent.TimeUnit;
 import static io.micrometer.core.instrument.Meter.Type.consume;
 
 /**
+ * {@link StepMeterRegistry} for Ganglia.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class GangliaMeterRegistry extends StepMeterRegistry {
     private final Logger logger = LoggerFactory.getLogger(GangliaMeterRegistry.class);
@@ -162,8 +165,7 @@ public class GangliaMeterRegistry extends StepMeterRegistry {
         Meter.Id id = meter.getId();
         String baseUnit = id.getBaseUnit();
         try {
-            ganglia.announce(nameMapper.toHierarchicalName(id.withName(id.getName() + "." + suffix),
-                    config().namingConvention()),
+            ganglia.announce(getMetricName(id, suffix),
                     DoubleFormat.decimalOrNan(value),
                     GMetricType.DOUBLE,
                     baseUnit == null ? "" : baseUnit,
@@ -174,6 +176,12 @@ public class GangliaMeterRegistry extends StepMeterRegistry {
         } catch (GangliaException e) {
             logger.warn("Unable to publish metric " + id.getName() + " to ganglia", e);
         }
+    }
+
+    // VisibleForTesting
+    String getMetricName(Meter.Id id, @Nullable String suffix) {
+        return nameMapper.toHierarchicalName(id.withName(suffix != null ? id.getName() + "." + suffix : id.getName()),
+                config().namingConvention());
     }
 
     @Override

--- a/implementations/micrometer-registry-ganglia/src/test/java/io/micrometer/ganglia/GangliaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-ganglia/src/test/java/io/micrometer/ganglia/GangliaMeterRegistryTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.ganglia;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link GangliaMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class GangliaMeterRegistryTest {
+
+    private final GangliaMeterRegistry registry = new GangliaMeterRegistry(GangliaConfig.DEFAULT, Clock.SYSTEM);
+
+    @Test
+    void getMetricNameWhenSuffixIsNullShouldNotAppendSuffix() {
+        Meter.Id id = new Meter.Id("name", Tags.empty(), null, null, Meter.Type.COUNTER);
+        assertThat(registry.getMetricName(id, null)).isEqualTo("name");
+    }
+
+    @Test
+    void getMetricNameWhenSuffixIsNotNullShouldAppendSuffix() {
+        Meter.Id id = new Meter.Id("name", Tags.empty(), null, null, Meter.Type.COUNTER);
+        assertThat(registry.getMetricName(id, "suffix")).isEqualTo("nameSuffix");
+    }
+
+}


### PR DESCRIPTION
This PR prevents `null` suffix in `GangliaMeterRegistry` as it doesn't seem to be intentional.