### PR TITLE
Add missed lock files from "Upgrade to Gradle Wrapper 5.0"

### DIFF
--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-spring-legacy/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,5 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.springframework.boot:spring-boot-autoconfigure-processor:1.5.17.RELEASE
+org.springframework.boot:spring-boot-configuration-processor:1.5.17.RELEASE

--- a/micrometer-spring-legacy/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.


### PR DESCRIPTION
This PR adds missed newly-created lock files from "Upgrade to Gradle Wrapper 5.0" (#1084). I confirmed `./gradlew clean check` works without them but created this just in case.