### PR TITLE
Prevent publishing NaN or infinite values to Dynatrace

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -136,13 +136,8 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     Stream<DynatraceCustomMetric> writeMeter(Meter meter) {
         final long wallTime = clock.wallTime();
         return StreamSupport.stream(meter.measure().spliterator(), false)
-                .filter(this::isPublishable)
+                .filter(ms -> Double.isFinite(ms.getValue()))
                 .map(ms -> createCustomMetric(meter.getId(), wallTime, ms.getValue()));
-    }
-
-    private boolean isPublishable(Measurement measurement) {
-        double value = measurement.getValue();
-        return !Double.isNaN(value) && !Double.isInfinite(value);
     }
 
     private Stream<DynatraceCustomMetric> writeLongTaskTimer(LongTaskTimer longTaskTimer) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -132,10 +132,17 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private Stream<DynatraceCustomMetric> writeMeter(Meter meter) {
+    // VisibleForTesting
+    Stream<DynatraceCustomMetric> writeMeter(Meter meter) {
         final long wallTime = clock.wallTime();
         return StreamSupport.stream(meter.measure().spliterator(), false)
+                .filter(this::isPublishable)
                 .map(ms -> createCustomMetric(meter.getId(), wallTime, ms.getValue()));
+    }
+
+    private boolean isPublishable(Measurement measurement) {
+        double value = measurement.getValue();
+        return !Double.isNaN(value) && !Double.isInfinite(value);
     }
 
     private Stream<DynatraceCustomMetric> writeLongTaskTimer(LongTaskTimer longTaskTimer) {

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
@@ -16,12 +16,17 @@
 package io.micrometer.dynatrace;
 
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.ipc.http.HttpSender;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Johnny Lim
  */
 class DynatraceMeterRegistryTest {
+
+    private final DynatraceMeterRegistry meterRegistry = createMeterRegistry();
 
     @Test
     void constructorWhenUriIsMissingShouldThrowMissingRequiredConfigurationException() {
@@ -101,6 +108,72 @@ class DynatraceMeterRegistryTest {
 
     @Test
     void putCustomMetricOnSuccessShouldAddMetricIdToCreatedCustomMetrics() throws NoSuchFieldException, IllegalAccessException {
+        Field createdCustomMetricsField = DynatraceMeterRegistry.class.getDeclaredField("createdCustomMetrics");
+        createdCustomMetricsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Set<String> createdCustomMetrics = (Set<String>) createdCustomMetricsField.get(meterRegistry);
+        assertThat(createdCustomMetrics).isEmpty();
+
+        DynatraceMetricDefinition customMetric = new DynatraceMetricDefinition("metricId", null, null, null, new String[]{"type"});
+        meterRegistry.putCustomMetric(customMetric);
+        assertThat(createdCustomMetrics).containsExactly("metricId");
+    }
+
+    @Test
+    void writeMeterWithGauge() {
+        meterRegistry.gauge("my.gauge", 1d);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeMeter(gauge)).hasSize(1);
+    }
+
+    @Test
+    void writeMeterWithGaugeShouldDropNanValue() {
+        meterRegistry.gauge("my.gauge", Double.NaN);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeMeter(gauge)).isEmpty();
+    }
+
+    @Test
+    void writeMeterWithGaugeShouldDropInfiniteValues() {
+        meterRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeMeter(gauge)).isEmpty();
+
+        meterRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
+        gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeMeter(gauge)).isEmpty();
+    }
+
+    @Test
+    void writeMeterWithTimeGauge() {
+        AtomicReference<Double> obj = new AtomicReference<>(1d);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeMeter(timeGauge)).hasSize(1);
+    }
+
+    @Test
+    void writeMeterWithTimeGaugeShouldDropNanValue() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.NaN);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeMeter(timeGauge)).isEmpty();
+    }
+
+    @Test
+    void writeMeterWithTimeGaugeShouldDropInfiniteValues() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeMeter(timeGauge)).isEmpty();
+
+        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeMeter(timeGauge)).isEmpty();
+    }
+
+    private DynatraceMeterRegistry createMeterRegistry() {
         DynatraceConfig config = new DynatraceConfig() {
             @Override
             public String get(String key) {
@@ -122,18 +195,9 @@ class DynatraceMeterRegistryTest {
                 return "apiToken";
             }
         };
-        DynatraceMeterRegistry registry = DynatraceMeterRegistry.builder(config)
-                .httpClient(request -> new HttpSender.Response(200, null))
-                .build();
-
-        Field createdCustomMetricsField = DynatraceMeterRegistry.class.getDeclaredField("createdCustomMetrics");
-        createdCustomMetricsField.setAccessible(true);
-        @SuppressWarnings("unchecked") Set<String> createdCustomMetrics = (Set<String>) createdCustomMetricsField.get(registry);
-        assertThat(createdCustomMetrics).isEmpty();
-
-        DynatraceMetricDefinition customMetric = new DynatraceMetricDefinition("metricId", null, null, null, new String[]{"type"});
-        registry.putCustomMetric(customMetric);
-        assertThat(createdCustomMetrics).containsExactly("metricId");
+        return DynatraceMeterRegistry.builder(config)
+            .httpClient(request -> new HttpSender.Response(200, null))
+            .build();
     }
 
 }


### PR DESCRIPTION
This PR prevents publishing NaN or infinite values to Dynatrace.

A build for this PR will fail due to the dependency lock problem. After inclusion of the dependency lock updates in #1109, I expect the build will pass.

Closes gh-1115