### PR TITLE
Polish New Relic Insights support

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
  * Configuration for {@link NewRelicMeterRegistry}.
  *
  * @author Jon Schneider
+ * @since 1.0.0
  */
 public interface NewRelicConfig extends StepRegistryConfig {
     /**

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
@@ -21,6 +21,12 @@ import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
 import java.util.regex.Pattern;
 
+/**
+ * {@link NamingConvention} for New Relic Insights.
+ *
+ * @author Jon Schneider
+ * @since 1.0.0
+ */
 public class NewRelicNamingConvention implements NamingConvention {
     private final NamingConvention delegate;
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicMetricsExportAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.context.annotation.Import;
  * Configuration for exporting metrics to New Relic.
  *
  * @author Jon Schneider
+ * @since 1.0.0
  */
 @Configuration
 @AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * {@link ConfigurationProperties} for configuring New Relic metrics export.
  *
  * @author Jon Schneider
+ * @since 1.0.0
  */
 @ConfigurationProperties(prefix = "management.metrics.export.newrelic")
 public class NewRelicProperties extends StepRegistryProperties {


### PR DESCRIPTION
This PR polishes New Relic Insights support mostly by adding missing Javadoc `@since` tags.