### PR TITLE
Fix broken tests

### DIFF
--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/humio/HumioMetricsExportAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/export/humio/HumioMetricsExportAutoConfigurationTest.java
@@ -43,7 +43,7 @@ class HumioMetricsExportAutoConfigurationTest {
     @Test
     void defaultTag() {
         registerAndRefresh(ClockConfiguration.class, HumioMetricsExportAutoConfiguration.class);
-        assertThat(context.getBean(HumioConfig.class).tags()).isNull();
+        assertThat(context.getBean(HumioConfig.class).tags()).isEmpty();
     }
 
     @AfterEach


### PR DESCRIPTION
This PR fixes broken tests which are not detected as with the current Gradle configuration the `micrometer-spring-legacy` module runs tests only for JUnit 4 but they are written in JUnit 5. For `MetricsAutoConfigurationTest` and `MetricsAutoConfigurationIntegrationTest` I guess they went wrong when merging from 1.0.x to 1.1.x.

I'll prepare another PR against the 1.0.x branch to make them run in Gradle tests.