### PR TITLE
use shield type of badge for CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micrometer Application Metrics
 
-[![Build Status](https://circleci.com/gh/micrometer-metrics/micrometer.svg?style=svg)](https://circleci.com/gh/micrometer-metrics/micrometer)
+[![Build Status](https://circleci.com/gh/micrometer-metrics/micrometer.svg?style=shield)](https://circleci.com/gh/micrometer-metrics/micrometer)
 [![Apache 2.0](https://img.shields.io/github/license/micrometer-metrics/micrometer.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 An application metrics facade for the most popular monitoring tools. Instrument your code with dimensional metrics with a


### PR DESCRIPTION
Switch badge from:

![Build Status](https://circleci.com/gh/micrometer-metrics/micrometer.svg?style=svg)

to:

![Build Status](https://circleci.com/gh/micrometer-metrics/micrometer.svg?style=shield)

For consistency with the license badge
