### PR TITLE
Split Dynatrace messages if they are too large

### DIFF
--- a/implementations/micrometer-registry-dynatrace/build.gradle
+++ b/implementations/micrometer-registry-dynatrace/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     compile 'org.apache.commons:commons-text:latest.release'
 
     testCompile project(':micrometer-test')
-    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.+'
+    testCompile 'com.fasterxml.jackson.core:jackson-databind:latest.release'
 }

--- a/implementations/micrometer-registry-dynatrace/build.gradle
+++ b/implementations/micrometer-registry-dynatrace/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     compile 'org.apache.commons:commons-text:latest.release'
 
     testCompile project(':micrometer-test')
+    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.9.+'
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -59,16 +59,4 @@ public interface DynatraceConfig extends StepRegistryConfig {
 
         return v;
     }
-
-    /**
-     * The maximum size of message to send when sending messages to Dynatrace
-     * @return maxMessageSize in characters; -1 indicates unlimited message size
-     */
-    default long maxMessageSize() {
-        String v = get(prefix() + ".maxMessageSize");
-        if (StringUtils.isEmpty(v))
-            return -1L;
-
-        return Long.parseLong(v);
-    }
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -59,4 +59,16 @@ public interface DynatraceConfig extends StepRegistryConfig {
 
         return v;
     }
+
+    /**
+     * The maximum size of message to send when sending messages to Dynatrace
+     * @return maxMessageSize in characters; -1 indicates unlimited message size
+     */
+    default long maxMessageSize() {
+        String v = get(prefix() + ".maxMessageSize");
+        if (StringUtils.isEmpty(v))
+            return -1L;
+
+        return Long.parseLong(v);
+    }
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -249,7 +249,8 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private List<Tuple<String, Integer>> createPostMessages(String type, List<DynatraceTimeSeries> timeSeries) {
+    // VisibleForTesting
+    List<Tuple<String, Integer>> createPostMessages(String type, List<DynatraceTimeSeries> timeSeries) {
         final StringBuilder sb = new StringBuilder(1024);
         sb.append("{\"type\":\"").append(type).append('\"')
                 .append(",\"series\":[");

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -234,18 +234,26 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     private void postCustomMetricValues(String type, List<DynatraceTimeSeries> timeSeries, String customDeviceMetricEndpoint) {
         try {
             httpClient.post(customDeviceMetricEndpoint)
-                    .withJsonContent("{\"type\":\"" + type + "\"" +
-                            ",\"series\":[" +
-                            timeSeries.stream()
-                                    .map(DynatraceTimeSeries::asJson)
-                                    .collect(joining(",")) +
-                            "]}")
+                    .withJsonContent(createPostMessage(type, timeSeries))
                     .send()
                     .onSuccess(response -> logger.debug("successfully sent {} metrics to Dynatrace.", timeSeries.size()))
                     .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
         } catch (Throwable e) {
             logger.error("failed to send metrics to dynatrace", e);
         }
+    }
+
+    private String createPostMessage(String type, List<DynatraceTimeSeries> timeSeries) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"type\":\"").append(type).append('\"')
+            .append(",\"series\":[")
+            .append(timeSeries.stream()
+                    .map(DynatraceTimeSeries::asJson)
+                    .collect(joining(",")))
+            .append("]}");
+        String message = sb.toString();
+        logger.debug("created post message:\n{}", message);
+        return message;
     }
 
     private Meter.Id idWithSuffix(Meter.Id id, String suffix) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -41,7 +41,6 @@ import java.util.stream.StreamSupport;
 import static io.micrometer.dynatrace.DynatraceMetricDefinition.DynatraceUnit;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
 
 /**
  * {@link StepMeterRegistry} for Dynatrace.

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -16,7 +16,6 @@
 package io.micrometer.dynatrace;
 
 import io.micrometer.core.instrument.*;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
@@ -28,7 +27,10 @@ import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +39,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static io.micrometer.dynatrace.DynatraceMetricDefinition.DynatraceUnit;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -50,6 +53,7 @@ import static java.util.stream.Collectors.joining;
  */
 public class DynatraceMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("dynatrace-metrics-publisher");
+    private static final int MAX_MESSAGE_SIZE = 15360; //max messsage size that Dynatrace will accept
     private final Logger logger = LoggerFactory.getLogger(DynatraceMeterRegistry.class);
     private final DynatraceConfig config;
     private final HttpSender httpClient;
@@ -232,50 +236,56 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     private void postCustomMetricValues(String type, List<DynatraceTimeSeries> timeSeries, String customDeviceMetricEndpoint) {
         try {
-            for (String postMessage : createPostMessages(type, timeSeries)) {
+            for (Tuple<String, Integer> postMessage : createPostMessages(type, timeSeries)) {
                 httpClient.post(customDeviceMetricEndpoint)
-                    .withJsonContent(postMessage)
-                    .send()
-                    .onSuccess(response -> logger.debug("successfully sent {} metrics to Dynatrace.", timeSeries.size()))
-                    .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
+                        .withJsonContent(postMessage.x)
+                        .send()
+                        .onSuccess(response -> logger.debug("successfully sent {} metrics to Dynatrace ({} bytes).",
+                                postMessage.y, postMessage.x.getBytes(UTF_8).length))
+                        .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
             }
         } catch (Throwable e) {
             logger.error("failed to send metrics to dynatrace", e);
         }
     }
 
-    private List<String> createPostMessages(String type, List<DynatraceTimeSeries> timeSeries) {
-        final StringBuilder sb = new StringBuilder();
+    private List<Tuple<String, Integer>> createPostMessages(String type, List<DynatraceTimeSeries> timeSeries) {
+        final StringBuilder sb = new StringBuilder(1024);
         sb.append("{\"type\":\"").append(type).append('\"')
-            .append(",\"series\":[");
+                .append(",\"series\":[");
         final String header = sb.toString();
         final String footer = "]}";
-        long maxMessageSize = config.maxMessageSize() < 0 ? Long.MIN_VALUE :
-            config.maxMessageSize() - (header.length() + footer.length());
-        List<String> bodies = createPostMessageBodies(timeSeries, maxMessageSize);
-        return bodies.stream().map(b -> {
+        final int headerFooterBytes = header.getBytes(UTF_8).length + footer.getBytes(UTF_8).length;
+        final int maxMessageSize = MAX_MESSAGE_SIZE - headerFooterBytes;
+        List<Tuple<String, Integer>> bodies = createPostMessageBodies(timeSeries, maxMessageSize);
+        return bodies.stream().map(t -> {
             StringBuilder bsb = new StringBuilder();
-            bsb.append(header).append(b).append(footer);
+            bsb.append(header).append(t.x).append(footer);
             String message = bsb.toString();
             logger.debug("created post message:\n{}", message);
-            return message;
+            return new Tuple<>(message, t.y);
         }).collect(Collectors.toList());
     }
 
-    private List<String> createPostMessageBodies(List<DynatraceTimeSeries> timeSeries, long maxSize) {
-        ArrayList<String> messages = new ArrayList<>();
+    private List<Tuple<String, Integer>> createPostMessageBodies(List<DynatraceTimeSeries> timeSeries, long maxSize) {
+        ArrayList<Tuple<String, Integer>> messages = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         int skippedMetrics = 0;
+        int metricCount = 0;
+        long totalByteCount = 0;
         for (DynatraceTimeSeries ts : timeSeries) {
             boolean skip = false;
             String json = ts.asJson();
+            int jsonByteCount = json.getBytes(UTF_8).length;
             if (maxSize > -1) {
                 if (json.length() > maxSize) {
                     skip = true;
                     skippedMetrics++;
-                } else if ((sb.length() + json.length()) > maxSize) {
-                    messages.add(sb.toString());
+                } else if ((totalByteCount + jsonByteCount) > maxSize) {
+                    messages.add(new Tuple<>(sb.toString(), metricCount));
                     sb.setLength(0);
+                    totalByteCount = 0;
+                    metricCount = 0;
                 }
             }
             if (!skip) {
@@ -283,9 +293,11 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                     sb.append(',');
                 }
                 sb.append(json);
+                totalByteCount += jsonByteCount;
+                metricCount++;
             }
         }
-        messages.add(sb.toString());
+        messages.add(new Tuple<>(sb.toString(), metricCount));
         if (skippedMetrics > 0) {
             logger.info("skipped {} timeSeries metrics because they were too large", skippedMetrics);
         }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -16,6 +16,7 @@
 package io.micrometer.dynatrace;
 
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
@@ -27,9 +28,7 @@ import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -233,27 +232,64 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     private void postCustomMetricValues(String type, List<DynatraceTimeSeries> timeSeries, String customDeviceMetricEndpoint) {
         try {
-            httpClient.post(customDeviceMetricEndpoint)
-                    .withJsonContent(createPostMessage(type, timeSeries))
+            for (String postMessage : createPostMessages(type, timeSeries)) {
+                httpClient.post(customDeviceMetricEndpoint)
+                    .withJsonContent(postMessage)
                     .send()
                     .onSuccess(response -> logger.debug("successfully sent {} metrics to Dynatrace.", timeSeries.size()))
                     .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
+            }
         } catch (Throwable e) {
             logger.error("failed to send metrics to dynatrace", e);
         }
     }
 
-    private String createPostMessage(String type, List<DynatraceTimeSeries> timeSeries) {
-        StringBuilder sb = new StringBuilder();
+    private List<String> createPostMessages(String type, List<DynatraceTimeSeries> timeSeries) {
+        final StringBuilder sb = new StringBuilder();
         sb.append("{\"type\":\"").append(type).append('\"')
-            .append(",\"series\":[")
-            .append(timeSeries.stream()
-                    .map(DynatraceTimeSeries::asJson)
-                    .collect(joining(",")))
-            .append("]}");
-        String message = sb.toString();
-        logger.debug("created post message:\n{}", message);
-        return message;
+            .append(",\"series\":[");
+        final String header = sb.toString();
+        final String footer = "]}";
+        long maxMessageSize = config.maxMessageSize() < 0 ? Long.MIN_VALUE :
+            config.maxMessageSize() - (header.length() + footer.length());
+        List<String> bodies = createPostMessageBodies(timeSeries, maxMessageSize);
+        return bodies.stream().map(b -> {
+            StringBuilder bsb = new StringBuilder();
+            bsb.append(header).append(b).append(footer);
+            String message = bsb.toString();
+            logger.debug("created post message:\n{}", message);
+            return message;
+        }).collect(Collectors.toList());
+    }
+
+    private List<String> createPostMessageBodies(List<DynatraceTimeSeries> timeSeries, long maxSize) {
+        ArrayList<String> messages = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        int skippedMetrics = 0;
+        for (DynatraceTimeSeries ts : timeSeries) {
+            boolean skip = false;
+            String json = ts.asJson();
+            if (maxSize > -1) {
+                if (json.length() > maxSize) {
+                    skip = true;
+                    skippedMetrics++;
+                } else if ((sb.length() + json.length()) > maxSize) {
+                    messages.add(sb.toString());
+                    sb.setLength(0);
+                }
+            }
+            if (!skip) {
+                if (sb.length() > 0) {
+                    sb.append(',');
+                }
+                sb.append(json);
+            }
+        }
+        messages.add(sb.toString());
+        if (skippedMetrics > 0) {
+            logger.info("skipped {} timeSeries metrics because they were too large", skippedMetrics);
+        }
+        return messages;
     }
 
     private Meter.Id idWithSuffix(Meter.Id id, String suffix) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/Tuple.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/Tuple.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/Tuple.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/Tuple.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace;
+
+class Tuple<X, Y> {
+    public final X x;
+    public final Y y;
+    public Tuple(X x, Y y) {
+        this.x = x;
+        this.y = y;
+    }
+}


### PR DESCRIPTION
If the Dynatrace message is greater than 15360 bytes, create multiple messages.

See #1104

https://github.com/micrometer-metrics/micrometer/pull/1126 rebased onto 1.1.x branch.

There were some open issues with https://github.com/micrometer-metrics/micrometer/pull/1126