### PR TITLE
Fix statsd buffering for metrics updates faster than pollingInterval

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
@@ -61,13 +61,16 @@ public class BufferingFlux {
                     .bufferUntil(line -> {
                         final int bytesLength = line.getBytes().length;
                         final long now = System.currentTimeMillis();
-                        final long last = lastTime.getAndSet(now);
+                        // Update last time to now if this is the first time
+                        lastTime.compareAndSet(0, now);
+                        final long last = lastTime.get();
                         long diff;
                         if (last != 0L) {
                             diff = now - last;
                             if (diff > maxMillisecondsBetweenEmits && byteSize.get() > 0) {
                                 // This creates a buffer, reset size
                                 byteSize.set(bytesLength);
+                                lastTime.compareAndSet(last, now);
                                 return true;
                             }
                         }
@@ -82,6 +85,7 @@ public class BufferingFlux {
                         if (projectedBytes > maxByteArraySize) {
                             // This creates a buffer, reset size
                             byteSize.set(bytesLength);
+                            lastTime.compareAndSet(last, now);
                             return true;
                         }
 


### PR DESCRIPTION
I found that the time computation for determining whether to buffer or not was not correct (#1043).  It was always computing the time since the last value, not since it was last flushed. If you had metrics that were triggered faster than the pollingInterval (which is the value used to determine how long to buffer events), they would not be written at the correct time and would only flush when reaching the maximum packet size.

I couldn't come up with a way to write this as a test using StepVerifier, I was only able to demonstrate the problem by directly subscribing to the BufferedFlux and toggling a boolean once a value was received.  Without my changes, this would show that no value is emitted after 500ms, where the values were written every 100ms and the BufferedFlux is configured to emit events after 200ms max.