### PR TITLE
[Issue#1192] Strip invalid characters from events for NR Naming convention.

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
@@ -19,10 +19,16 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
+import java.util.regex.Pattern;
 
 public class NewRelicNamingConvention implements NamingConvention {
     private final NamingConvention delegate;
 
+    private static final Pattern INVALID_CHARACTERS_PATTERN = Pattern.compile("[^\\w:]");
+
+    private static String toValidNewRelicString(String input) {
+        return INVALID_CHARACTERS_PATTERN.matcher(input).replaceAll("_");
+    }
     public NewRelicNamingConvention() {
         this(NamingConvention.camelCase);
     }
@@ -33,12 +39,12 @@ public class NewRelicNamingConvention implements NamingConvention {
 
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        return StringEscapeUtils.escapeJson(delegate.name(name, type, baseUnit));
+        return StringEscapeUtils.escapeJson(toValidNewRelicString(delegate.name(name, type, baseUnit)));
     }
 
     @Override
     public String tagKey(String key) {
-        return StringEscapeUtils.escapeJson(delegate.tagKey(key));
+        return StringEscapeUtils.escapeJson(toValidNewRelicString(delegate.tagKey(key)));
     }
 
     @Override

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicNamingConventionTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicNamingConventionTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.newrelic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Meter.Type;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link NewRelicNamingConvention}.
+ *
+ * @author Mustafa Shabib
+ */
+class NewRelicNamingConventionTest {
+  private final NewRelicNamingConvention newRelicNamingConvention = new NewRelicNamingConvention();
+
+  private static final String VALID_NAME = "validName";
+  private static final String INVALID_NAME = "invalid-name";
+
+  @Test
+  void name() {
+    String validString = newRelicNamingConvention.name(VALID_NAME, Type.COUNTER);
+    assertThat(validString).isEqualTo(VALID_NAME);
+  }
+
+  @Test
+  void nameShouldStripInvalidCharacters() {
+    String validString = newRelicNamingConvention.name(INVALID_NAME, Type.COUNTER);
+    assertThat(validString).isEqualTo("invalid_name");
+  }
+
+  @Test
+  void tagKey() {
+    String validString = newRelicNamingConvention.tagKey(VALID_NAME);
+    assertThat(validString).isEqualTo(VALID_NAME);
+  }
+
+  @Test
+  void tagKeyShouldStripInvalidCharacters() {
+    String validString = newRelicNamingConvention.tagKey(INVALID_NAME);
+    assertThat(validString).isEqualTo("invalid_name");
+  }
+
+  @Test
+  void tagValue() {
+    String validString = newRelicNamingConvention.tagValue(VALID_NAME);
+    assertThat(validString).isEqualTo(VALID_NAME);
+  }
+
+  @Test
+  void tagValueShouldNotStripInvalidCharacters() {
+    String validString = newRelicNamingConvention.tagValue(INVALID_NAME);
+    assertThat(validString).isEqualTo(INVALID_NAME);
+  }
+}


### PR DESCRIPTION
Strip invalid characters from events for New Relic naming convention.

Modifies the NewRelicNamingConvention to remove invalid chars.

See #1192 for original issue. 