### PR TITLE
Handle null MemoryUsage in JvmMemoryMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
+import io.micrometer.core.lang.Nullable;
 
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
@@ -108,6 +109,7 @@ public class JvmMemoryMetrics implements MeterBinder {
         return getter.applyAsLong(usage);
     }
 
+    @Nullable
     private MemoryUsage getUsage(MemoryPoolMXBean memoryPoolMXBean) {
         try {
             return memoryPoolMXBean.getUsage();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -27,6 +27,8 @@ import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
+import java.util.function.ToLongFunction;
 
 import static java.util.Collections.emptyList;
 
@@ -34,6 +36,7 @@ import static java.util.Collections.emptyList;
  * Record metrics that report utilization of various memory and buffer pools.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  * @see MemoryPoolMXBean
  * @see BufferPoolMXBean
  */
@@ -77,23 +80,42 @@ public class JvmMemoryMetrics implements MeterBinder {
             String area = MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap";
             Iterable<Tag> tagsWithId = Tags.concat(tags, "id", memoryPoolBean.getName(), "area", area);
 
-            Gauge.builder("jvm.memory.used", memoryPoolBean, (mem) -> mem.getUsage().getUsed())
+            Gauge.builder("jvm.memory.used", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getUsed))
                 .tags(tagsWithId)
                 .description("The amount of used memory")
                 .baseUnit("bytes")
                 .register(registry);
 
-            Gauge.builder("jvm.memory.committed", memoryPoolBean, (mem) -> mem.getUsage().getCommitted())
+            Gauge.builder("jvm.memory.committed", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getCommitted))
                 .tags(tagsWithId)
                 .description("The amount of memory in bytes that is committed for the Java virtual machine to use")
                 .baseUnit("bytes")
                 .register(registry);
 
-            Gauge.builder("jvm.memory.max", memoryPoolBean, (mem) -> mem.getUsage().getMax())
+            Gauge.builder("jvm.memory.max", memoryPoolBean, (mem) -> getUsageValue(mem, MemoryUsage::getMax))
                 .tags(tagsWithId)
                 .description("The maximum amount of memory in bytes that can be used for memory management")
                 .baseUnit("bytes")
                 .register(registry);
         }
     }
+
+    private double getUsageValue(MemoryPoolMXBean memoryPoolMXBean, ToLongFunction<MemoryUsage> getter) {
+        MemoryUsage usage = getUsage(memoryPoolMXBean);
+        if (usage == null) {
+            return Double.NaN;
+        }
+        return getter.applyAsLong(usage);
+    }
+
+    private MemoryUsage getUsage(MemoryPoolMXBean memoryPoolMXBean) {
+        try {
+            return memoryPoolMXBean.getUsage();
+        } catch (InternalError e) {
+            // Defensive for potential InternalError with some specific JVM options. Based on its Javadoc,
+            // MemoryPoolMXBean.getUsage() should return null, not throwing InternalError, so it seems to be a JVM bug.
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
This PR changes to handle `null` `MemoryUsage` in `JvmMemoryMetrics`.

This PR also changes to be defensive against `InternalError` from `MemoryPoolMXBean.getUsage()` which seems to be a JDK bug based on its Javadoc.

Closes gh-1224