### PR TITLE
Align access modifiers for properties config adapters

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/newrelic/NewRelicPropertiesConfigAdapter.java
@@ -23,10 +23,10 @@ import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAda
  *
  * @author Jon Schneider
  */
-public class NewRelicPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<NewRelicProperties>
+class NewRelicPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<NewRelicProperties>
     implements NewRelicConfig {
 
-    public NewRelicPropertiesConfigAdapter(NewRelicProperties properties) {
+    NewRelicPropertiesConfigAdapter(NewRelicProperties properties) {
         super(properties);
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/signalfx/SignalFxPropertiesConfigAdapter.java
@@ -23,10 +23,10 @@ import io.micrometer.spring.autoconfigure.export.StepRegistryPropertiesConfigAda
  *
  * @author Jon Schneider
  */
-public class SignalFxPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<SignalFxProperties>
+class SignalFxPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<SignalFxProperties>
         implements SignalFxConfig {
 
-    public SignalFxPropertiesConfigAdapter(SignalFxProperties properties) {
+    SignalFxPropertiesConfigAdapter(SignalFxProperties properties) {
         super(properties);
         accessToken(); // validate that an access token is set
     }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimplePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/simple/SimplePropertiesConfigAdapter.java
@@ -26,9 +26,9 @@ import java.time.Duration;
  *
  * @author Jon Schneider
  */
-public class SimplePropertiesConfigAdapter extends PropertiesConfigAdapter<SimpleProperties> implements SimpleConfig {
+class SimplePropertiesConfigAdapter extends PropertiesConfigAdapter<SimpleProperties> implements SimpleConfig {
 
-    public SimplePropertiesConfigAdapter(SimpleProperties properties) {
+    SimplePropertiesConfigAdapter(SimpleProperties properties) {
         super(properties);
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/statsd/StatsdPropertiesConfigAdapter.java
@@ -26,9 +26,9 @@ import java.time.Duration;
  *
  * @author Jon Schneider
  */
-public class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<StatsdProperties> implements StatsdConfig {
+class StatsdPropertiesConfigAdapter extends PropertiesConfigAdapter<StatsdProperties> implements StatsdConfig {
 
-    public StatsdPropertiesConfigAdapter(StatsdProperties properties) {
+    StatsdPropertiesConfigAdapter(StatsdProperties properties) {
         super(properties);
     }
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontPropertiesConfigAdapter.java
@@ -23,9 +23,9 @@ import io.micrometer.wavefront.WavefrontConfig;
  *
  * @author Jon Schneider
  */
-public class WavefrontPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<WavefrontProperties> implements WavefrontConfig {
+class WavefrontPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<WavefrontProperties> implements WavefrontConfig {
 
-    public WavefrontPropertiesConfigAdapter(WavefrontProperties properties) {
+    WavefrontPropertiesConfigAdapter(WavefrontProperties properties) {
         super(properties);
     }
 


### PR DESCRIPTION
This PR changes to align access modifiers for properties config adapters with Spring Boot 2.x support.

See https://github.com/micrometer-metrics/micrometer/pull/1198#discussion_r252930073