### PR TITLE
Add removeAllMeters() to MeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -53,6 +53,7 @@ import static java.util.Objects.requireNonNull;
  * thread, e.g. it should respond immediately by avoiding IO call, deep stack recursion or any coordination.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public abstract class MeterRegistry {
     protected final Clock clock;
@@ -658,6 +659,15 @@ public abstract class MeterRegistry {
         }
 
         return null;
+    }
+
+    /**
+     * Remove all meters.
+     * @since 1.1.2
+     */
+    @Incubating(since = "1.1.2")
+    public void removeAllMeters() {
+        meterMap.keySet().forEach(this::remove);
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -28,6 +28,12 @@ import javax.annotation.Nonnull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link MeterRegistry}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class MeterRegistryTest {
     private MeterRegistry registry = new SimpleMeterRegistry();
 
@@ -152,5 +158,19 @@ class MeterRegistryTest {
         assertThat(registry.getMeters()).hasSize(2);
         registry.remove(timer);
         assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    void removeAllMeters() {
+        registry.counter("my.counter");
+        registry.counter("my.counter2");
+
+        assertThat(registry.find("my.counter").counter()).isNotNull();
+        assertThat(registry.find("my.counter2").counter()).isNotNull();
+
+        registry.removeAllMeters();
+
+        assertThat(registry.find("my.counter").counter()).isNull();
+        assertThat(registry.find("my.counter2").counter()).isNull();
     }
 }


### PR DESCRIPTION
This PR adds `removeAllMeters()` to `MeterRegistry` to support clearing all meters.

See gh-569