### PR TITLE
Migrate to junit5

### DIFF
--- a/benchmarks/benchmarks-core/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/benchmarks/benchmarks-core/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-appoptics/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-appoptics/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -95,6 +95,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-appoptics/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -95,6 +95,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -96,6 +96,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-atlas/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -96,6 +96,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -104,6 +104,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-azure-monitor/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -105,6 +105,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -97,6 +97,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-cloudwatch/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -97,6 +97,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-datadog/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-dynatrace/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-elastic/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-ganglia/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-graphite/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-humio/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-humio/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-humio/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-humio/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-humio/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-humio/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-humio/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-humio/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-influx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-jmx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-kairos/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-kairos/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-kairos/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-kairos/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-kairos/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-kairos/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-kairos/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-kairos/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-new-relic/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-prometheus/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -94,6 +94,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-signalfx/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -93,6 +93,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -120,6 +120,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.threeten:threetenbp:1.3.3
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1

--- a/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-stackdriver/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -120,6 +120,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.threeten:threetenbp:1.3.3
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -97,6 +97,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -97,6 +97,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/junitPlatform.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-wavefront/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -92,6 +92,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/micrometer-core/gradle/dependency-locks/junitPlatform.lockfile
+++ b/micrometer-core/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/micrometer-core/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-core/gradle/dependency-locks/testApt.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testApt.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package io.micrometer.core.instrument.binder.db;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
 
 import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -27,16 +28,16 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Kristof Depypere
  */
-public class PostgreSQLDatabaseMetricsTest {
+class PostgreSQLDatabaseMetricsTest {
     private static final String DATABASE_NAME = "test";
     private static final String FUNCTIONAL_COUNTER_KEY = "key";
     private DataSource dataSource = mock(DataSource.class);
     private MeterRegistry registry = new SimpleMeterRegistry();
 
     @Test
-    public void shouldRegisterPostesMetrics() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldRegisterPostgreSqlMetrics() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
         registry.get("postgres.size").tag("database", DATABASE_NAME).gauge();
         registry.get("postgres.connections").tag("database", DATABASE_NAME).gauge();
@@ -62,33 +63,33 @@ public class PostgreSQLDatabaseMetricsTest {
     }
 
     @Test
-    public void shouldBridgePgStatReset() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldBridgePgStatReset() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
 
-        //first reset
-        Double result = postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        // first reset
+        Double result = metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
 
-        //then
+        // then
         assertThat(result).isEqualTo(15);
     }
 
     @Test
-    public void shouldBridgeDoublePgStatReset() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldBridgeDoublePgStatReset() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
 
-        //first reset
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 3);
+        // first reset
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 3);
 
-        //second reset
-        Double result = postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 1);
+        // second reset
+        Double result = metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 1);
 
         assertThat(result).isEqualTo(14);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
  *
  * @author Michael Weirauch
  */
-public class JvmMemoryMetricsTest {
+class JvmMemoryMetricsTest {
 
     @Test
     void memoryMetrics() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IOUtilsTest {
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "This is a sample.";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes());
@@ -39,7 +39,7 @@ class IOUtilsTest {
     }
 
     @Test
-    public void testToStringWithCharset() {
+    void testToStringWithCharset() {
         String expected = "This is a sample.";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/TimeUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/TimeUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TimeUtilsTest {
+    
     @Test
     void simpleParse() {
         assertThat(TimeUtils.simpleParse("5ns")).isEqualByComparingTo(Duration.ofNanos(5));

--- a/micrometer-core/src/test/java/io/micrometer/core/ipc/http/RequestTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/ipc/http/RequestTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
  */
 class RequestTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     void compressShouldAddContentEncodingHeader() throws IOException, NoSuchFieldException, IllegalAccessException {
         HttpSender.Request.Builder builder = HttpSender.Request.build("https://micrometer.io/", mock(HttpSender.class)).compress();

--- a/micrometer-jersey2/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -242,6 +242,7 @@ org.springframework.security:spring-security-config:4.2.9.RELEASE
 org.springframework.security:spring-security-core:4.2.9.RELEASE
 org.springframework.security:spring-security-test:4.2.9.RELEASE
 org.springframework.security:spring-security-web:4.2.9.RELEASE
+org.springframework.test:spring-test-junit5:1.0.0
 org.springframework.ws:spring-ws-core:2.4.3.RELEASE
 org.springframework.ws:spring-xml:2.4.3.RELEASE
 org.springframework:spring-aop:4.3.20.RELEASE

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -250,6 +250,7 @@ org.springframework.security:spring-security-config:4.2.9.RELEASE
 org.springframework.security:spring-security-core:4.2.9.RELEASE
 org.springframework.security:spring-security-test:4.2.9.RELEASE
 org.springframework.security:spring-security-web:4.2.9.RELEASE
+org.springframework.test:spring-test-junit5:1.0.0
 org.springframework.ws:spring-ws-core:2.4.3.RELEASE
 org.springframework.ws:spring-xml:2.4.3.RELEASE
 org.springframework:spring-aop:4.3.20.RELEASE

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedAspectTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +32,7 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -39,9 +40,10 @@ import static io.micrometer.core.aop.TimedAspect.EXCEPTION_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = TimedAspectTest.TestAspectConfig.class)
-public class TimedAspectTest {
+class TimedAspectTest {
+    
     @Autowired
     private TimedService service;
 
@@ -49,31 +51,31 @@ public class TimedAspectTest {
     private MeterRegistry registry;
 
     @Test
-    public void serviceIsTimed() {
+    void serviceIsTimed() {
         service.timeMe();
         assertThat(registry.get("something").timer().count()).isEqualTo(1);
     }
 
     @Test
-    public void serviceIsTimedWhenNoValue() {
+    void serviceIsTimedWhenNoValue() {
         service.timeWithoutValue();
         assertThat(registry.get(TimedAspect.DEFAULT_METRIC_NAME).timer().count()).isEqualTo(1);
     }
 
     @Test
-    public void serviceIsTimedWhenThereIsAnException() {
+    void serviceIsTimedWhenThereIsAnException() {
         assertThrows(RuntimeException.class, () -> service.timeWithException());
         assertThat(registry.get("somethingElse").tags(EXCEPTION_TAG, "RuntimeException").timer().count()).isEqualTo(1);
     }
 
     @Test
-    public void serviceIsTimedWhenThereIsNoException() {
+    void serviceIsTimedWhenThereIsNoException() {
         service.timeWithoutException();
         assertThat(registry.get("somethingElse").tags(EXCEPTION_TAG, "none").timer().count()).isEqualTo(1);
     }
 
     @Test
-    public void serviceIsTimedWithHistogram() {
+    void serviceIsTimedWithHistogram() {
         // given...
         // ... we are waiting for a metric to be created with a histogram
         AtomicReference<DistributionStatisticConfig> myConfig = new AtomicReference<>();

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedUtilsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package io.micrometer.spring;
 
 import io.micrometer.core.annotation.Timed;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -25,36 +26,37 @@ import java.lang.annotation.Target;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TimedUtilsTest {
+class TimedUtilsTest {
+
     @Test
-    public void timedClass() {
+    void timedClass() {
         assertThat(TimedUtils.findTimedAnnotations(TimedClass.class)).isNotEmpty();
     }
 
     @Test
-    public void timedMethod() throws NoSuchMethodException {
+    void timedMethod() throws NoSuchMethodException {
         assertThat(TimedUtils.findTimedAnnotations(TimedClass.class.getDeclaredMethod("foo")))
             .isNotEmpty();
     }
 
     @Test
-    public void subclassedTimedClass() {
+    void subclassedTimedClass() {
         assertThat(TimedUtils.findTimedAnnotations(SpecialTimedClass.class)).isNotEmpty();
     }
 
     @Test
-    public void subclassedTimedMethod() throws NoSuchMethodException {
+    void subclassedTimedMethod() throws NoSuchMethodException {
         assertThat(TimedUtils.findTimedAnnotations(SpecialTimedClass.class.getDeclaredMethod("foo")))
             .isNotEmpty();
     }
 
     @Test
-    public void inheritedTimedClass() {
+    void inheritedTimedClass() {
         assertThat(TimedUtils.findTimedAnnotations(SpecialTimedClass.class)).isNotEmpty();
     }
 
     @Test
-    public void inheritedTimedMethod() throws NoSuchMethodException {
+    void inheritedTimedMethod() throws NoSuchMethodException {
         assertThat(TimedUtils.findTimedAnnotations(SpecialTimedClass.class.getDeclaredMethod("foo")))
             .isNotEmpty();
     }
@@ -68,7 +70,7 @@ public class TimedUtilsTest {
     @Timed
     static class TimedClass {
         @Timed
-        public void foo() {
+        void foo() {
         }
     }
 
@@ -81,7 +83,7 @@ public class TimedUtilsTest {
 
     class InheritedTimedClass extends TimedClass {
         @Override
-        public void foo() {
+        void foo() {
             super.foo();
         }
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedUtilsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/TimedUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@ package io.micrometer.spring.async;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,20 +31,20 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static java.util.Collections.emptyList;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = ThreadPoolTaskExecutorMetricsIntegrationTest.App.class)
-public class ThreadPoolTaskExecutorMetricsIntegrationTest {
+class ThreadPoolTaskExecutorMetricsIntegrationTest {
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Issue("#459")
     @Test
-    public void executorMetricsPhase() {
+    void executorMetricsPhase() {
         registry.get("jvm.memory.max").gauge();
     }
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsTest.java
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.CountDownLatch;
@@ -34,13 +35,13 @@ public class ThreadPoolTaskExecutorMetricsTest {
     private MeterRegistry registry;
     private Iterable<Tag> userTags = Tags.of("userTagKey", "userTagValue");
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
     }
 
     @Test
-    public void executor() throws InterruptedException {
+    void verifyThreadPoolExecutorMetrics() throws InterruptedException {
         CountDownLatch lock = new CountDownLatch(1);
         ThreadPoolTaskExecutor pool = ThreadPoolTaskExecutorMetrics.monitor(registry, "exec", userTags);
         pool.setAwaitTerminationSeconds(1);
@@ -60,7 +61,7 @@ public class ThreadPoolTaskExecutorMetricsTest {
     }
 
     @Test
-    public void monitorExecutorService() throws InterruptedException {
+    void monitorExecutorService() throws InterruptedException {
         CountDownLatch taskStart = new CountDownLatch(1);
         CountDownLatch taskComplete = new CountDownLatch(1);
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/async/ThreadPoolTaskExecutorMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class ThreadPoolTaskExecutorMetricsTest {
+class ThreadPoolTaskExecutorMetricsTest {
     private MeterRegistry registry;
     private Iterable<Tag> userTags = Tags.of("userTagKey", "userTagValue");
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,26 +17,28 @@ package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
-public class CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest {
+class CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     /**
      * The simple registry is off by default UNLESS there is no other registry implementation on
      * the classpath, in which case it is on.
      */
     @Test
-    public void simpleWithNoCompositeCreated() {
+    void simpleWithNoCompositeCreated() {
         assertThat(registry).isInstanceOf(SimpleMeterRegistry.class);
     }
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,27 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.MetricsApp.class)
-public class CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest {
+class CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
-    public void compositeNotCreatedWhenPrimaryRegistryExists() {
+    void compositeNotCreatedWhenPrimaryRegistryExists() {
         assertThat(registry).isInstanceOf(SimpleMeterRegistry.class);
     }
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationNoRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationNoRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,30 @@ package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = "management.metrics.export.simple.enabled=false")
-public class CompositeMeterRegistryConfigurationNoRegistryTest {
+class CompositeMeterRegistryConfigurationNoRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     /**
      * An empty composite is created in the absence of any other registry implementation.
      * This effectively no-ops instrumentation code throughout the application.
      */
     @Test
-    public void emptyCompositeCreated() {
+    void emptyCompositeCreated() {
         assertThat(registry)
             .isInstanceOf(CompositeMeterRegistry.class)
             .matches(r -> ((CompositeMeterRegistry) r).getRegistries().isEmpty());

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationSingleRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationSingleRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,24 +17,26 @@ package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.graphite.GraphiteMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = "management.metrics.export.graphite.enabled=true")
-public class CompositeMeterRegistryConfigurationSingleRegistryTest {
+class CompositeMeterRegistryConfigurationSingleRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
-    public void noCompositeCreated() {
+    void noCompositeCreated() {
         assertThat(registry).isInstanceOf(GraphiteMeterRegistry.class);
     }
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,29 +19,31 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.jmx.JmxMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = {
     "management.metrics.export.jmx.enabled=true",
     "management.metrics.export.prometheus.enabled=true",
     "management.metrics.export.prometheus.pushgateway.enabled=false",
 })
-public class CompositeMeterRegistryConfigurationTest {
+class CompositeMeterRegistryConfigurationTest {
+
     @Autowired
     private MeterRegistry registry;
 
     @Test
-    public void compositeRegistryIsCreated() {
+    void compositeRegistryIsCreated() {
         assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
 
         assertThat(((CompositeMeterRegistry) registry).getRegistries())

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/JvmMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/JvmMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Johnny Lim
  */
-public class JvmMetricsAutoConfigurationTest {
+class JvmMetricsAutoConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
@@ -50,7 +50,7 @@ public class JvmMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void autoConfiguresJvmMetrics() {
+    void autoConfiguresJvmMetrics() {
         registerAndRefresh();
         assertThat(context.getBean(JvmGcMetrics.class)).isNotNull();
         assertThat(context.getBean(JvmMemoryMetrics.class)).isNotNull();
@@ -60,7 +60,7 @@ public class JvmMetricsAutoConfigurationTest {
 
     @Test
     @Deprecated
-    public void allowsJvmMetricsToBeDisabled() {
+    void allowsJvmMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.jvm.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(JvmGcMetrics.class)).isEmpty();
@@ -70,7 +70,7 @@ public class JvmMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void allowsCustomJvmGcMetricsToBeUsed() {
+    void allowsCustomJvmGcMetricsToBeUsed() {
         registerAndRefresh(CustomJvmGcMetricsConfiguration.class);
         assertThat(context.getBean(JvmGcMetrics.class)).isEqualTo(context.getBean("customJvmGcMetrics"));
         assertThat(context.getBean(JvmMemoryMetrics.class)).isNotNull();
@@ -79,7 +79,7 @@ public class JvmMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void allowsCustomJvmMemoryMetricsToBeUsed() {
+    void allowsCustomJvmMemoryMetricsToBeUsed() {
         registerAndRefresh(CustomJvmMemoryMetricsConfiguration.class);
         assertThat(context.getBean(JvmGcMetrics.class)).isNotNull();
         assertThat(context.getBean(JvmMemoryMetrics.class)).isEqualTo(context.getBean("customJvmMemoryMetrics"));
@@ -88,7 +88,7 @@ public class JvmMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void allowsCustomJvmThreadMetricsToBeUsed() {
+    void allowsCustomJvmThreadMetricsToBeUsed() {
         registerAndRefresh(CustomJvmThreadMetricsConfiguration.class);
         assertThat(context.getBean(JvmGcMetrics.class)).isNotNull();
         assertThat(context.getBean(JvmMemoryMetrics.class)).isNotNull();
@@ -97,7 +97,7 @@ public class JvmMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void allowsCustomClassLoaderMetricsToBeUsed() {
+    void allowsCustomClassLoaderMetricsToBeUsed() {
         registerAndRefresh(CustomClassLoaderMetricsConfiguration.class);
         assertThat(context.getBean(JvmGcMetrics.class)).isNotNull();
         assertThat(context.getBean(JvmMemoryMetrics.class)).isNotNull();

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/Log4J2MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/Log4J2MetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.mock;
  * @author Andy Wilkinson
  * @author Johnny Lim
  */
-public class Log4J2MetricsAutoConfigurationTest {
+class Log4J2MetricsAutoConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
@@ -46,21 +46,21 @@ public class Log4J2MetricsAutoConfigurationTest {
     }
 
     @Test
-    public void autoConfiguresLog4J2Metrics() {
+    void autoConfiguresLog4J2Metrics() {
         registerAndRefresh();
         assertThat(context.getBean(Log4j2Metrics.class)).isNotNull();
     }
 
     @Test
     @Deprecated
-    public void allowsLogbackMetricsToBeDisabled() {
+    void allowsLogbackMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.log4j2.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(Log4j2Metrics.class)).isEmpty();
     }
 
     @Test
-    public void allowsCustomLog4J2MetricsToBeUsed() {
+    void allowsCustomLog4J2MetricsToBeUsed() {
         registerAndRefresh(CustomLog4J2MetricsConfiguration.class);
         assertThat(context.getBean(Log4j2Metrics.class)).isEqualTo(context.getBean("customLog4J2Metrics"));
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/LogbackMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/LogbackMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Johnny Lim
  */
-public class LogbackMetricsAutoConfigurationTest {
+class LogbackMetricsAutoConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
@@ -47,21 +47,21 @@ public class LogbackMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void autoConfiguresLogbackMetrics() {
+    void autoConfiguresLogbackMetrics() {
         registerAndRefresh();
         assertThat(context.getBean(LogbackMetrics.class)).isNotNull();
     }
 
     @Test
     @Deprecated
-    public void allowsLogbackMetricsToBeDisabled() {
+    void allowsLogbackMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.logback.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(LogbackMetrics.class)).isEmpty();
     }
 
     @Test
-    public void allowsCustomLogbackMetricsToBeUsed() {
+    void allowsCustomLogbackMetricsToBeUsed() {
         registerAndRefresh(CustomLogbackMetricsConfiguration.class);
         assertThat(context.getBean(LogbackMetrics.class)).isEqualTo(context.getBean("customLogbackMetrics"));
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryCustomizerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryCustomizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,35 +18,37 @@ package io.micrometer.spring.autoconfigure;
 import io.micrometer.atlas.AtlasMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Jon Schneider
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @TestPropertySource(properties = {
         "management.metrics.export.prometheus.enabled=true",
         "management.metrics.export.atlas.enabled=true"
 })
-public class MeterRegistryCustomizerTest {
+class MeterRegistryCustomizerTest {
+    
     @Autowired
-    AtlasMeterRegistry atlasRegistry;
+    private AtlasMeterRegistry atlasRegistry;
 
     @Autowired
-    PrometheusMeterRegistry prometheusRegistry;
+    private PrometheusMeterRegistry prometheusRegistry;
 
     @Test
-    public void commonTagsAreAppliedToAutoConfiguredBinders() {
+    void commonTagsAreAppliedToAutoConfiguredBinders() {
         atlasRegistry.get("jvm.memory.used").tags("region", "us-east-1").gauge();
         prometheusRegistry.get("jvm.memory.used").tags("region", "us-east-1").gauge();
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ class MetricsAutoConfigurationTest {
     }
 
     @Test
-    public void automaticallyRegisteredBinders() {
+    void automaticallyRegisteredBinders() {
         assertThat(context.getBeansOfType(MeterBinder.class).values())
                 .hasAtLeastOneElementOfType(Log4j2Metrics.class)
                 .hasAtLeastOneElementOfType(LogbackMetrics.class)

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PrometheusEndpointIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PrometheusEndpointIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,18 @@
  */
 package io.micrometer.spring.autoconfigure;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = PrometheusEndpointIntegrationTest.MetricsApp.class,
         properties = {
@@ -34,13 +34,13 @@ import static org.assertj.core.api.Assertions.assertThat;
                 "management.metrics.export.prometheus.enabled=true"
         }
 )
-public class PrometheusEndpointIntegrationTest {
+class PrometheusEndpointIntegrationTest {
 
     @Autowired
     private TestRestTemplate testRestTemplate;
 
     @Test
-    public void producesTextPlain() {
+    void producesTextPlain() {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN_VALUE);
         HttpEntity<Void> request = new HttpEntity<>(headers);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ package io.micrometer.spring.autoconfigure;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,29 +27,29 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PropertiesMeterFilterIntegrationTest.MetricsApp.class)
 @TestPropertySource(properties = {
     "management.metrics.enable[my.timer]=true", /* overriden by programmatic filter */
     "management.metrics.enable[my.counter]=false"
 })
-public class PropertiesMeterFilterIntegrationTest {
+class PropertiesMeterFilterIntegrationTest {
 
     @Autowired
     private MeterRegistry registry;
 
     @Test
-    public void propertyBasedMeterFilters() {
+    void propertyBasedMeterFilters() {
         registry.counter("my.counter");
         assertThat(registry.find("my.counter").counter()).isNull();
     }
 
     @Test
-    public void propertyBasedMeterFiltersCanTakeLowerPrecedenceThanProgrammaticallyBoundFilters() {
+    void propertyBasedMeterFiltersCanTakeLowerPrecedenceThanProgrammaticallyBoundFilters() {
         registry.timer("my.timer");
         assertThat(registry.find("my.timer").meter()).isNull();
     }
@@ -57,7 +58,7 @@ public class PropertiesMeterFilterIntegrationTest {
     static class MetricsApp {
         @Bean
         @Order(Ordered.HIGHEST_PRECEDENCE)
-        public MeterRegistryCustomizer meterFilter() {
+        public MeterRegistryCustomizer<?> meterFilter() {
             return r -> r.config().meterFilter(MeterFilter.deny(id -> id.getName().contains("my.timer")));
         }
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,15 @@ import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link PropertiesMeterFilter}.
@@ -40,64 +40,63 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artsiom Yudovin
  */
 @SuppressWarnings("ConstantConditions")
-public class PropertiesMeterFilterTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
+class PropertiesMeterFilterTest {
 
     private MetricsProperties properties = new MetricsProperties();
 
     private PropertiesMeterFilter filter = new PropertiesMeterFilter(properties);
 
     @Test
-    public void createWhenPropertiesIsNullShouldThrowException() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Properties must not be null");
-        new PropertiesMeterFilter(null);
+    void createWhenPropertiesIsNullShouldThrowException() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+            new PropertiesMeterFilter(null);
+        });
+        assertThat(ex.getMessage()).isEqualTo("Properties must not be null");
     }
 
     @Test
-    public void acceptWhenHasNoEnabledPropertiesShouldReturnNeutral() {
+    void acceptWhenHasNoEnabledPropertiesShouldReturnNeutral() {
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.NEUTRAL);
     }
 
     @Test
-    public void acceptWhenHasNoMatchingEnabledPropertyShouldReturnNeutral() {
+    void acceptWhenHasNoMatchingEnabledPropertyShouldReturnNeutral() {
         properties.getEnable().put("something.else", false);
         assertThat(filter.accept(createSpringBootMeter()))
             .isEqualTo(MeterFilterReply.NEUTRAL);
     }
 
     @Test
-    public void acceptWhenHasEnableFalseShouldReturnDeny() {
+    void acceptWhenHasEnableFalseShouldReturnDeny() {
         enable("spring.boot", false);
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.DENY);
     }
 
     @Test
-    public void acceptWhenHasEnableTrueShouldReturnNeutral() {
+    void acceptWhenHasEnableTrueShouldReturnNeutral() {
         enable("spring.boot", true);
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.NEUTRAL);
     }
 
     @Test
-    public void acceptWhenHasHigherEnableFalseShouldReturnDeny() {
+    void acceptWhenHasHigherEnableFalseShouldReturnDeny() {
         enable("spring", false);
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.DENY);
     }
 
     @Test
-    public void acceptWhenHasHigherEnableTrueShouldReturnNeutral() {
+    void acceptWhenHasHigherEnableTrueShouldReturnNeutral() {
         enable("spring", true);
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.NEUTRAL);
     }
 
     @Test
-    public void acceptWhenHasHigherEnableFalseExactEnableTrueShouldReturnNeutral() {
+    void acceptWhenHasHigherEnableFalseExactEnableTrueShouldReturnNeutral() {
         enable("spring", false);
         enable("spring.boot", true);
         assertThat(filter.accept(createSpringBootMeter()))
@@ -105,7 +104,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void acceptWhenHasHigherEnableTrueExactEnableFalseShouldReturnDeny() {
+    void acceptWhenHasHigherEnableTrueExactEnableFalseShouldReturnDeny() {
         enable("spring", true);
         enable("spring.boot", false);
         assertThat(filter.accept(createSpringBootMeter()))
@@ -113,14 +112,14 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void acceptWhenHasAllEnableFalseShouldReturnDeny() {
+    void acceptWhenHasAllEnableFalseShouldReturnDeny() {
         enable("all", false);
         assertThat(filter.accept(createSpringBootMeter()))
                 .isEqualTo(MeterFilterReply.DENY);
     }
 
     @Test
-    public void acceptWhenHasAllEnableFalseButHigherEnableTrueShouldReturnNeutral() {
+    void acceptWhenHasAllEnableFalseButHigherEnableTrueShouldReturnNeutral() {
         enable("all", false);
         enable("spring", true);
         assertThat(filter.accept(createSpringBootMeter()))
@@ -128,35 +127,35 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHistogramTrueShouldSetPercentilesHistogramToTrue() {
+    void configureWhenHasHistogramTrueShouldSetPercentilesHistogramToTrue() {
         percentilesHistogram("spring.boot", true);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .isPercentileHistogram()).isTrue();
     }
 
     @Test
-    public void configureWhenHasHistogramFalseShouldSetPercentilesHistogramToFalse() {
+    void configureWhenHasHistogramFalseShouldSetPercentilesHistogramToFalse() {
         percentilesHistogram("spring.boot", false);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .isPercentileHistogram()).isFalse();
     }
 
     @Test
-    public void configureWhenHasHigherHistogramTrueShouldSetPercentilesHistogramToTrue() {
+    void configureWhenHasHigherHistogramTrueShouldSetPercentilesHistogramToTrue() {
         percentilesHistogram("spring", true);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .isPercentileHistogram()).isTrue();
     }
 
     @Test
-    public void configureWhenHasHigherHistogramFalseShouldSetPercentilesHistogramToFalse() {
+    void configureWhenHasHigherHistogramFalseShouldSetPercentilesHistogramToFalse() {
         percentilesHistogram("spring", false);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .isPercentileHistogram()).isFalse();
     }
 
     @Test
-    public void configureWhenHasHigherHistogramTrueAndLowerFalseShouldSetPercentilesHistogramToFalse() {
+    void configureWhenHasHigherHistogramTrueAndLowerFalseShouldSetPercentilesHistogramToFalse() {
         percentilesHistogram("spring", true);
         percentilesHistogram("spring.boot", false);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
@@ -164,7 +163,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHigherHistogramFalseAndLowerTrueShouldSetPercentilesHistogramToFalse() {
+    void configureWhenHasHigherHistogramFalseAndLowerTrueShouldSetPercentilesHistogramToFalse() {
         percentilesHistogram("spring", false);
         percentilesHistogram("spring.boot", true);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
@@ -172,28 +171,28 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenAllHistogramTrueSetPercentilesHistogramToTrue() {
+    void configureWhenAllHistogramTrueSetPercentilesHistogramToTrue() {
         percentilesHistogram("all", true);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .isPercentileHistogram()).isTrue();
     }
 
     @Test
-    public void configureWhenHasPercentilesShouldSetPercentilesToValue() {
+    void configureWhenHasPercentilesShouldSetPercentilesToValue() {
         percentiles("spring.boot", 0.5, 0.9);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getPercentiles()).containsExactly(0.5, 0.9);
     }
 
     @Test
-    public void configureWhenHasHigherPercentilesShouldSetPercentilesToValue() {
+    void configureWhenHasHigherPercentilesShouldSetPercentilesToValue() {
         percentiles("spring", 0.5, 0.9);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getPercentiles()).containsExactly(0.5, 0.9);
     }
 
     @Test
-    public void configureWhenHasHigherPercentilesAndLowerShouldSetPercentilesToHigher() {
+    void configureWhenHasHigherPercentilesAndLowerShouldSetPercentilesToHigher() {
         percentiles("spring", 0.5);
         percentiles("spring.boot", 0.9);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
@@ -201,28 +200,28 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenAllPercentilesSetShouldSetPercentilesToValue() {
+    void configureWhenAllPercentilesSetShouldSetPercentilesToValue() {
         percentiles("all", 0.5);
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getPercentiles()).containsExactly(0.5);
     }
 
     @Test
-    public void configureWhenHasSlaShouldSetSlaToValue() {
+    void configureWhenHasSlaShouldSetSlaToValue() {
         slas("spring.boot", "1", "2", "3");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getSlaBoundaries()).containsExactly(1000000, 2000000, 3000000);
     }
 
     @Test
-    public void configureWhenHasHigherSlaShouldSetPercentilesToValue() {
+    void configureWhenHasHigherSlaShouldSetPercentilesToValue() {
         slas("spring", "1", "2", "3");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
                 .getSlaBoundaries()).containsExactly(1000000, 2000000, 3000000);
     }
 
     @Test
-    public void configureWhenHasHigherSlaAndLowerShouldSetSlaToHigher() {
+    void configureWhenHasHigherSlaAndLowerShouldSetSlaToHigher() {
         slas("spring", "1", "2", "3");
         slas("spring.boot", "4", "5", "6");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
@@ -230,7 +229,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasMinimumExpectedValueShouldSetMinimumExpectedToValue() {
+    void configureWhenHasMinimumExpectedValueShouldSetMinimumExpectedToValue() {
         setMinimumExpectedValue("spring.boot", 10);
         assertThat(filter.configure(createSpringBootMeter(),
                 DistributionStatisticConfig.DEFAULT).getMinimumExpectedValue())
@@ -238,7 +237,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHigherMinimumExpectedValueShouldSetMinimumExpectedValueToValue() {
+    void configureWhenHasHigherMinimumExpectedValueShouldSetMinimumExpectedValueToValue() {
         setMinimumExpectedValue("spring", 10);
         assertThat(filter.configure(createSpringBootMeter(),
                 DistributionStatisticConfig.DEFAULT).getMinimumExpectedValue())
@@ -246,7 +245,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHigherMinimumExpectedValueAndLowerShouldSetMinimumExpectedValueToHigher() {
+    void configureWhenHasHigherMinimumExpectedValueAndLowerShouldSetMinimumExpectedValueToHigher() {
         setMinimumExpectedValue("spring", 10);
         setMinimumExpectedValue("spring.boot", 50);
         assertThat(filter.configure(createSpringBootMeter(),
@@ -255,7 +254,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasMaximumExpectedValueShouldSetMaximumExpectedToValue() {
+    void configureWhenHasMaximumExpectedValueShouldSetMaximumExpectedToValue() {
         setMaximumExpectedValue("spring.boot", 5000);
         assertThat(filter.configure(createSpringBootMeter(),
                 DistributionStatisticConfig.DEFAULT).getMaximumExpectedValue())
@@ -263,7 +262,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHigherMaximumExpectedValueShouldSetMaximumExpectedValueToValue() {
+    void configureWhenHasHigherMaximumExpectedValueShouldSetMaximumExpectedValueToValue() {
         setMaximumExpectedValue("spring", 5000);
         assertThat(filter.configure(createSpringBootMeter(),
                 DistributionStatisticConfig.DEFAULT).getMaximumExpectedValue())
@@ -271,7 +270,7 @@ public class PropertiesMeterFilterTest {
     }
 
     @Test
-    public void configureWhenHasHigherMaximumExpectedValueAndLowerShouldSetMaximumExpectedValueToHigher() {
+    void configureWhenHasHigherMaximumExpectedValueAndLowerShouldSetMaximumExpectedValueToHigher() {
         setMaximumExpectedValue("spring", 5000);
         setMaximumExpectedValue("spring.boot", 10000);
         assertThat(filter.configure(createSpringBootMeter(),

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/SystemMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/SystemMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
  * @author Stephane Nicoll
  * @author Johnny Lim
  */
-public class SystemMetricsAutoConfigurationTest {
+class SystemMetricsAutoConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
@@ -49,61 +49,61 @@ public class SystemMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void autoConfiguresUptimeMetrics() {
+    void autoConfiguresUptimeMetrics() {
         registerAndRefresh();
         assertThat(context.getBean(UptimeMetrics.class)).isNotNull();
     }
 
     @Test
     @Deprecated
-    public void allowsUptimeMetricsToBeDisabled() {
+    void allowsUptimeMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.uptime.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(UptimeMetrics.class)).isEmpty();
     }
 
     @Test
-    public void allowsCustomUptimeMetricsToBeUsed() {
+    void allowsCustomUptimeMetricsToBeUsed() {
         registerAndRefresh(CustomUptimeMetricsConfiguration.class);
         assertThat(context.getBean(UptimeMetrics.class)).isEqualTo(context.getBean("customUptimeMetrics"));
     }
 
     @Test
-    public void autoConfiguresProcessorMetrics() {
+    void autoConfiguresProcessorMetrics() {
         registerAndRefresh();
         assertThat(context.getBean(ProcessorMetrics.class)).isNotNull();
     }
 
     @Test
     @Deprecated
-    public void allowsProcessorMetricsToBeDisabled() {
+    void allowsProcessorMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.processor.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(ProcessorMetrics.class)).isEmpty();
     }
 
     @Test
-    public void allowsCustomProcessorMetricsToBeUsed() {
+    void allowsCustomProcessorMetricsToBeUsed() {
         registerAndRefresh(CustomProcessorMetricsConfiguration.class);
         assertThat(context.getBean(ProcessorMetrics.class)).isEqualTo(context.getBean("customProcessorMetrics"));
     }
 
     @Test
-    public void autoConfiguresFileDescriptorMetrics() {
+    void autoConfiguresFileDescriptorMetrics() {
         registerAndRefresh();
         assertThat(context.getBean(FileDescriptorMetrics.class)).isNotNull();
     }
 
     @Test
     @Deprecated
-    public void allowsFileDescriptorMetricsToBeDisabled() {
+    void allowsFileDescriptorMetricsToBeDisabled() {
         EnvironmentTestUtils.addEnvironment(context, "management.metrics.binders.files.enabled=false");
         registerAndRefresh();
         assertThat(context.getBeansOfType(FileDescriptorMetrics.class)).isEmpty();
     }
 
     @Test
-    public void allowsCustomFileDescriptorMetricsToBeUsed() {
+    void allowsCustomFileDescriptorMetricsToBeUsed() {
         registerAndRefresh(CustomFileDescriptorMetricsConfiguration.class);
         assertThat(context.getBean(FileDescriptorMetrics.class)).isEqualTo(context.getBean("customFileDescriptorMetrics"));
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/StringToDurationConverterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/StringToDurationConverterTest.java
@@ -15,28 +15,28 @@
  */
 package io.micrometer.spring.autoconfigure.export;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class StringToDurationConverterTest {
+class StringToDurationConverterTest {
     private StringToDurationConverter converter = new StringToDurationConverter();
 
     @Test
-    public void rfc() {
+    void rfc() {
         assertThat(converter.convert("PT10M")).isEqualTo(Duration.ofMinutes(10));
     }
 
     @Test
-    public void shorthand() {
+    void shorthand() {
         assertThat(converter.convert("10s")).isEqualTo(Duration.ofSeconds(10));
     }
 
     @Test
-    public void invalidShorthand() {
+    void invalidShorthand() {
         assertThatThrownBy(() -> converter.convert("10rs"))
             .isInstanceOf(IllegalArgumentException.class);
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsMetricsExportAutoConfigurationTest.java
@@ -92,7 +92,7 @@ class AppOpticsMetricsExportAutoConfigurationTest {
     }
 
     @Test
-    public void stopsMeterRegistryWhenContextIsClosed() {
+    void stopsMeterRegistryWhenContextIsClosed() {
         AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
         registerAndRefresh(context, BaseConfiguration.class);
         AppOpticsMeterRegistry registry = spyOnDisposableBean(AppOpticsMeterRegistry.class, context);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package io.micrometer.spring.autoconfigure.export.appoptics;
 
 import io.micrometer.spring.autoconfigure.export.properties.StepRegistryPropertiesConfigAdapterTest;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Stephane Nicoll
  */
-public class AppOpticsPropertiesConfigAdapterTest extends
+class AppOpticsPropertiesConfigAdapterTest extends
         StepRegistryPropertiesConfigAdapterTest<AppOpticsProperties, AppOpticsPropertiesConfigAdapter> {
 
     @Override
@@ -40,7 +41,7 @@ public class AppOpticsPropertiesConfigAdapterTest extends
     }
 
     @Test
-    public void whenPropertiesUrisIsSetAdapterUriReturnsIt() {
+    void whenPropertiesUrisIsSetAdapterUriReturnsIt() {
         AppOpticsProperties properties = createProperties();
         properties.setUri("https://appoptics.example.com/v1/measurements");
         assertThat(createConfigAdapter(properties).uri())
@@ -48,14 +49,14 @@ public class AppOpticsPropertiesConfigAdapterTest extends
     }
 
     @Test
-    public void whenPropertiesApiTokenIsSetAdapterApiTokenReturnsIt() {
+    void whenPropertiesApiTokenIsSetAdapterApiTokenReturnsIt() {
         AppOpticsProperties properties = createProperties();
         properties.setApiToken("ABC123");
         assertThat(createConfigAdapter(properties).apiToken()).isEqualTo("ABC123");
     }
 
     @Test
-    public void whenPropertiesHostTagIsSetAdapterHostTagReturnsIt() {
+    void whenPropertiesHostTagIsSetAdapterHostTagReturnsIt() {
         AppOpticsProperties properties = createProperties();
         properties.setHostTag("node");
         assertThat(createConfigAdapter(properties).hostTag()).isEqualTo("node");

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/appoptics/AppOpticsPropertiesConfigAdapterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapterTest.java
@@ -17,7 +17,7 @@ package io.micrometer.spring.autoconfigure.export.properties;
 
 import java.time.Duration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,7 +35,7 @@ public abstract class StepRegistryPropertiesConfigAdapterTest<P extends StepRegi
     protected abstract A createConfigAdapter(P properties);
 
     @Test
-    public void whenPropertiesStepIsSetAdapterStepReturnsIt() {
+    void whenPropertiesStepIsSetAdapterStepReturnsIt() {
         P properties = createProperties();
         properties.setStep(Duration.ofSeconds(42));
         assertThat(createConfigAdapter(properties).step())
@@ -43,14 +43,14 @@ public abstract class StepRegistryPropertiesConfigAdapterTest<P extends StepRegi
     }
 
     @Test
-    public void whenPropertiesEnabledIsSetAdapterEnabledReturnsIt() {
+    void whenPropertiesEnabledIsSetAdapterEnabledReturnsIt() {
         P properties = createProperties();
         properties.setEnabled(false);
         assertThat(createConfigAdapter(properties).enabled()).isFalse();
     }
 
     @Test
-    public void whenPropertiesConnectTimeoutIsSetAdapterConnectTimeoutReturnsIt() {
+    void whenPropertiesConnectTimeoutIsSetAdapterConnectTimeoutReturnsIt() {
         P properties = createProperties();
         properties.setConnectTimeout(Duration.ofMinutes(42));
         assertThat(createConfigAdapter(properties).connectTimeout())
@@ -58,7 +58,7 @@ public abstract class StepRegistryPropertiesConfigAdapterTest<P extends StepRegi
     }
 
     @Test
-    public void whenPropertiesReadTimeoutIsSetAdapterReadTimeoutReturnsIt() {
+    void whenPropertiesReadTimeoutIsSetAdapterReadTimeoutReturnsIt() {
         P properties = createProperties();
         properties.setReadTimeout(Duration.ofMillis(42));
         assertThat(createConfigAdapter(properties).readTimeout())
@@ -66,14 +66,14 @@ public abstract class StepRegistryPropertiesConfigAdapterTest<P extends StepRegi
     }
 
     @Test
-    public void whenPropertiesNumThreadsIsSetAdapterNumThreadsReturnsIt() {
+    void whenPropertiesNumThreadsIsSetAdapterNumThreadsReturnsIt() {
         P properties = createProperties();
         properties.setNumThreads(42);
         assertThat(createConfigAdapter(properties).numThreads()).isEqualTo(42);
     }
 
     @Test
-    public void whenPropertiesBatchSizeIsSetAdapterBatchSizeReturnsIt() {
+    void whenPropertiesBatchSizeIsSetAdapterBatchSizeReturnsIt() {
         P properties = createProperties();
         properties.setBatchSize(10042);
         assertThat(createConfigAdapter(properties).batchSize()).isEqualTo(10042);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesTest.java
@@ -16,7 +16,8 @@
 package io.micrometer.spring.autoconfigure.export.properties;
 
 import io.micrometer.core.instrument.step.StepRegistryConfig;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/jersey/JerseyServerMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/jersey/JerseyServerMetricsAutoConfigurationTest.java
@@ -151,7 +151,7 @@ class JerseyServerMetricsAutoConfigurationTest {
         }
 
         @Path("/users")
-        public class TestResource {
+        class TestResource {
 
             @GET
             @Path("/{id}")

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/kafka/consumer/KafkaMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/kafka/consumer/KafkaMetricsAutoConfigurationTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 /**
  * Tests for {@link KafkaMetricsAutoConfiguration}.
  */
-public class KafkaMetricsAutoConfigurationTest {
+class KafkaMetricsAutoConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
@@ -43,19 +43,19 @@ public class KafkaMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void whenThereIsNoMBeanServerAutoConfigurationBacksOff() {
+    void whenThereIsNoMBeanServerAutoConfigurationBacksOff() {
         registerAndRefresh();
         assertThat(context.getBeansOfType(KafkaConsumerMetrics.class)).isEmpty();
     }
 
     @Test
-    public void whenThereIsAnMBeanServerKafkaConsumerMetricsIsConfigured() {
+    void whenThereIsAnMBeanServerKafkaConsumerMetricsIsConfigured() {
         registerAndRefresh(JmxAutoConfiguration.class);
         assertThat(context.getBean(KafkaConsumerMetrics.class)).isNotNull();
     }
 
     @Test
-    public void allowsCustomKafkaConsumerMetricsToBeUsed() {
+    void allowsCustomKafkaConsumerMetricsToBeUsed() {
         registerAndRefresh(JmxAutoConfiguration.class, CustomKafkaConsumerMetricsConfiguration.class);
         assertThat(context.getBean(KafkaConsumerMetrics.class)).isEqualTo(context.getBean("customKafkaConsumerMetrics"));
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/client/RestTemplateMetricsAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package io.micrometer.spring.autoconfigure.web.client;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.spring.autoconfigure.MetricsProperties;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.embedded.LocalServerPort;
@@ -35,7 +36,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,14 +50,15 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = RestTemplateMetricsAutoConfigurationTest.ClientApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
         "management.port=-1", // Disable the entire Spring Boot actuator, so that it does not get needlessly instrumented
         "security.ignored=/**",
 })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-public class RestTemplateMetricsAutoConfigurationTest {
+class RestTemplateMetricsAutoConfigurationTest {
+    
     @Autowired
     private MeterRegistry registry;
 
@@ -76,8 +78,8 @@ public class RestTemplateMetricsAutoConfigurationTest {
 
     private RestTemplate client;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         rootUri = "http://localhost:" + port;
         client = restTemplateBuilder
                 .rootUri(rootUri)
@@ -85,13 +87,13 @@ public class RestTemplateMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void restTemplatesCreatedWithBuilderAreInstrumented() {
+    void restTemplatesCreatedWithBuilderAreInstrumented() {
         client.getForObject("/it/1", String.class);
         assertThat(registry.get("http.client.requests").meters()).hasSize(1);
     }
 
     @Test
-    public void asyncRestTemplatesInContextAreInstrumented() throws Exception {
+    void asyncRestTemplatesInContextAreInstrumented() throws Exception {
         // therefore a full absolute URI is used
         ListenableFuture<ResponseEntity<String>> future = asyncClient.getForEntity(rootUri + "/it/2", String.class);
 
@@ -106,7 +108,7 @@ public class RestTemplateMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void afterMaxUrisReachedFurtherUrisAreDenied() {
+    void afterMaxUrisReachedFurtherUrisAreDenied() {
         int maxUriTags = metricsProperties.getWeb().getClient().getMaxUriTags();
         for (int i = 0; i < maxUriTags + 10; i++) {
             client.getForObject("/it/" + i, String.class);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/jetty/JettyMetricsAutoConfigurationTest.java
@@ -49,7 +49,7 @@ class JettyMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void autoConfiguresThreadPoolMetricsWithEmbeddedServletJetty() {
+    void autoConfiguresThreadPoolMetricsWithEmbeddedServletJetty() {
         AnnotationConfigEmbeddedWebApplicationContext context = new AnnotationConfigEmbeddedWebApplicationContext();
         context.register(MeterRegistryConfiguration.class, ServletWebServerConfiguration.class,
                 JettyMetricsAutoConfiguration.class);
@@ -64,7 +64,7 @@ class JettyMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void allowsCustomJettyServerThreadPoolMetricsBinderToBeUsed() {
+    void allowsCustomJettyServerThreadPoolMetricsBinderToBeUsed() {
         registerAndRefresh(MeterRegistryConfiguration.class,
                 CustomJettyServerThreadPoolMetricsBinder.class,
                 JettyMetricsAutoConfiguration.class);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/web/servlet/WebMvcMetricsAutoConfigurationTest.java
@@ -74,7 +74,7 @@ class WebMvcMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void definesTagsProviderAndFilterWhenMeterRegistryIsPresent() {
+    void definesTagsProviderAndFilterWhenMeterRegistryIsPresent() {
         registerAndRefresh(MeterRegistryConfiguration.class, WebMvcMetricsAutoConfiguration.class);
 
         assertThat(this.context.getBean(DefaultWebMvcTagsProvider.class)).isNotNull();
@@ -82,7 +82,7 @@ class WebMvcMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void tagsProviderBacksOff() {
+    void tagsProviderBacksOff() {
         registerAndRefresh(MeterRegistryConfiguration.class, TagsProviderConfiguration.class,
                 WebMvcMetricsAutoConfiguration.class);
 
@@ -92,7 +92,7 @@ class WebMvcMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void afterMaxUrisReachedFurtherUrisAreDenied() throws Exception {
+    void afterMaxUrisReachedFurtherUrisAreDenied() throws Exception {
         this.context.setServletContext(new MockServletContext());
 
         EnvironmentTestUtils.addEnvironment(this.context, "management.metrics.web.server.max-uri-tags=2");
@@ -114,7 +114,7 @@ class WebMvcMetricsAutoConfigurationTest {
     }
 
     @Test
-    public void shouldNotDenyIfMaxUrisIsNotReached() throws Exception {
+    void shouldNotDenyIfMaxUrisIsNotReached() throws Exception {
         this.context.setServletContext(new MockServletContext());
 
         EnvironmentTestUtils.addEnvironment(this.context, "management.metrics.web.server.max-uri-tags=5");

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManagerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/export/prometheus/PrometheusPushGatewayManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ class PrometheusPushGatewayManagerTest {
     private ScheduledFuture<Object> future;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         MockitoAnnotations.initMocks(this);
         this.scheduler = mockScheduler(TaskScheduler.class);
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ package io.micrometer.spring.integration;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -30,24 +31,22 @@ import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.support.Transformers;
 import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
 import org.springframework.integration.ws.WebServiceHeaders;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
-public class SpringIntegrationMetricsTest {
+class SpringIntegrationMetricsTest {
+    
     @Autowired
-    TestSpringIntegrationApplication.TempConverter converter;
+    private TestSpringIntegrationApplication.TempConverter converter;
 
     @Autowired
-    MeterRegistry registry;
-
-    @Autowired
-    MockClock clock;
+    private MeterRegistry registry;
 
     @Test
-    public void springIntegrationMetrics() {
+    void springIntegrationMetrics() {
         converter.fahrenheitToCelcius(68.0f);
 
         assertThat(registry.get("spring.integration.channel.sends")
@@ -58,7 +57,8 @@ public class SpringIntegrationMetricsTest {
 
     @SpringBootApplication
     @IntegrationComponentScan
-    public static class TestSpringIntegrationApplication {
+    static class TestSpringIntegrationApplication {
+        
         @Bean
         MockClock clock() {
             return new MockClock();

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsHikariTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsHikariTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ package io.micrometer.spring.jdbc;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvider;
@@ -27,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.sql.DataSource;
 import java.util.Collection;
@@ -37,22 +38,20 @@ import static java.util.Collections.emptyList;
 /**
  * @author Arthur Gavlyukovskiy
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @TestPropertySource(properties = {
     "spring.datasource.generate-unique-name=true",
     "management.security.enabled=false",
     "spring.datasource.type=com.zaxxer.hikari.HikariDataSource"
 })
-public class DataSourcePoolMetricsHikariTest {
+class DataSourcePoolMetricsHikariTest {
+    
     @Autowired
-    DataSource dataSource;
-
-    @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
-    public void dataSourceIsInstrumented() {
+    void dataSourceIsInstrumented() {
         registry.get("data.source.connections.active").meter();
     }
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ package io.micrometer.spring.jdbc;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.metadata.DataSourcePoolMetadataProvider;
@@ -27,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -38,22 +39,23 @@ import static java.util.Collections.emptyList;
 /**
  * @author Jon Schneider
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @TestPropertySource(properties = {
     "spring.datasource.generate-unique-name=true",
     "management.security.enabled=false",
     "spring.datasource.type=org.apache.tomcat.jdbc.pool.DataSource"
 })
-public class DataSourcePoolMetricsTest {
+class DataSourcePoolMetricsTest {
+    
     @Autowired
-    DataSource dataSource;
+    private DataSource dataSource;
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
-    public void dataSourceIsInstrumented() throws SQLException {
+    void dataSourceIsInstrumented() throws SQLException {
         dataSource.getConnection().getMetaData();
         registry.find("data.source.connections.max").meter();
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ExecutorServiceMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ExecutorServiceMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ExecutorServiceMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ExecutorServiceMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@ package io.micrometer.spring.scheduling;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
@@ -26,11 +27,11 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author Jon Schneider
  * @author Clint Checketts
  */
-public class ExecutorServiceMetricsTest {
+class ExecutorServiceMetricsTest {
     private MeterRegistry registry = new SimpleMeterRegistry();
 
     @Test
-    public void threadPoolTaskExecutor() {
+    void threadPoolTaskExecutor() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
         exec.initialize();
 
@@ -39,7 +40,7 @@ public class ExecutorServiceMetricsTest {
     }
 
     @Test
-    public void taskScheduler() {
+    void taskScheduler() {
         ThreadPoolTaskScheduler sched = new ThreadPoolTaskScheduler();
         sched.initialize();
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package io.micrometer.spring.scheduling;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,16 +28,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
-@Ignore("Race condition still...")
-public class ScheduledMethodMetricsTest {
+@Disabled
+class ScheduledMethodMetricsTest {
 
     static CountDownLatch longTaskStarted = new CountDownLatch(1);
     static CountDownLatch longTaskShouldComplete = new CountDownLatch(1);
@@ -45,13 +45,13 @@ public class ScheduledMethodMetricsTest {
     static CountDownLatch shortBeepsExecuted = new CountDownLatch(1);
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Autowired
-    ThreadPoolTaskScheduler scheduler;
+    private ThreadPoolTaskScheduler scheduler;
 
     @Test
-    public void shortTasksAreInstrumented() throws InterruptedException {
+    void shortTasksAreInstrumented() throws InterruptedException {
         shortBeepsExecuted.await();
         while (scheduler.getActiveCount() > 0) {
         }
@@ -62,7 +62,7 @@ public class ScheduledMethodMetricsTest {
     }
 
     @Test
-    public void longTasksAreInstrumented() throws InterruptedException {
+    void longTasksAreInstrumented() throws InterruptedException {
         longTaskStarted.await();
 
         assertThat(registry.get("long.beep").longTaskTimer().activeTasks()).isEqualTo(1);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/security/SpringSecurityTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/security/SpringSecurityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -29,7 +30,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,23 +38,24 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
     // changed to spring.security.* in Boot 2
     "security.user.password=foo"
 })
-public class SpringSecurityTest {
+class SpringSecurityTest {
+    
     @Autowired
-    MockMvc mvc;
+    private MockMvc mvc;
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     @WithMockUser
-    public void securityAllowsAccess() throws Exception {
+    void securityAllowsAccess() throws Exception {
         mvc.perform(get("/api/secured")).andExpect(status().isOk());
 
         registry.get("http.server.requests")
@@ -62,7 +64,7 @@ public class SpringSecurityTest {
     }
 
     @Test
-    public void securityBlocksAccess() throws Exception {
+    void securityBlocksAccess() throws Exception {
         mvc.perform(get("/api/secured")).andExpect(status().isUnauthorized());
 
         registry.get("http.server.requests")

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProviderTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/DefaultRestTemplateExchangeTagsProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 package io.micrometer.spring.web.client;
 
 import io.micrometer.core.instrument.Tag;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
@@ -31,36 +30,35 @@ import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
-public class DefaultRestTemplateExchangeTagsProviderTest {
+class DefaultRestTemplateExchangeTagsProviderTest {
 
     private DefaultRestTemplateExchangeTagsProvider tagsProvider = new DefaultRestTemplateExchangeTagsProvider();
 
     private MockClientHttpRequest httpRequest = new MockClientHttpRequest();
     private ClientHttpResponse httpResponse = new MockClientHttpResponse(new byte[]{}, HttpStatus.OK);
 
-    @Before
-    public void before() throws URISyntaxException {
+    @BeforeEach
+    void before() throws URISyntaxException {
         httpRequest.setMethod(HttpMethod.GET);
         httpRequest.setURI(new URI("http://localhost/test/123"));
     }
 
     @Test
-    public void uriTagSetFromUriTemplate() {
+    void uriTagSetFromUriTemplate() {
         Iterable<Tag> tags = tagsProvider.getTags("/test/{id}", httpRequest, httpResponse);
 
         assertThat(tags).contains(Tag.of("uri", "/test/{id}"));
     }
 
     @Test
-    public void uriTagSetFromRequestWhenNoUriTemplate() {
+    void uriTagSetFromRequestWhenNoUriTemplate() {
         Iterable<Tag> tags = tagsProvider.getTags(null, httpRequest, httpResponse);
 
         assertThat(tags).contains(Tag.of("uri", "/test/123"));
     }
 
     @Test
-    public void uriTagSetFromRequestWhenUriTemplateIsBlank() {
+    void uriTagSetFromRequestWhenUriTemplateIsBlank() {
         Iterable<Tag> tags = tagsProvider.getTags(" ", httpRequest, httpResponse);
 
         assertThat(tags).contains(Tag.of("uri", "/test/123"));

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/client/MetricsRestTemplateCustomizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
@@ -40,21 +41,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Jon Schneider
  */
-public class MetricsRestTemplateCustomizerTest {
+class MetricsRestTemplateCustomizerTest {
 
     private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
     private RestTemplate restTemplate = new RestTemplate();
     private MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
 
-    @Before
-    public void before() {
+    @BeforeEach
+    void before() {
         MetricsRestTemplateCustomizer customizer = new MetricsRestTemplateCustomizer(
                 registry, new DefaultRestTemplateExchangeTagsProvider(), "http.client.requests");
         customizer.customize(restTemplate);
     }
 
     @Test
-    public void interceptRestTemplate() {
+    void interceptRestTemplate() {
         mockServer.expect(MockRestRequestMatchers.requestTo("/test/123"))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
                 .andRespond(MockRestResponseCreators.withSuccess("OK",
@@ -76,7 +77,7 @@ public class MetricsRestTemplateCustomizerTest {
 
     @Issue("#283")
     @Test
-    public void normalizeUriToContainLeadingSlash() {
+    void normalizeUriToContainLeadingSlash() {
         mockServer.expect(MockRestRequestMatchers.requestTo("test/123"))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
                 .andRespond(MockRestResponseCreators.withSuccess("OK",
@@ -91,7 +92,7 @@ public class MetricsRestTemplateCustomizerTest {
     }
 
     @Test
-    public void interceptRestTemplateWithUri() throws URISyntaxException {
+    void interceptRestTemplateWithUri() throws URISyntaxException {
         mockServer.expect(MockRestRequestMatchers.requestTo("http://localhost/test/123"))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
                 .andRespond(MockRestResponseCreators.withSuccess("OK",

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/jersey2/server/JerseyServerMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/jersey2/server/JerseyServerMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,29 +21,30 @@ import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import java.time.Duration;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = JerseyServerMetricsTest.JerseyApp.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
         "spring.jersey.type=filter",
         "spring.jersey.filter.order=-2147483648"
 })
-public class JerseyServerMetricsTest {
+class JerseyServerMetricsTest {
+
     @Autowired
     private TestRestTemplate client;
 
@@ -52,7 +53,7 @@ public class JerseyServerMetricsTest {
 
     @Issue("#486")
     @Test
-    public void jerseyWeb() {
+    void jerseyWeb() {
         client.getForObject("/ping/1", String.class);
 
         RetryConfig retryConfig = RetryConfig.custom()
@@ -70,17 +71,17 @@ public class JerseyServerMetricsTest {
 
     @SpringBootApplication(scanBasePackages = "ignore")
     @Import({JerseyConfig.class, PingResource.class})
-    public static class JerseyApp {
+    static class JerseyApp {
     }
 
-    public static class JerseyConfig extends ResourceConfig {
+    static class JerseyConfig extends ResourceConfig {
         public JerseyConfig() {
             this.register(PingResource.class);
         }
     }
 
     @Path("/ping")
-    public static class PingResource {
+    static class PingResource {
         @GET
         @Path("/{id}")
         public String ping(@PathParam("id") String id) {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,7 +31,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,23 +47,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * @author Jon Schneider
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc
 @WebAppConfiguration
 @TestPropertySource(properties = "security.ignored=/**")
-public class WebMvcMetricsFilterAutoTimedTest {
+class WebMvcMetricsFilterAutoTimedTest {
 
     @Autowired
     private MeterRegistry registry;
 
     @Autowired
-    private MockClock clock;
-
-    @Autowired
     private MockMvc mvc;
 
     @Test
-    public void metricsCanBeAutoTimed() throws Exception {
+    void metricsCanBeAutoTimed() throws Exception {
         this.mvc.perform(get("/api/10")).andExpect(status().isOk());
 
         assertThat(this.registry.get("http.server.requests").tags("status", "200").timer().count()).isEqualTo(1);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,9 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,7 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.*;
@@ -49,23 +50,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @author Jon Schneider
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "security.ignored=/**")
-public class WebMvcMetricsFilterCustomExceptionHandlerTest {
+class WebMvcMetricsFilterCustomExceptionHandlerTest {
 
     @Autowired
     private SimpleMeterRegistry registry;
 
     @Autowired
-    private MockClock clock;
-
-    @Autowired
     private MockMvc mvc;
 
     @Test
-    public void handledExceptionIsRecordedInMetricTag() throws Exception {
+    void handledExceptionIsRecordedInMetricTag() throws Exception {
         mvc.perform(get("/api/handledError")).andExpect(status().is5xxServerError());
 
         assertThat(this.registry.get("http.server.requests")
@@ -73,7 +71,7 @@ public class WebMvcMetricsFilterCustomExceptionHandlerTest {
     }
 
     @Test
-    public void rethrownExceptionIsRecordedInMetricTag() {
+    void rethrownExceptionIsRecordedInMetricTag() {
         assertThatCode(() -> mvc.perform(get("/api/rethrownError"))
             .andExpect(status().is5xxServerError()));
 
@@ -116,16 +114,17 @@ public class WebMvcMetricsFilterCustomExceptionHandlerTest {
         }
     }
 
+    @SuppressWarnings("serial")
     static class Exception1 extends RuntimeException {
     }
 
+    @SuppressWarnings("serial")
     static class Exception2 extends RuntimeException {
     }
 
     @ControllerAdvice
     static class CustomExceptionHandler {
 
-        @SuppressWarnings("unused")
         @ExceptionHandler
         ResponseEntity<String> handleError(Exception1 ex) {
             return new ResponseEntity<>("this is a custom exception body",

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration;
 import io.prometheus.client.CollectorRegistry;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
@@ -40,7 +41,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.*;
@@ -73,11 +74,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Jon Schneider
  * @author Nikolay Rybak
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @AutoConfigureMockMvc
 @TestPropertySource(properties = "security.ignored=/**")
-public class WebMvcMetricsFilterTest {
+class WebMvcMetricsFilterTest {
+
     @Autowired
     private SimpleMeterRegistry registry;
 
@@ -96,7 +98,7 @@ public class WebMvcMetricsFilterTest {
     private CyclicBarrier completableFutureBarrier;
 
     @Test
-    public void timedMethod() throws Exception {
+    void timedMethod() throws Exception {
         mvc.perform(get("/api/c1/10")).andExpect(status().isOk());
 
         assertThat(this.registry.get("http.server.requests")
@@ -105,7 +107,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void subclassedTimedMethod() throws Exception {
+    void subclassedTimedMethod() throws Exception {
         mvc.perform(get("/api/c1/metaTimed/10")).andExpect(status().isOk());
 
         assertThat(this.registry.get("http.server.requests")
@@ -114,7 +116,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void untimedMethod() throws Exception {
+    void untimedMethod() throws Exception {
         mvc.perform(get("/api/c1/untimed/10")).andExpect(status().isOk());
 
         assertThat(this.registry.find("http.server.requests")
@@ -123,7 +125,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void timedControllerClass() throws Exception {
+    void timedControllerClass() throws Exception {
         mvc.perform(get("/api/c2/10")).andExpect(status().isOk());
 
         assertThat(this.registry.get("http.server.requests").tags("status", "200")
@@ -131,7 +133,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void badClientRequest() throws Exception {
+    void badClientRequest() throws Exception {
         mvc.perform(get("/api/c1/oops")).andExpect(status().is4xxClientError());
 
         assertThat(this.registry.get("http.server.requests").tags("status", "400")
@@ -139,7 +141,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void redirectRequest() throws Exception {
+    void redirectRequest() throws Exception {
         mvc.perform(get("/api/redirect")
                 .header(TEST_MISBEHAVE_HEADER, "302")).andExpect(status().is3xxRedirection());
 
@@ -148,7 +150,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void notFoundRequest() throws Exception {
+    void notFoundRequest() throws Exception {
         mvc.perform(get("/api/not/found")
                 .header(TEST_MISBEHAVE_HEADER, "404"))
                 .andExpect(status().is4xxClientError());
@@ -158,7 +160,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void unhandledError() {
+    void unhandledError() {
         assertThatCode(() -> mvc.perform(get("/api/c1/unhandledError/10"))
                 .andExpect(status().isOk()))
                 .hasRootCauseInstanceOf(RuntimeException.class);
@@ -169,7 +171,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void endpointThrowsError() throws Exception {
+    void endpointThrowsError() throws Exception {
         mvc.perform(get("/api/c1/error/10")).andExpect(status().is4xxClientError());
 
         assertThat(this.registry.get("http.server.requests").tags("status", "422")
@@ -177,7 +179,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void endpointThrowsAnonymousError() throws Exception {
+    void endpointThrowsAnonymousError() throws Exception {
         try {
             mvc.perform(get("/api/c1/anonymousError/10"));
         } catch (Throwable ignore) {
@@ -189,7 +191,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void regexBasedRequestMapping() throws Exception {
+    void regexBasedRequestMapping() throws Exception {
         mvc.perform(get("/api/c1/regex/.abc")).andExpect(status().isOk());
 
         assertThat(this.registry.get("http.server.requests")
@@ -198,7 +200,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void recordQuantiles() throws Exception {
+    void recordQuantiles() throws Exception {
         mvc.perform(get("/api/c1/percentiles/10")).andExpect(status().isOk());
 
         assertThat(prometheusRegistry.scrape()).contains("quantile=\"0.5\"");
@@ -206,7 +208,7 @@ public class WebMvcMetricsFilterTest {
     }
 
     @Test
-    public void recordHistogram() throws Exception {
+    void recordHistogram() throws Exception {
         mvc.perform(get("/api/c1/histogram/10")).andExpect(status().isOk());
 
         assertThat(prometheusRegistry.scrape()).contains("le=\"0.001\"");
@@ -342,6 +344,7 @@ public class WebMvcMetricsFilterTest {
             throw new IllegalStateException("Boom on " + id + "!");
         }
 
+        @SuppressWarnings("serial")
         @Timed
         @GetMapping("/anonymousError/{id}")
         public String alwaysThrowsAnonymousException(@PathVariable Long id) throws Exception {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcTagsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2018 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@
 package io.micrometer.spring.web.servlet;
 
 import io.micrometer.core.instrument.Tag;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.HandlerMapping;
@@ -30,13 +31,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Brian Clozel
  * @author Michael McFadyen
  */
-public class WebMvcTagsTest {
+class WebMvcTagsTest {
     private final MockHttpServletRequest request = new MockHttpServletRequest();
 
     private final MockHttpServletResponse response = new MockHttpServletResponse();
 
     @Test
-    public void uriTagValueIsBestMatchingPatternWhenAvailable() {
+    void uriTagValueIsBestMatchingPatternWhenAvailable() {
         this.request.setAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE,
                 "/spring");
         this.response.setStatus(301);
@@ -45,85 +46,85 @@ public class WebMvcTagsTest {
     }
 
     @Test
-    public void uriTagValueIsRootWhenRequestHasNoPatternOrPathInfo() {
+    void uriTagValueIsRootWhenRequestHasNoPatternOrPathInfo() {
         assertThat(WebMvcTags.uri(this.request, null).getValue()).isEqualTo("root");
     }
 
     @Test
-    public void uriTagValueIsRootWhenRequestHasNoPatternAndSlashPathInfo() {
+    void uriTagValueIsRootWhenRequestHasNoPatternAndSlashPathInfo() {
         this.request.setPathInfo("/");
         assertThat(WebMvcTags.uri(this.request, null).getValue()).isEqualTo("root");
     }
 
     @Test
-    public void uriTagValueIsUnknownWhenRequestHasNoPatternAndNonRootPathInfo() {
+    void uriTagValueIsUnknownWhenRequestHasNoPatternAndNonRootPathInfo() {
         this.request.setPathInfo("/example");
         assertThat(WebMvcTags.uri(this.request, null).getValue()).isEqualTo("UNKNOWN");
     }
 
     @Test
-    public void uriTagValueIsRedirectionWhenResponseStatusIs3xx() {
+    void uriTagValueIsRedirectionWhenResponseStatusIs3xx() {
         this.response.setStatus(301);
         Tag tag = WebMvcTags.uri(this.request, this.response);
         assertThat(tag.getValue()).isEqualTo("REDIRECTION");
     }
 
     @Test
-    public void uriTagValueIsNotFoundWhenResponseStatusIs404() {
+    void uriTagValueIsNotFoundWhenResponseStatusIs404() {
         this.response.setStatus(404);
         Tag tag = WebMvcTags.uri(this.request, this.response);
         assertThat(tag.getValue()).isEqualTo("NOT_FOUND");
     }
 
     @Test
-    public void uriTagToleratesCustomResponseStatus() {
+    void uriTagToleratesCustomResponseStatus() {
         this.response.setStatus(601);
         Tag tag = WebMvcTags.uri(this.request, this.response);
         assertThat(tag.getValue()).isEqualTo("root");
     }
 
     @Test
-    public void uriTagIsUnknownWhenRequestIsNull() {
+    void uriTagIsUnknownWhenRequestIsNull() {
         Tag tag = WebMvcTags.uri(null, null);
         assertThat(tag.getValue()).isEqualTo("UNKNOWN");
     }
 
     @Test
-    public void outcomeTagIsUnknownWhenResponseIsNull() {
+    void outcomeTagIsUnknownWhenResponseIsNull() {
         Tag tag = WebMvcTags.outcome(null);
         assertThat(tag.getValue()).isEqualTo("UNKNOWN");
     }
 
     @Test
-    public void outcomeTagIsInformationalWhenResponseIs1xx() {
+    void outcomeTagIsInformationalWhenResponseIs1xx() {
         this.response.setStatus(100);
         Tag tag = WebMvcTags.outcome(this.response);
         assertThat(tag.getValue()).isEqualTo("INFORMATIONAL");
     }
 
     @Test
-    public void outcomeTagIsSuccessWhenResponseIs2xx() {
+    void outcomeTagIsSuccessWhenResponseIs2xx() {
         this.response.setStatus(200);
         Tag tag = WebMvcTags.outcome(this.response);
         assertThat(tag.getValue()).isEqualTo("SUCCESS");
     }
 
     @Test
-    public void outcomeTagIsRedirectionWhenResponseIs3xx() {
+    void outcomeTagIsRedirectionWhenResponseIs3xx() {
         this.response.setStatus(301);
         Tag tag = WebMvcTags.outcome(this.response);
         assertThat(tag.getValue()).isEqualTo("REDIRECTION");
     }
 
     @Test
-    public void outcomeTagIsClientErrorWhenResponseIs4xx() {
+    void outcomeTagIsClientErrorWhenResponseIs4xx() {
         this.response.setStatus(400);
         Tag tag = WebMvcTags.outcome(this.response);
         assertThat(tag.getValue()).isEqualTo("CLIENT_ERROR");
     }
 
     @Test
-    public void outcomeTagIsServerErrorWhenResponseIs5xx() {
+    void outcomeTagIsServerErrorWhenResponseIs5xx() {
         this.response.setStatus(500);
         Tag tag = WebMvcTags.outcome(this.response);
         assertThat(tag.getValue()).isEqualTo("SERVER_ERROR");

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     // JUnit 5
     compile 'org.junit.jupiter:junit-jupiter-api:5.+'
     runtime 'org.junit.jupiter:junit-jupiter-engine:5.+'
+    compile 'org.springframework.test:spring-test-junit5:1.+'
 
     compile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
     compile 'com.github.tomakehurst:wiremock:2.+'

--- a/micrometer-test/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/compileClasspath.lockfile
@@ -90,6 +90,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/micrometer-test/gradle/dependency-locks/junitPlatform.lockfile
+++ b/micrometer-test/gradle/dependency-locks/junitPlatform.lockfile
@@ -1,0 +1,9 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.0.0
+org.junit.platform:junit-platform-commons:1.0.0
+org.junit.platform:junit-platform-console:1.0.0
+org.junit.platform:junit-platform-engine:1.0.0
+org.junit.platform:junit-platform-launcher:1.0.0
+org.opentest4j:opentest4j:1.0.0

--- a/micrometer-test/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-test/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -95,6 +95,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/micrometer-test/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-test/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -97,6 +97,7 @@ org.ow2.asm:asm:5.0.4
 org.pcollections:pcollections:3.0.3
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25
+org.springframework.test:spring-test-junit5:1.0.0
 org.xmlunit:xmlunit-core:2.5.1
 org.xmlunit:xmlunit-legacy:2.5.1
 ru.lanwen.wiremock:wiremock-junit5:1.2.0

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/samples/micrometer-samples-core/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/samples/micrometer-samples-core/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.


### PR DESCRIPTION
Intent is to have consistent JUnit5 testing paradigm across all modules. Apart from zillion locks changes are:
* replace annotations 
@RunWith(SpringRunner.class) -> @ExtendWith(SpringExtension.class)
org.junit.Test ->  org.junit.jupiter.api.Test
![image](https://user-images.githubusercontent.com/4628962/50570866-26bd5d80-0d50-11e9-8e1a-1aa526319b7d.png)

* change class and method access modifiers to package-private as per JUnit5 conventions;

The only module using JUnit4 is `micrometer-jersey2` referring to open issue of `JerseyTest` incompatibility with JUnit5.
https://github.com/micrometer-metrics/micrometer/blob/master/micrometer-jersey2/build.gradle#L15

https://github.com/jersey/jersey/issues/3662