### PR TITLE
Remove a metric from MetricRegistry when removing a meter

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -33,7 +33,10 @@ import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
 
 /**
+ * Dropwizard {@link MeterRegistry}.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public abstract class DropwizardMeterRegistry extends MeterRegistry {
     private final MetricRegistry registry;
@@ -47,7 +50,13 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
         this.dropwizardClock = new DropwizardClock(clock);
         this.registry = registry;
         this.nameMapper = nameMapper;
-        config().namingConvention(NamingConvention.camelCase);
+        config()
+            .namingConvention(NamingConvention.camelCase)
+            .onMeterRemoved(this::onMeterRemoved);
+    }
+
+    private void onMeterRemoved(Meter meter) {
+        registry.remove(hierarchicalName(meter.getId()));
     }
 
     public MetricRegistry getDropwizardRegistry() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
@@ -29,6 +29,12 @@ import java.util.concurrent.TimeUnit;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link DropwizardMeterRegistry}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class DropwizardMeterRegistryTest {
     private final MockClock clock = new MockClock();
 
@@ -90,4 +96,13 @@ class DropwizardMeterRegistryTest {
         assertThat(summaryHist2.value()).isEqualTo(0);
         assertThat(timerHist.value()).isEqualTo(0);
     }
+
+    @Issue("#1038")
+    @Test
+    void removeShouldWork() {
+        Counter counter = registry.counter("test");
+        registry.remove(counter);
+        assertThat(registry.counter("test")).isNotNull();
+    }
+
 }


### PR DESCRIPTION
This PR changes to remove a metric from `MetricRegistry` when removing a meter from `DropwizardMeterRegistry`.

Fixes gh-1038