### PR TITLE
Remove redundant 'System.out.println()' in TelegrafStatsdLineBuilder.

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
@@ -47,9 +47,7 @@ public class TelegrafStatsdLineBuilder extends FlavorStatsdLineBuilder {
     @Override
     String line(String amount, @Nullable Statistic stat, String type) {
         updateIfNamingConventionChanged();
-        String line = name + tagsByStatistic(stat) + ":" + amount + "|" + type;
-        System.out.println(line);
-        return line;
+        return name + tagsByStatistic(stat) + ":" + amount + "|" + type;
     }
 
     private void updateIfNamingConventionChanged() {


### PR DESCRIPTION
Removed redundant stdout when using Telegraf StatsD line builder.