### PR TITLE
Revise cache metrics implementations + tests

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -218,7 +218,6 @@ public final class Tags implements Iterable<Tag> {
         } else if (tags instanceof Tags) {
             return (Tags) tags;
         } else if (tags instanceof Collection) {
-            @SuppressWarnings("unchecked")
             Collection<? extends Tag> tagsCollection = (Collection<? extends Tag>) tags;
             return new Tags(tagsCollection.toArray(new Tag[0]));
         } else {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
@@ -23,7 +23,6 @@ import io.micrometer.core.lang.Nullable;
 
 import java.lang.ref.WeakReference;
 
-
 /**
  * A common base class for cache metrics that ensures that all caches are instrumented
  * with the same basic set of metrics while allowing for additional detail that is specific
@@ -47,17 +46,23 @@ public abstract class CacheMeterBinder implements MeterBinder {
 
     @Override
     public final void bindTo(MeterRegistry registry) {
-        Long cacheSize = size();
-        if (cacheSize != null) {
-            Gauge.builder("cache.size", cache.get(), c -> cacheSize)
+        if (size() != null) {
+            Gauge.builder("cache.size", cache.get(),
+                    c -> {
+                        Long size = size();
+                        return size == null ? 0 : size;
+                    })
                     .tags(tags)
                     .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
                     .register(registry);
         }
 
-        Long missCount = missCount();
-        if (missCount != null) {
-            FunctionCounter.builder("cache.gets", cache.get(),  c -> missCount)
+        if (missCount() != null) {
+            FunctionCounter.builder("cache.gets", cache.get(),
+                    c -> {
+                        Long misses = missCount();
+                        return misses == null ? 0 : misses;
+                    })
                     .tags(tags).tag("result", "miss")
                     .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
                     .register(registry);
@@ -73,9 +78,12 @@ public abstract class CacheMeterBinder implements MeterBinder {
                 .description("The number of entries added to the cache")
                 .register(registry);
 
-        Long evictionCount = evictionCount();
-        if (evictionCount != null) {
-            FunctionCounter.builder("cache.evictions", cache.get(), c -> evictionCount)
+        if (evictionCount() != null) {
+            FunctionCounter.builder("cache.evictions", cache.get(),
+                    c -> {
+                        Long evictions = evictionCount();
+                        return evictions == null ? 0 : evictions;
+                    })
                     .tags(tags)
                     .description("cache evictions")
                     .register(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
@@ -47,27 +47,23 @@ public abstract class CacheMeterBinder implements MeterBinder {
 
     @Override
     public final void bindTo(MeterRegistry registry) {
-        if (size() != null) {
-            Gauge.builder("cache.size", cache.get(),
-                    c -> {
-                        Long size = size();
-                        return size == null ? 0 : size;
-                    })
-                    .tags(tags)
-                    .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
-                    .register(registry);
-        }
+        Gauge.builder("cache.size", cache.get(),
+                c -> {
+                    Long size = size();
+                    return size == null ? 0 : size;
+                })
+                .tags(tags)
+                .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
+                .register(registry);
 
-        if (missCount() != null) {
-            FunctionCounter.builder("cache.gets", cache.get(),
-                    c -> {
-                        Long misses = missCount();
-                        return misses == null ? 0 : misses;
-                    })
-                    .tags(tags).tag("result", "miss")
-                    .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
-                    .register(registry);
-        }
+        FunctionCounter.builder("cache.gets", cache.get(),
+                c -> {
+                    Long misses = missCount();
+                    return misses == null ? 0 : misses;
+                })
+                .tags(tags).tag("result", "miss")
+                .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
+                .register(registry);
 
         FunctionCounter.builder("cache.gets", cache.get(), c -> hitCount())
                 .tags(tags).tag("result", "hit")
@@ -79,16 +75,14 @@ public abstract class CacheMeterBinder implements MeterBinder {
                 .description("The number of entries added to the cache")
                 .register(registry);
 
-        if (evictionCount() != null) {
-            FunctionCounter.builder("cache.evictions", cache.get(),
-                    c -> {
-                        Long evictions = evictionCount();
-                        return evictions == null ? 0 : evictions;
-                    })
-                    .tags(tags)
-                    .description("cache evictions")
-                    .register(registry);
-        }
+        FunctionCounter.builder("cache.evictions", cache.get(),
+                c -> {
+                    Long evictions = evictionCount();
+                    return evictions == null ? 0 : evictions;
+                })
+                .tags(tags)
+                .description("cache evictions")
+                .register(registry);
 
         bindImplementationSpecificMetrics(registry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
@@ -47,23 +47,19 @@ public abstract class CacheMeterBinder implements MeterBinder {
 
     @Override
     public final void bindTo(MeterRegistry registry) {
-        Gauge.builder("cache.size", cache.get(),
-                c -> {
-                    Long size = size();
-                    return size == null ? 0 : size;
-                })
-                .tags(tags)
-                .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
-                .register(registry);
+        if (size() != null) {
+            Gauge.builder("cache.size", cache.get(), c -> size())
+                    .tags(tags)
+                    .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
+                    .register(registry);
+        }
 
-        FunctionCounter.builder("cache.gets", cache.get(),
-                c -> {
-                    Long misses = missCount();
-                    return misses == null ? 0 : misses;
-                })
-                .tags(tags).tag("result", "miss")
-                .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
-                .register(registry);
+        if (missCount() != null) {
+            FunctionCounter.builder("cache.gets", cache.get(),  c -> missCount())
+                    .tags(tags).tag("result", "miss")
+                    .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
+                    .register(registry);
+        }
 
         FunctionCounter.builder("cache.gets", cache.get(), c -> hitCount())
                 .tags(tags).tag("result", "hit")
@@ -75,14 +71,12 @@ public abstract class CacheMeterBinder implements MeterBinder {
                 .description("The number of entries added to the cache")
                 .register(registry);
 
-        FunctionCounter.builder("cache.evictions", cache.get(),
-                c -> {
-                    Long evictions = evictionCount();
-                    return evictions == null ? 0 : evictions;
-                })
-                .tags(tags)
-                .description("cache evictions")
-                .register(registry);
+        if (evictionCount() != null) {
+            FunctionCounter.builder("cache.evictions", cache.get(), c -> evictionCount())
+                    .tags(tags)
+                    .description("cache evictions")
+                    .register(registry);
+        }
 
         bindImplementationSpecificMetrics(registry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinder.java
@@ -47,15 +47,17 @@ public abstract class CacheMeterBinder implements MeterBinder {
 
     @Override
     public final void bindTo(MeterRegistry registry) {
-        if (size() != null) {
-            Gauge.builder("cache.size", cache.get(), c -> size())
+        Long cacheSize = size();
+        if (cacheSize != null) {
+            Gauge.builder("cache.size", cache.get(), c -> cacheSize)
                     .tags(tags)
                     .description("The number of entries in this cache. This may be an approximation, depending on the type of cache.")
                     .register(registry);
         }
 
-        if (missCount() != null) {
-            FunctionCounter.builder("cache.gets", cache.get(),  c -> missCount())
+        Long missCount = missCount();
+        if (missCount != null) {
+            FunctionCounter.builder("cache.gets", cache.get(),  c -> missCount)
                     .tags(tags).tag("result", "miss")
                     .description("the number of times cache lookup methods have returned an uncached (newly loaded) value, or null")
                     .register(registry);
@@ -71,8 +73,9 @@ public abstract class CacheMeterBinder implements MeterBinder {
                 .description("The number of entries added to the cache")
                 .register(registry);
 
-        if (evictionCount() != null) {
-            FunctionCounter.builder("cache.evictions", cache.get(), c -> evictionCount())
+        Long evictionCount = evictionCount();
+        if (evictionCount != null) {
+            FunctionCounter.builder("cache.evictions", cache.get(), c -> evictionCount)
                     .tags(tags)
                     .description("cache evictions")
                     .register(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -67,7 +67,7 @@ public class CaffeineCacheMetrics extends CacheMeterBinder {
      * @param <C>       The cache type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      */
-    public static <C extends Cache> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
+    public static <C extends Cache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
         return monitor(registry, cache, cacheName, Tags.of(tags));
     }
 
@@ -83,7 +83,7 @@ public class CaffeineCacheMetrics extends CacheMeterBinder {
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      * @see CacheStats
      */
-    public static <C extends Cache> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
+    public static <C extends Cache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
         new CaffeineCacheMetrics(cache, cacheName, tags).bindTo(registry);
         return cache;
     }
@@ -99,7 +99,7 @@ public class CaffeineCacheMetrics extends CacheMeterBinder {
      * @param <C>       The cache type.
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      */
-    public static <C extends AsyncLoadingCache> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
+    public static <C extends AsyncLoadingCache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
         return monitor(registry, cache, cacheName, Tags.of(tags));
     }
 
@@ -115,7 +115,7 @@ public class CaffeineCacheMetrics extends CacheMeterBinder {
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      * @see CacheStats
      */
-    public static <C extends AsyncLoadingCache> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
+    public static <C extends AsyncLoadingCache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
         monitor(registry, cache.synchronous(), cacheName, tags);
         return cache;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -99,12 +99,12 @@ public class EhCache2Metrics extends CacheMeterBinder {
                 .register(registry);
 
         FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutAddedCount)
-                .tags(getTagsWithCacheName())
+                .tags(getTagsWithCacheName()).tags("result", "added")
                 .description("Cache puts resulting in a new key/value pair")
                 .register(registry);
 
-        FunctionCounter.builder("cache.puts.updated", stats, StatisticsGateway::cachePutUpdatedCount)
-                .tags(getTagsWithCacheName())
+        FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutUpdatedCount)
+                .tags(getTagsWithCacheName()).tags("result", "updated")
                 .description("Cache puts resulting in an updated value")
                 .register(registry);
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -103,7 +103,7 @@ public class EhCache2Metrics extends CacheMeterBinder {
                 .description("Cache puts resulting in a new key/value pair")
                 .register(registry);
 
-        FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutAddedCount)
+        FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutUpdatedCount)
                 .tags(getTagsWithCacheName()).tags("result", "updated")
                 .description("Cache puts resulting in an updated value")
                 .register(registry);
@@ -113,7 +113,7 @@ public class EhCache2Metrics extends CacheMeterBinder {
         rollbackTransactionMetrics(registry);
         recoveryTransactionMetrics(registry);
 
-        Gauge.builder("cache.local.offheap.size", stats, StatisticsGateway::getLocalOffHeapSize)
+        Gauge.builder("cache.local.offheap.size", stats, StatisticsGateway::getLocalOffHeapSizeInBytes)
                 .tags(getTagsWithCacheName())
                 .description("Local off-heap size")
                 .baseUnit("bytes")

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -89,6 +89,7 @@ public class EhCache2Metrics extends CacheMeterBinder {
     @Override
     protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
         Gauge.builder("cache.remoteSize", stats, StatisticsGateway::getRemoteSize)
+                .tags(getTagsWithCacheName())
                 .description("The number of entries held remotely in this cache")
                 .register(registry);
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -99,12 +99,12 @@ public class EhCache2Metrics extends CacheMeterBinder {
                 .register(registry);
 
         FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutAddedCount)
-                .tags(getTagsWithCacheName()).tags("result", "added")
+                .tags(getTagsWithCacheName())
                 .description("Cache puts resulting in a new key/value pair")
                 .register(registry);
 
-        FunctionCounter.builder("cache.puts.added", stats, StatisticsGateway::cachePutUpdatedCount)
-                .tags(getTagsWithCacheName()).tags("result", "updated")
+        FunctionCounter.builder("cache.puts.updated", stats, StatisticsGateway::cachePutUpdatedCount)
+                .tags(getTagsWithCacheName())
                 .description("Cache puts resulting in an updated value")
                 .register(registry);
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetrics.java
@@ -44,7 +44,7 @@ public class GuavaCacheMetrics extends CacheMeterBinder {
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      * @see com.google.common.cache.CacheStats
      */
-    public static <C extends Cache> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
+    public static <C extends Cache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, String... tags) {
         return monitor(registry, cache, cacheName, Tags.of(tags));
     }
 
@@ -60,7 +60,7 @@ public class GuavaCacheMetrics extends CacheMeterBinder {
      * @return The instrumented cache, unchanged. The original cache is not wrapped or proxied in any way.
      * @see com.google.common.cache.CacheStats
      */
-    public static <C extends Cache> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
+    public static <C extends Cache<?, ?>> C monitor(MeterRegistry registry, C cache, String cacheName, Iterable<Tag> tags) {
         new GuavaCacheMetrics(cache, cacheName, tags).bindTo(registry);
         return cache;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -129,17 +129,19 @@ public class JCacheMetrics extends CacheMeterBinder {
     }
 
     private Long lookupStatistic(String name) {
-        try {
-            List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
-            for (MBeanServer mBeanServer : mBeanServers) {
-                try {
-                    return (Long) mBeanServer.getAttribute(objectName, name);
-                } catch (AttributeNotFoundException | InstanceNotFoundException ex) {
-                    // did not find MBean, try the next server
+        if (objectName != null) {
+            try {
+                List<MBeanServer> mBeanServers = MBeanServerFactory.findMBeanServer(null);
+                for (MBeanServer mBeanServer : mBeanServers) {
+                    try {
+                        return (Long) mBeanServer.getAttribute(objectName, name);
+                    } catch (AttributeNotFoundException | InstanceNotFoundException ex) {
+                        // did not find MBean, try the next server
+                    }
                 }
+            } catch (MBeanException | ReflectionException ex) {
+                throw new IllegalStateException(ex);
             }
-        } catch (MBeanException | ReflectionException ex) {
-            throw new IllegalStateException(ex);
         }
 
         // didn't find the MBean in any servers

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -30,12 +30,19 @@ abstract class AbstractCacheMetricsTest {
     /**
      * Verifies base metrics presence
      */
-    protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
-        meterRegistry.get("cache.size").tags(expectedTag).gauge();
-        meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "hit").functionCounter();
-        meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "miss").functionCounter();
+    protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry, CacheMeterBinder meterBinder) {
         meterRegistry.get("cache.puts").tags(expectedTag).functionCounter();
-        meterRegistry.get("cache.evictions").tags(expectedTag).functionCounter();
+        meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "hit").functionCounter();
+
+        if (meterBinder.size() != null) {
+            meterRegistry.get("cache.size").tags(expectedTag).gauge();
+        }
+        if (meterBinder.missCount() != null) {
+            meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "miss").functionCounter();
+        }
+        if (meterBinder.evictionCount() != null) {
+            meterRegistry.get("cache.evictions").tags(expectedTag).functionCounter();
+        }
     }
 
     protected RequiredSearch fetch(MeterRegistry meterRegistry, String name) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.cache;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * @author Oleksii Bondar
+ */
+abstract class AbstractCacheMetricsTest {
+
+    protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
+        meterRegistry.get("cache.size").gauge();
+        meterRegistry.get("cache.gets").functionCounter();
+        meterRegistry.get("cache.puts").functionCounter();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -28,7 +28,7 @@ abstract class AbstractCacheMetricsTest {
     protected Tags expectedTag = Tags.of("app", "test");
 
     /**
-     * Verifies base metrics presense
+     * Verifies base metrics presence
      */
     protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
         meterRegistry.get("cache.size").tags(expectedTag).gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -19,7 +19,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.search.RequiredSearch;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * @author Oleksii Bondar
@@ -39,11 +38,11 @@ abstract class AbstractCacheMetricsTest {
         meterRegistry.get("cache.evictions").tags(getTags()).functionCounter();
     }
 
-    protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name) {
+    protected RequiredSearch fetch(MeterRegistry meterRegistry, String name) {
         return meterRegistry.get(name).tags(getTags());
     }
 
-    protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name, Iterable<Tag> tags) {
+    protected RequiredSearch fetch(MeterRegistry meterRegistry, String name, Iterable<Tag> tags) {
         return fetch(meterRegistry, name).tags(tags);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -25,21 +25,21 @@ import io.micrometer.core.instrument.search.RequiredSearch;
  */
 abstract class AbstractCacheMetricsTest {
 
-    protected abstract Tags getTags();
+    protected Tags expectedTag = Tags.of("app", "test");
 
     /**
      * Verifies base metrics presense
      */
     protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
-        meterRegistry.get("cache.size").tags(getTags()).gauge();
-        meterRegistry.get("cache.gets").tags(getTags()).tag("result", "hit").functionCounter();
-        meterRegistry.get("cache.gets").tags(getTags()).tag("result", "miss").functionCounter();
-        meterRegistry.get("cache.puts").tags(getTags()).functionCounter();
-        meterRegistry.get("cache.evictions").tags(getTags()).functionCounter();
+        meterRegistry.get("cache.size").tags(expectedTag).gauge();
+        meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "hit").functionCounter();
+        meterRegistry.get("cache.gets").tags(expectedTag).tag("result", "miss").functionCounter();
+        meterRegistry.get("cache.puts").tags(expectedTag).functionCounter();
+        meterRegistry.get("cache.evictions").tags(expectedTag).functionCounter();
     }
 
     protected RequiredSearch fetch(MeterRegistry meterRegistry, String name) {
-        return meterRegistry.get(name).tags(getTags());
+        return meterRegistry.get(name).tags(expectedTag);
     }
 
     protected RequiredSearch fetch(MeterRegistry meterRegistry, String name, Iterable<Tag> tags) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -16,15 +16,29 @@
 package io.micrometer.core.instrument.binder.cache;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.search.RequiredSearch;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * @author Oleksii Bondar
  */
 abstract class AbstractCacheMetricsTest {
+    
+    protected abstract Tags getTags();
 
     protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
         meterRegistry.get("cache.size").gauge();
         meterRegistry.get("cache.gets").functionCounter();
         meterRegistry.get("cache.puts").functionCounter();
+    }
+    
+    protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name) {
+        return meterRegistry.get(name).tags(getTags());
+    }
+    
+    protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name, Iterable<Tag> tags) {
+        return fetch(meterRegistry, name).tags(tags);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -28,10 +28,15 @@ abstract class AbstractCacheMetricsTest {
 
     protected abstract Tags getTags();
 
+    /**
+     * Verifies base metrics presense
+     */
     protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
         meterRegistry.get("cache.size").tags(getTags()).gauge();
-        meterRegistry.get("cache.gets").tags(getTags()).functionCounter();
+        meterRegistry.get("cache.gets").tags(getTags()).tag("result", "hit").functionCounter();
+        meterRegistry.get("cache.gets").tags(getTags()).tag("result", "miss").functionCounter();
         meterRegistry.get("cache.puts").tags(getTags()).functionCounter();
+        meterRegistry.get("cache.evictions").tags(getTags()).functionCounter();
     }
 
     protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/AbstractCacheMetricsTest.java
@@ -25,19 +25,19 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
  * @author Oleksii Bondar
  */
 abstract class AbstractCacheMetricsTest {
-    
+
     protected abstract Tags getTags();
 
     protected void verifyCommonCacheMetrics(MeterRegistry meterRegistry) {
-        meterRegistry.get("cache.size").gauge();
-        meterRegistry.get("cache.gets").functionCounter();
-        meterRegistry.get("cache.puts").functionCounter();
+        meterRegistry.get("cache.size").tags(getTags()).gauge();
+        meterRegistry.get("cache.gets").tags(getTags()).functionCounter();
+        meterRegistry.get("cache.puts").tags(getTags()).functionCounter();
     }
-    
+
     protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name) {
         return meterRegistry.get(name).tags(getTags());
     }
-    
+
     protected RequiredSearch fetch(SimpleMeterRegistry meterRegistry, String name, Iterable<Tag> tags) {
         return fetch(meterRegistry, name).tags(tags);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -26,13 +26,11 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link CaffeineCacheMetrics}.
@@ -85,9 +83,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
         metrics.bindTo(meterRegistry);
 
-        assertThrows(MeterNotFoundException.class, () -> {
-            meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();
-        });
+        assertThat(meterRegistry.find("cache.load.duration").timeGauge()).isNull();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -60,6 +60,14 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
     }
     
     @Test
+    void constructInstanceViaStaticMethodMonitor() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        meterRegistry.get("cache.eviction.weight").tags(expectedTag).gauge();
+    }
+    
+    @Test
     void doNotReportMetricsForNonLoadingCache() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         Cache<Object, Object> cache = Caffeine.newBuilder().build();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -69,7 +69,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         FunctionCounter failedLoad = fetch(registry, "cache.load", Tags.of("result", "failure")).functionCounter();
         assertThat(failedLoad.count()).isEqualTo(stats.loadFailureCount());
     }
-    
+
     @Test
     void constructInstanceViaStaticMethodMonitor() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -77,7 +77,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
         meterRegistry.get("cache.eviction.weight").tags(expectedTag).gauge();
     }
-    
+
     @Test
     void doNotReportMetricsForNonLoadingCache() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -51,7 +51,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
-        verifyCommonCacheMetrics(registry);
+        verifyCommonCacheMetrics(registry, metrics);
 
         Gauge evictionWeight = fetch(registry, "cache.eviction.weight").gauge();
         CacheStats stats = cache.stats();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
@@ -50,7 +51,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void reportExpectedGeneralMetrics() {
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
         verifyCommonCacheMetrics(registry);
@@ -72,7 +73,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void constructInstanceViaStaticMethodMonitor() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
 
         meterRegistry.get("cache.eviction.weight").tags(expectedTag).gauge();
@@ -80,7 +81,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void doNotReportMetricsForNonLoadingCache() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         Cache<Object, Object> cache = Caffeine.newBuilder().build();
         CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
         metrics.bindTo(meterRegistry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link CaffeineCacheMetrics}.
+ *
+ * @author Oleksii Bondar
+ */
+class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
+
+    private Tags expectedTag = Tags.of("app", "test");
+    private LoadingCache<String, String> cache = Caffeine.newBuilder().build(new CacheLoader<String, String>() {
+        public String load(String key) throws Exception {
+            return "";
+        };
+    });
+    private CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
+
+    @Test
+    void reportExpectedGeneralMetrics() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        metrics.bindTo(meterRegistry);
+
+        meterRegistry.get("cache.eviction.weight").tags(expectedTag).gauge();
+
+        // specific to LoadingCache instance
+        meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();
+        meterRegistry.get("cache.load").tags(expectedTag).tag("result", "success").functionCounter();
+        meterRegistry.get("cache.load").tags(expectedTag).tag("result", "failure").functionCounter();
+    }
+    
+    @Test
+    void doNotReportMetricsForNonLoadingCache() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Cache<Object, Object> cache = Caffeine.newBuilder().build();
+        CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
+        metrics.bindTo(meterRegistry);
+
+        assertThrows(MeterNotFoundException.class, () -> {
+            meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();
+        });
+    }
+
+    @Test
+    void returnCacheSize() {
+        assertThat(metrics.size()).isEqualTo(cache.estimatedSize());
+    }
+
+    @Test
+    void returnHitCount() {
+        assertThat(metrics.hitCount()).isEqualTo(cache.stats().hitCount());
+    }
+
+    @Test
+    void returnMissCount() {
+        assertThat(metrics.missCount()).isEqualTo(cache.stats().missCount());
+    }
+
+    @Test
+    void returnEvictionCount() {
+        assertThat(metrics.evictionCount()).isEqualTo(cache.stats().evictionCount());
+    }
+
+    @Test
+    void returnPutCount() {
+        assertThat(metrics.putCount()).isEqualTo(cache.stats().loadCount());
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -41,7 +41,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
-    private Tags expectedTag = Tags.of("app", "test");
     private LoadingCache<String, String> cache = Caffeine.newBuilder().build(new CacheLoader<String, String>() {
         public String load(String key) throws Exception {
             return "";
@@ -114,11 +113,6 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
     @Test
     void returnPutCount() {
         assertThat(metrics.putCount()).isEqualTo(cache.stats().loadCount());
-    }
-
-    @Override
-    protected Tags getTags() {
-        return expectedTag;
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.cache;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EhCache2Metrics}.
+ *
+ * @author Oleksii Bondar
+ */
+class EhCache2MetricsTest extends AbstractCacheMetricsTest {
+
+    private static CacheManager cacheManager;
+    private static Cache cache;
+
+    @Test
+    void reportMetrics() {
+        Tags expectedTag = Tags.of("app", "test");
+        EhCache2Metrics metrics = new EhCache2Metrics(cache, expectedTag);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        metrics.bindTo(meterRegistry);
+
+        verifyCommonCacheMetrics(meterRegistry);
+
+        meterRegistry.get("cache.remoteSize").tags(expectedTag).gauge();
+        meterRegistry.get("cache.removals").tags(expectedTag).functionCounter();
+        meterRegistry.get("cache.puts.added").tags(expectedTag).functionCounter();
+        meterRegistry.get("cache.puts.added").tags(expectedTag).functionCounter();
+        meterRegistry.get("cache.local.offheap.size").tags(expectedTag).gauge();
+        meterRegistry.get("cache.local.heap.size").tags(expectedTag).gauge();
+        meterRegistry.get("cache.local.disk.size").tags(expectedTag).gauge();
+
+        // miss metrics
+        meterRegistry.get("cache.misses").tags(expectedTag).tag("reason", "expired").functionCounter();
+        meterRegistry.get("cache.misses").tags(expectedTag).tag("reason", "notFound").functionCounter();
+
+        // commit transaction metrics
+        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "readOnly").functionCounter();
+        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "exception").functionCounter();
+        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "committed").functionCounter();
+
+        // rollback transaction metrics
+        meterRegistry.get("cache.xa.rollbacks").tags(expectedTag).tag("result", "exception").functionCounter();
+        meterRegistry.get("cache.xa.rollbacks").tags(expectedTag).tag("result", "success").functionCounter();
+
+        // recovery transaction metrics
+        meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "nothing").functionCounter();
+        meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "success").functionCounter();
+
+    }
+
+    @BeforeAll
+    static void setup() {
+        cacheManager = CacheManager.newInstance();
+        cacheManager.addCache("testCache");
+        cache = cacheManager.getCache("testCache");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        cacheManager.removeAllCaches();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -53,7 +53,7 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
-        verifyCommonCacheMetrics(registry);
+        verifyCommonCacheMetrics(registry, metrics);
 
         StatisticsGateway stats = cache.getStatistics();
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -46,7 +46,6 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
     private static CacheManager cacheManager;
     private static Cache cache;
 
-    private Tags expectedTag = Tags.of("app", "test");
     private EhCache2Metrics metrics = new EhCache2Metrics(cache, expectedTag);
 
     @Test
@@ -195,8 +194,4 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         cacheManager.removeAllCaches();
     }
 
-    @Override
-    protected Tags getTags() {
-        return expectedTag;
-    }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -42,43 +44,80 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
 
     private static CacheManager cacheManager;
     private static Cache cache;
-    
+
     private Tags expectedTag = Tags.of("app", "test");
     private EhCache2Metrics metrics = new EhCache2Metrics(cache, expectedTag);
-    
+
     @Test
     void reportMetrics() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        metrics.bindTo(meterRegistry);
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        metrics.bindTo(registry);
 
-        verifyCommonCacheMetrics(meterRegistry);
+        verifyCommonCacheMetrics(registry);
 
-        meterRegistry.get("cache.remoteSize").tags(expectedTag).gauge();
-        meterRegistry.get("cache.removals").tags(expectedTag).functionCounter();
-        meterRegistry.get("cache.puts.added").tags(expectedTag).functionCounter();
-        meterRegistry.get("cache.puts.added").tags(expectedTag).functionCounter();
-        meterRegistry.get("cache.local.offheap.size").tags(expectedTag).gauge();
-        meterRegistry.get("cache.local.heap.size").tags(expectedTag).gauge();
-        meterRegistry.get("cache.local.disk.size").tags(expectedTag).gauge();
+        StatisticsGateway stats = cache.getStatistics();
+
+        Gauge remoteSize = fetch(registry, "cache.remoteSize").gauge();
+        assertThat(remoteSize.value()).isEqualTo(stats.getRemoteSize());
+
+        FunctionCounter cacheRemovals = fetch(registry, "cache.removals").functionCounter();
+        assertThat(cacheRemovals.count()).isEqualTo(stats.cacheRemoveCount());
+
+        String cacheAdded = "cache.puts.added";
+        FunctionCounter putsAdded = fetch(registry, cacheAdded, Tags.of("result", "added")).functionCounter();
+        assertThat(putsAdded.count()).isEqualTo(stats.cachePutAddedCount());
+
+        FunctionCounter putsUpdated = fetch(registry, cacheAdded, Tags.of("result", "updated")).functionCounter();
+        assertThat(putsUpdated.count()).isEqualTo(stats.cachePutUpdatedCount());
+
+        Gauge offHeapSize = fetch(registry, "cache.local.offheap.size").gauge();
+        assertThat(offHeapSize.value()).isEqualTo(stats.getLocalOffHeapSizeInBytes());
+
+        Gauge heapSize = fetch(registry, "cache.local.heap.size").gauge();
+        assertThat(heapSize.value()).isEqualTo(stats.getLocalHeapSizeInBytes());
+
+        Gauge diskSize = fetch(registry, "cache.local.disk.size").gauge();
+        assertThat(diskSize.value()).isEqualTo(stats.getLocalDiskSizeInBytes());
 
         // miss metrics
-        meterRegistry.get("cache.misses").tags(expectedTag).tag("reason", "expired").functionCounter();
-        meterRegistry.get("cache.misses").tags(expectedTag).tag("reason", "notFound").functionCounter();
+        String misses = "cache.misses";
+        FunctionCounter expiredMisses = fetch(registry, misses, Tags.of("reason", "expired")).functionCounter();
+        assertThat(expiredMisses.count()).isEqualTo(stats.cacheMissExpiredCount());
+
+        FunctionCounter notFoundMisses = fetch(registry, misses, Tags.of("reason", "notFound")).functionCounter();
+        assertThat(notFoundMisses.count()).isEqualTo(stats.cacheMissNotFoundCount());
 
         // commit transaction metrics
-        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "readOnly").functionCounter();
-        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "exception").functionCounter();
-        meterRegistry.get("cache.xa.commits").tags(expectedTag).tag("result", "committed").functionCounter();
+        String xaCommits = "cache.xa.commits";
+        FunctionCounter readOnlyCommits = fetch(registry, xaCommits, Tags.of("result", "readOnly")).functionCounter();
+        assertThat(readOnlyCommits.count()).isEqualTo(stats.xaCommitReadOnlyCount());
+
+        FunctionCounter exceptionCommits = fetch(registry, xaCommits, Tags.of("result", "exception")).functionCounter();
+        assertThat(exceptionCommits.count()).isEqualTo(stats.xaCommitExceptionCount());
+
+        FunctionCounter committedCommits = fetch(registry, xaCommits, Tags.of("result", "committed")).functionCounter();
+        assertThat(committedCommits.count()).isEqualTo(stats.xaCommitCommittedCount());
 
         // rollback transaction metrics
-        meterRegistry.get("cache.xa.rollbacks").tags(expectedTag).tag("result", "exception").functionCounter();
-        meterRegistry.get("cache.xa.rollbacks").tags(expectedTag).tag("result", "success").functionCounter();
+        String xaRollbacks = "cache.xa.rollbacks";
+        FunctionCounter exceptionRollback = fetch(registry, xaRollbacks, Tags.of("result", "exception"))
+                .functionCounter();
+        assertThat(exceptionRollback.count()).isEqualTo(stats.xaRollbackExceptionCount());
+
+        FunctionCounter successRollback = fetch(registry, xaRollbacks, Tags.of("result", "success")).functionCounter();
+        assertThat(successRollback.count()).isEqualTo(stats.xaRollbackSuccessCount());
 
         // recovery transaction metrics
-        meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "nothing").functionCounter();
-        meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "success").functionCounter();
+        String xaRecoveries = "cache.xa.recoveries";
+        FunctionCounter nothingRecovered = fetch(registry, xaRecoveries, Tags.of("result", "nothing"))
+                .functionCounter();
+        assertThat(nothingRecovered.count()).isEqualTo(stats.xaRecoveryNothingCount());
+
+        FunctionCounter successRecoveries = fetch(registry, xaRecoveries, Tags.of("result", "success"))
+                .functionCounter();
+        assertThat(successRecoveries.count()).isEqualTo(stats.xaRecoveryRecoveredCount());
     }
-    
+
     @Test
     void constructInstanceViaStaticMethodMonitor() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -123,17 +162,39 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         cacheManager.addCache("testCache");
         cache = cacheManager.getCache("testCache");
         StatisticsGateway stats = mock(StatisticsGateway.class);
+        // randomize stats to address false-positive checks
         Random random = new Random();
         when(stats.getSize()).thenReturn(random.nextLong());
         when(stats.cacheEvictedCount()).thenReturn(random.nextLong());
         when(stats.cacheHitCount()).thenReturn(random.nextLong());
         when(stats.cacheMissCount()).thenReturn(random.nextLong());
         when(stats.cachePutCount()).thenReturn(random.nextLong());
+        when(stats.getRemoteSize()).thenReturn(random.nextLong());
+        when(stats.cacheRemoveCount()).thenReturn(random.nextLong());
+        when(stats.cachePutAddedCount()).thenReturn(random.nextLong());
+        when(stats.cachePutUpdatedCount()).thenReturn(random.nextLong());
+        when(stats.getLocalOffHeapSizeInBytes()).thenReturn(random.nextLong());
+        when(stats.getLocalHeapSizeInBytes()).thenReturn(random.nextLong());
+        when(stats.getLocalDiskSizeInBytes()).thenReturn(random.nextLong());
+        when(stats.cacheMissExpiredCount()).thenReturn(random.nextLong());
+        when(stats.cacheMissNotFoundCount()).thenReturn(random.nextLong());
+        when(stats.xaCommitCommittedCount()).thenReturn(random.nextLong());
+        when(stats.xaCommitExceptionCount()).thenReturn(random.nextLong());
+        when(stats.xaCommitReadOnlyCount()).thenReturn(random.nextLong());
+        when(stats.xaRollbackExceptionCount()).thenReturn(random.nextLong());
+        when(stats.xaRollbackSuccessCount()).thenReturn(random.nextLong());
+        when(stats.xaRecoveryRecoveredCount()).thenReturn(random.nextLong());
+        when(stats.xaRecoveryNothingCount()).thenReturn(random.nextLong());
         ReflectionTestUtils.setField(cache, "statistics", stats);
     }
 
     @AfterAll
     static void cleanup() {
         cacheManager.removeAllCaches();
+    }
+
+    @Override
+    protected Tags getTags() {
+        return expectedTag;
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -63,10 +63,11 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         FunctionCounter cacheRemovals = fetch(registry, "cache.removals").functionCounter();
         assertThat(cacheRemovals.count()).isEqualTo(stats.cacheRemoveCount());
 
-        FunctionCounter putsAdded = fetch(registry, "cache.puts.added").functionCounter();
+        String cacheAdded = "cache.puts.added";
+        FunctionCounter putsAdded = fetch(registry, cacheAdded, Tags.of("result", "added")).functionCounter();
         assertThat(putsAdded.count()).isEqualTo(stats.cachePutAddedCount());
 
-        FunctionCounter putsUpdated = fetch(registry, "cache.puts.updated").functionCounter();
+        FunctionCounter putsUpdated = fetch(registry, cacheAdded, Tags.of("result", "updated")).functionCounter();
         assertThat(putsUpdated.count()).isEqualTo(stats.cachePutUpdatedCount());
 
         Gauge offHeapSize = fetch(registry, "cache.local.offheap.size").gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -78,6 +78,14 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "nothing").functionCounter();
         meterRegistry.get("cache.xa.recoveries").tags(expectedTag).tag("result", "success").functionCounter();
     }
+    
+    @Test
+    void constructInstanceViaStaticMethodMonitor() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        EhCache2Metrics.monitor(meterRegistry, cache, expectedTag);
+
+        meterRegistry.get("cache.remoteSize").tags(expectedTag).gauge();
+    }
 
     @Test
     void returnCacheSize() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -162,29 +162,30 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         cacheManager.addCache("testCache");
         cache = cacheManager.getCache("testCache");
         StatisticsGateway stats = mock(StatisticsGateway.class);
-        // randomize stats to address false-positive checks
+        // generate non-negative random value to address false-positives
+        int valueBound = 100000;
         Random random = new Random();
-        when(stats.getSize()).thenReturn(random.nextLong());
-        when(stats.cacheEvictedCount()).thenReturn(random.nextLong());
-        when(stats.cacheHitCount()).thenReturn(random.nextLong());
-        when(stats.cacheMissCount()).thenReturn(random.nextLong());
-        when(stats.cachePutCount()).thenReturn(random.nextLong());
-        when(stats.getRemoteSize()).thenReturn(random.nextLong());
-        when(stats.cacheRemoveCount()).thenReturn(random.nextLong());
-        when(stats.cachePutAddedCount()).thenReturn(random.nextLong());
-        when(stats.cachePutUpdatedCount()).thenReturn(random.nextLong());
-        when(stats.getLocalOffHeapSizeInBytes()).thenReturn(random.nextLong());
-        when(stats.getLocalHeapSizeInBytes()).thenReturn(random.nextLong());
-        when(stats.getLocalDiskSizeInBytes()).thenReturn(random.nextLong());
-        when(stats.cacheMissExpiredCount()).thenReturn(random.nextLong());
-        when(stats.cacheMissNotFoundCount()).thenReturn(random.nextLong());
-        when(stats.xaCommitCommittedCount()).thenReturn(random.nextLong());
-        when(stats.xaCommitExceptionCount()).thenReturn(random.nextLong());
-        when(stats.xaCommitReadOnlyCount()).thenReturn(random.nextLong());
-        when(stats.xaRollbackExceptionCount()).thenReturn(random.nextLong());
-        when(stats.xaRollbackSuccessCount()).thenReturn(random.nextLong());
-        when(stats.xaRecoveryRecoveredCount()).thenReturn(random.nextLong());
-        when(stats.xaRecoveryNothingCount()).thenReturn(random.nextLong());
+        when(stats.getSize()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheEvictedCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheHitCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheMissCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cachePutCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.getRemoteSize()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheRemoveCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cachePutAddedCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cachePutUpdatedCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.getLocalOffHeapSizeInBytes()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.getLocalHeapSizeInBytes()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.getLocalDiskSizeInBytes()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheMissExpiredCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.cacheMissNotFoundCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaCommitCommittedCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaCommitExceptionCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaCommitReadOnlyCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaRollbackExceptionCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaRollbackSuccessCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaRecoveryRecoveredCount()).thenReturn((long) random.nextInt(valueBound));
+        when(stats.xaRecoveryNothingCount()).thenReturn((long) random.nextInt(valueBound));
         ReflectionTestUtils.setField(cache, "statistics", stats);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -63,11 +63,10 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
         FunctionCounter cacheRemovals = fetch(registry, "cache.removals").functionCounter();
         assertThat(cacheRemovals.count()).isEqualTo(stats.cacheRemoveCount());
 
-        String cacheAdded = "cache.puts.added";
-        FunctionCounter putsAdded = fetch(registry, cacheAdded, Tags.of("result", "added")).functionCounter();
+        FunctionCounter putsAdded = fetch(registry, "cache.puts.added").functionCounter();
         assertThat(putsAdded.count()).isEqualTo(stats.cachePutAddedCount());
 
-        FunctionCounter putsUpdated = fetch(registry, cacheAdded, Tags.of("result", "updated")).functionCounter();
+        FunctionCounter putsUpdated = fetch(registry, "cache.puts.updated").functionCounter();
         assertThat(putsUpdated.count()).isEqualTo(stats.cachePutUpdatedCount());
 
         Gauge offHeapSize = fetch(registry, "cache.local.offheap.size").gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/EhCache2MetricsTest.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.cache;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -50,7 +51,7 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void reportMetrics() {
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
         verifyCommonCacheMetrics(registry);
@@ -120,7 +121,7 @@ class EhCache2MetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void constructInstanceViaStaticMethodMonitor() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         EhCache2Metrics.monitor(meterRegistry, cache, expectedTag);
 
         meterRegistry.get("cache.remoteSize").tags(expectedTag).gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -50,7 +50,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
-        verifyCommonCacheMetrics(registry);
+        verifyCommonCacheMetrics(registry, metrics);
 
         // common metrics
         Gauge cacheSize = fetch(registry, "cache.size").gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -47,7 +48,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void reportExpectedMetrics() {
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindTo(registry);
 
         verifyCommonCacheMetrics(registry);
@@ -81,7 +82,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void constructInstanceViaStaticMethodMonitor() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         GuavaCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
 
         meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -43,7 +43,6 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
             return "";
         };
     });
-    private Tags expectedTag = Tags.of("app", "test");
     private GuavaCacheMetrics metrics = new GuavaCacheMetrics(cache, "testCache", expectedTag);
 
     @Test
@@ -113,8 +112,4 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
         assertThat(metrics.putCount()).isEqualTo(cache.stats().loadCount());
     }
 
-    @Override
-    protected Tags getTags() {
-        return expectedTag;
-    }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -54,6 +54,14 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
     }
     
     @Test
+    void constructInstanceViaStaticMethodMonitor() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        GuavaCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();
+    }
+    
+    @Test
     void returnCacheSize() {
         assertThat(metrics.size()).isEqualTo(cache.size());
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -61,7 +61,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
         FunctionCounter failedLoad = fetch(registry, "cache.load", Tags.of("result", "failure")).functionCounter();
         assertThat(failedLoad.count()).isEqualTo(stats.loadExceptionCount());
     }
-    
+
     @Test
     void constructInstanceViaStaticMethodMonitor() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -69,7 +69,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
 
         meterRegistry.get("cache.load.duration").tags(expectedTag).timeGauge();
     }
-    
+
     @Test
     void returnCacheSize() {
         assertThat(metrics.size()).isEqualTo(cache.size());
@@ -94,7 +94,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
     void returnPutCount() {
         assertThat(metrics.putCount()).isEqualTo(cache.stats().loadCount());
     }
-    
+
     @Override
     protected Tags getTags() {
         return expectedTag;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -27,7 +27,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,17 +37,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
-    @Mock
     private static IMap<String, String> cache;
-    
+
     private Tags expectedTag = Tags.of("app", "test");
+    private HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
 
     @Test
     void reportMetrics() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         metrics.bindTo(meterRegistry);
-        
+
         verifyCommonCacheMetrics(meterRegistry);
 
         meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "backup").gauge();
@@ -71,31 +69,26 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void returnCacheSize() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.size()).isEqualTo(cache.size());
     }
-    
+
     @Test
     void returnNullForMissCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.missCount()).isNull();
     }
 
     @Test
     void returnNullForEvictionCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.evictionCount()).isNull();
     }
 
     @Test
     void returnHitCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.hitCount()).isEqualTo(cache.getLocalMapStats().getHits());
     }
 
     @Test
     void returnPutCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.putCount()).isEqualTo(cache.getLocalMapStats().getPutOperationCount());
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.cache;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.NearCacheStats;
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.NearCacheStatsImpl;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link HazelcastCacheMetrics}.
+ *
+ * @author Oleksii Bondar
+ */
+class HazelcastCacheMetricsTest {
+
+    @Mock
+    private static IMap<String, String> cache;
+
+    @Test
+    void reportMetrics() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Tags expectedTag = Tags.of("app", "test");
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
+        metrics.bindTo(meterRegistry);
+
+        meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "backup").gauge();
+        meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "owned").gauge();
+        meterRegistry.get("cache.entry.memory").tags(expectedTag).tag("ownership", "backup").gauge();
+        meterRegistry.get("cache.entry.memory").tags(expectedTag).tag("ownership", "owned").gauge();
+        meterRegistry.get("cache.partition.gets").tags(expectedTag).functionCounter();
+
+        // near cache stats
+        meterRegistry.get("cache.near.requests").tags(expectedTag).tag("result", "hit").gauge();
+        meterRegistry.get("cache.near.requests").tags(expectedTag).tag("result", "miss").gauge();
+        meterRegistry.get("cache.near.evictions").tags(expectedTag).gauge();
+        meterRegistry.get("cache.near.persistences").tags(expectedTag).gauge();
+
+        // timings
+        meterRegistry.get("cache.gets.latency").tags(expectedTag).functionTimer();
+        meterRegistry.get("cache.puts.latency").tags(expectedTag).functionTimer();
+        meterRegistry.get("cache.removals.latency").tags(expectedTag).functionTimer();
+    }
+
+    @Test
+    void returnNullForMissCount() {
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        assertThat(metrics.missCount()).isNull();
+    }
+
+    @Test
+    void returnNullForEvictionCount() {
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        assertThat(metrics.evictionCount()).isNull();
+    }
+
+    @Test
+    void returnHitCount() {
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        assertThat(metrics.hitCount()).isEqualTo(cache.getLocalMapStats().getHits());
+    }
+
+    @Test
+    void returnPutCount() {
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        assertThat(metrics.putCount()).isEqualTo(cache.getLocalMapStats().getPutOperationCount());
+    }
+
+    @BeforeAll
+    static void setup() {
+        cache = Hazelcast.newHazelcastInstance().getMap("mycache");
+        NearCacheStats nearCacheStats = new NearCacheStatsImpl();
+        ((LocalMapStatsImpl) cache.getLocalMapStats()).setNearCacheStats(nearCacheStats);
+    }
+
+    @AfterAll
+    static void cleanup() {
+        Hazelcast.shutdownAll();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -53,7 +54,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void reportMetrics() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         metrics.bindTo(meterRegistry);
 
         verifyCommonCacheMetrics(meterRegistry);
@@ -106,7 +107,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void constructInstanceViaStaticMethodMonitor() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         HazelcastCacheMetrics.monitor(meterRegistry, cache, expectedTag);
 
         meterRegistry.get("cache.partition.gets").tags(expectedTag).functionCounter();
@@ -114,7 +115,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void defaultMissCountMetricToZero() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         HazelcastCacheMetrics.monitor(meterRegistry, cache, expectedTag);
 
         FunctionCounter cacheEviction = fetch(meterRegistry, "cache.evictions").functionCounter();
@@ -123,7 +124,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void defaultEvictionCountmetricToZero() {
-        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MeterRegistry registry = new SimpleMeterRegistry();
         HazelcastCacheMetrics.monitor(registry, cache, expectedTag);
 
         FunctionCounter missCount = fetch(registry, "cache.gets", Tags.of("result", "miss")).functionCounter();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Oleksii Bondar
  */
-class HazelcastCacheMetricsTest {
+class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Mock
     private static IMap<String, String> cache;
@@ -47,6 +47,8 @@ class HazelcastCacheMetricsTest {
         Tags expectedTag = Tags.of("app", "test");
         HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         metrics.bindTo(meterRegistry);
+        
+        verifyCommonCacheMetrics(meterRegistry);
 
         meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "backup").gauge();
         meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "owned").gauge();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -49,7 +49,6 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     private static IMap<String, String> cache;
 
-    private Tags expectedTag = Tags.of("app", "test");
     private HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
 
     @Test
@@ -182,11 +181,6 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     @AfterAll
     static void cleanup() {
         Hazelcast.shutdownAll();
-    }
-
-    @Override
-    protected Tags getTags() {
-        return expectedTag;
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -40,11 +40,12 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Mock
     private static IMap<String, String> cache;
+    
+    private Tags expectedTag = Tags.of("app", "test");
 
     @Test
     void reportMetrics() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
-        Tags expectedTag = Tags.of("app", "test");
         HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         metrics.bindTo(meterRegistry);
         
@@ -69,26 +70,32 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     }
 
     @Test
+    void returnCacheSize() {
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
+        assertThat(metrics.size()).isEqualTo(cache.size());
+    }
+    
+    @Test
     void returnNullForMissCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.missCount()).isNull();
     }
 
     @Test
     void returnNullForEvictionCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.evictionCount()).isNull();
     }
 
     @Test
     void returnHitCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.hitCount()).isEqualTo(cache.getLocalMapStats().getHits());
     }
 
     @Test
     void returnPutCount() {
-        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, Tags.of("app", "test"));
+        HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
         assertThat(metrics.putCount()).isEqualTo(cache.getLocalMapStats().getPutOperationCount());
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -62,16 +62,16 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
         Gauge backupEntries = fetch(meterRegistry, "cache.entries", Tags.of("ownership", "backup")).gauge();
         assertThat(backupEntries.value()).isEqualTo(localMapStats.getBackupEntryCount());
-        
+
         Gauge ownedEntries = fetch(meterRegistry, "cache.entries", Tags.of("ownership", "owned")).gauge();
         assertThat(ownedEntries.value()).isEqualTo(localMapStats.getOwnedEntryCount());
-        
+
         Gauge backupEntryMemory = fetch(meterRegistry, "cache.entry.memory", Tags.of("ownership", "backup")).gauge();
         assertThat(backupEntryMemory.value()).isEqualTo(localMapStats.getBackupEntryMemoryCost());
-        
+
         Gauge ownedEntryMemory = fetch(meterRegistry, "cache.entry.memory", Tags.of("ownership", "owned")).gauge();
         assertThat(ownedEntryMemory.value()).isEqualTo(localMapStats.getOwnedEntryMemoryCost());
-        
+
         FunctionCounter partitionGets = fetch(meterRegistry, "cache.partition.gets").functionCounter();
         assertThat(partitionGets.count()).isEqualTo(localMapStats.getGetOperationCount());
 
@@ -152,10 +152,10 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     static void cleanup() {
         Hazelcast.shutdownAll();
     }
-    
+
     @Override
     protected Tags getTags() {
         return expectedTag;
     }
-    
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -17,18 +17,27 @@ package io.micrometer.core.instrument.binder.cache;
 
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.IMap;
+import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link HazelcastCacheMetrics}.
@@ -49,24 +58,51 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
         verifyCommonCacheMetrics(meterRegistry);
 
-        meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "backup").gauge();
-        meterRegistry.get("cache.entries").tags(expectedTag).tag("ownership", "owned").gauge();
-        meterRegistry.get("cache.entry.memory").tags(expectedTag).tag("ownership", "backup").gauge();
-        meterRegistry.get("cache.entry.memory").tags(expectedTag).tag("ownership", "owned").gauge();
-        meterRegistry.get("cache.partition.gets").tags(expectedTag).functionCounter();
+        LocalMapStats localMapStats = cache.getLocalMapStats();
+
+        Gauge backupEntries = fetch(meterRegistry, "cache.entries", Tags.of("ownership", "backup")).gauge();
+        assertThat(backupEntries.value()).isEqualTo(localMapStats.getBackupEntryCount());
+        
+        Gauge ownedEntries = fetch(meterRegistry, "cache.entries", Tags.of("ownership", "owned")).gauge();
+        assertThat(ownedEntries.value()).isEqualTo(localMapStats.getOwnedEntryCount());
+        
+        Gauge backupEntryMemory = fetch(meterRegistry, "cache.entry.memory", Tags.of("ownership", "backup")).gauge();
+        assertThat(backupEntryMemory.value()).isEqualTo(localMapStats.getBackupEntryMemoryCost());
+        
+        Gauge ownedEntryMemory = fetch(meterRegistry, "cache.entry.memory", Tags.of("ownership", "owned")).gauge();
+        assertThat(ownedEntryMemory.value()).isEqualTo(localMapStats.getOwnedEntryMemoryCost());
+        
+        FunctionCounter partitionGets = fetch(meterRegistry, "cache.partition.gets").functionCounter();
+        assertThat(partitionGets.count()).isEqualTo(localMapStats.getGetOperationCount());
 
         // near cache stats
-        meterRegistry.get("cache.near.requests").tags(expectedTag).tag("result", "hit").gauge();
-        meterRegistry.get("cache.near.requests").tags(expectedTag).tag("result", "miss").gauge();
-        meterRegistry.get("cache.near.evictions").tags(expectedTag).gauge();
-        meterRegistry.get("cache.near.persistences").tags(expectedTag).gauge();
+        NearCacheStats nearCacheStats = localMapStats.getNearCacheStats();
+        Gauge hitCacheRequests = fetch(meterRegistry, "cache.near.requests", Tags.of("result", "hit")).gauge();
+        assertThat(hitCacheRequests.value()).isEqualTo(nearCacheStats.getHits());
+
+        Gauge missCacheRequests = fetch(meterRegistry, "cache.near.requests", Tags.of("result", "miss")).gauge();
+        assertThat(missCacheRequests.value()).isEqualTo(nearCacheStats.getMisses());
+
+        Gauge nearPersistance = fetch(meterRegistry, "cache.near.persistences").gauge();
+        assertThat(nearPersistance.value()).isEqualTo(nearCacheStats.getPersistenceCount());
+
+        Gauge nearEvictions = fetch(meterRegistry, "cache.near.evictions").gauge();
+        assertThat(nearEvictions.value()).isEqualTo(nearCacheStats.getEvictions());
 
         // timings
-        meterRegistry.get("cache.gets.latency").tags(expectedTag).functionTimer();
-        meterRegistry.get("cache.puts.latency").tags(expectedTag).functionTimer();
-        meterRegistry.get("cache.removals.latency").tags(expectedTag).functionTimer();
+        FunctionTimer getsLatency = fetch(meterRegistry, "cache.gets.latency").functionTimer();
+        assertThat(getsLatency.count()).isEqualTo(localMapStats.getGetOperationCount());
+        assertThat(getsLatency.totalTime(TimeUnit.NANOSECONDS)).isEqualTo(localMapStats.getTotalGetLatency());
+
+        FunctionTimer putsLatency = fetch(meterRegistry, "cache.puts.latency").functionTimer();
+        assertThat(putsLatency.count()).isEqualTo(localMapStats.getPutOperationCount());
+        assertThat(putsLatency.totalTime(TimeUnit.NANOSECONDS)).isEqualTo(localMapStats.getTotalPutLatency());
+
+        FunctionTimer removeLatency = fetch(meterRegistry, "cache.removals.latency").functionTimer();
+        assertThat(removeLatency.count()).isEqualTo(localMapStats.getRemoveOperationCount());
+        assertThat(removeLatency.totalTime(TimeUnit.NANOSECONDS)).isEqualTo(localMapStats.getTotalPutLatency());
     }
-    
+
     @Test
     void constructInstanceViaStaticMethodMonitor() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -103,7 +139,12 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     @BeforeAll
     static void setup() {
         cache = Hazelcast.newHazelcastInstance().getMap("mycache");
-        NearCacheStats nearCacheStats = new NearCacheStatsImpl();
+        NearCacheStats nearCacheStats = mock(NearCacheStatsImpl.class);
+        Random random = new Random();
+        when(nearCacheStats.getHits()).thenReturn(random.nextLong());
+        when(nearCacheStats.getMisses()).thenReturn(random.nextLong());
+        when(nearCacheStats.getPersistenceCount()).thenReturn(random.nextLong());
+        when(nearCacheStats.getEvictions()).thenReturn(random.nextLong());
         ((LocalMapStatsImpl) cache.getLocalMapStats()).setNearCacheStats(nearCacheStats);
     }
 
@@ -111,5 +152,10 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     static void cleanup() {
         Hazelcast.shutdownAll();
     }
-
+    
+    @Override
+    protected Tags getTags() {
+        return expectedTag;
+    }
+    
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -56,7 +56,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         metrics.bindTo(meterRegistry);
 
-        verifyCommonCacheMetrics(meterRegistry);
+        verifyCommonCacheMetrics(meterRegistry, metrics);
 
         LocalMapStats localMapStats = cache.getLocalMapStats();
 
@@ -113,21 +113,19 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     }
 
     @Test
-    void defaultMissCountMetricToZero() {
+    void doNotReportEvictionCountSinceNotImplemented() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         HazelcastCacheMetrics.monitor(meterRegistry, cache, expectedTag);
 
-        FunctionCounter cacheEviction = fetch(meterRegistry, "cache.evictions").functionCounter();
-        assertThat(cacheEviction.count()).isEqualTo(0.);
+        assertThat(meterRegistry.find("cache.evictions").functionCounter()).isNull();
     }
 
     @Test
-    void defaultEvictionCountmetricToZero() {
+    void doNotReportMissCountSinceNotImplemented() {
         MeterRegistry registry = new SimpleMeterRegistry();
         HazelcastCacheMetrics.monitor(registry, cache, expectedTag);
 
-        FunctionCounter missCount = fetch(registry, "cache.gets", Tags.of("result", "miss")).functionCounter();
-        assertThat(missCount.count()).isEqualTo(0.);
+        assertThat(registry.find("cache.gets").tags(Tags.of("result", "miss")).functionCounter()).isNull();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -66,6 +66,14 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
         meterRegistry.get("cache.puts.latency").tags(expectedTag).functionTimer();
         meterRegistry.get("cache.removals.latency").tags(expectedTag).functionTimer();
     }
+    
+    @Test
+    void constructInstanceViaStaticMethodMonitor() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        HazelcastCacheMetrics.monitor(meterRegistry, cache, expectedTag);
+
+        meterRegistry.get("cache.partition.gets").tags(expectedTag).functionCounter();
+    }
 
     @Test
     void returnCacheSize() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -91,6 +91,8 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
     void reportExpectedMetrics() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         metrics.bindTo(meterRegistry);
+        
+        verifyCommonCacheMetrics(meterRegistry, metrics);
 
         Gauge cacheRemovals = fetch(meterRegistry, "cache.removals").gauge();
         assertThat(cacheRemovals.value()).isEqualTo(expectedAttributeValue.doubleValue());

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -18,13 +18,6 @@ package io.micrometer.core.instrument.binder.cache;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.test.util.ReflectionTestUtils;
-
 import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.management.Attribute;
@@ -42,6 +35,13 @@ import javax.management.ReflectionException;
 
 import java.net.URI;
 import java.util.Random;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -17,7 +17,6 @@ package io.micrometer.core.instrument.binder.cache;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import javax.cache.Cache;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -96,7 +96,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         Gauge cacheRemovals = fetch(meterRegistry, "cache.removals").gauge();
         assertThat(cacheRemovals.value()).isEqualTo(expectedAttributeValue.doubleValue());
     }
-    
+
     @Test
     void constructInstanceViaStaticMethodMonitor() {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
@@ -129,7 +129,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
     void returnPutCount() {
         assertThat(metrics.putCount()).isEqualTo(expectedAttributeValue);
     }
-    
+
     @Test
     void defaultValueWhenNoMBeanAttributeFound() throws MalformedObjectNameException {
         // change source MBean to emulate AttributeNotFoundException
@@ -138,7 +138,16 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
         assertThat(metrics.hitCount()).isEqualTo(0L);
     }
-    
+
+    @Test
+    void defaultValueWhenObjectNameNotInitialized() throws MalformedObjectNameException {
+        // set cacheManager to null to emulate scenario when objectName not initialized
+        when(cache.getCacheManager()).thenReturn(null);
+        metrics = new JCacheMetrics(cache, expectedTag);
+
+        assertThat(metrics.hitCount()).isEqualTo(0L);
+    }
+
     private static class CacheMBeanStub implements DynamicMBean {
 
         private Long expectedAttributeValue;
@@ -179,7 +188,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         }
 
     }
-    
+
     @Override
     protected Tags getTags() {
         return expectedTag;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -94,6 +94,14 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
         meterRegistry.get("cache.removals").tags(expectedTag).gauge();
     }
+    
+    @Test
+    void constructInstanceViaStaticMethodMonitor() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        JCacheMetrics.monitor(meterRegistry, cache, expectedTag);
+
+        meterRegistry.get("cache.removals").tags(expectedTag).gauge();
+    }
 
     @Test
     void returnCacheSize() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -61,7 +61,6 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
     @Mock
     private CacheManager cacheManager;
 
-    private Tags expectedTag = Tags.of("app", "test");
     private JCacheMetrics metrics;
     private MBeanServer mbeanServer;
     private Long expectedAttributeValue = new Random().nextLong();
@@ -188,11 +187,6 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
             return new MBeanInfo(CacheMBeanStub.class.getName(), "description", null, null, null, null);
         }
 
-    }
-
-    @Override
-    protected Tags getTags() {
-        return expectedTag;
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -92,7 +93,8 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         metrics.bindTo(meterRegistry);
 
-        meterRegistry.get("cache.removals").tags(expectedTag).gauge();
+        Gauge cacheRemovals = fetch(meterRegistry, "cache.removals").gauge();
+        assertThat(cacheRemovals.value()).isEqualTo(expectedAttributeValue.doubleValue());
     }
     
     @Test
@@ -176,6 +178,11 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
             return new MBeanInfo(CacheMBeanStub.class.getName(), "description", null, null, null, null);
         }
 
+    }
+    
+    @Override
+    protected Tags getTags() {
+        return expectedTag;
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2018 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.cache;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
+import java.net.URI;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CaffeineCacheMetrics}.
+ *
+ * @author Oleksii Bondar
+ */
+class JCacheMetricsTest extends AbstractCacheMetricsTest {
+
+    @Mock
+    private Cache<String, String> cache;
+
+    @Mock
+    private CacheManager cacheManager;
+
+    private Tags expectedTag = Tags.of("app", "test");
+    private JCacheMetrics metrics;
+    private MBeanServer mbeanServer;
+    private Long expectedAttributeValue = new Random().nextLong();
+
+    @BeforeEach
+    void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        when(cache.getCacheManager()).thenReturn(cacheManager);
+        when(cache.getName()).thenReturn("testCache");
+        when(cacheManager.getURI()).thenReturn(new URI("http://localhost"));
+        metrics = new JCacheMetrics(cache, expectedTag);
+
+        // emulate MBean server with MBean used for statistic lookup
+        mbeanServer = MBeanServerFactory.createMBeanServer();
+        ObjectName objectName = new ObjectName("javax.cache:type=CacheStatistics");
+        ReflectionTestUtils.setField(metrics, "objectName", objectName);
+        CacheMBeanStub mBean = new CacheMBeanStub(expectedAttributeValue);
+        mbeanServer.registerMBean(mBean, objectName);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (mbeanServer != null) {
+            MBeanServerFactory.releaseMBeanServer(mbeanServer);
+        }
+    }
+
+    @Test
+    void reportExpectedMetrics() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        metrics.bindTo(meterRegistry);
+
+        meterRegistry.get("cache.removals").tags(expectedTag).gauge();
+    }
+
+    @Test
+    void returnCacheSize() {
+        assertThat(metrics.size()).isNull();
+    }
+
+    @Test
+    void returnNullForMissCount() {
+        assertThat(metrics.missCount()).isEqualTo(expectedAttributeValue);
+    }
+
+    @Test
+    void returnNullForEvictionCount() {
+        assertThat(metrics.evictionCount()).isEqualTo(expectedAttributeValue);
+    }
+
+    @Test
+    void returnHitCount() {
+        assertThat(metrics.hitCount()).isEqualTo(expectedAttributeValue);
+    }
+
+    @Test
+    void returnPutCount() {
+        assertThat(metrics.putCount()).isEqualTo(expectedAttributeValue);
+    }
+    
+    @Test
+    void defaultValueWhenNoMBeanAttributeFound() throws MalformedObjectNameException {
+        // change source MBean to emulate AttributeNotFoundException
+        ObjectName objectName = new ObjectName("javax.cache:type=CacheInformation");
+        ReflectionTestUtils.setField(metrics, "objectName", objectName);
+
+        assertThat(metrics.hitCount()).isEqualTo(0L);
+    }
+    
+    private static class CacheMBeanStub implements DynamicMBean {
+
+        private Long expectedAttributeValue;
+
+        public CacheMBeanStub(Long attributeValue) {
+            this.expectedAttributeValue = attributeValue;
+        }
+
+        @Override
+        public Object getAttribute(String attribute) throws AttributeNotFoundException, MBeanException, ReflectionException {
+            return expectedAttributeValue;
+        }
+
+        @Override
+        public void setAttribute(Attribute attribute) throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+        }
+
+        @Override
+        public AttributeList getAttributes(String[] attributes) {
+            return null;
+        }
+
+        @Override
+        public AttributeList setAttributes(AttributeList attributes) {
+            return null;
+        }
+
+        @Override
+        public Object invoke(String actionName,
+                             Object[] params,
+                             String[] signature) throws MBeanException, ReflectionException {
+            return null;
+        }
+
+        @Override
+        public MBeanInfo getMBeanInfo() {
+            return new MBeanInfo(CacheMBeanStub.class.getName(), "description", null, null, null, null);
+        }
+
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.binder.cache;
 
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -90,7 +91,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void reportExpectedMetrics() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         metrics.bindTo(meterRegistry);
 
         Gauge cacheRemovals = fetch(meterRegistry, "cache.removals").gauge();
@@ -99,7 +100,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @Test
     void constructInstanceViaStaticMethodMonitor() {
-        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
         JCacheMetrics.monitor(meterRegistry, cache, expectedTag);
 
         meterRegistry.get("cache.removals").tags(expectedTag).gauge();


### PR DESCRIPTION
Initially, I was planning just cover package `io.micrometer.core.instrument.binder.cache` with unit tests since there was none. As a result of this effort, I've addressed few bugs/improvements:
* removed non-needed null checks from `CacheMeterBinder` - null values defaulted to 0;
* appended common tags to `cache.remoteSize` metric - can't think of a good reason why it shouldn't be there unless accidentally missed;
* added null check for `objectName` before `MbeanServer.getAttribute` since could be initialized as per implementation (i.e. when `cacheManager` is null)
* used proper methods for
** `cache.put`: `cachePutAddedCount` -> `cachePutUpdatedCount`
** `getLocalOffHeapSize` -> `getLocalOffHeapSizeInBytes`
* add unit test coverage:
Initial coverage
![image](https://user-images.githubusercontent.com/4628962/50557395-a0dedb00-0c99-11e9-806a-faec2cdc92c9.png)

After these changes:
![image](https://user-images.githubusercontent.com/4628962/50566778-2b532900-0cf2-11e9-996f-a75585b1e8ff.png)
