### PR TITLE
Fix a wrong index when copying an array in Tags.and(Tag...)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -29,6 +29,7 @@ import static java.util.stream.Collectors.joining;
  * @author Jon Schneider
  * @author Maciej Walkowiak
  * @author Phillip Webb
+ * @author Johnny Lim
  */
 public final class Tags implements Iterable<Tag> {
 
@@ -98,7 +99,7 @@ public final class Tags implements Iterable<Tag> {
         }
         Tag[] newTags = new Tag[last + tags.length];
         System.arraycopy(this.tags, 0, newTags, 0, last);
-        System.arraycopy(tags, 0, newTags, this.tags.length, tags.length);
+        System.arraycopy(tags, 0, newTags, last, tags.length);
         return new Tags(newTags);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
@@ -26,8 +26,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
+ * Tests for {@link Tags}.
+ *
  * @author Phil Webb
  * @author Maciej Walkowiak
+ * @author Jon Schneider
+ * @author Johnny Lim
  */
 class TagsTest {
 
@@ -141,6 +145,17 @@ class TagsTest {
         Tags source = Tags.of("t1", "v1");
         Tags merged = source.and((Tag[]) null);
         assertThat(source).isSameAs(merged);
+    }
+
+    @Test
+    void andTagsMultipleTimesShouldWork() {
+        Tags tags = Tags.empty().and(Tag.of("t1", "v1"));
+
+        Tags firstAnd = tags.and(Tag.of("t1", "v1"));
+        assertThat(firstAnd).isEqualTo(tags);
+
+        Tags secondAnd = firstAnd.and(Tag.of("t1", "v1"));
+        assertThat(secondAnd).isEqualTo(tags);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a wrong index when copying an array in `Tags.and(Tag...)`.