### PR TITLE
Add access token validation to SignalFxPropertiesConfigAdapter

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
@@ -28,6 +28,7 @@ public class SignalFxPropertiesConfigAdapter extends StepRegistryPropertiesConfi
 
     public SignalFxPropertiesConfigAdapter(SignalFxProperties properties) {
         super(properties);
+        accessToken(); // validate that an access token is set
     }
 
     @Override


### PR DESCRIPTION
This PR adds access token validation to `SignalFxPropertiesConfigAdapter` as it seems missed to sync to Spring Boot legacy support from https://github.com/spring-projects/spring-boot/commit/f478911c54d8a96807d553ca111abc387e5e821a#diff-493821fa211b7c866ae825420a4541feR35.