### PR TITLE
Forbid instance creation for stateless utility classes

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
@@ -25,10 +25,10 @@ import java.util.Locale;
  *
  * @author Jon Schneider
  */
-public class DoubleFormat {
+public final class DoubleFormat {
     /**
      * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
-     * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
+     * create one per thread as this seems to offer a significant performance improvement over creating one per-thread:
      * http://stackoverflow.com/a/1285297/2648
      * https://github.com/indeedeng/java-dogstatsd-client/issues/4
      */
@@ -62,6 +62,9 @@ public class DoubleFormat {
         DecimalFormatSymbols otherSymbols = new DecimalFormatSymbols(Locale.US);
         return new DecimalFormat("##0.0#####",otherSymbols);
     });
+    
+    private DoubleFormat() {
+    }
 
     /**
      * @param d Number to format.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/JsonUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/JsonUtils.java
@@ -15,7 +15,11 @@
  */
 package io.micrometer.core.instrument.util;
 
-public class JsonUtils {
+public final class JsonUtils {
+
+    private JsonUtils() {
+    }
+    
     /**
      * Based on https://stackoverflow.com/a/49564514/510017
      *


### PR DESCRIPTION
Define private constructors and mark class as final to protect class from extension