### PR TITLE
Use JUnit platform consistently

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
         classpath 'io.spring.gradle:spring-release-plugin:0.20.1'
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.2.0'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.4'
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:3.4.0'
         classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.3"
     }
@@ -88,6 +87,8 @@ subprojects {
     test {
         // set heap size for the test JVM(s)
         maxHeapSize = "1500m"
+
+        useJUnitPlatform()
     }
 
     license {

--- a/implementations/micrometer-registry-atlas/build.gradle
+++ b/implementations/micrometer-registry-atlas/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'com.netflix.spectator:spectator-reg-atlas:latest.release'

--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'nebula.optional-base'
 
 dependencies {

--- a/implementations/micrometer-registry-datadog/build.gradle
+++ b/implementations/micrometer-registry-datadog/build.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'nebula.optional-base'
 
 dependencies {

--- a/implementations/micrometer-registry-ganglia/build.gradle
+++ b/implementations/micrometer-registry-ganglia/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'io.dropwizard.metrics:metrics-ganglia:3.+'

--- a/implementations/micrometer-registry-graphite/build.gradle
+++ b/implementations/micrometer-registry-graphite/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'io.dropwizard.metrics:metrics-graphite:3.+'

--- a/implementations/micrometer-registry-influx/build.gradle
+++ b/implementations/micrometer-registry-influx/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'

--- a/implementations/micrometer-registry-jmx/build.gradle
+++ b/implementations/micrometer-registry-jmx/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'io.dropwizard.metrics:metrics-core:3.+'

--- a/implementations/micrometer-registry-new-relic/build.gradle
+++ b/implementations/micrometer-registry-new-relic/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'

--- a/implementations/micrometer-registry-prometheus/build.gradle
+++ b/implementations/micrometer-registry-prometheus/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'io.prometheus:simpleclient_common:latest.release'

--- a/implementations/micrometer-registry-signalfx/build.gradle
+++ b/implementations/micrometer-registry-signalfx/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'com.signalfx.public:signalfx-java:latest.release'

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.2'
 }
 
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'io.projectreactor:reactor-core:latest.release'

--- a/implementations/micrometer-registry-wavefront/build.gradle
+++ b/implementations/micrometer-registry-wavefront/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.2'
 }
 
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'nebula.optional-base'
 
 dependencies {

--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     testCompile 'org.assertj:assertj-core:3.+'
 
     // JERSEY-3662
-    testCompile 'junit:junit:4.12'
+    testCompileOnly 'junit:junit:4.12'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:latest.release'
     testCompile 'org.mockito:mockito-core:2.10.0'
 }

--- a/micrometer-jersey2/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-jersey2/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -34,6 +34,7 @@ net.bytebuddy:byte-buddy:1.7.4
 net.sf.ehcache:ehcache:2.10.4
 org.apache.tomcat.embed:tomcat-embed-core:8.5.28
 org.apache.tomcat:tomcat-annotations-api:8.5.28
+org.apiguardian:apiguardian-api:1.0.0
 org.aspectj:aspectjweaver:1.8.13
 org.assertj:assertj-core:3.9.0
 org.codehaus.mojo:animal-sniffer-annotations:1.14
@@ -65,9 +66,13 @@ org.javassist:javassist:3.22.0-GA
 org.jboss.logging:jboss-logging:3.3.1.Final
 org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec:1.0.1.Final
 org.jboss:jandex:2.0.3.Final
+org.junit.platform:junit-platform-commons:1.4.0-RC2
+org.junit.platform:junit-platform-engine:1.4.0-RC2
+org.junit.vintage:junit-vintage-engine:5.4.0-RC2
 org.latencyutils:LatencyUtils:2.0.3
 org.mockito:mockito-core:2.10.0
 org.objenesis:objenesis:2.6
+org.opentest4j:opentest4j:1.1.1
 org.pcollections:pcollections:3.0.1
 org.reactivestreams:reactive-streams:1.0.2
 org.slf4j:slf4j-api:1.7.25

--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -72,4 +72,7 @@ dependencies {
     testCompile 'org.springframework.integration:spring-integration-xml'
 
     testCompile 'org.springframework.security:spring-security-test'
+
+    testCompileOnly 'junit:junit:4.12'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:latest.release'
 }

--- a/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -158,6 +158,7 @@ org.junit.jupiter:junit-jupiter-api:5.1.0-RC1
 org.junit.jupiter:junit-jupiter-engine:5.1.0-RC1
 org.junit.platform:junit-platform-commons:1.1.0-RC1
 org.junit.platform:junit-platform-engine:1.1.0-RC1
+org.junit.vintage:junit-vintage-engine:5.1.0-RC1
 org.latencyutils:LatencyUtils:2.0.3
 org.mockito:mockito-core:1.10.19
 org.objenesis:objenesis:2.1

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'org.junit.platform.gradle.plugin'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.assertj:assertj-core:latest.release'


### PR DESCRIPTION
This PR changes to use JUnit platform consistently by:

- Changing to use JUnit Vintage Engine for `micrometer-jersey2` and `micrometer-spring-legacy`.
- Removing JUnit Platform Gradle plugin as there's out-of-box support for it since Gradle 4.6 and it'll be deprecated since Gradle 5.2. (https://github.com/junit-team/junit5/issues/1317)
- Changing to use JUnit Jupiter Engine for `micrometer-spring-legacy`. (#1209)

Merging #1209 is a prerequisite for this to be merged forward.

This PR also updates dependency locks for JUnit Vintage Engine which seems to be safe even in maintenance releases and intentionally didn't include lock files (`annotationProcessor.lockfile`, `testAnnotationProcessor.lockfile` and `apt.lockfile`) which are not strictly necessary to build successfully.

As a side note, `org.junit.vintage:junit-vintage-engine` "5.1.0-RC1" has been used to update dependency locks for `micrometer-spring-legacy` and changed its version to "latest.release" for JUnit platform compatibility.

FTR how I updated dependency locks is as follows:

```
...
* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-jersey2:testRuntimeClasspath'.
> Dependency lock state for configuration 'testRuntimeClasspath' is out of date:
    - Resolved 'org.opentest4j:opentest4j:1.1.1' which is not part of the lock state
    - Resolved 'org.junit.platform:junit-platform-commons:1.4.0-RC2' which is not part of the lock state
    - Resolved 'org.junit.platform:junit-platform-engine:1.4.0-RC2' which is not part of the lock state
    - Resolved 'org.apiguardian:apiguardian-api:1.0.0' which is not part of the lock state
    - Resolved 'org.junit.vintage:junit-vintage-engine:5.4.0-RC2' which is not part of the lock state
...

./gradlew :micrometer-jersey2:test --update-locks org.opentest4j:opentest4j,org.junit.platform:junit-platform-commons,org.junit.platform:junit-platform-engine,org.apiguardian:apiguardian-api,org.junit.vintage:junit-vintage-engine

...
* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-spring-legacy:testRuntimeClasspath'.
> Dependency lock state for configuration 'testRuntimeClasspath' is out of date: Resolved 'org.junit.vintage:junit-vintage-engine:5.1.0-RC1' which is not part of the lock state
...

./gradlew :micrometer-spring-legacy:test --update-locks org.junit.vintage:junit-vintage-engine
```