### PR TITLE
Relocate META-INF/native/libnetty_transport_native_epoll_x86_64.so

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -29,6 +29,7 @@ shadowJar {
     relocate 'reactor', 'io.micrometer.shaded.reactor'
     relocate 'org.reactivestreams', 'io.micrometer.shaded.org.reactorstreams'
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
+    relocate 'META-INF/native/libnetty', 'META-INF/native/libio_micrometer_shaded_netty'
     relocate 'org.pcollections', 'io.micrometer.shaded.statsd.org.pcollections'
 }
 


### PR DESCRIPTION
This PR relocates `META-INF/native/libnetty_transport_native_epoll_x86_64.so` to `META-INF/native/libio_micrometer_shaded_netty_transport_native_epoll_x86_64.so`.

Fixes gh-976