### PR TITLE
support tcp protocol in statsd exporter

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -72,11 +72,28 @@ public interface StatsdConfig extends MeterRegistryConfig {
     }
 
     /**
-     * @return The UDP port of the StatsD agent.
+     * @return The port of the StatsD agent.
      */
     default int port() {
         String v = get(prefix() + ".port");
         return (v == null) ? 8125 : Integer.parseInt(v);
+    }
+
+    /**
+     * @return the protocol of the connection to the agent
+     */
+    default StatsdProtocol protocol() {
+        final String v = get(prefix() + ".protocol");
+
+        if (v == null)
+            return StatsdProtocol.UDP;
+
+        for (StatsdProtocol protocol : StatsdProtocol.values()) {
+            if (protocol.toString().equalsIgnoreCase(v))
+                return protocol;
+        }
+
+        throw new IllegalArgumentException("Unrecognized statsd protocol '" + v + "' (check property " + prefix() + ".protocol)");
     }
 
     /**

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -231,7 +231,6 @@ public class StatsdMeterRegistry extends MeterRegistry {
                 meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
                     .doOnEach(n -> poll())
                     .subscribe());
-
             });
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -130,26 +130,26 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
             // now that we're connected, start polling gauges and other pollable meter types
             meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
-                .doOnEach(n -> poll())
-                .subscribe());
+                    .doOnEach(n -> poll())
+                    .subscribe());
         }
 
         config().onMeterRemoved(meter -> {
             //noinspection SuspiciousMethodCalls
             meter.use(
-                this::removePollableMeter,
-                c -> ((StatsdCounter) c).shutdown(),
-                t -> ((StatsdTimer) t).shutdown(),
-                d -> ((StatsdDistributionSummary) d).shutdown(),
-                this::removePollableMeter,
-                this::removePollableMeter,
-                this::removePollableMeter,
-                this::removePollableMeter,
-                m -> {
-                    for (Measurement measurement : m.measure()) {
-                        pollableMeters.remove(m.getId().withTag(measurement.getStatistic()));
-                    }
-                });
+                    this::removePollableMeter,
+                    c -> ((StatsdCounter) c).shutdown(),
+                    t -> ((StatsdTimer) t).shutdown(),
+                    d -> ((StatsdDistributionSummary) d).shutdown(),
+                    this::removePollableMeter,
+                    this::removePollableMeter,
+                    this::removePollableMeter,
+                    this::removePollableMeter,
+                    m -> {
+                        for (Measurement measurement : m.measure()) {
+                            pollableMeters.remove(m.getId().withTag(measurement.getStatistic()));
+                        }
+                    });
         });
 
         if (config.enabled())
@@ -184,7 +184,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     public void start() {
         final Flux<String> bufferingPublisher = BufferingFlux.create(Flux.from(processor), "\n", statsdConfig.maxPacketLength(), statsdConfig.pollingFrequency().toMillis())
-            .onBackpressureLatest();
+                .onBackpressureLatest();
 
         if (started.compareAndSet(false, true) && lineSink == null) {
             if (statsdConfig.protocol() == StatsdProtocol.UDP) {
@@ -197,41 +197,41 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     private void prepareUdpClient(Flux<String> bufferingPublisher) {
         UdpClient.create()
-            .host(statsdConfig.host())
-            .port(statsdConfig.port())
-            .handle((in, out) -> out
-                .options(NettyPipeline.SendOptions::flushOnEach)
-                .sendString(bufferingPublisher)
-                .neverComplete()
-            )
-            .connect()
-            .subscribe(client -> {
-                this.client.replace(client);
+                .host(statsdConfig.host())
+                .port(statsdConfig.port())
+                .handle((in, out) -> out
+                        .options(NettyPipeline.SendOptions::flushOnEach)
+                        .sendString(bufferingPublisher)
+                        .neverComplete()
+                )
+                .connect()
+                .subscribe(client -> {
+                    this.client.replace(client);
 
-                // now that we're connected, start polling gauges and other pollable meter types
-                meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
-                    .doOnEach(n -> poll())
-                    .subscribe());
-            });
+                    // now that we're connected, start polling gauges and other pollable meter types
+                    meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
+                            .doOnEach(n -> poll())
+                            .subscribe());
+                });
     }
 
     private void prepareTcpClient(Flux<String> bufferingPublisher) {
         TcpClient.create()
-            .host(statsdConfig.host())
-            .port(statsdConfig.port())
-            .handle((in, out) -> out
-                .options(NettyPipeline.SendOptions::flushOnEach)
-                .sendString(bufferingPublisher)
-                .neverComplete())
-            .connect()
-            .subscribe(client -> {
-                this.client.replace(client);
+                .host(statsdConfig.host())
+                .port(statsdConfig.port())
+                .handle((in, out) -> out
+                        .options(NettyPipeline.SendOptions::flushOnEach)
+                        .sendString(bufferingPublisher)
+                        .neverComplete())
+                .connect()
+                .subscribe(client -> {
+                    this.client.replace(client);
 
-                // now that we're connected, start polling gauges and other pollable meter types
-                meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
-                    .doOnEach(n -> poll())
-                    .subscribe());
-            });
+                    // now that we're connected, start polling gauges and other pollable meter types
+                    meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
+                            .doOnEach(n -> poll())
+                            .subscribe());
+                });
     }
 
     public void stop() {
@@ -289,9 +289,9 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @SuppressWarnings("ConstantConditions")
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector
-        pauseDetector) {
+            pauseDetector) {
         Timer timer = new StatsdTimer(id, lineBuilder(id), processor, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-            statsdConfig.step().toMillis());
+                statsdConfig.step().toMillis());
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -299,7 +299,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @SuppressWarnings("ConstantConditions")
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig
-        distributionStatisticConfig, double scale) {
+            distributionStatisticConfig, double scale) {
         DistributionSummary summary = new StatsdDistributionSummary(id, lineBuilder(id), processor, clock, distributionStatisticConfig, scale);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
@@ -314,10 +314,10 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T
-        obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit
-                                                     totalTimeFunctionUnit) {
+            obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit
+                                                         totalTimeFunctionUnit) {
         StatsdFunctionTimer ft = new StatsdFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit,
-            getBaseTimeUnit(), lineBuilder(id), processor);
+                getBaseTimeUnit(), lineBuilder(id), processor);
         pollableMeters.put(id, ft);
         return ft;
     }
@@ -352,9 +352,9 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @Override
     protected DistributionStatisticConfig defaultHistogramConfig() {
         return DistributionStatisticConfig.builder()
-            .expiry(statsdConfig.step())
-            .build()
-            .merge(DistributionStatisticConfig.DEFAULT);
+                .expiry(statsdConfig.step())
+                .build()
+                .merge(DistributionStatisticConfig.DEFAULT);
     }
 
     public int queueSize() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.UnicastProcessor;
 import reactor.netty.NettyPipeline;
 import reactor.netty.udp.UdpClient;
+import reactor.netty.tcp.TcpClient;
 import reactor.util.concurrent.Queues;
 
 import java.lang.reflect.InvocationTargetException;
@@ -55,7 +56,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     private final Map<Meter.Id, StatsdPollable> pollableMeters = new ConcurrentHashMap<>();
     private final AtomicBoolean started = new AtomicBoolean(false);
     Processor<String, String> processor;
-    private Disposable.Swap udpClient = Disposables.swap();
+    private Disposable.Swap client = Disposables.swap();
     private Disposable.Swap meterPoller = Disposables.swap();
 
     @Nullable
@@ -129,26 +130,26 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
             // now that we're connected, start polling gauges and other pollable meter types
             meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
-                    .doOnEach(n -> poll())
-                    .subscribe());
+                .doOnEach(n -> poll())
+                .subscribe());
         }
 
         config().onMeterRemoved(meter -> {
             //noinspection SuspiciousMethodCalls
             meter.use(
-                    this::removePollableMeter,
-                    c -> ((StatsdCounter) c).shutdown(),
-                    t -> ((StatsdTimer) t).shutdown(),
-                    d -> ((StatsdDistributionSummary) d).shutdown(),
-                    this::removePollableMeter,
-                    this::removePollableMeter,
-                    this::removePollableMeter,
-                    this::removePollableMeter,
-                    m -> {
-                        for (Measurement measurement : m.measure()) {
-                            pollableMeters.remove(m.getId().withTag(measurement.getStatistic()));
-                        }
-                    });
+                this::removePollableMeter,
+                c -> ((StatsdCounter) c).shutdown(),
+                t -> ((StatsdTimer) t).shutdown(),
+                d -> ((StatsdDistributionSummary) d).shutdown(),
+                this::removePollableMeter,
+                this::removePollableMeter,
+                this::removePollableMeter,
+                this::removePollableMeter,
+                m -> {
+                    for (Measurement measurement : m.measure()) {
+                        pollableMeters.remove(m.getId().withTag(measurement.getStatistic()));
+                    }
+                });
         });
 
         if (config.enabled())
@@ -183,32 +184,60 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     public void start() {
         final Flux<String> bufferingPublisher = BufferingFlux.create(Flux.from(processor), "\n", statsdConfig.maxPacketLength(), statsdConfig.pollingFrequency().toMillis())
-                .onBackpressureLatest();
+            .onBackpressureLatest();
 
         if (started.compareAndSet(false, true) && lineSink == null) {
-            UdpClient.create()
-                    .host(statsdConfig.host())
-                    .port(statsdConfig.port())
-                    .handle((in, out) -> out
-                            .options(NettyPipeline.SendOptions::flushOnEach)
-                            .sendString(bufferingPublisher)
-                            .neverComplete()
-                    )
-                    .connect()
-                    .subscribe(client -> {
-                        this.udpClient.replace(client);
-
-                        // now that we're connected, start polling gauges and other pollable meter types
-                        meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
-                                .doOnEach(n -> poll())
-                                .subscribe());
-                    });
+            if (statsdConfig.protocol() == StatsdProtocol.UDP) {
+                prepareUdpClient(bufferingPublisher);
+            } else if (statsdConfig.protocol() == StatsdProtocol.TCP) {
+                prepareTcpClient(bufferingPublisher);
+            }
         }
+    }
+
+    private void prepareUdpClient(Flux<String> bufferingPublisher) {
+        UdpClient.create()
+            .host(statsdConfig.host())
+            .port(statsdConfig.port())
+            .handle((in, out) -> out
+                .options(NettyPipeline.SendOptions::flushOnEach)
+                .sendString(bufferingPublisher)
+                .neverComplete()
+            )
+            .connect()
+            .subscribe(client -> {
+                this.client.replace(client);
+
+                // now that we're connected, start polling gauges and other pollable meter types
+                meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
+                    .doOnEach(n -> poll())
+                    .subscribe());
+            });
+    }
+
+    private void prepareTcpClient(Flux<String> bufferingPublisher) {
+        TcpClient.create()
+            .host(statsdConfig.host())
+            .port(statsdConfig.port())
+            .handle((in, out) -> out
+                .options(NettyPipeline.SendOptions::flushOnEach)
+                .sendString(bufferingPublisher)
+                .neverComplete())
+            .connect()
+            .subscribe(client -> {
+                this.client.replace(client);
+
+                // now that we're connected, start polling gauges and other pollable meter types
+                meterPoller.replace(Flux.interval(statsdConfig.pollingFrequency())
+                    .doOnEach(n -> poll())
+                    .subscribe());
+
+            });
     }
 
     public void stop() {
         if (started.compareAndSet(true, false)) {
-            udpClient.dispose();
+            client.dispose();
             meterPoller.dispose();
         }
     }
@@ -261,9 +290,9 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @SuppressWarnings("ConstantConditions")
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector
-            pauseDetector) {
+        pauseDetector) {
         Timer timer = new StatsdTimer(id, lineBuilder(id), processor, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                statsdConfig.step().toMillis());
+            statsdConfig.step().toMillis());
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -271,7 +300,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @SuppressWarnings("ConstantConditions")
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig
-            distributionStatisticConfig, double scale) {
+        distributionStatisticConfig, double scale) {
         DistributionSummary summary = new StatsdDistributionSummary(id, lineBuilder(id), processor, clock, distributionStatisticConfig, scale);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
@@ -286,10 +315,10 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T
-            obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit
-                                                         totalTimeFunctionUnit) {
+        obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit
+                                                     totalTimeFunctionUnit) {
         StatsdFunctionTimer ft = new StatsdFunctionTimer<>(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit,
-                getBaseTimeUnit(), lineBuilder(id), processor);
+            getBaseTimeUnit(), lineBuilder(id), processor);
         pollableMeters.put(id, ft);
         return ft;
     }
@@ -324,9 +353,9 @@ public class StatsdMeterRegistry extends MeterRegistry {
     @Override
     protected DistributionStatisticConfig defaultHistogramConfig() {
         return DistributionStatisticConfig.builder()
-                .expiry(statsdConfig.step())
-                .build()
-                .merge(DistributionStatisticConfig.DEFAULT);
+            .expiry(statsdConfig.step())
+            .build()
+            .merge(DistributionStatisticConfig.DEFAULT);
     }
 
     public int queueSize() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdProtocol.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdProtocol.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.statsd;
+
+public enum StatsdProtocol {
+    UDP,
+    TCP
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdProperties.java
@@ -16,6 +16,7 @@
 package io.micrometer.spring.autoconfigure.export.statsd;
 
 import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.statsd.StatsdProtocol;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.time.Duration;
@@ -48,6 +49,11 @@ public class StatsdProperties {
      * Port of the StatsD server to receive exported metrics.
      */
     private Integer port = 8125;
+
+    /**
+     * Protocol of the StatsD server to receive exported metrics.
+     */
+    private StatsdProtocol protocol = StatsdProtocol.UDP;
 
     /**
      * Total length of a single payload should be kept within your network's MTU.
@@ -96,6 +102,14 @@ public class StatsdProperties {
 
     public void setPort(Integer port) {
         this.port = port;
+    }
+
+    public StatsdProtocol getProtocol() {
+        return this.protocol;
+    }
+
+    public void setProtocol(StatsdProtocol protocol) {
+        this.protocol = protocol;
     }
 
     public Integer getMaxPacketLength() {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -18,6 +18,7 @@ package io.micrometer.spring.autoconfigure.export.statsd;
 import io.micrometer.spring.autoconfigure.export.properties.PropertiesConfigAdapter;
 import io.micrometer.statsd.StatsdConfig;
 import io.micrometer.statsd.StatsdFlavor;
+import io.micrometer.statsd.StatsdProtocol;
 
 import java.time.Duration;
 
@@ -55,6 +56,11 @@ public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<Stats
     @Override
     public int port() {
         return get(StatsdProperties::getPort, StatsdConfig.super::port);
+    }
+
+    @Override
+    public StatsdProtocol protocol() {
+        return get(StatsdProperties::getProtocol, StatsdConfig.super::protocol);
     }
 
     @Override


### PR DESCRIPTION
Some statsd agents like `Telegraf` support TCP protocol as well and we do use it to gather our metrics, So I opened this PR to add possibility to chose the agent's protocol.

Please do let me know if anything is missing.