### PR TITLE
Avoid creating meter binders before registry has been customized

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterRegistryPostProcessor.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterRegistryPostProcessor.java
@@ -22,7 +22,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -71,17 +70,11 @@ class MeterRegistryPostProcessor implements BeanPostProcessor {
 
     private MeterRegistryConfigurer getConfigurer() {
         if (this.configurer == null) {
-            this.configurer = new MeterRegistryConfigurer(
-                    getOrEmpty(this.meterBinders.getIfAvailable()),
-                    getOrEmpty(this.meterFilters.getIfAvailable()),
-                    getOrEmpty(this.meterRegistryCustomizers.getIfAvailable()),
+            this.configurer = new MeterRegistryConfigurer(this.meterRegistryCustomizers,
+                    this.meterFilters, this.meterBinders,
                     this.metricsProperties.getObject().isUseGlobalRegistry());
         }
         return this.configurer;
-    }
-
-    private <T> List<T> getOrEmpty(List<T> list) {
-        return list != null ? list : Collections.emptyList();
     }
 
 }


### PR DESCRIPTION
This PR changes to avoid creating meter binders before registry has been customized by porting from the fix for https://github.com/spring-projects/spring-boot/issues/15483.