### PR TITLE
Remove inaccurate statement from MeterRegistry#gauge JavaDoc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -407,12 +407,6 @@ public abstract class MeterRegistry implements AutoCloseable {
      * Register a gauge that reports the value of the object after the function
      * {@code f} is applied. The registration will keep a weak reference to the object so it will
      * not prevent garbage collection. Applying {@code f} on the object should be thread safe.
-     * <p>
-     * If multiple gauges are registered with the same id, then the values will be aggregated and
-     * the sum will be reported. For example, registering multiple gauges for active threads in
-     * a thread pool with the same id would produce a value that is the overall number
-     * of active threads. For other behaviors, manage it on the user side and avoid multiple
-     * registrations.
      *
      * @param name          Name of the gauge being registered.
      * @param tags          Sequence of dimensions for breaking down the name.


### PR DESCRIPTION
As stated in https://github.com/micrometer-metrics/micrometer/issues/1176, the behaviour described in the javadoc never existed.

Fixes #1176