### PR TITLE
Add instrumentation for pools of HttpComponents HttpClient

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -201,13 +201,13 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
         poolRoutePendingGauge.register(routesToRows(routes, PoolStats::getPending));
     }
 
-    private Set<MultiGauge.Row> routesToRows(Set<HttpRoute> routes, Function<PoolStats, Integer> valueFunction) {
+    private Iterable<MultiGauge.Row<?>> routesToRows(Set<HttpRoute> routes, Function<PoolStats, Integer> valueFunction) {
         return routes.stream()
             .map((route) -> routeToRow(route, () -> valueFunction.apply(connectionManager.getStats(route))))
             .collect(Collectors.toSet());
     }
 
-    private MultiGauge.Row routeToRow(HttpRoute route, Supplier<Number> valueFunction) {
+    private MultiGauge.Row<Supplier<Number>> routeToRow(HttpRoute route, Supplier<Number> valueFunction) {
         Tags tags = Tags.of(
             "target.host", route.getTargetHost().getHostName(),
             "target.port", String.valueOf(route.getTargetHost().getPort()),

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,202 @@
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import com.google.common.base.Preconditions;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNull;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.pool.PoolStats;
+
+import javax.annotation.PreDestroy;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Collects metrics from a {@link PoolingHttpClientConnectionManager}.
+ *
+ * It monitors the overall connection pool and can also be used to monitor
+ * connection pools per route.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @since 1.2.0
+ */
+public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
+
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_MAX             = "httpcomponents.httpclient.pool.total.max";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_AVAILABLE       = "httpcomponents.httpclient.pool.total.available";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_LEASED          = "httpcomponents.httpclient.pool.total.leased";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING         = "httpcomponents.httpclient.pool.total.pending";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_DEFAULT_MAX_PER_ROUTE = "httpcomponents.httpclient.pool.route.max.default";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX             = "httpcomponents.httpclient.pool.route.max";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_AVAILABLE       = "httpcomponents.httpclient.pool.route.available";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_LEASED          = "httpcomponents.httpclient.pool.route.leased";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING         = "httpcomponents.httpclient.pool.route.pending";
+
+    private final ScheduledExecutorService routeUpdateTask = Executors.newScheduledThreadPool(1);
+    private final PoolingHttpClientConnectionManager connectionManager;
+    private final Iterable<Tag> tags;
+    private final boolean monitorRoutes;
+
+    private MultiGauge poolRouteMaxGauge;
+    private MultiGauge poolRouteAvailableGauge;
+    private MultiGauge poolRouteLeasedGauge;
+    private MultiGauge poolRoutePendingGauge;
+
+    /**
+     * Creates a metrics binder for the given pooling connection manager.
+     * This instance will not monitor pool statistics of specific routes.
+     *
+     * @param connectionManager The connection manager to monitor.
+     * @param name Name of the connection manager. Will be added as tag with the
+     *             key "httpclient".
+     * @param tags Tags to apply to all recorded metrics. Must be an even number
+     *             of arguments representing key/value pairs of tags.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, String... tags) {
+        this(connectionManager, name, Tags.of(tags));
+    }
+
+    /**
+     * Creates a metrics binder for the given pooling connection manager.
+     * This instance will not monitor pool statistics of specific routes.
+     *
+     * @param connectionManager The connection manager to monitor.
+     * @param name Name of the connection manager. Will be added as tag with the
+     *             key "httpclient".
+     * @param monitorRoutes When true, this metrics binder will monitor every
+     *                      route (target scheme, host and port). Be careful:
+     *                      Set this to true if and only if you are sure that
+     *                      your service accesses only a limited number of
+     *                      target schemes, hosts and ports. DO NOT ENABLE THIS
+     *                      FEATURE if your HttpClient accesses an unlimited
+     *                      number of routes (i.e. if the target host depends on
+     *                      the user input).
+     * @param tags Tags to apply to all recorded metrics. Must be an even number
+     *             of arguments representing key/value pairs of tags.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, boolean monitorRoutes, String... tags) {
+        this(connectionManager, name, monitorRoutes, Tags.of(tags));
+    }
+
+    /**
+     * Creates a metrics binder for the given pooling connection manager.
+     * This instance will not monitor pool statistics of specific routes.
+     *
+     * @param connectionManager The connection manager to monitor.
+     * @param name Name of the connection manager. Will be added as tag with the
+     *             key "httpclient".
+     * @param tags Tags to apply to all recorded metrics.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, Iterable<Tag> tags) {
+        this(connectionManager, name, false, tags);
+    }
+
+    /**
+     * Creates a metrics binder for the given pooling connection manager.
+     *
+     * @param connectionManager The connection manager to monitor.
+     * @param name Name of the connection manager. Will be added as tag with the
+     *             key "httpclient".
+     * @param monitorRoutes When true, this metrics binder will monitor every
+     *                      route (target scheme, host and port). Be careful:
+     *                      Set this to true if and only if you are sure that
+     *                      your service accesses only a limited number of
+     *                      target schemes, hosts and ports. DO NOT ENABLE THIS
+     *                      FEATURE if your HttpClient accesses an unlimited
+     *                      number of routes (i.e. if the target host depends on
+     *                      the user input).
+     * @param tags Tags to apply to all recorded metrics.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, boolean monitorRoutes, Iterable<Tag> tags) {
+        Preconditions.checkArgument(connectionManager instanceof PoolingHttpClientConnectionManager);
+        this.connectionManager = (PoolingHttpClientConnectionManager) connectionManager;
+        this.tags = Tags.concat(tags, "httpclient", name);
+        this.monitorRoutes = monitorRoutes;
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_MAX,
+            connectionManager,
+            (connectionManager) -> connectionManager.getTotalStats().getMax())
+            .tags(tags)
+            .register(registry);
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_AVAILABLE,
+            connectionManager,
+            (connectionManager) -> connectionManager.getTotalStats().getAvailable())
+            .tags(tags)
+            .register(registry);
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_LEASED,
+            connectionManager,
+            (connectionManager) -> connectionManager.getTotalStats().getLeased())
+            .tags(tags)
+            .register(registry);
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING,
+            connectionManager,
+            (connectionManager) -> connectionManager.getTotalStats().getPending())
+            .tags(tags)
+            .register(registry);
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_DEFAULT_MAX_PER_ROUTE,
+            connectionManager,
+            PoolingHttpClientConnectionManager::getDefaultMaxPerRoute)
+            .tags(tags)
+            .register(registry);
+
+        if (monitorRoutes) {
+            poolRouteMaxGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX)
+                .tags(tags)
+                .register(registry);
+            poolRouteAvailableGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_AVAILABLE)
+                .tags(tags)
+                .register(registry);
+            poolRouteLeasedGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_LEASED)
+                .tags(tags)
+                .register(registry);
+            poolRoutePendingGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING)
+                .tags(tags)
+                .register(registry);
+
+            routeUpdateTask.scheduleAtFixedRate(new RouteUpdater(), 10, 10, TimeUnit.SECONDS);
+            routeUpdateTask.execute(new RouteUpdater());
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        routeUpdateTask.shutdownNow();
+    }
+
+    private class RouteUpdater implements Runnable {
+        @Override
+        public void run() {
+            Set<HttpRoute> routes = connectionManager.getRoutes();
+            poolRouteMaxGauge.register(toRows(routes, PoolStats::getMax));
+            poolRouteAvailableGauge.register(toRows(routes, PoolStats::getAvailable));
+            poolRouteLeasedGauge.register(toRows(routes, PoolStats::getLeased));
+            poolRoutePendingGauge.register(toRows(routes, PoolStats::getPending));
+        }
+
+        private Set<MultiGauge.Row> toRows(Set<HttpRoute> routes, Function<PoolStats, Integer> valueFunction) {
+            return routes.stream()
+                .map((route) -> toRow(route, () -> valueFunction.apply(connectionManager.getStats(route))))
+                .collect(Collectors.toSet());
+        }
+
+        private MultiGauge.Row toRow(HttpRoute route, Supplier<Number> valueFunction) {
+            Tags tags = Tags.of(
+                "target.host", route.getTargetHost().getHostName(),
+                "target.port", String.valueOf(route.getTargetHost().getPort()),
+                "target.scheme", route.getTargetHost().getSchemeName()
+            );
+            return MultiGauge.Row.of(tags, valueFunction);
+        }
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -40,14 +40,13 @@ import java.util.stream.Collectors;
 public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
 
     private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_MAX             = "httpcomponents.httpclient.pool.total.max";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_AVAILABLE       = "httpcomponents.httpclient.pool.total.available";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_LEASED          = "httpcomponents.httpclient.pool.total.leased";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS     = "httpcomponents.httpclient.pool.total.connections";
     private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING         = "httpcomponents.httpclient.pool.total.pending";
     private static final String NAME_HTTPCLIENT_CONNECTION_POOL_DEFAULT_MAX_PER_ROUTE = "httpcomponents.httpclient.pool.route.max.default";
     private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX             = "httpcomponents.httpclient.pool.route.max";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_AVAILABLE       = "httpcomponents.httpclient.pool.route.available";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_LEASED          = "httpcomponents.httpclient.pool.route.leased";
+    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS     = "httpcomponents.httpclient.pool.route.connections";
     private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING         = "httpcomponents.httpclient.pool.route.pending";
+    private static final String TAG_CONNECTIONS_STATE = "state";
 
     private final PoolingHttpClientConnectionManager connectionManager;
     private final Iterable<Tag> tags;
@@ -110,15 +109,15 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
             (connectionManager) -> connectionManager.getTotalStats().getMax())
             .tags(tags)
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_AVAILABLE,
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getAvailable())
-            .tags(tags)
+            .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_LEASED,
+        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getLeased())
-            .tags(tags)
+            .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
         Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING,
             connectionManager,
@@ -136,11 +135,11 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
         poolRouteMaxGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX)
             .tags(tags)
             .register(registry);
-        poolRouteAvailableGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_AVAILABLE)
-            .tags(tags)
+        poolRouteAvailableGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS)
+            .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
-        poolRouteLeasedGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_LEASED)
-            .tags(tags)
+        poolRouteLeasedGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS)
+            .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
         poolRoutePendingGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING)
             .tags(tags)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -27,7 +27,7 @@ import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
  * It monitors the overall connection pool state.
  *
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
- * @since 1.2.0
+ * @since 1.3.0
  */
 public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -39,13 +39,13 @@ import java.util.stream.Collectors;
  */
 public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
 
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_MAX             = "httpcomponents.httpclient.pool.total.max";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS     = "httpcomponents.httpclient.pool.total.connections";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING         = "httpcomponents.httpclient.pool.total.pending";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_DEFAULT_MAX_PER_ROUTE = "httpcomponents.httpclient.pool.route.max.default";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX             = "httpcomponents.httpclient.pool.route.max";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS     = "httpcomponents.httpclient.pool.route.connections";
-    private static final String NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING         = "httpcomponents.httpclient.pool.route.pending";
+    private static final String METER_TOTAL_MAX = "httpcomponents.httpclient.pool.total.max";
+    private static final String METER_TOTAL_CONNECTIONS = "httpcomponents.httpclient.pool.total.connections";
+    private static final String METER_TOTAL_PENDING = "httpcomponents.httpclient.pool.total.pending";
+    private static final String METER_DEFAULT_MAX_PER_ROUTE = "httpcomponents.httpclient.pool.route.max.default";
+    private static final String METER_ROUTE_MAX = "httpcomponents.httpclient.pool.route.max";
+    private static final String METER_ROUTE_CONNECTIONS = "httpcomponents.httpclient.pool.route.connections";
+    private static final String METER_ROUTE_PENDING = "httpcomponents.httpclient.pool.route.pending";
     private static final String TAG_CONNECTIONS_STATE = "state";
 
     private final PoolingHttpClientConnectionManager connectionManager;
@@ -104,27 +104,27 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
     }
 
     private void registerTotalMetrics(MeterRegistry registry) {
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_MAX,
+        Gauge.builder(METER_TOTAL_MAX,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getMax())
             .tags(tags)
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS,
+        Gauge.builder(METER_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getAvailable())
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_CONNECTIONS,
+        Gauge.builder(METER_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getLeased())
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_TOTAL_PENDING,
+        Gauge.builder(METER_TOTAL_PENDING,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getPending())
             .tags(tags)
             .register(registry);
-        Gauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_DEFAULT_MAX_PER_ROUTE,
+        Gauge.builder(METER_DEFAULT_MAX_PER_ROUTE,
             connectionManager,
             PoolingHttpClientConnectionManager::getDefaultMaxPerRoute)
             .tags(tags)
@@ -132,16 +132,16 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
     }
 
     private void registerPerRouteMetrics(MeterRegistry registry) {
-        poolRouteMaxGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_MAX)
+        poolRouteMaxGauge = MultiGauge.builder(METER_ROUTE_MAX)
             .tags(tags)
             .register(registry);
-        poolRouteAvailableGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS)
+        poolRouteAvailableGauge = MultiGauge.builder(METER_ROUTE_CONNECTIONS)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
-        poolRouteLeasedGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_CONNECTIONS)
+        poolRouteLeasedGauge = MultiGauge.builder(METER_ROUTE_CONNECTIONS)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
-        poolRoutePendingGauge = MultiGauge.builder(NAME_HTTPCLIENT_CONNECTION_POOL_ROUTE_PENDING)
+        poolRoutePendingGauge = MultiGauge.builder(METER_ROUTE_PENDING)
             .tags(tags)
             .register(registry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.core.instrument.binder.httpcomponents;
 
 import com.google.common.base.Preconditions;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument.binder.httpcomponents;
 
-import com.google.common.base.Preconditions;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNull;
@@ -61,6 +60,12 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
     /**
      * Creates a metrics binder for the given pooling connection manager.
      *
+     * For convenience this constructor will take care of casting the given
+     * {@link HttpClientConnectionManager} to the required {@link
+     * PoolingHttpClientConnectionManager}. An {@link IllegalArgumentException}
+     * is thrown, if the given {@code connectionManager} is not an instance of
+     * {@link PoolingHttpClientConnectionManager}.
+     *
      * @param connectionManager The connection manager to monitor.
      * @param name Name of the connection manager. Will be added as tag with the
      *             key "httpclient".
@@ -74,13 +79,21 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
     /**
      * Creates a metrics binder for the given pooling connection manager.
      *
+     * For convenience this constructor will take care of casting the given
+     * {@link HttpClientConnectionManager} to the required {@link
+     * PoolingHttpClientConnectionManager}. An {@link IllegalArgumentException}
+     * is thrown, if the given {@code connectionManager} is not an instance of
+     * {@link PoolingHttpClientConnectionManager}.
+     *
      * @param connectionManager The connection manager to monitor.
      * @param name Name of the connection manager. Will be added as tag with the
      *             key "httpclient".
      * @param tags Tags to apply to all recorded metrics.
      */
     public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, Iterable<Tag> tags) {
-        Preconditions.checkArgument(connectionManager instanceof PoolingHttpClientConnectionManager);
+        if (!(connectionManager instanceof PoolingHttpClientConnectionManager)) {
+            throw new IllegalArgumentException("The given connectionManager is not an instance of PoolingHttpClientConnectionManager.");
+        }
         this.connectionManager = (PoolingHttpClientConnectionManager) connectionManager;
         this.tags = Tags.concat(tags, "httpclient", name);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -39,12 +39,19 @@ import java.util.stream.Collectors;
  */
 public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
 
+    private static final String METER_TOTAL_MAX_DESC = "The configured maximum number of allowed persistent connections for all routes.";
     private static final String METER_TOTAL_MAX = "httpcomponents.httpclient.pool.total.max";
+    private static final String METER_TOTAL_CONNECTIONS_DESC = "The number of persistent and leased connections for all routes.";
     private static final String METER_TOTAL_CONNECTIONS = "httpcomponents.httpclient.pool.total.connections";
+    private static final String METER_TOTAL_PENDING_DESC = "The number of connection requests being blocked awaiting a free connection for all routes.";
     private static final String METER_TOTAL_PENDING = "httpcomponents.httpclient.pool.total.pending";
+    private static final String METER_DEFAULT_MAX_PER_ROUTE_DESC = "The configured default maximum number of allowed persistent connections per route.";
     private static final String METER_DEFAULT_MAX_PER_ROUTE = "httpcomponents.httpclient.pool.route.max.default";
+    private static final String METER_ROUTE_MAX_DESC = "The configured maximum number of allowed persistent connections per route.";
     private static final String METER_ROUTE_MAX = "httpcomponents.httpclient.pool.route.max";
+    private static final String METER_ROUTE_CONNECTIONS_DESC = "The number of persistent and leased connections per route.";
     private static final String METER_ROUTE_CONNECTIONS = "httpcomponents.httpclient.pool.route.connections";
+    private static final String METER_ROUTE_PENDING_DESC = "The number of connection requests being blocked awaiting a free connection for all routes.";
     private static final String METER_ROUTE_PENDING = "httpcomponents.httpclient.pool.route.pending";
     private static final String TAG_CONNECTIONS_STATE = "state";
 
@@ -107,41 +114,50 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
         Gauge.builder(METER_TOTAL_MAX,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getMax())
+            .description(METER_TOTAL_MAX_DESC)
             .tags(tags)
             .register(registry);
         Gauge.builder(METER_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getAvailable())
+            .description(METER_TOTAL_CONNECTIONS_DESC)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
         Gauge.builder(METER_TOTAL_CONNECTIONS,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getLeased())
+            .description(METER_TOTAL_CONNECTIONS_DESC)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
         Gauge.builder(METER_TOTAL_PENDING,
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getPending())
+            .description(METER_TOTAL_PENDING_DESC)
             .tags(tags)
             .register(registry);
         Gauge.builder(METER_DEFAULT_MAX_PER_ROUTE,
             connectionManager,
             PoolingHttpClientConnectionManager::getDefaultMaxPerRoute)
+            .description(METER_DEFAULT_MAX_PER_ROUTE_DESC)
             .tags(tags)
             .register(registry);
     }
 
     private void registerPerRouteMetrics(MeterRegistry registry) {
         poolRouteMaxGauge = MultiGauge.builder(METER_ROUTE_MAX)
+            .description(METER_ROUTE_MAX_DESC)
             .tags(tags)
             .register(registry);
         poolRouteAvailableGauge = MultiGauge.builder(METER_ROUTE_CONNECTIONS)
+            .description(METER_ROUTE_CONNECTIONS_DESC)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "available")
             .register(registry);
         poolRouteLeasedGauge = MultiGauge.builder(METER_ROUTE_CONNECTIONS)
+            .description(METER_ROUTE_CONNECTIONS_DESC)
             .tags(tags).tag(TAG_CONNECTIONS_STATE, "leased")
             .register(registry);
         poolRoutePendingGauge = MultiGauge.builder(METER_ROUTE_PENDING)
+            .description(METER_ROUTE_PENDING_DESC)
             .tags(tags)
             .register(registry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -78,6 +78,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
      * @param tags Tags to apply to all recorded metrics. Must be an even number
      *             of arguments representing key/value pairs of tags.
      */
+    @SuppressWarnings("WeakerAccess")
     public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, String... tags) {
         this(connectionManager, name, Tags.of(tags));
     }
@@ -96,6 +97,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
      *             key "httpclient".
      * @param tags Tags to apply to all recorded metrics.
      */
+    @SuppressWarnings("WeakerAccess")
     public PoolingHttpClientConnectionManagerMetricsBinder(HttpClientConnectionManager connectionManager, String name, Iterable<Tag> tags) {
         if (!(connectionManager instanceof PoolingHttpClientConnectionManager)) {
             throw new IllegalArgumentException("The given connectionManager is not an instance of PoolingHttpClientConnectionManager.");
@@ -193,6 +195,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
      * USE THIS METHOD if your HttpClient accesses a big or unlimited number of
      * routes (i.e. if the target host depends on the user input).
      */
+    @SuppressWarnings("WeakerAccess")
     public void updateRoutes() {
         Set<HttpRoute> routes = connectionManager.getRoutes();
         poolRouteMaxGauge.register(routesToRows(routes, PoolStats::getMax));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -17,20 +17,13 @@ package io.micrometer.core.instrument.binder.httpcomponents;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
-import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.apache.http.HttpHost;
 import org.apache.http.conn.HttpClientConnectionManager;
-import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.pool.PoolStats;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -115,97 +108,6 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         assertThat(registry.get("httpcomponents.httpclient.pool.route.max.default")
             .tags("httpclient", "test")
             .gauge().value()).isEqualTo(7.0);
-    }
-
-    @Test
-    void routeStats() {
-        HttpRoute route1 = httpRoute("http", "one.example.com", 80);
-        PoolStats route1Stats = mock(PoolStats.class);
-        when(route1Stats.getMax()).thenReturn(19);
-        when(route1Stats.getLeased()).thenReturn(29);
-        when(route1Stats.getPending()).thenReturn(31);
-        when(route1Stats.getAvailable()).thenReturn(37);
-        when(connectionManager.getStats(route1)).thenReturn(route1Stats);
-
-        HttpRoute route2 = httpRoute("https", "two.example.com", 443);
-        PoolStats route2Stats = mock(PoolStats.class);
-        when(route2Stats.getMax()).thenReturn(41);
-        when(route2Stats.getLeased()).thenReturn(43);
-        when(route2Stats.getPending()).thenReturn(47);
-        when(route2Stats.getAvailable()).thenReturn(53);
-        when(connectionManager.getStats(route2)).thenReturn(route2Stats);
-
-        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Arrays.asList(route1, route2)));
-        binder.updateRoutes();
-
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
-            .gauge().value()).isEqualTo(19);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
-            .gauge().value()).isEqualTo(29);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
-            .gauge().value()).isEqualTo(31);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "available")
-            .gauge().value()).isEqualTo(37);
-
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
-            .gauge().value()).isEqualTo(41);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443", "state", "leased")
-            .gauge().value()).isEqualTo(43);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
-            .gauge().value()).isEqualTo(47);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443", "state", "available")
-            .gauge().value()).isEqualTo(53);
-    }
-
-    @Test
-    void noRouteMetricsWhenRoutesNotUpdated() {
-        HttpRoute route = httpRoute("http", "one.example.com", 80);
-        PoolStats routeStats = mock(PoolStats.class);
-        when(routeStats.getMax()).thenReturn(19);
-        when(routeStats.getLeased()).thenReturn(29);
-        when(routeStats.getPending()).thenReturn(31);
-        when(routeStats.getAvailable()).thenReturn(37);
-        when(connectionManager.getStats(route)).thenReturn(routeStats);
-
-        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Collections.singletonList(route)));
-        // do not call binder.updateRoutes();
-
-        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.max").gauge());
-        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.connections").gauge());
-        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.available").gauge());
-    }
-
-    @Test
-    void routeMetricsGetUpdated() {
-        HttpRoute route = httpRoute("http", "one.example.com", 80);
-        PoolStats routeStats = mock(PoolStats.class);
-        when(connectionManager.getStats(route)).thenReturn(routeStats);
-        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Collections.singletonList(route)));
-
-        when(routeStats.getLeased()).thenReturn(17);
-        binder.updateRoutes();
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
-            .gauge().value()).isEqualTo(17);
-
-        when(routeStats.getLeased()).thenReturn(19);
-        binder.updateRoutes();
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
-            .gauge().value()).isEqualTo(19);
-    }
-
-    private HttpRoute httpRoute(String scheme, String host, Integer port) {
-        HttpHost httpHost = new HttpHost(host, port, scheme);
-        return new HttpRoute(httpHost);
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.pool.PoolStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PoolingHttpClientConnectionManagerMetricsBinder}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+class PoolingHttpClientConnectionManagerMetricsBinderTest {
+
+    private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private PoolingHttpClientConnectionManager connectionManager;
+    private PoolingHttpClientConnectionManagerMetricsBinder binder;
+
+    @BeforeEach
+    void setup() {
+        connectionManager = mock(PoolingHttpClientConnectionManager.class);
+        binder = new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
+        binder.bindTo(registry);
+    }
+
+    @Test
+    void creationWithNonPoolingHttpClientThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            HttpClientConnectionManager connectionManager = mock(HttpClientConnectionManager.class);
+            new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
+        });
+    }
+
+    @Test
+    void creationWithPoolingHttpClientIsOk() {
+        HttpClientConnectionManager connectionManager = mock(PoolingHttpClientConnectionManager.class);
+        new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
+    }
+
+    @Test
+    void totalMax() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getMax()).thenReturn(13);
+        when(connectionManager.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.max")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(13.0);
+    }
+
+    @Test
+    void totalAvailable() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getAvailable()).thenReturn(17);
+        when(connectionManager.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.available")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(17.0);
+    }
+
+    @Test
+    void totalLeased() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getLeased()).thenReturn(23);
+        when(connectionManager.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.leased")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(23.0);
+    }
+
+    @Test
+    void totalPending() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getPending()).thenReturn(37);
+        when(connectionManager.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.pending")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(37.0);
+    }
+
+    @Test
+    void routeMaxDefault() {
+        when(connectionManager.getDefaultMaxPerRoute()).thenReturn(7);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max.default")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(7.0);
+    }
+
+    @Test
+    void routeStats() {
+        HttpRoute route1 = httpRoute("http", "one.example.com", 80);
+        PoolStats route1Stats = mock(PoolStats.class);
+        when(route1Stats.getMax()).thenReturn(19);
+        when(route1Stats.getLeased()).thenReturn(29);
+        when(route1Stats.getPending()).thenReturn(31);
+        when(route1Stats.getAvailable()).thenReturn(37);
+        when(connectionManager.getStats(route1)).thenReturn(route1Stats);
+
+        HttpRoute route2 = httpRoute("https", "two.example.com", 443);
+        PoolStats route2Stats = mock(PoolStats.class);
+        when(route2Stats.getMax()).thenReturn(41);
+        when(route2Stats.getLeased()).thenReturn(43);
+        when(route2Stats.getPending()).thenReturn(47);
+        when(route2Stats.getAvailable()).thenReturn(53);
+        when(connectionManager.getStats(route2)).thenReturn(route2Stats);
+
+        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Arrays.asList(route1, route2)));
+        binder.updateRoutes();
+
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(19);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(29);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(31);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.available")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(37);
+
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+            .gauge().value()).isEqualTo(41);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+            .gauge().value()).isEqualTo(43);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+            .gauge().value()).isEqualTo(47);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.available")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+            .gauge().value()).isEqualTo(53);
+    }
+
+    @Test
+    void noRouteMetricsWhenRoutesNotUpdated() {
+        HttpRoute route = httpRoute("http", "one.example.com", 80);
+        PoolStats routeStats = mock(PoolStats.class);
+        when(routeStats.getMax()).thenReturn(19);
+        when(routeStats.getLeased()).thenReturn(29);
+        when(routeStats.getPending()).thenReturn(31);
+        when(routeStats.getAvailable()).thenReturn(37);
+        when(connectionManager.getStats(route)).thenReturn(routeStats);
+
+        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Collections.singletonList(route)));
+        // do not call binder.updateRoutes();
+
+        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.max").gauge());
+        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.leased").gauge());
+        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.pending").gauge());
+        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.available").gauge());
+    }
+
+    @Test
+    void routeMetricsGetUpdated() {
+        HttpRoute route = httpRoute("http", "one.example.com", 80);
+        PoolStats routeStats = mock(PoolStats.class);
+        when(connectionManager.getStats(route)).thenReturn(routeStats);
+        when(connectionManager.getRoutes()).thenReturn(new HashSet<>(Collections.singletonList(route)));
+
+        when(routeStats.getLeased()).thenReturn(17);
+        binder.updateRoutes();
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(17);
+
+        when(routeStats.getLeased()).thenReturn(19);
+        binder.updateRoutes();
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+            .gauge().value()).isEqualTo(19);
+    }
+
+    private HttpRoute httpRoute(String scheme, String host, Integer port) {
+        HttpHost httpHost = new HttpHost(host, port, scheme);
+        return new HttpRoute(httpHost);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -84,8 +84,8 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getAvailable()).thenReturn(17);
         when(connectionManager.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.available")
-            .tags("httpclient", "test")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+            .tags("httpclient", "test", "state", "available")
             .gauge().value()).isEqualTo(17.0);
     }
 
@@ -94,8 +94,8 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getLeased()).thenReturn(23);
         when(connectionManager.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.leased")
-            .tags("httpclient", "test")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+            .tags("httpclient", "test", "state", "leased")
             .gauge().value()).isEqualTo(23.0);
     }
 
@@ -141,27 +141,27 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
             .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
             .gauge().value()).isEqualTo(19);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
             .gauge().value()).isEqualTo(29);
         assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
             .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
             .gauge().value()).isEqualTo(31);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.available")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "available")
             .gauge().value()).isEqualTo(37);
 
         assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
             .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
             .gauge().value()).isEqualTo(41);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443", "state", "leased")
             .gauge().value()).isEqualTo(43);
         assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
             .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
             .gauge().value()).isEqualTo(47);
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.available")
-            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "https", "target.host", "two.example.com", "target.port", "443", "state", "available")
             .gauge().value()).isEqualTo(53);
     }
 
@@ -179,8 +179,7 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         // do not call binder.updateRoutes();
 
         assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.max").gauge());
-        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.leased").gauge());
-        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.pending").gauge());
+        assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.connections").gauge());
         assertThrows(MeterNotFoundException.class, () -> registry.get("httpcomponents.httpclient.pool.route.available").gauge());
     }
 
@@ -193,14 +192,14 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
 
         when(routeStats.getLeased()).thenReturn(17);
         binder.updateRoutes();
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
             .gauge().value()).isEqualTo(17);
 
         when(routeStats.getLeased()).thenReturn(19);
         binder.updateRoutes();
-        assertThat(registry.get("httpcomponents.httpclient.pool.route.leased")
-            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80")
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+            .tags("target.scheme", "http", "target.host", "one.example.com", "target.port", "80", "state", "leased")
             .gauge().value()).isEqualTo(19);
     }
 


### PR DESCRIPTION
Hi! This PR adds instrumentation for monitoring thread pools and limits of Apache HttpComponents `PoolingHttpClientConnectionManager` for #533 .

For now I just tested it locally, but we will soon use these metrics in one of our applications, where the `HttpClient` instances have to deal with very high traffic.