### PR TITLE
Relax copyright year in license header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ subprojects {
         maxHeapSize = "1500m"
     }
 
+    license {
+        ext.year = Calendar.getInstance().get(Calendar.YEAR)
+        skipExistingHeaders = true
+    }
 }
 
 wrapper {

--- a/gradle/licenseHeader.txt
+++ b/gradle/licenseHeader.txt
@@ -1,4 +1,4 @@
-Copyright 2017 Pivotal Software, Inc.
+Copyright ${year} Pivotal Software, Inc.
 <p>
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR relaxes copyright year in license header by porting 92377796f2c5c9b58a0724074f427e61985e7a6c into the 1.0.x branch.