### PR TITLE
Include meter name in exception message

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -355,7 +355,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             throw new IllegalArgumentException("Prometheus requires that all meters with the same name have the same" +
-                    " set of tag keys. There is already an existing meter containing tag keys [" +
+                    " set of tag keys. There is already an existing meter named '" + name + "' containing tag keys [" +
                     existingCollector.getTagKeys().stream().collect(joining(", ")) + "]. The meter you are attempting to register" +
                     " has keys [" + tagKeys.stream().collect(joining(", ")) + "].");
         });


### PR DESCRIPTION
This PR changes to include meter name in exception message for meter redefinition in Prometheus.

Closes gh-1016