### PR TITLE
Remove jar.deleteAllActions() usages

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -33,7 +33,7 @@ shadowJar {
     relocate 'org.pcollections', 'io.micrometer.shaded.statsd.org.pcollections'
 }
 
-jar.deleteAllActions()
+jar.enabled = false
 jar.dependsOn shadowJar
 
 publishing {

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -92,7 +92,7 @@ shadowJar {
     relocate 'org.pcollections', 'io.micrometer.shaded.org.pcollections'
 }
 
-jar.deleteAllActions()
+jar.enabled = false
 jar.dependsOn shadowJar
 
 publishing {


### PR DESCRIPTION
This PR removes `jar.deleteAllActions()` which has been removed in Gradle 5.0. I failed to see the reason why it exists and a quick search on it didn't give much information. I might miss something here. Please let me know if it must be handled differently with some reason.