### PR TITLE
Updating Sysdig line builder to sanitize replace all non-alphanumeric characters with an underscore

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilderTest.java
@@ -49,4 +49,27 @@ class SysdigStatsdLineBuilderTest {
         registry.config().namingConvention(NamingConvention.dot);
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter#statistic=count,my_tag=my_value:1|c");
     }
+
+    @Issue("#970")
+    @Test
+    void sanitizeAllNonAlphaNumericCharacters() {
+        String badCounterName = "\"\';^*()!~`_./?a{counter}:with123 weirdChars";
+        String badTagName = "\"\';^*()!~`_./?a{tag}:with123 weirdChars";
+        String badValueName = "\"\';^*()!~`_./?a{value}:with123 weirdChars";
+        Counter c = registry.counter(badCounterName,
+                badTagName,
+                badValueName);
+        SysdigStatsdLineBuilder lb = new SysdigStatsdLineBuilder(c.getId(), registry.config());
+
+        registry.config().namingConvention(NamingConvention.dot);
+        StringBuilder expected = new StringBuilder();
+        expected.append("___________.__a_counter__with123_weirdChars")
+                .append("#statistic=count,___________.__a_tag__with123_weirdChars")
+                .append("=___________.__a_value__with123_weirdChars:1|c");
+
+
+        assertThat(lb.line("1", Statistic.COUNT, "c"))
+                .isEqualTo(expected.toString());
+    }
+
 }


### PR DESCRIPTION
According to Sysdig they only allow the following for metrics:

> Allowed characters: a-z A-Z 0-9 _ .

Replace everything else with an underscore