### PR TITLE
Avoid invoking String.getBytes() on payload if possible in Dynatrace

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -240,8 +240,12 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                 httpClient.post(customDeviceMetricEndpoint)
                         .withJsonContent(postMessage.payload)
                         .send()
-                        .onSuccess(response -> logger.debug("successfully sent {} metrics to Dynatrace ({} bytes).",
-                                postMessage.metricCount, postMessage.payload.getBytes(UTF_8).length))
+                        .onSuccess(response -> {
+                            if (logger.isDebugEnabled()) {
+                                logger.debug("successfully sent {} metrics to Dynatrace ({} bytes).",
+                                    postMessage.metricCount, postMessage.payload.getBytes(UTF_8).length);
+                            }
+                        })
                         .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
             }
         } catch (Throwable e) {


### PR DESCRIPTION
This PR changes to avoid invoking `String.getBytes()` on payload if possible in Dynatrace.