### PR TITLE
Add a Checkstyle rule for System.out.println()

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -21,10 +21,20 @@
                       value="Line has leading tab characters; indentation should be performed with spaces only." />
             <property name="ignoreComments" value="true" />
         </module>
+        <module name="Regexp">
+            <property name="id" value="sysout"/>
+            <property name="format" value="System\.out\.println"/>
+            <property name="illegalPattern" value="true"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
 
         <!-- Whitespace -->
         <module name="com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck" />
 
         <module name="SuppressionCommentFilter"/>
+    </module>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml"/>
     </module>
 </module>

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+    <suppress id="sysout" files="ClearCustomMetricDescriptors.java"/>
+    <suppress id="sysout" files="HttpSender.java"/>
+    <suppress id="sysout" files="[\\/]samples[\\/].*"/>
+    <suppress id="sysout" files="[\\/]src[\\/]test[\\/].*"/>
+</suppressions>


### PR DESCRIPTION
This PR adds a Checkstyle rule for `System.out.println()` to prevent it from being introduced accidentally.

For example, see #984.