### PR TITLE
Prevent publishing infinite values to InfluxDB

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -33,7 +33,10 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 
 /**
+ * {@link MeterRegistry} for InfluxDB.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class InfluxMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("influx-metrics-publisher");
@@ -167,8 +170,9 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         return Stream.of(influxLineProtocol(id, "counter", Stream.of(new Field("value", count))));
     }
 
-    private Stream<String> writeGauge(Meter.Id id, Double value) {
-        return value.isNaN() ? Stream.empty() :
+    // VisibleForTesting
+    Stream<String> writeGauge(Meter.Id id, Double value) {
+        return value.isNaN() || value.isInfinite() ? Stream.empty() :
                 Stream.of(influxLineProtocol(id, "gauge", Stream.of(new Field("value", value))));
     }
 

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.influx;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.TimeGauge;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link InfluxMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class InfluxMeterRegistryTest {
+
+    private final InfluxMeterRegistry meterRegistry = new InfluxMeterRegistry(InfluxConfig.DEFAULT, Clock.SYSTEM);
+
+    @Test
+    void writeGauge() {
+        meterRegistry.gauge("my.gauge", 1d);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeGauge(gauge.getId(), 1d)).hasSize(1);
+    }
+
+    @Test
+    void writeGaugeShouldDropNanValue() {
+        meterRegistry.gauge("my.gauge", Double.NaN);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeGauge(gauge.getId(), Double.NaN)).isEmpty();
+    }
+
+    @Test
+    void writeGaugeShouldDropInfiniteValues() {
+        meterRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeGauge(gauge.getId(), Double.POSITIVE_INFINITY)).isEmpty();
+
+        meterRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
+        gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(meterRegistry.writeGauge(gauge.getId(), Double.NEGATIVE_INFINITY)).isEmpty();
+    }
+
+    @Test
+    void writeTimeGauge() {
+        AtomicReference<Double> obj = new AtomicReference<>(1d);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeGauge(timeGauge.getId(), 1d)).hasSize(1);
+    }
+
+    @Test
+    void writeTimeGaugeShouldDropNanValue() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.NaN);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeGauge(timeGauge.getId(), Double.NaN)).isEmpty();
+    }
+
+    @Test
+    void writeTimeGaugeShouldDropInfiniteValues() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeGauge(timeGauge.getId(), Double.POSITIVE_INFINITY)).isEmpty();
+
+        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterRegistry.writeGauge(timeGauge.getId(), Double.NEGATIVE_INFINITY)).isEmpty();
+    }
+
+}


### PR DESCRIPTION
This PR prevents publishing infinite values to InfluxDB.

Closes gh-1120