### PR TITLE
Respect time unit parameter in FunctionTimer.totalTime()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionTimer.java
@@ -43,6 +43,8 @@ public interface FunctionTimer extends Meter {
     double count();
 
     /**
+     * The total time of all occurrences of the timed event.
+     *
      * @param unit The base unit of time to scale the total to.
      * @return The total time of all occurrences of the timed event.
      */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
@@ -28,6 +28,7 @@ import java.util.function.ToLongFunction;
  * A timer that tracks monotonically increasing functions for count and totalTime.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class CumulativeFunctionTimer<T> implements FunctionTimer {
     private final Meter.Id id;
@@ -58,16 +59,13 @@ public class CumulativeFunctionTimer<T> implements FunctionTimer {
         return obj2 != null ? (lastCount = countFunction.applyAsLong(obj2)) : lastCount;
     }
 
-    /**
-     * The total time of all occurrences of the timed event.
-     */
+    @Override
     public double totalTime(TimeUnit unit) {
         T obj2 = ref.get();
-        if (obj2 == null)
-            return lastTime;
-        return (lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2),
-            totalTimeFunctionUnits,
-            unit));
+        if (obj2 != null) {
+            lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnits, baseTimeUnit());
+        }
+        return TimeUtils.convert(lastTime, baseTimeUnit(), unit);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
@@ -30,6 +30,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
 
+/**
+ * {@link FunctionTimer} for Dropwizard Metrics.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public class DropwizardFunctionTimer<T> extends AbstractMeter implements FunctionTimer {
     private final WeakReference<T> ref;
     private final ToLongFunction<T> countFunction;
@@ -145,11 +151,10 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
     @Override
     public double totalTime(TimeUnit unit) {
         T obj2 = ref.get();
-        if (obj2 == null)
-            return lastTime;
-        return (lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2),
-            totalTimeFunctionUnits,
-            unit));
+        if (obj2 != null) {
+            lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnits, baseTimeUnit());
+        }
+        return TimeUtils.convert(lastTime, baseTimeUnit(), unit);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -28,6 +28,7 @@ import java.util.function.ToLongFunction;
  * A timer that tracks monotonically increasing functions for count and totalTime.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class StepFunctionTimer<T> implements FunctionTimer {
     private final Id id;
@@ -68,17 +69,15 @@ public class StepFunctionTimer<T> implements FunctionTimer {
         return count.poll();
     }
 
-    /**
-     * The total time of all occurrences of the timed event.
-     */
+    @Override
     public double totalTime(TimeUnit unit) {
         T obj2 = ref.get();
         if (obj2 != null) {
             double prevLast = lastTime;
-            lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnits, unit);
+            lastTime = TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnits, baseTimeUnit());
             total.getCurrent().add(lastTime - prevLast);
         }
-        return total.poll();
+        return TimeUtils.convert(total.poll(), baseTimeUnit(), unit);
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimerTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.cumulative;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CumulativeFunctionTimer}.
+ *
+ * @author Johnny Lim
+ */
+class CumulativeFunctionTimerTest {
+
+    @Test
+    void totalTimeWhenStateObjectChangedToNullShouldWorkWithChangedTimeUnit() {
+        CumulativeFunctionTimer functionTimer = new CumulativeFunctionTimer(
+                null, new Object(), (o) -> 1L, (o) -> 1d, TimeUnit.SECONDS, TimeUnit.SECONDS);
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        System.gc();
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimerTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.dropwizard;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.MockClock;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DropwizardFunctionTimer}.
+ *
+ * @author Johnny Lim
+ */
+class DropwizardFunctionTimerTest {
+
+    @Test
+    void totalTimeWhenStateObjectChangedToNullShouldWorkWithChangedTimeUnit() {
+        DropwizardFunctionTimer functionTimer = new DropwizardFunctionTimer(
+                null, new MockClock(), new Object(), (o) -> 1L, (o) -> 1d, TimeUnit.SECONDS, TimeUnit.SECONDS);
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        System.gc();
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.MockClock;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StepFunctionTimer}.
+ *
+ * @author Johnny Lim
+ */
+class StepFunctionTimerTest {
+
+    @Test
+    void totalTimeWhenStateObjectChangedToNullShouldWorkWithChangedTimeUnit() {
+        MockClock clock = new MockClock();
+        StepFunctionTimer functionTimer = new StepFunctionTimer(
+                null, clock, 1000L, new Object(), (o) -> 1L, (o) -> 1d, TimeUnit.SECONDS, TimeUnit.SECONDS);
+        clock.add(Duration.ofSeconds(1));
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        System.gc();
+        assertThat(functionTimer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1000d);
+        assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
+    }
+
+}


### PR DESCRIPTION
This PR changes to respect time unit parameter in `FunctionTimer.totalTime()`.