### PR TITLE
Make checkedForIndexTemplate volatile in ElasticMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -55,7 +55,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     private final ElasticConfig config;
     private final HttpSender httpClient;
 
-    private boolean checkedForIndexTemplate = false;
+    private volatile boolean checkedForIndexTemplate = false;
 
     @SuppressWarnings("deprecation")
     public ElasticMeterRegistry(ElasticConfig config, Clock clock) {


### PR DESCRIPTION
This PR makes `checkedForIndexTemplate` `volatile` in `ElasticMeterRegistry` as it could be accessed by another thread via the `close()` method and cause a visibility issue theoretically.