### PR TITLE
Remove HttpSender.print() usages

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -92,7 +92,6 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             if (httpClient
                     .head(config.host() + ES_METRICS_TEMPLATE)
                     .withBasicAuthentication(config.userName(), config.password())
-                    .print()
                     .send()
                     .onError(response -> {
                         if (response.code() != 404) {

--- a/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
+++ b/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
@@ -93,7 +93,6 @@ public class KairosMeterRegistry extends StepMeterRegistry {
                                         this::writeCustomMetric)
                                 ).collect(Collectors.joining(",", "[", "]"))
                         )
-                        .print()
                         .send()
                         .onSuccess(response -> logger.debug("successfully sent {} metrics to kairos.", batch.size()))
                         .onError(response -> logger.error("failed to send metrics to kairos: {}", response.body()));


### PR DESCRIPTION
This PR removes `HttpSender.print()` usages as it doesn't seem to be intentional.