### PR TITLE
Handle NaN in LoggingMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -38,8 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
-import static io.micrometer.core.instrument.util.DoubleFormat.decimal;
-import static io.micrometer.core.instrument.util.DoubleFormat.decimalOrWhole;
+import static io.micrometer.core.instrument.util.DoubleFormat.decimalOrNan;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -154,7 +153,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
                                             " mean=" + print.time(timer.mean(getBaseTimeUnit())));
                                 },
                                 meter -> loggingSink.accept(print.id() + StreamSupport.stream(meter.measure().spliterator(), false)
-                                        .map(ms -> ms.getStatistic().getTagValueRepresentation() + "=" + decimalOrWhole(ms.getValue())))
+                                        .map(ms -> ms.getStatistic().getTagValueRepresentation() + "=" + decimalOrNan(ms.getValue())))
                         );
                     });
         }
@@ -194,7 +193,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
         }
 
         String unitlessRate(double rate) {
-            return decimal(rate / (double) config.step().getSeconds()) + "/s";
+            return decimalOrNan(rate / (double) config.step().getSeconds()) + "/s";
         }
 
         String value(double value) {
@@ -204,10 +203,10 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
         // see https://stackoverflow.com/a/3758880/510017
         String humanReadableByteCount(double bytes) {
             int unit = 1024;
-            if (bytes < unit) return decimalOrWhole(bytes) + " B";
+            if (bytes < unit) return decimalOrNan(bytes) + " B";
             int exp = (int) (Math.log(bytes) / Math.log(unit));
             String pre = "KMGTPE".charAt(exp - 1) + "i";
-            return decimalOrWhole(bytes / Math.pow(unit, exp)) + " " + pre + "B";
+            return decimalOrNan(bytes / Math.pow(unit, exp)) + " " + pre + "B";
         }
 
         String humanReadableBaseUnit(double value) {
@@ -215,7 +214,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
             if ("bytes".equals(baseUnit)) {
                 return humanReadableByteCount(value);
             }
-            return decimalOrWhole(value) + (baseUnit != null ? " " + baseUnit : "");
+            return decimalOrNan(value) + (baseUnit != null ? " " + baseUnit : "");
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
@@ -16,10 +16,17 @@
 package io.micrometer.core.instrument.logging;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link LoggingMeterRegistry}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class LoggingMeterRegistryTest {
     private final LoggingMeterRegistry registry = new LoggingMeterRegistry();
 
@@ -49,4 +56,21 @@ class LoggingMeterRegistryTest {
         LoggingMeterRegistry.Printer printer = registry.new Printer(registry.timer("my.timer"));
         assertThat(printer.time(12345 /* ms */)).isEqualTo("12.345s");
     }
+
+    @Test
+    void printerValueWhenGaugeIsNaNShouldPrintNaN() {
+        registry.gauge("my.gauge", Double.NaN);
+        Gauge gauge = registry.find("my.gauge").gauge();
+        LoggingMeterRegistry.Printer printer = registry.new Printer(gauge);
+        assertThat(printer.value(Double.NaN)).isEqualTo("NaN");
+    }
+
+    @Test
+    void printerValueWhenGaugeIsInfinityShouldPrintInfinity() {
+        registry.gauge("my.gauge", Double.POSITIVE_INFINITY);
+        Gauge gauge = registry.find("my.gauge").gauge();
+        LoggingMeterRegistry.Printer printer = registry.new Printer(gauge);
+        assertThat(printer.value(Double.POSITIVE_INFINITY)).isEqualTo("∞");
+    }
+
 }


### PR DESCRIPTION
This PR changes to print "NaN" for NaN in `LoggingMeterRegistry` as it prints a broken character like "�" for NaN now.