### PR TITLE
Influx: Move histogram/percentile fields into the timer table

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.*;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
-import org.apache.commons.lang.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.influx;
 
-import com.google.common.collect.Lists;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
@@ -28,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -215,7 +215,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
         final ValueAtPercentile[] percentileValues = timer.takeSnapshot().percentileValues();
         if (percentileValues.length > 0) {
-            List<Field> quantiles = Lists.newArrayListWithExpectedSize(percentileValues.length);
+            List<Field> quantiles = new ArrayList<>(percentileValues.length);
             for (ValueAtPercentile v : percentileValues) {
                 quantiles.add(new Field("quantile" + v.percentile(), v.value(getBaseTimeUnit())));
             }

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -15,10 +15,20 @@
  */
 package io.micrometer.influx;
 
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
-import io.micrometer.core.instrument.util.*;
+import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.MeterPartition;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringUtils;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import org.slf4j.Logger;

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -18,13 +18,18 @@ package io.micrometer.influx;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionTimer;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramGauges;
+import io.micrometer.core.instrument.distribution.HistogramSupport;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.step.StepDistributionSummary;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.step.StepTimer;
 import io.micrometer.core.instrument.util.DoubleFormat;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
@@ -39,7 +44,6 @@ import java.util.ArrayList;
 import java.net.MalformedURLException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -119,6 +123,18 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         } catch (Throwable e) {
             logger.error("unable to create database '{}'", config.db(), e);
         }
+    }
+
+    @Override
+    protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
+        return new StepTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
+            this.config.step().toMillis(), false);
+    }
+
+    @Override
+    protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
+        return new StepDistributionSummary(id, clock, distributionStatisticConfig, scale,
+            config.step().toMillis(),false);
     }
 
     @Override
@@ -216,8 +232,6 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
 
     private Stream<String> writeTimer(Timer timer) {
 
-        final Stream<Field> totalFields;
-
         final Stream<Field> fields = Stream.of(
                 new Field("sum", timer.totalTime(getBaseTimeUnit())),
                 new Field("count", timer.count()),
@@ -225,18 +239,9 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 new Field("upper", timer.max(getBaseTimeUnit()))
         );
 
-        try {
-            Collection<Gauge> percentilesGauges = this.get(timer.getId().getName() + ".percentile").gauges();
-            List<Field> percentiles = new ArrayList<>(percentilesGauges.size());
-            percentilesGauges.forEach( gauge -> {
-                percentiles.add(new Field("phi" + gauge.getId().getTag("phi"), gauge.value()));
-            });
-            totalFields = Stream.concat(fields, percentiles.stream());
-            return Stream.of(influxLineProtocol(timer.getId(), "histogram", totalFields));
-        } catch (MeterNotFoundException ex) {
-            // Not all timer has percentile gauges
-            return Stream.of(influxLineProtocol(timer.getId(), "histogram", fields));
-        }
+        final Stream<Field> totalFields = writePercentiles(timer, fields);
+
+        return Stream.of(influxLineProtocol(timer.getId(), "histogram", totalFields));
     }
 
     private Stream<String> writeSummary(DistributionSummary summary) {
@@ -247,7 +252,24 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                 new Field("upper", summary.max())
         );
 
-        return Stream.of(influxLineProtocol(summary.getId(), "histogram", fields));
+        final Stream<Field> totalFields = writePercentiles(summary, fields);
+        return Stream.of(influxLineProtocol(summary.getId(), "histogram", totalFields));
+    }
+
+    private Stream<Field> writePercentiles(HistogramSupport histogramSupport, Stream<Field> fields) {
+        Stream<Field> totalFields;
+        final ValueAtPercentile[] percentileValues = histogramSupport.takeSnapshot().percentileValues();
+        if (percentileValues.length > 0) {
+            List<Field> quantiles = new ArrayList<>(percentileValues.length);
+            for (ValueAtPercentile v : percentileValues) {
+                quantiles.add(new Field("phi" + v.percentile(), v.value(getBaseTimeUnit())));
+            }
+            totalFields = Stream.concat(fields, quantiles.stream());
+        }
+        else {
+            totalFields = fields;
+        }
+        return totalFields;
     }
 
     private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields) {

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.distribution.HistogramGauges;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryWriteTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryWriteTest.java
@@ -58,8 +58,8 @@ public class InfluxMeterRegistryWriteTest {
 
         String[] result = doWriteTimer(timer).collect(Collectors.toList()).get(0).split(",");
         assertEquals(result[0], "test_timer");
-        assertTrue(result[5].startsWith("quantile0.5="));
-        assertTrue(result[6].startsWith("quantile0.95="));
+        assertTrue(result[5].startsWith("phi0.5="));
+        assertTrue(result[6].startsWith("phi0.95="));
     }
 
     /**

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryWriteTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryWriteTest.java
@@ -1,0 +1,58 @@
+package io.micrometer.influx;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Timer;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author ma_chao
+ * @date 2018/12/29 10:45
+ */
+public class InfluxMeterRegistryWriteTest {
+
+    private InfluxMeterRegistry registry = new InfluxMeterRegistry(InfluxConfig.DEFAULT, Clock.SYSTEM);
+
+    @Test
+    public void timerPercentileTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        Timer timer = Timer.builder("test.timer")
+            .publishPercentiles(0.5, 0.95)
+            .register(registry);
+
+        timer.record(Duration.ofSeconds(5));
+        timer.record(Duration.ofSeconds(1));
+        String[] result = doTestWriteTimer(timer).collect(Collectors.toList()).get(0).split(",");
+        assertEquals(timer.takeSnapshot().percentileValues().length, 2);
+        assertEquals(timer.takeSnapshot().percentileValues()[0].percentile(), 0.5, 0);
+        assertEquals(timer.takeSnapshot().percentileValues()[1].percentile(), 0.95, 0);
+        assertThat(timer.takeSnapshot().percentileValues()[0].value(TimeUnit.SECONDS))
+            .isEqualTo(1, offset(0.1));
+        assertThat(timer.takeSnapshot().percentileValues()[1].value(TimeUnit.SECONDS))
+            .isEqualTo(5.0, offset(0.1));
+
+        assertEquals(result[0], "test_timer");
+        assertTrue(result[5].startsWith("quantile0.5="));
+        assertTrue(result[6].startsWith("quantile0.95="));
+    }
+
+    /**
+     * Not change the visibility of private method testWriteTimer, so test it to use reflection
+     */
+    @SuppressWarnings("unchecked")
+    private Stream<String> doTestWriteTimer(Timer timer) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method writeTimer = InfluxMeterRegistry.class.getDeclaredMethod("writeTimer", Timer.class);
+        writeTimer.setAccessible(true);
+        return (Stream<String>) writeTimer.invoke(registry, timer);
+    }
+}


### PR DESCRIPTION
This PR add quantile fields in writeTimer method when publish to influxdb.