### PR TITLE
Addresses #878: Reading kafka records-lag metrics with topic and partition name

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -21,6 +21,8 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
 import io.micrometer.core.lang.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.management.*;
 import java.lang.management.ManagementFactory;
@@ -51,6 +53,9 @@ import static java.util.Collections.emptyList;
 @NonNullApi
 @NonNullFields
 public class KafkaConsumerMetrics implements MeterBinder {
+
+    private final Logger logger = LoggerFactory.getLogger(KafkaConsumerMetrics.class);
+
     private static final String JMX_DOMAIN = "kafka.consumer";
     private static final String METRIC_NAME_PREFIX = "kafka.consumer.";
 
@@ -85,6 +90,8 @@ public class KafkaConsumerMetrics implements MeterBinder {
     @Override
     public void bindTo(MeterRegistry registry) {
         registerMetricsEventually("consumer-fetch-manager-metrics", (o, tags) -> {
+            registerGaugeForObject(registry, o, "records-lag", tags, "The latest lag of the partition", "records");
+            registerGaugeForObject(registry, o, "records-lag-avg", tags, "The average lag of the partition", "records");
             registerGaugeForObject(registry, o, "records-lag-max", tags, "The maximum lag in terms of number of records for any partition in this window. An increasing value over time is your best indication that the consumer group is not keeping up with the producers.", "records");
             registerGaugeForObject(registry, o, "fetch-size-avg", tags, "The average number of bytes fetched per request.", "bytes");
             registerGaugeForObject(registry, o, "fetch-size-max", tags, "The maximum number of bytes fetched per request.", "bytes");
@@ -96,7 +103,9 @@ public class KafkaConsumerMetrics implements MeterBinder {
 
             if (kafkaMajorVersion(tags) >= 2) {
                 // KAFKA-6184
-                registerTimeGaugeForObject(registry, o, "records-lead-min", tags, "The lag between the consumer offset and the start offset of the log. If this gets close to zero, it's an indication that the consumer may lose data soon.");
+                registerTimeGaugeForObject(registry, o, "records-lead", tags, "The latest lead of the partition.");
+                registerTimeGaugeForObject(registry, o, "records-lead-min", tags, "The min lead of the partition. The lag between the consumer offset and the start offset of the log. If this gets close to zero, it's an indication that the consumer may lose data soon.");
+                registerTimeGaugeForObject(registry, o, "records-lead-avg", tags, "The average lead of the partition.");
             }
 
             registerTimeGaugeForObject(registry, o, "fetch-latency-avg", tags, "The average time taken for a fetch request.");
@@ -241,6 +250,7 @@ public class KafkaConsumerMetrics implements MeterBinder {
         NotificationListener notificationListener = (notification, handback) -> {
             MBeanServerNotification mbs = (MBeanServerNotification) notification;
             ObjectName o = mbs.getMBeanName();
+            logger.trace("Got a JMX notification for object: {} with properties: {}", o.getCanonicalName(), o.getKeyPropertyListString());
             perObject.accept(o, Tags.concat(tags, nameTag(o)));
         };
 
@@ -248,8 +258,7 @@ public class KafkaConsumerMetrics implements MeterBinder {
             if (!MBeanServerNotification.REGISTRATION_NOTIFICATION.equals(notification.getType()))
                 return false;
             ObjectName obj = ((MBeanServerNotification) notification).getMBeanName();
-            return obj.getDomain().equals(JMX_DOMAIN) && obj.getKeyProperty("type").equals(type) &&
-                    obj.getKeyProperty("partition") == null && obj.getKeyProperty("topic") == null;
+            return obj.getDomain().equals(JMX_DOMAIN) && obj.getKeyProperty("type").equals(type);
         };
 
         try {
@@ -273,6 +282,16 @@ public class KafkaConsumerMetrics implements MeterBinder {
         String clientId = name.getKeyProperty("client-id");
         if (clientId != null) {
             tags = Tags.concat(tags, "client.id", clientId);
+        }
+
+        String topic = name.getKeyProperty("topic");
+        if (topic != null) {
+            tags = Tags.concat(tags, "topic", topic);
+        }
+
+        String partition = name.getKeyProperty("partition");
+        if (partition != null) {
+            tags = Tags.concat(tags, "partition", partition);
         }
 
         return tags;


### PR DESCRIPTION
I verified that this works as intended by creating a lag locally. I received the correct metrics via JMX and micrometer.

Caveat:
- I was not able to formulate a test for this, I also tried running the current tests for the KafkaConsumer and I believe they are not really testing anything. Most of the tests have no assertions and no real Kafka is being used when they run. But it might be that I miss some important parts