### PR TITLE
Add executor.queue.remaining for ThreadPoolExecutor

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -35,6 +35,7 @@ import static java.util.Arrays.asList;
  *
  * @author Jon Schneider
  * @author Clint Checketts
+ * @author Johnny Lim
  */
 @NonNullApi
 @NonNullFields
@@ -160,6 +161,12 @@ public class ExecutorServiceMetrics implements MeterBinder {
         Gauge.builder("executor.queued", tp, tpRef -> tpRef.getQueue().size())
                 .tags(tags)
                 .description("The approximate number of tasks that are queued for execution")
+                .baseUnit("tasks")
+                .register(registry);
+
+        Gauge.builder("executor.queue.remaining", tp, tpRef -> tpRef.getQueue().remainingCapacity())
+                .tags(tags)
+                .description("The number of additional elements that this queue can ideally accept without blocking")
                 .baseUnit("tasks")
                 .register(registry);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -28,6 +28,13 @@ import java.util.concurrent.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+/**
+ * Tests for {@link ExecutorServiceMetrics}.
+ *
+ * @author Clint Checketts
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class ExecutorServiceMetricsTest {
     private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
     private Iterable<Tag> userTags = Tags.of("userTagKey", "userTagValue");
@@ -101,6 +108,7 @@ class ExecutorServiceMetricsTest {
     private void assertThreadPoolExecutorMetrics(String executorName) {
         registry.get("executor.completed").tags(userTags).tag("name", executorName).meter();
         registry.get("executor.queued").tags(userTags).tag("name", executorName).gauge();
+        registry.get("executor.queue.remaining").tags(userTags).tag("name", executorName).gauge();
         registry.get("executor.active").tags(userTags).tag("name", executorName).gauge();
         registry.get("executor.pool.size").tags(userTags).tag("name", executorName).gauge();
         registry.get("executor").tags(userTags).tag("name", executorName).timer();


### PR DESCRIPTION
This PR adds `executor.queue.remaining` for `ThreadPoolExecutor`.

Closes gh-1187