### PR TITLE
Replace spaces with dashes to fix error when sending messages to influx

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -53,7 +53,7 @@ public class JvmMemoryMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         for (BufferPoolMXBean bufferPoolBean : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
-            Iterable<Tag> tagsWithId = Tags.concat(tags, "id", bufferPoolBean.getName());
+            Iterable<Tag> tagsWithId = Tags.concat(tags, "id", bufferPoolBean.getName().replace(" ", "-"));
 
             Gauge.builder("jvm.buffer.count", bufferPoolBean, BufferPoolMXBean::getCount)
                     .tags(tagsWithId)
@@ -76,7 +76,7 @@ public class JvmMemoryMetrics implements MeterBinder {
 
         for (MemoryPoolMXBean memoryPoolBean : ManagementFactory.getPlatformMXBeans(MemoryPoolMXBean.class)) {
             String area = MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap";
-            Iterable<Tag> tagsWithId = Tags.concat(tags, "id", memoryPoolBean.getName(), "area", area);
+            Iterable<Tag> tagsWithId = Tags.concat(tags, "id", memoryPoolBean.getName().replace(" ", "-"), "area", area);
 
             Gauge.builder("jvm.memory.used", memoryPoolBean, (mem) -> mem.getUsage().getUsed())
                     .tags(tagsWithId)


### PR DESCRIPTION
Fixes error when sending JVM memory metrics to Influx. 
Influx does not support spaces for its tags. 
So the value `PS Eden Space` breaks it. With `Invalid field format unable to parse` error. 
I have replaced space with dash. 

https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#tag-set