### PR TITLE
Align junit5 conventions and minor cleanup

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package io.micrometer.core.instrument.binder.db;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
 
 import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -27,16 +28,16 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Kristof Depypere
  */
-public class PostgreSQLDatabaseMetricsTest {
+class PostgreSQLDatabaseMetricsTest {
     private static final String DATABASE_NAME = "test";
     private static final String FUNCTIONAL_COUNTER_KEY = "key";
     private DataSource dataSource = mock(DataSource.class);
     private MeterRegistry registry = new SimpleMeterRegistry();
 
     @Test
-    public void shouldRegisterPostesMetrics() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldRegisterPostgreSqlMetrics() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
         registry.get("postgres.size").tag("database", DATABASE_NAME).gauge();
         registry.get("postgres.connections").tag("database", DATABASE_NAME).gauge();
@@ -62,33 +63,33 @@ public class PostgreSQLDatabaseMetricsTest {
     }
 
     @Test
-    public void shouldBridgePgStatReset() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldBridgePgStatReset() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
 
-        //first reset
-        Double result = postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        // first reset
+        Double result = metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
 
-        //then
+        // then
         assertThat(result).isEqualTo(15);
     }
 
     @Test
-    public void shouldBridgeDoublePgStatReset() {
-        PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
-        postgreSQLDatabaseMetrics.bindTo(registry);
+    void shouldBridgeDoublePgStatReset() {
+        PostgreSQLDatabaseMetrics metrics = new PostgreSQLDatabaseMetrics(dataSource, DATABASE_NAME);
+        metrics.bindTo(registry);
 
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 5);
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 10);
 
-        //first reset
-        postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 3);
+        // first reset
+        metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 3);
 
-        //second reset
-        Double result = postgreSQLDatabaseMetrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 1);
+        // second reset
+        Double result = metrics.resettableFunctionalCounter(FUNCTIONAL_COUNTER_KEY, () -> 1);
 
         assertThat(result).isEqualTo(14);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Marten Deinum
  */
+@SuppressWarnings("deprecation")
 class HibernateMetricsTest {
 
     private MeterRegistry registry;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
  *
  * @author Michael Weirauch
  */
-public class JvmMemoryMetricsTest {
+class JvmMemoryMetricsTest {
 
     @Test
     void memoryMetrics() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class IOUtilsTest {
 
     @Test
-    public void testToString() {
+    void testToString() {
         String expected = "This is a sample.";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes());
@@ -39,7 +39,7 @@ class IOUtilsTest {
     }
 
     @Test
-    public void testToStringWithCharset() {
+    void testToStringWithCharset() {
         String expected = "This is a sample.";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));

--- a/micrometer-core/src/test/java/io/micrometer/core/ipc/http/RequestTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/ipc/http/RequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,11 @@ import static org.mockito.Mockito.mock;
  */
 class RequestTest {
 
+    @SuppressWarnings("unchecked")
     @Test
     void compressShouldAddContentEncodingHeader() throws IOException, NoSuchFieldException, IllegalAccessException {
-        HttpSender.Request.Builder builder = HttpSender.Request.build("https://micrometer.io/", mock(HttpSender.class)).compress();
+        HttpSender sender = mock(HttpSender.class);
+        HttpSender.Request.Builder builder = HttpSender.Request.build("https://micrometer.io/", sender).compress();
         Field requestHeadersField = HttpSender.Request.Builder.class.getDeclaredField("requestHeaders");
         requestHeadersField.setAccessible(true);
         Map<String, String> requestHeaders = (Map<String, String>) requestHeadersField.get(builder);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 public class CompositeMeterRegistryConfigurationDefaultSimpleRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     /**
      * The simple registry is off by default UNLESS there is no other registry implementation on

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest.MetricsApp.class)
 public class CompositeMeterRegistryConfigurationExistingPrimaryRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     public void compositeNotCreatedWhenPrimaryRegistryExists() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationNoRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationNoRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = "management.metrics.export.simple.enabled=false")
 public class CompositeMeterRegistryConfigurationNoRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     /**
      * An empty composite is created in the absence of any other registry implementation.

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationSingleRegistryTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeMeterRegistryConfigurationSingleRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = CompositeMeterRegistryConfigurationTest.MetricsApp.class)
 @TestPropertySource(properties = "management.metrics.export.graphite.enabled=true")
 public class CompositeMeterRegistryConfigurationSingleRegistryTest {
+    
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     public void noCompositeCreated() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryCustomizerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/MeterRegistryCustomizerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,12 @@ import static org.assertj.core.api.Assertions.assertThat;
         "management.metrics.export.atlas.enabled=true"
 })
 public class MeterRegistryCustomizerTest {
+    
     @Autowired
-    AtlasMeterRegistry atlasRegistry;
+    private AtlasMeterRegistry atlasRegistry;
 
     @Autowired
-    PrometheusMeterRegistry prometheusRegistry;
+    private PrometheusMeterRegistry prometheusRegistry;
 
     @Test
     public void commonTagsAreAppliedToAutoConfiguredBinders() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class PropertiesMeterFilterIntegrationTest {
     static class MetricsApp {
         @Bean
         @Order(Ordered.HIGHEST_PRECEDENCE)
-        public MeterRegistryCustomizer meterFilter() {
+        public MeterRegistryCustomizer<?> meterFilter() {
             return r -> r.config().meterFilter(MeterFilter.deny(id -> id.getName().contains("my.timer")));
         }
     }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/integration/SpringIntegrationMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,14 +37,12 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 public class SpringIntegrationMetricsTest {
+    
     @Autowired
-    TestSpringIntegrationApplication.TempConverter converter;
+    private TestSpringIntegrationApplication.TempConverter converter;
 
     @Autowired
-    MeterRegistry registry;
-
-    @Autowired
-    MockClock clock;
+    private MeterRegistry registry;
 
     @Test
     public void springIntegrationMetrics() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsHikariTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsHikariTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,9 @@ import static java.util.Collections.emptyList;
     "spring.datasource.type=com.zaxxer.hikari.HikariDataSource"
 })
 public class DataSourcePoolMetricsHikariTest {
+    
     @Autowired
-    DataSource dataSource;
-
-    @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     public void dataSourceIsInstrumented() {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/jdbc/DataSourcePoolMetricsTest.java
@@ -46,11 +46,12 @@ import static java.util.Collections.emptyList;
     "spring.datasource.type=org.apache.tomcat.jdbc.pool.DataSource"
 })
 public class DataSourcePoolMetricsTest {
+    
     @Autowired
-    DataSource dataSource;
+    private DataSource dataSource;
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     public void dataSourceIsInstrumented() throws SQLException {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/scheduling/ScheduledMethodMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,10 +45,10 @@ public class ScheduledMethodMetricsTest {
     static CountDownLatch shortBeepsExecuted = new CountDownLatch(1);
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Autowired
-    ThreadPoolTaskScheduler scheduler;
+    private ThreadPoolTaskScheduler scheduler;
 
     @Test
     public void shortTasksAreInstrumented() throws InterruptedException {

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/security/SpringSecurityTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/security/SpringSecurityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,11 +45,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     "security.user.password=foo"
 })
 public class SpringSecurityTest {
+    
     @Autowired
-    MockMvc mvc;
+    private MockMvc mvc;
 
     @Autowired
-    MeterRegistry registry;
+    private MeterRegistry registry;
 
     @Test
     @WithMockUser

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterAutoTimedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,9 +54,6 @@ public class WebMvcMetricsFilterAutoTimedTest {
 
     @Autowired
     private MeterRegistry registry;
-
-    @Autowired
-    private MockClock clock;
 
     @Autowired
     private MockMvc mvc;

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterCustomExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,9 +59,6 @@ public class WebMvcMetricsFilterCustomExceptionHandlerTest {
     private SimpleMeterRegistry registry;
 
     @Autowired
-    private MockClock clock;
-
-    @Autowired
     private MockMvc mvc;
 
     @Test
@@ -116,16 +113,17 @@ public class WebMvcMetricsFilterCustomExceptionHandlerTest {
         }
     }
 
+    @SuppressWarnings("serial")
     static class Exception1 extends RuntimeException {
     }
 
+    @SuppressWarnings("serial")
     static class Exception2 extends RuntimeException {
     }
 
     @ControllerAdvice
     static class CustomExceptionHandler {
 
-        @SuppressWarnings("unused")
         @ExceptionHandler
         ResponseEntity<String> handleError(Exception1 ex) {
             return new ResponseEntity<>("this is a custom exception body",


### PR DESCRIPTION
Use consistent JUnit5 class/method conventions and minor cleanup(use proper access modifiers, remove unused variables, add/remove suppress warnings and copyrights)