### PR TITLE
Align tests' class names with their test target class names

### DIFF
--- a/micrometer-test/src/test/java/io/micrometer/core/ipc/http/HttpUrlConnectionSenderTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/ipc/http/HttpUrlConnectionSenderTest.java
@@ -15,9 +15,9 @@
  */
 package io.micrometer.core.ipc.http;
 
-public class ReactorNettyClientTest extends HttpSenderCompatibilityKit {
+public class HttpUrlConnectionSenderTest extends HttpSenderCompatibilityKit {
     @Override
     public HttpSender httpClient() {
-        return new ReactorNettySender();
+        return new HttpUrlConnectionSender();
     }
 }

--- a/micrometer-test/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTest.java
@@ -15,9 +15,9 @@
  */
 package io.micrometer.core.ipc.http;
 
-public class HttpUrlConnectionClientTest extends HttpSenderCompatibilityKit {
+public class ReactorNettySenderTest extends HttpSenderCompatibilityKit {
     @Override
     public HttpSender httpClient() {
-        return new HttpUrlConnectionSender();
+        return new ReactorNettySender();
     }
 }


### PR DESCRIPTION
This PR changes to align tests' class names with their test target class names.