### PR TITLE
Prevent publishing metrics to AppOptics when having no metrics

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -48,7 +48,9 @@ import static java.util.stream.Collectors.joining;
  */
 public class AppOpticsMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("appoptics-metrics-publisher");
-    private static final String BODY_NO_MEASUREMENTS = "{\"measurements\":[]}";
+    private static final String BODY_MEASUREMENTS_PREFIX = "{\"measurements\":[";
+    private static final String BODY_MEASUREMENTS_SUFFIX = "]}";
+    private static final String BODY_MEASUREMENTS_NONE = BODY_MEASUREMENTS_PREFIX + BODY_MEASUREMENTS_SUFFIX;
 
     private final Logger logger = LoggerFactory.getLogger(AppOpticsMeterRegistry.class);
 
@@ -111,8 +113,8 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
                         )
                         .filter(Optional::isPresent)
                         .map(Optional::get)
-                        .collect(joining(",", "{\"measurements\":[", "]}"));
-                if (body.equals(BODY_NO_MEASUREMENTS)) {
+                        .collect(joining(",", BODY_MEASUREMENTS_PREFIX, BODY_MEASUREMENTS_SUFFIX));
+                if (body.equals(BODY_MEASUREMENTS_NONE)) {
                     continue;
                 }
                 httpClient.post(config.uri())

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -48,6 +48,7 @@ import static java.util.stream.Collectors.joining;
  */
 public class AppOpticsMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("appoptics-metrics-publisher");
+    private static final String BODY_NO_MEASUREMENTS = "{\"measurements\":[]}";
 
     private final Logger logger = LoggerFactory.getLogger(AppOpticsMeterRegistry.class);
 
@@ -111,7 +112,7 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
                         .filter(Optional::isPresent)
                         .map(Optional::get)
                         .collect(joining(",", "{\"measurements\":[", "]}"));
-                if (body.equals("{\"measurements\":[]}")) {
+                if (body.equals(BODY_NO_MEASUREMENTS)) {
                     continue;
                 }
                 httpClient.post(config.uri())


### PR DESCRIPTION
This PR changes to prevent publishing metrics to AppOptics when having no metrics.

Closes gh-1235