### PR TITLE
Add Javadoc since tags for StatsD protocol

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -81,6 +81,7 @@ public interface StatsdConfig extends MeterRegistryConfig {
 
     /**
      * @return the protocol of the connection to the agent
+     * @since 1.2.0
      */
     default StatsdProtocol protocol() {
         final String v = get(prefix() + ".protocol");

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdProtocol.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdProtocol.java
@@ -15,6 +15,12 @@
  */
 package io.micrometer.statsd;
 
+/**
+ * Protocol for StatsD.
+ *
+ * @author Soroosh Sarabadani
+ * @since 1.2.0
+ */
 public enum StatsdProtocol {
     UDP,
     TCP


### PR DESCRIPTION
This PR adds Javadoc `@since` tags for StatsD protocol.