### PR TITLE
Handle NaN and infinities for Humio meter registry

### DIFF
--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
@@ -22,16 +22,14 @@ import java.time.Duration;
 import java.util.Map;
 
 /**
+ * Configuration for {@link HumioMeterRegistry}.
+ *
  * @author Martin Westergaard Lassen
+ * @since 1.1.0
  */
 public interface HumioConfig extends StepRegistryConfig {
-    /**
-     * Get the value associated with a key.
-     *
-     * @param key Key to lookup in the config.
-     * @return Value for the key or null if no key is present.
-     */
-    String get(String key);
+
+    HumioConfig DEFAULT = k -> null;
 
     @Override
     default String prefix() {
@@ -60,7 +58,7 @@ public interface HumioConfig extends StepRegistryConfig {
      * is distinct from Micrometer's notion of tags, which divides a metric along dimensional boundaries.
      * All metrics from this registry will be stored under a datasource defined by these tags.
      *
-     * @return Tags which unique determine the datasource to store metrics in.
+     * @return Tags which uniquely determine the datasource to store metrics in.
      */
     @Nullable
     default Map<String, String> tags() {

--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioNamingConvention.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioNamingConvention.java
@@ -19,6 +19,13 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.lang.Nullable;
 
+/**
+ * {@link NamingConvention} for Humio.
+ *
+ * @author Martin Westergaard Lassen
+ * @author Jon Schneider
+ * @since 1.1.0
+ */
 public class HumioNamingConvention implements NamingConvention {
 
     private final NamingConvention delegate;

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryCompatibilityTest.java
@@ -21,6 +21,12 @@ import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
 
 import java.time.Duration;
 
+/**
+ * Compatibility tests for {@link HumioMeterRegistry}.
+ *
+ * @author Martin Westergaard Lassen
+ * @author Jon Schneider
+ */
 public class HumioMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
     private final HumioConfig config = new HumioConfig() {
         @Override

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -88,13 +88,16 @@ class HumioMeterRegistryTest {
     }
 
     @Test
-    void writeGaugeShouldDropInfiniteValues() {
+    void writeGaugeShouldDropPositiveInfiniteValue() {
         meterRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
         Gauge gauge = meterRegistry.find("my.gauge").gauge();
         assertThat(createBatch().writeGauge(gauge)).isNull();
+    }
 
+    @Test
+    void writeGaugeShouldDropNegativeInfiniteValue() {
         meterRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
-        gauge = meterRegistry.find("my.gauge").gauge();
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
         assertThat(createBatch().writeGauge(gauge)).isNull();
     }
 
@@ -115,15 +118,18 @@ class HumioMeterRegistryTest {
     }
 
     @Test
-    void writeTimeGaugeShouldDropInfiniteValues() {
+    void writeTimeGaugeShouldDropPositiveInfiniteValue() {
         AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
         meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
         TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
         assertThat(createBatch().writeGauge(timeGauge)).isNull();
+    }
 
-        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
+    @Test
+    void writeTimeGaugeShouldDropNegativeInfiniteValue() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
         meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
         assertThat(createBatch().writeGauge(timeGauge)).isNull();
     }
 
@@ -135,12 +141,15 @@ class HumioMeterRegistryTest {
     }
 
     @Test
-    void writeFunctionCounterShouldDropInfiniteValues() {
+    void writeFunctionCounterShouldDropPositiveInfiniteValue() {
         FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(meterRegistry);
         clock.add(config.step());
         assertThat(createBatch().writeFunctionCounter(counter)).isNull();
+    }
 
-        counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(meterRegistry);
+    @Test
+    void writeFunctionCounterShouldDropNegativeInfiniteValue() {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(meterRegistry);
         clock.add(config.step());
         assertThat(createBatch().writeFunctionCounter(counter)).isNull();
     }

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -16,23 +16,40 @@
 package io.micrometer.humio;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.TimeGauge;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link HumioMeterRegistry}.
+ *
+ * @author Martin Westergaard Lassen
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 @ExtendWith(WiremockResolver.class)
 class HumioMeterRegistryTest {
-    private MockClock clock = new MockClock();
+
+    private final HumioConfig config = HumioConfig.DEFAULT;
+    private final MockClock clock = new MockClock();
+    private final HumioMeterRegistry meterRegistry = new HumioMeterRegistry(config, clock);
 
     @Test
     void writeTimer(@WiremockResolver.Wiremock WireMockServer server) {
-        HumioMeterRegistry registry = humioRegistry(server);
+        HumioMeterRegistry registry = humioMeterRegistry(server);
         registry.timer("my.timer", "status", "success");
 
         server.stubFor(any(anyUrl()));
@@ -43,7 +60,7 @@ class HumioMeterRegistryTest {
 
     @Test
     void datasourceTags(@WiremockResolver.Wiremock WireMockServer server) {
-        HumioMeterRegistry registry = humioRegistry(server, "name", "micrometer");
+        HumioMeterRegistry registry = humioMeterRegistry(server, "name", "micrometer");
         registry.counter("my.counter").increment();
 
         server.stubFor(any(anyUrl()));
@@ -52,7 +69,83 @@ class HumioMeterRegistryTest {
                 .withRequestBody(containing("\"tags\":{\"name\": \"micrometer\"}")));
     }
 
-    private HumioMeterRegistry humioRegistry(WireMockServer server, String... tags) {
+    @Test
+    void writeGauge() {
+        meterRegistry.gauge("my.gauge", 1d);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(createBatch().writeGauge(gauge)).isNotNull();
+    }
+
+    private HumioMeterRegistry.Batch createBatch() {
+        return meterRegistry.new Batch(clock.wallTime());
+    }
+
+    @Test
+    void writeGaugeShouldDropNanValue() {
+        meterRegistry.gauge("my.gauge", Double.NaN);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(createBatch().writeGauge(gauge)).isNull();
+    }
+
+    @Test
+    void writeGaugeShouldDropInfiniteValues() {
+        meterRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
+        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(createBatch().writeGauge(gauge)).isNull();
+
+        meterRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
+        gauge = meterRegistry.find("my.gauge").gauge();
+        assertThat(createBatch().writeGauge(gauge)).isNull();
+    }
+
+    @Test
+    void writeTimeGauge() {
+        AtomicReference<Double> obj = new AtomicReference<>(1d);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(createBatch().writeGauge(timeGauge)).isNotNull();
+    }
+
+    @Test
+    void writeTimeGaugeShouldDropNanValue() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.NaN);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(createBatch().writeGauge(timeGauge)).isNull();
+    }
+
+    @Test
+    void writeTimeGaugeShouldDropInfiniteValues() {
+        AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(createBatch().writeGauge(timeGauge)).isNull();
+
+        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
+        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
+        assertThat(createBatch().writeGauge(timeGauge)).isNull();
+    }
+
+    @Test
+    void writeFunctionCounter() {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(meterRegistry);
+        clock.add(config.step());
+        assertThat(createBatch().writeFunctionCounter(counter)).isNotNull();
+    }
+
+    @Test
+    void writeFunctionCounterShouldDropInfiniteValues() {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(meterRegistry);
+        clock.add(config.step());
+        assertThat(createBatch().writeFunctionCounter(counter)).isNull();
+
+        counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(meterRegistry);
+        clock.add(config.step());
+        assertThat(createBatch().writeFunctionCounter(counter)).isNull();
+    }
+
+    private HumioMeterRegistry humioMeterRegistry(WireMockServer server, String... tags) {
         return new HumioMeterRegistry(new HumioConfig() {
             @Override
             public String get(String key) {

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioNamingConventionTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioNamingConventionTest.java
@@ -20,6 +20,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link HumioNamingConvention}.
+ *
+ * @author Martin Westergaard Lassen
+ * @author Jon Schneider
+ */
 class HumioNamingConventionTest {
     private final NamingConvention namingConvention = new HumioNamingConvention();
 

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/shadow.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/shadow.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-core/gradle/dependency-locks/shadow.lockfile
+++ b/micrometer-core/gradle/dependency-locks/shadow.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
@@ -80,6 +80,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
@@ -80,6 +80,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
@@ -80,6 +80,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
@@ -80,6 +80,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -80,6 +80,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioMetricsExportAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Import;
  * Configuration for exporting metrics to Humio.
  *
  * @author Jon Schneider
+ * @since 1.1.0
  */
 @Configuration
 @AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioProperties.java
@@ -26,6 +26,7 @@ import java.util.Map;
  * {@link ConfigurationProperties} for configuring Humio metrics export.
  *
  * @author Jon Schneider
+ * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "management.metrics.export.humio")
 public class HumioProperties extends StepRegistryProperties {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * Adapter to convert {@link HumioProperties} to a {@link HumioConfig}.
  *
  * @author Jon Schneider
+ * @since 1.1.0
  */
 class HumioPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<HumioProperties> implements HumioConfig {
 

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,0 +1,3 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
@@ -81,6 +81,7 @@ io.prometheus:simpleclient_pushgateway:0.5.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1


### PR DESCRIPTION
This PR changes to handle NaN and infinities for Humio meter registry.

This PR also polishes Humio support along the way.

Note: I added a separate commit updating depedency locks to pass a build. FTR I did the following to update dependency locks:

```
./gradlew clean check
...
* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-spring-legacy:compileClasspath'.
> Dependency lock state for configuration 'compileClasspath' is out of date: Resolved 'javax.inject:javax.inject:1' which is not part of the lock state
...

./gradlew :micrometer-spring-legacy:classes --update-locks javax.inject:javax.inject

...
* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-samples-boot1:compileClasspath'.
> Dependency lock state for configuration 'compileClasspath' is out of date: Resolved 'javax.inject:javax.inject:1' which is not part of the lock state
...

./gradlew :micrometer-samples-boot1:classes --update-locks javax.inject:javax.inject
```

If the dependency lock updates are inappropriate, we can drop the commit when merging.