### PR TITLE
Migration of registry-cloudwatch to AWS SDK 2.x

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'nebula.optional-base'
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
+    compile 'software.amazon.awssdk:cloudwatch:latest.release'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -15,20 +15,23 @@
  */
 package io.micrometer.cloudwatch;
 
-import com.amazonaws.AbortedException;
-import com.amazonaws.handlers.AsyncHandler;
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync;
-import com.amazonaws.services.cloudwatch.model.*;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.lang.Nullable;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
@@ -46,23 +49,24 @@ import static java.util.stream.StreamSupport.stream;
  * @author Dawid Kublik
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Pierre-Yves B.
  */
 public class CloudWatchMeterRegistry extends StepMeterRegistry {
     private final CloudWatchConfig config;
-    private final AmazonCloudWatchAsync amazonCloudWatchAsync;
+    private final CloudWatchAsyncClient cloudWatchAsyncClient;
     private final Logger logger = LoggerFactory.getLogger(CloudWatchMeterRegistry.class);
 
     public CloudWatchMeterRegistry(CloudWatchConfig config, Clock clock,
-                                   AmazonCloudWatchAsync amazonCloudWatchAsync) {
-        this(config, clock, amazonCloudWatchAsync, new NamedThreadFactory("cloudwatch-metrics-publisher"));
+                                   CloudWatchAsyncClient cloudWatchAsyncClient) {
+        this(config, clock, cloudWatchAsyncClient, new NamedThreadFactory("cloudwatch-metrics-publisher"));
     }
 
     public CloudWatchMeterRegistry(CloudWatchConfig config, Clock clock,
-                                   AmazonCloudWatchAsync amazonCloudWatchAsync, ThreadFactory threadFactory) {
+                                   CloudWatchAsyncClient cloudWatchAsyncClient, ThreadFactory threadFactory) {
         super(config, clock);
         requireNonNull(config.namespace());
 
-        this.amazonCloudWatchAsync = amazonCloudWatchAsync;
+        this.cloudWatchAsyncClient = cloudWatchAsyncClient;
         this.config = config;
         config().namingConvention(NamingConvention.identity);
         start(threadFactory);
@@ -84,26 +88,22 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
     }
 
     private void sendMetricData(List<MetricDatum> metricData) {
-        PutMetricDataRequest putMetricDataRequest = new PutMetricDataRequest()
-                .withNamespace(config.namespace())
-                .withMetricData(metricData);
+        PutMetricDataRequest putMetricDataRequest = PutMetricDataRequest.builder()
+                .namespace(config.namespace())
+                .metricData(metricData)
+                .build();
         CountDownLatch latch = new CountDownLatch(1);
-        amazonCloudWatchAsync.putMetricDataAsync(putMetricDataRequest, new AsyncHandler<PutMetricDataRequest, PutMetricDataResult>() {
-            @Override
-            public void onError(Exception exception) {
-                if (exception instanceof AbortedException) {
-                    logger.warn("sending metric data was aborted: {}", exception.getMessage());
+        cloudWatchAsyncClient.putMetricData(putMetricDataRequest).whenCompleteAsync((response, t) -> {
+            if (t != null) {
+                if (t instanceof AbortedException) {
+                    logger.warn("sending metric data was aborted: {}", t.getMessage());
                 } else {
-                    logger.error("error sending metric data.", exception);
+                    logger.error("error sending metric data.", t);
                 }
-                latch.countDown();
+            } else {
+                logger.debug("published metric with namespace:{}", putMetricDataRequest.namespace());
             }
-
-            @Override
-            public void onSuccess(PutMetricDataRequest request, PutMetricDataResult result) {
-                logger.debug("published metric with namespace:{}", request.getNamespace());
-                latch.countDown();
-            }
+            latch.countDown();
         });
         try {
             latch.await(config.readTimeout().toMillis(), TimeUnit.MILLISECONDS);
@@ -217,12 +217,13 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             }
 
             List<Tag> tags = id.getConventionTags(config().namingConvention());
-            return new MetricDatum()
-                    .withMetricName(getMetricName(id, suffix))
-                    .withDimensions(toDimensions(tags))
-                    .withTimestamp(new Date(wallTime))
-                    .withValue(CloudWatchUtils.clampMetricValue(value))
-                    .withUnit(toStandardUnit(unit));
+            return MetricDatum.builder()
+                    .metricName(getMetricName(id, suffix))
+                    .dimensions(toDimensions(tags))
+                    .timestamp(Instant.ofEpochMilli(wallTime))
+                    .value(CloudWatchUtils.clampMetricValue(value))
+                    .unit(toStandardUnit(unit))
+                    .build();
         }
 
         // VisibleForTesting
@@ -233,23 +234,23 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         private StandardUnit toStandardUnit(@Nullable String unit) {
             if (unit == null) {
-                return StandardUnit.None;
+                return StandardUnit.NONE;
             }
             switch (unit.toLowerCase()) {
                 case "bytes":
-                    return StandardUnit.Bytes;
+                    return StandardUnit.BYTES;
                 case "milliseconds":
-                    return StandardUnit.Milliseconds;
+                    return StandardUnit.MILLISECONDS;
                 case "count":
-                    return StandardUnit.Count;
+                    return StandardUnit.COUNT;
             }
-            return StandardUnit.None;
+            return StandardUnit.NONE;
         }
 
 
         private List<Dimension> toDimensions(List<Tag> tags) {
             return tags.stream()
-                    .map(tag -> new Dimension().withName(tag.getKey()).withValue(tag.getValue()))
+                    .map(tag -> Dimension.builder().name(tag.getKey()).value(tag.getValue()).build())
                     .collect(toList());
         }
     }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.util.MathUtils;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 
 import java.util.AbstractList;
 import java.util.List;

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -15,12 +15,12 @@
  */
 package io.micrometer.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/implementations/micrometer-registry-cloudwatch2/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch2/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'nebula.optional-base'
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
+    compile 'software.amazon.awssdk:cloudwatch:latest.release'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/CloudWatchConfig.java
@@ -23,10 +23,7 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
  * Configuration for CloudWatch exporting.
  *
  * @author Dawid Kublik
- * @deprecated the micrometer-registry-cloudwatch implementation has been deprecated in favour of
- *             micrometer-registry-cloudwatch2, which uses AWS SDK for Java 2.x
  */
-@Deprecated
 public interface CloudWatchConfig extends StepRegistryConfig {
 
     int MAX_BATCH_SIZE = 20;

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
@@ -17,10 +17,7 @@ package io.micrometer.cloudwatch;
 
 /**
  * Utilities for cloudwatch registry
- * @deprecated the micrometer-registry-cloudwatch implementation has been deprecated in favour of
- *             micrometer-registry-cloudwatch2, which uses AWS SDK for Java 2.x
  */
-@Deprecated
 final class CloudWatchUtils {
 
     /**

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.util.MathUtils;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 
 import java.util.AbstractList;
 import java.util.List;
@@ -25,10 +25,7 @@ import java.util.List;
  * Modified from {@link io.micrometer.core.instrument.util.MeterPartition}.
  *
  * @author Dawid Kublik
- * @deprecated the micrometer-registry-cloudwatch implementation has been deprecated in favour of
- *             micrometer-registry-cloudwatch2, which uses AWS SDK for Java 2.x
  */
-@Deprecated
 public class MetricDatumPartition extends AbstractList<List<MetricDatum>> {
     private final List<MetricDatum> list;
     private final int partitionSize;

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/package-info.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.micrometer.cloudwatch;
+
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryCompatibilityTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
+
+import java.time.Duration;
+
+class CloudWatchMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final CloudWatchConfig config = new CloudWatchConfig() {
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+
+        @Override
+        public String namespace() {
+            return "DOESNOTMATTER";
+        }
+    };
+
+    @Override
+    public MeterRegistry registry() {
+        //noinspection ConstantConditions
+        return new CloudWatchMeterRegistry(config, new MockClock(), null);
+    }
+
+    @Override
+    public Duration step() {
+        return config.step();
+    }
+}

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -15,12 +15,12 @@
  */
 package io.micrometer.cloudwatch;
 
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch/CloudWatchUtilsTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test methods in CloudWatchUtils
+ */
+class CloudWatchUtilsTest {
+
+    private static final double EXPECTED_MIN = 8.515920e-109;
+    private static final double EXPECTED_MAX = 1.174271e+108;
+
+    @Test
+    void testClamp() {
+        assertThat(CloudWatchUtils.clampMetricValue(Double.NaN))
+                .as("Check NaN")
+                .isEqualTo(Double.NaN);
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.MIN_VALUE))
+                .as("Check minimum value")
+                .isEqualTo(EXPECTED_MIN);
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.NEGATIVE_INFINITY))
+                .as("Check negative infinity")
+                .isEqualTo(-EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.POSITIVE_INFINITY))
+                .as("Check positive infinity")
+                .isEqualTo(EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-Double.MAX_VALUE))
+                .as("Check negative max value")
+                .isEqualTo(-EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(0))
+                .as("Check 0")
+                .isEqualTo(0);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-0))
+                .as("Check -0")
+                .isEqualTo(0);
+
+        assertThat(CloudWatchUtils.clampMetricValue(100.1))
+                .as("Check positive value")
+                .isEqualTo(100.1);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-10.2))
+                .as("Check negative value")
+                .isEqualTo(-10.2);
+    }
+}

--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     compile 'org.aspectj:aspectjweaver:1.8.+', optional
     compile 'io.prometheus:simpleclient_pushgateway:latest.release', optional
 
-    ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'signalfx', 'wavefront', 'dynatrace', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
+    ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
         compile project(":micrometer-registry-$sys"), optional
     }
 

--- a/samples/micrometer-samples-boot1/build.gradle
+++ b/samples/micrometer-samples-boot1/build.gradle
@@ -16,7 +16,7 @@ dependencyManagement {
 dependencies {
     compile project(':micrometer-spring-legacy')
 
-    ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'humio', 'appoptics', 'stackdriver'].each { sys ->
+    ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'humio', 'appoptics', 'stackdriver'].each { sys ->
         compile project(":micrometer-registry-$sys")
     }
 

--- a/samples/micrometer-samples-core/build.gradle
+++ b/samples/micrometer-samples-core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
         force = true
     }
 
-    ['atlas', 'prometheus', 'datadog', 'ganglia', 'elastic', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
+    ['atlas', 'prometheus', 'datadog', 'ganglia', 'elastic', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
         compile project(":micrometer-registry-$sys")
     }
 

--- a/scripts/sync-to-maven-central.sh
+++ b/scripts/sync-to-maven-central.sh
@@ -14,6 +14,7 @@ MODULES=(
     micrometer-test
     micrometer-registry-atlas
     micrometer-registry-cloudwatch
+    micrometer-registry-cloudwatch2
     micrometer-registry-datadog
     micrometer-registry-ganglia
     micrometer-registry-graphite

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ include 'micrometer-jersey2'
 
 include 'micrometer-test'
 
-['atlas', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
+['atlas', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
     include "micrometer-registry-$sys"
     project(":micrometer-registry-$sys").projectDir = new File(rootProject.projectDir, "implementations/micrometer-registry-$sys")
 }


### PR DESCRIPTION
The [AWS SDK for Java 2.0](https://github.com/aws/aws-sdk-java-v2) reached general availability back in November (more information on their [official blog post](https://aws.amazon.com/blogs/developer/aws-sdk-for-java-2-x-released/)) and has de facto become the preferred way of integrating with AWS using Java.

Amongst other benefits, using it rather than the old version improves performance and allows to write cleaner code.

This pull request migrates the _registry-cloudwatch_ implementation to the new SDK.