### PR TITLE
Add "clean" task to command in "Building Locally"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependencies {
 
 ## Building Locally
 
-Run `./gradlew pTML` to publish a Maven-style snapshot to your Maven local repo. To consume:
+Run `./gradlew clean pTML` to publish a Maven-style snapshot to your Maven local repo. To consume:
 
 ```groovy
 repositories {


### PR DESCRIPTION
This PR adds "clean" task to the command in the "Building Locally" section to guarantee a clean built artifact to be published.