### PR TITLE
added elasticsearch pipeline support

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -44,7 +44,8 @@ public interface ElasticConfig extends StepRegistryConfig {
      * @return property pipeline
      */
     default String pipeline() {
-        return null;
+        String v = get(prefix() + ".pipeline");
+        return v == null ? "" : v;
     }
 
     /**
@@ -131,5 +132,16 @@ public interface ElasticConfig extends StepRegistryConfig {
     default String password() {
         String v = get(prefix() + ".password");
         return v == null ? "" : v;
+    }
+
+    /**
+     * The separator to be used between the index name and the date format for rolling indices.
+     * Default is: "-"
+     *
+     * @return separator for rolling indixes date
+     */
+    default String dateFormatPrefix() {
+        String v = get(prefix() + ".dateFormatPrefix");
+        return v == null ? "-" : v;
     }
 }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -39,6 +39,15 @@ public interface ElasticConfig extends StepRegistryConfig {
     String get(String key);
 
     /**
+     * Property pipeline to be used to process incoming metrics.
+     *
+     * @return property pipeline
+     */
+    default String pipeline() {
+        return null;
+    }
+
+    /**
      * Property prefix to prepend to configuration names.
      *
      * @return property prefix

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -275,10 +275,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
         consumer.accept(sb);
         sb.append("}");
-        if(config.pipeline() != null && !config.pipeline().isEmpty()){
-            sb.append(",\"pipeline\":\"");
-            sb.append(config.pipeline());
-            sb.append("\"");
+        if (config.pipeline() != null && !config.pipeline().isEmpty()) {
+            sb.append(",\"pipeline\":\"").append(config.pipeline()).append("\"");
         }
         sb.append("}");
 

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -166,7 +166,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     private String indexName() {
         ZonedDateTime dt = ZonedDateTime.ofInstant(new Date(config().clock().wallTime()).toInstant(), ZoneOffset.UTC);
-        return config.index() + "-" + indexDateFormatter.format(dt);
+        return config.index() + config.dateFormatPrefix() + indexDateFormatter.format(dt);
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -263,7 +263,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         String timestamp = TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(config().clock().wallTime()));
         String name = getConventionName(meter.getId());
         String type = meter.getId().getType().toString().toLowerCase();
-        sb.append("{\"").append(config.timestampFieldName()).append("\":\"").append(timestamp).append('"')
+        sb.append("{\"index\":{\"").append(config.timestampFieldName()).append("\":\"").append(timestamp).append('"')
                 .append(",\"name\":\"").append(escapeJson(name)).append('"')
                 .append(",\"type\":\"").append(type).append('"');
 
@@ -274,6 +274,12 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         }
 
         consumer.accept(sb);
+        sb.append("}");
+        if(config.pipeline() != null && !config.pipeline().isEmpty()){
+            sb.append(",\"pipeline\":\"");
+            sb.append(config.pipeline());
+            sb.append("\"");
+        }
         sb.append("}");
 
         return sb.toString();

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -56,7 +56,7 @@ class ElasticMeterRegistryTest {
     @Test
     void writeTimer() {
         Timer timer = Timer.builder("myTimer").register(registry);
-        assertThat(registry.writeTimer(timer)).contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":0.0}");
+        assertThat(registry.writeTimer(timer)).contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":0,\"sum\":0.0,\"mean\":0.0,\"max\":0.0}}");
     }
 
     @Test
@@ -65,7 +65,7 @@ class ElasticMeterRegistryTest {
         counter.increment();
         clock.add(config.step());
         assertThat(registry.writeCounter(counter))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":1.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":1.0}}");
     }
 
     @Test
@@ -73,7 +73,7 @@ class ElasticMeterRegistryTest {
         FunctionCounter counter = FunctionCounter.builder("myCounter", 123.0, Number::doubleValue).register(registry);
         clock.add(config.step());
         assertThat(registry.writeFunctionCounter(counter))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":123.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"count\":123.0}}");
     }
 
     @Test
@@ -87,21 +87,21 @@ class ElasticMeterRegistryTest {
     void writeGauge() {
         Gauge gauge = Gauge.builder("myGauge", 123.0, Number::doubleValue).register(registry);
         assertThat(registry.writeGauge(gauge))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}}");
     }
 
     @Test
     void writeTimeGauge() {
         TimeGauge gauge = TimeGauge.builder("myGauge", 123.0, TimeUnit.MILLISECONDS, Number::doubleValue).register(registry);
         assertThat(registry.writeTimeGauge(gauge))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myGauge\",\"type\":\"gauge\",\"value\":123.0}}");
     }
 
     @Test
     void writeLongTaskTimer() {
         LongTaskTimer timer = LongTaskTimer.builder("longTaskTimer").register(registry);
         assertThat(registry.writeLongTaskTimer(timer))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"longTaskTimer\",\"type\":\"long_task_timer\",\"activeTasks\":0,\"duration\":0.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"longTaskTimer\",\"type\":\"long_task_timer\",\"activeTasks\":0,\"duration\":0.0}}");
     }
 
     @Test
@@ -111,14 +111,14 @@ class ElasticMeterRegistryTest {
         summary.record(456);
         clock.add(config.step());
         assertThat(registry.writeSummary(summary))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"summary\",\"type\":\"distribution_summary\",\"count\":2,\"sum\":579.0,\"mean\":289.5,\"max\":456.0}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"summary\",\"type\":\"distribution_summary\",\"count\":2,\"sum\":579.0,\"mean\":289.5,\"max\":456.0}}");
     }
 
     @Test
     void writeMeter() {
         Timer timer = Timer.builder("myTimer").register(registry);
         assertThat(registry.writeMeter(timer))
-                .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":\"0.0\",\"total\":\"0.0\",\"max\":\"0.0\"}");
+                .contains("{ \"index\" : {} }\n{\"index\":{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":\"0.0\",\"total\":\"0.0\",\"max\":\"0.0\"}}");
     }
 
     @Test
@@ -127,7 +127,7 @@ class ElasticMeterRegistryTest {
         counter.increment();
         clock.add(config.step());
         assertThat(registry.writeCounter(counter)).contains("{ \"index\" : {} }\n" +
-                "{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"foo\":\"bar\",\"spam\":\"eggs\",\"count\":1.0}");
+                "{\"index\":{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"myCounter\",\"type\":\"counter\",\"foo\":\"bar\",\"spam\":\"eggs\",\"count\":1.0}}");
     }
 
     @Issue("#497")
@@ -147,7 +147,7 @@ class ElasticMeterRegistryTest {
         c.increment(10);
         clock.add(config.step());
         assertThat(registry.writeCounter(c)).contains("{ \"index\" : {} }\n" +
-                "{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"counter\",\"type\":\"counter\",\"count\":10.0}");
+                "{\"index\":{\"@timestamp\":\"1970-01-01T00:01:00.001Z\",\"name\":\"counter\",\"type\":\"counter\",\"count\":10.0}}");
     }
 
     @Issue("#1134")

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -38,8 +38,7 @@ public class ElasticProperties extends StepRegistryProperties {
     private String index = "metrics";
 
     /**
-     * Index date format used for rolling indices. Appended to the index name, preceded by
-     * a '-'.
+     * Index date format used for rolling indices. Appended to the index name
      */
     private String indexDateFormat = "yyyy-MM";
 
@@ -67,6 +66,11 @@ public class ElasticProperties extends StepRegistryProperties {
      * Ingest pipeline of the Elastic server.
      */
     private String pipeline = "";
+
+    /**
+     * Prefix to separate the index name from the date format used for rolling indices.
+     */
+    private String dateFormatPrefix = "-";
 
     public String getHost() {
         return this.host;
@@ -130,6 +134,14 @@ public class ElasticProperties extends StepRegistryProperties {
 
     public void setPipeline(String pipeline) {
         this.pipeline = pipeline;
+    }
+
+    public String getDateFormatPrefix() {
+        return this.dateFormatPrefix;
+    }
+
+    public void setDateFormatPrefix(String dateFormatPrefix) {
+        this.dateFormatPrefix = dateFormatPrefix;
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -63,6 +63,11 @@ public class ElasticProperties extends StepRegistryProperties {
      */
     private String password = "";
 
+    /**
+     * Ingest pipeline of the Elastic server.
+     */
+    private String pipeline = "";
+
     public String getHost() {
         return this.host;
     }
@@ -117,6 +122,14 @@ public class ElasticProperties extends StepRegistryProperties {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getPipeline() {
+        return this.pipeline;
+    }
+
+    public void setPipeline(String pipeline) {
+        this.pipeline = pipeline;
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -68,4 +68,9 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
     public String pipeline() {
         return get(ElasticProperties::getPassword, ElasticConfig.super::pipeline);
     }
+
+    @Override
+    public String dateFormatPrefix() {
+        return get(ElasticProperties::getDateFormatPrefix, ElasticConfig.super::dateFormatPrefix);
+    }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -63,4 +63,9 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
     public String password() {
         return get(ElasticProperties::getPassword, ElasticConfig.super::password);
     }
+
+    @Override
+    public String pipeline() {
+        return get(ElasticProperties::getPassword, ElasticConfig.super::pipeline);
+    }
 }


### PR DESCRIPTION
Changes:

- Added an integration of ElasticSearch [ingest pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/pipeline.html) to be able to pre-processes micrometer metrics
- Added a way to customize the separator between the index name and the date part (not all of us are using `-`)