### PR TITLE
Remove Object creation in StrongReferenceGaugeFunction

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
@@ -35,7 +35,7 @@ class StrongReferenceGaugeFunction<T> implements ToDoubleFunction<T> {
     private final ToDoubleFunction<T> f;
 
     StrongReferenceGaugeFunction(@Nullable T obj, ToDoubleFunction<T> f) {
-        this.obj = obj == null ? new Object() : obj;
+        this.obj = obj;
         this.f = f;
     }
 


### PR DESCRIPTION
This PR removes `Object` creation in `StrongReferenceGaugeFunction` as it doesn't seem to be necessary unless I'm missing something.