### PR TITLE
Use system-dependent line separator for logs

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -134,7 +134,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                     } else if (status >= 400) {
                         try (InputStream in = con.getErrorStream()) {
                             logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                                    .lines().collect(joining("\n")));
+                                    .lines().collect(joining(System.lineSeparator())));
                         }
                     } else {
                         logger.error("failed to send metrics: http " + status);
@@ -290,7 +290,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
             } else if (status >= 400) {
                 try (InputStream in = con.getErrorStream()) {
                     String msg = new BufferedReader(new InputStreamReader(in))
-                            .lines().collect(joining("\n"));
+                            .lines().collect(joining(System.lineSeparator()));
                     if (msg.contains("metric_name not found")) {
                         // Do nothing. Metrics that are newly created in Datadog are not immediately available
                         // for metadata modification. We will keep trying this request on subsequent publishes,

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -86,7 +86,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
             } else if (status >= 400) {
                 try (InputStream in = con.getErrorStream()) {
                     logger.error("unable to create database '{}': {}", config.db(), new BufferedReader(new InputStreamReader(in))
-                            .lines().collect(joining("\n")));
+                            .lines().collect(joining(System.lineSeparator())));
                 }
             }
         } catch (Throwable e) {
@@ -174,7 +174,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
                     } else if (status >= 400) {
                         try (InputStream in = con.getErrorStream()) {
                             logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                                    .lines().collect(joining("\n")));
+                                    .lines().collect(joining(System.lineSeparator())));
                         }
                     } else {
                         logger.error("failed to send metrics: http " + status);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -251,7 +251,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             } else if (status >= 400) {
                 try (InputStream in = con.getErrorStream()) {
                     logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                            .lines().collect(joining("\n")));
+                            .lines().collect(joining(System.lineSeparator())));
                 }
             } else {
                 logger.error("failed to send metrics: http " + status);

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -106,7 +106,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                         } else {
                             try (InputStream in = con.getErrorStream()) {
                                 logger.error("failed to send metrics: " + new BufferedReader(new InputStreamReader(in))
-                                        .lines().collect(joining("\n")));
+                                        .lines().collect(joining(System.lineSeparator())));
                             }
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
This PR changes to use system-dependent line separator for logs.