### PR TITLE
Remove unused StatsdGauge.shutdown()

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
@@ -33,7 +33,6 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
     private final ToDoubleFunction<T> value;
     private final AtomicReference<Double> lastValue = new AtomicReference<>(Double.NaN);
     private final boolean alwaysPublish;
-    private volatile boolean shutdown = false;
 
     StatsdGauge(Id id, StatsdLineBuilder lineBuilder, Subscriber<String> subscriber, @Nullable T obj, ToDoubleFunction<T> value, boolean alwaysPublish) {
         super(id);
@@ -53,7 +52,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
     @Override
     public void poll() {
         double val = value();
-        if (!shutdown && !Double.isNaN(val) && !Double.isInfinite(val) && (alwaysPublish || lastValue.getAndSet(val) != val)) {
+        if (!Double.isNaN(val) && !Double.isInfinite(val) && (alwaysPublish || lastValue.getAndSet(val) != val)) {
             subscriber.onNext(lineBuilder.gauge(val));
         }
     }
@@ -69,7 +68,4 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
         return MeterEquivalence.hashCode(this);
     }
 
-    void shutdown() {
-        this.shutdown = true;
-    }
 }


### PR DESCRIPTION
This PR removes unused `StatsdGauge.shutdown()`.