### PR TITLE
Add Javadoc for RestTemplateExchangeTags.outcome()

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTags.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/client/RestTemplateExchangeTags.java
@@ -131,6 +131,13 @@ public final class RestTemplateExchangeTags {
         return Tag.of("clientName", host);
     }
 
+    /**
+     * Creates an {@code outcome} {@code Tag} derived from the
+     * {@link ClientHttpResponse#getStatusCode() status} of the given {@code response}.
+     * @param response the response
+     * @return the outcome tag
+     * @since 1.1.2
+     */
     public static Tag outcome(ClientHttpResponse response) {
         try {
             if (response != null) {


### PR DESCRIPTION
This PR adds Javadoc for `RestTemplateExchangeTags.outcome()`.