### PR TITLE
Use Maven-compatible versions

### DIFF
--- a/implementations/micrometer-registry-appoptics/build.gradle
+++ b/implementations/micrometer-registry-appoptics/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
     testCompile 'org.mockito:mockito-core:latest.release'

--- a/implementations/micrometer-registry-azure-monitor/build.gradle
+++ b/implementations/micrometer-registry-azure-monitor/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':micrometer-core')
     compile 'com.microsoft.azure:applicationinsights-core:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
     // required by jdk 9+

--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'nebula.optional-base'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
     compile 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
 
     testCompile project(':micrometer-test')

--- a/implementations/micrometer-registry-datadog/build.gradle
+++ b/implementations/micrometer-registry-datadog/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'nebula.optional-base'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
     compile 'org.apache.commons:commons-text:latest.release'
 
     testCompile project(':micrometer-test')

--- a/implementations/micrometer-registry-dynatrace/build.gradle
+++ b/implementations/micrometer-registry-dynatrace/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'nebula.optional-base'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
     compile 'org.apache.commons:commons-text:latest.release'
 
     testCompile project(':micrometer-test')

--- a/implementations/micrometer-registry-graphite/build.gradle
+++ b/implementations/micrometer-registry-graphite/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-graphite:4.0.+'
+    compile 'io.dropwizard.metrics:metrics-graphite:[4.0,4.1)'
 
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor.netty:reactor-netty:latest.release'

--- a/implementations/micrometer-registry-influx/build.gradle
+++ b/implementations/micrometer-registry-influx/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-jmx/build.gradle
+++ b/implementations/micrometer-registry-jmx/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-jmx:4.0.+'
+    compile 'io.dropwizard.metrics:metrics-jmx:[4.0,4.1)'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-new-relic/build.gradle
+++ b/implementations/micrometer-registry-new-relic/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-signalfx/build.gradle
+++ b/implementations/micrometer-registry-signalfx/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':micrometer-core')
     compile 'com.signalfx.public:signalfx-java:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-wavefront/build.gradle
+++ b/implementations/micrometer-registry-wavefront/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    compile 'org.slf4j:slf4j-api:[1.7,1.8)'
 
     testCompile project(':micrometer-test')
 }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     }
 
     // instrumentation options
-    compile 'io.dropwizard.metrics:metrics-core:4.0.+', optional
+    compile 'io.dropwizard.metrics:metrics-core:[4.0,4.1)', optional
 
     // cache monitoring
     compile 'com.google.guava:guava:latest.release', optional
@@ -30,8 +30,8 @@ dependencies {
 
     // server runtime monitoring
     // 9.4+ are incompatible with the latest version of wiremock as of 1/4/2019
-    compile 'org.eclipse.jetty:jetty-server:9.2.+', optional
-    compile 'org.apache.tomcat.embed:tomcat-embed-core:8.+', optional
+    compile 'org.eclipse.jetty:jetty-server:[9.2,9.3)', optional
+    compile 'org.apache.tomcat.embed:tomcat-embed-core:[8,9)', optional
 
     // hystrix monitoring
     // metrics are better with https://github.com/Netflix/Hystrix/pull/1568 introduced
@@ -40,15 +40,15 @@ dependencies {
     compile 'com.netflix.hystrix:hystrix-core:1.5.12', optional
 
     // log monitoring
-    compile 'ch.qos.logback:logback-classic:1.2.+', optional
-    compile 'org.apache.logging.log4j:log4j-core:2.+', optional
+    compile 'ch.qos.logback:logback-classic:[1.2,1.3)', optional
+    compile 'org.apache.logging.log4j:log4j-core:[2,3)', optional
 
     // reactor
     compile 'io.projectreactor:reactor-core:latest.release', optional
     compile 'io.projectreactor.netty:reactor-netty:latest.release', optional
 
     // @Timed AOP
-    compile 'org.aspectj:aspectjweaver:1.8.+', optional
+    compile 'org.aspectj:aspectjweaver:[1.8,1.9)', optional
 
     compile 'com.squareup.okhttp3:okhttp:latest.release', optional
 

--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'nebula.optional-base'
 
 dependencies {
     compile project(':micrometer-core')
-    compile 'org.glassfish.jersey.core:jersey-server:2.+', optional
-    runtime 'org.glassfish.jersey.inject:jersey-hk2:2.+'
+    compile 'org.glassfish.jersey.core:jersey-server:[2,3)', optional
+    runtime 'org.glassfish.jersey.inject:jersey-hk2:[2,3)'
 
     testCompile 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+'
 

--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.springframework:spring-webmvc', optional
     compile 'org.springframework:spring-web', optional
     compile 'javax.servlet:javax.servlet-api:3.1.0', optional
-    compile 'org.aspectj:aspectjweaver:1.8.+', optional
+    compile 'org.aspectj:aspectjweaver:[1.8,1.9)', optional
     compile 'io.prometheus:simpleclient_pushgateway:latest.release', optional
 
     ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'signalfx', 'wavefront', 'dynatrace', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->


### PR DESCRIPTION
This PR changes to use Maven-compatible versions as the current Gradle build shows as follows:

```
...
Maven publication 'nebula' contains dependencies that will produce a pom file that cannot be consumed by a Maven client.
  - org.eclipse.jetty:jetty-server:9.2.+ declared with a Maven incompatible version notation
  - org.apache.logging.log4j:log4j-core:2.+ declared with a Maven incompatible version notation
  - io.dropwizard.metrics:metrics-core:4.0.+ declared with a Maven incompatible version notation
  - ch.qos.logback:logback-classic:1.2.+ declared with a Maven incompatible version notation
  - org.aspectj:aspectjweaver:1.8.+ declared with a Maven incompatible version notation
  - org.apache.tomcat.embed:tomcat-embed-core:8.+ declared with a Maven incompatible version notation
...
```