### PR TITLE
#878: Fix kafka consumer fetch manager metrics to be reported per topic and…

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetricsTest.java
@@ -57,10 +57,6 @@ class KafkaConsumerMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry();
         kafkaConsumerMetrics.bindTo(registry);
 
-        // fetch metrics
-        registry.get("kafka.consumer.records.lag.max").tag("client.id", "consumer-1").gauge();
-        registry.get("kafka.consumer.records.lag.max").tag("client.id", "consumer-2").gauge();
-
         // consumer group metrics
         registry.get("kafka.consumer.assigned.partitions").tag("client.id", "consumer-1").gauge();
 


### PR DESCRIPTION
… partition (#878)

The kafka consumer fetch manager metrics have been registered too many times and therewith
also for the wrong mbeans. Hence, when using prometheus as a registry, for example, only
the metrics registered for the wrong mbean were shown with NaN as values. With this fix
the metrics are registered for the right mbeans and in case they are provided for different levels
like per consumer and topic as well as per consumer, topic and partition they are only registered
once for the lowest level of details. Aggregations can be done with the monitoring tools.