### PR TITLE
Fix that deny filters always take precedence

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -598,8 +598,12 @@ public abstract class MeterRegistry {
 
     private boolean accept(Meter.Id id) {
         for (MeterFilter filter : filters) {
-            if (filter.accept(id) == MeterFilterReply.DENY)
+            MeterFilterReply reply = filter.accept(id);
+            if (reply == MeterFilterReply.DENY) {
                 return false;
+            } else if (reply == MeterFilterReply.ACCEPT) {
+                return true;
+            }
         }
         return true;
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -45,6 +45,16 @@ class MeterRegistryTest {
     }
 
     @Test
+    void overidingAcceptMeterFilter() {
+        registry.config().meterFilter(MeterFilter.accept(m -> m.getName().startsWith("jvm.important")));
+        registry.config().meterFilter(MeterFilter.deny(m -> m.getName().startsWith("jvm")));
+	
+        assertThat(registry.counter("jvm.my.counter")).isInstanceOf(NoopCounter.class);
+        assertThat(registry.counter("jvm.important.counter")).isNotInstanceOf(NoopCounter.class);
+        assertThat(registry.counter("my.counter")).isNotInstanceOf(NoopCounter.class);
+    }
+
+    @Test
     void idTransformingMeterFilter() {
         registry.config().meterFilter(MeterFilter.ignoreTags("k1"));
 


### PR DESCRIPTION
I had some issues with writing MeterFilters. After accepting a Meter with my filter it is still filtered out by a proceeding `MeterFilter.deny`.  According to the [concepts documentation](https://micrometer.io/docs/concepts#_meter_filters):

> ACCEPT - If a filter returns ACCEPT, the meter is immediately registered without interrogating any further filters' accept methods.

So this PR tries to fix this and also provides a test, which I would expect to work (given the above section of the documentation), but it doesn't with the proposed changes.