### PR TITLE
Handle empty histogram distribution in Stackdriver registry

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -369,6 +369,9 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
 
         private Distribution distribution(HistogramSnapshot snapshot, boolean timeDomain) {
             CountAtBucket[] histogram = snapshot.histogramCounts();
+            if (histogram.length == 0) {
+                return Distribution.newBuilder().build();
+            }
 
             // selected finite buckets (represented as a normal histogram)
             AtomicLong truncatedSum = new AtomicLong();


### PR DESCRIPTION
The meter `jvm.gc.pause` was causing an `ArrayIndexOutOfBoundsException` when initially exporting since the `StepTimer` did not contain any histogram buckets.

This PR re-submits https://github.com/micrometer-metrics/micrometer/pull/1160 but against the 1.1.x branch.

The id of the meter that failed in my case was 

```
MeterId{name='jvm.gc.pause', tags=[tag(action=end of minor GC),tag(cause=Allocation Failure)]}
```

and contained a snapshot of
```
HistogramSnapshot{count=0, total=0.0, mean=0.0, max=2.0E7}
```

There are not any existing unit tests that I could update to verify my change, so I instead verified it by hand with a Spring Boot application. I verified the GCP Stackdriver metrics request included all expected entries especially the `jvm/gc/pause`:
```
time_series {
  metric {
    labels {
      key: "cause"
      value: "Allocation Failure"
    }
    labels {
      key: "action"
      value: "end of minor GC"
    }
    type: "custom.googleapis.com/jvm/gc/pause/max"
  }
  resource {
    type: "global"
    labels {
      key: "project_id"
      value: "...."
    }
  }
  metric_kind: GAUGE
  value_type: DOUBLE
  points {
    interval {
      end_time {
        seconds: 1547588380
        nanos: 376000000
      }
    }
    value {
      double_value: 29.0
    }
  }
}
```

Unit testing is also difficult as discussed here https://github.com/micrometer-metrics/micrometer/pull/1160#issuecomment-457350068 where it is currently not feasible to mock the Stackdriver client interactions.

Fixes #1001 

cc @shakuzen 