### PR TITLE
Limit pattern by name for ObjectName in TomcatMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -214,7 +214,7 @@ public class TomcatMetrics implements MeterBinder {
     private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
         if (getJmxDomain() != null) {
             try {
-                Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(getJmxDomain() + ":" + key + "=" + value + ",*"), null);
+                Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(getJmxDomain() + ":" + key + "=" + value + ",name=*"), null);
                 if (!objectNames.isEmpty()) {
                     // MBean is present, so we can register metrics now.
                     objectNames.forEach(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));


### PR DESCRIPTION
This PR limits pattern by name for `ObjectName` in `TomcatMetrics`. It seems okay to me but I'm not sure this could have any side effect I'm not aware of.

Closes gh-1145