### PR TITLE
Update TagsTest to adapt breaking changes in AssertJ 3.12.0

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
@@ -220,7 +220,7 @@ class TagsTest {
     void iteratorShouldIterateTags() {
         Tags tags = Tags.of("t1", "v1");
         Iterator<Tag> iterator = tags.iterator();
-        assertThat(iterator).containsExactly(Tag.of("t1", "v1"));
+        assertThat(iterator).toIterable().containsExactly(Tag.of("t1", "v1"));
     }
 
     @Test
@@ -282,7 +282,7 @@ class TagsTest {
 
     @Test
     void emptyShouldNotContainTags() {
-        assertThat(Tags.empty().iterator()).isEmpty();
+        assertThat(Tags.empty().iterator()).isExhausted();
     }
 
     private void assertTags(Tags tags, String... keyValues) {


### PR DESCRIPTION
This PR updates `TagsTest` to adapt breaking changes in AssertJ 3.12.0 made in https://github.com/joel-costigliola/assertj-core/commit/acafa14.