### PR TITLE
Use nanoseconds for Dropwizard timer snapshot mean

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
@@ -110,7 +110,8 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
                     @Override
                     public double getMean() {
                         double count = count();
-                        return count == 0 ? 0 : totalTime(baseTimeUnit()) / count;
+                        // This return value is expected to be in nanoseconds, for example in JmxReporter.JmxTimer.
+                        return count == 0 ? 0 : totalTime(TimeUnit.NANOSECONDS) / count;
                     }
 
                     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimerTest.java
@@ -40,4 +40,11 @@ class DropwizardFunctionTimerTest {
         assertThat(functionTimer.totalTime(TimeUnit.SECONDS)).isEqualTo(1d);
     }
 
+    @Test
+    void getDropwizardMeterGetSnapshotGetMeanShouldReturnNanoseconds() {
+        DropwizardFunctionTimer functionTimer = new DropwizardFunctionTimer(
+                null, new MockClock(), new Object(), (o) -> 1L, (o) -> 1d, TimeUnit.SECONDS, TimeUnit.SECONDS);
+        assertThat(functionTimer.getDropwizardMeter().getSnapshot().getMean()).isEqualTo(1000_000_000d);
+    }
+
 }


### PR DESCRIPTION
This PR changes to use nanoseconds for Dropwizard timer snapshot mean.

Closes gh-1161