### PR TITLE
Simplify build configuration for JDK versions > 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
 
       - checkout
@@ -39,48 +39,12 @@ jobs:
       - store_artifacts:
           path: ~/micrometer/test-results/
 
-  build_jdk11:
-    working_directory: ~/micrometer
-    environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-    docker:
-    - image: circleci/openjdk:11-jdk
-    steps:
-
-    - checkout
-
-    - restore_cache:
-        key: gradle-dependencies-{{ checksum "build.gradle" }}
-
-    - run:
-        name: downloadDependencies
-        command: ./gradlew downloadDependencies --console=plain
-
-    - save_cache:
-        key: gradle-dependencies-{{ checksum "build.gradle" }}
-        paths:
-        - ~/.gradle
-
-    - run:
-        name: run tests
-        command: ./gradlew check test
-
-    - run:
-        name: collect test reports
-        when: always
-        command: |
-          mkdir -p ~/micrometer/test-results/junit/
-          find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/micrometer/test-results/junit/ \;
-
-    - store_test_results:
-        path: ~/micrometer/test-results/
-
   deploy:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: circleci/openjdk:8-jdk
+      - image: circleci/openjdk:11-jdk
     steps:
       - checkout
       - restore_cache:
@@ -94,11 +58,9 @@ workflows:
   build_and_deploy:
     jobs:
       - build
-      - build_jdk11
       - deploy:
           requires:
             - build
-            - build_jdk11
           filters:
             branches:
               only:

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,20 @@ subprojects {
         }
     }
 
-    compileJava.options.encoding = 'UTF-8'
-    compileTestJava.options.encoding = 'UTF-8'
+    tasks {
+        compileJava {
+            options.encoding = 'UTF-8'
+            // ensure Java 8 baseline is enforced for main source
+            if (JavaVersion.current().isJava9Compatible()) {
+                options.compilerArgs.addAll(['--release', '8'])
+            }
+        }
+        compileTestJava {
+            options.encoding = 'UTF-8'
+            sourceCompatibility = JavaVersion.current()
+            targetCompatibility = JavaVersion.current()
+        }
+    }
 
     if(!project.name.contains('samples') && !project.name.contains('benchmarks')) {
         apply plugin: 'io.spring.publishing'


### PR DESCRIPTION
This adapts the setup that the JUnit 5 build uses to achieve the same (see https://github.com/junit-team/junit5/blob/master/build.gradle.kts) Java 8 compatibility without needing a build with JDK 8.

The build continues to work with JDK 8 and 11, but Java 8 compatible artifacts can be reliably produced with just a JDK 11 build using the new Java compiler arg `--release` (see [JEP 247](https://openjdk.java.net/jeps/247)). This opens up the opportunity for us to increase our build's JDK version while maintaining compatibility with Java 8 and not increasing complexity. If we want to use Java 9+ language features in test code, that is also a possibility now, but will require all contributors to have at least that version of the JDK installed to build locally.

---

Let me know what people think of this. It feels like a better future-looking direction to go.