### PR TITLE
Avoid using raw types for MultiGauge if possible

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
@@ -33,7 +33,7 @@ class StrongReferenceGaugeFunction<T> implements ToDoubleFunction<T> {
      */
     @Nullable
     @SuppressWarnings("FieldCanBeLocal")
-    private final Object obj;
+    private final T obj;
 
     private final ToDoubleFunction<T> f;
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -92,7 +92,7 @@ class MultiGaugeTest {
             this.hex = hex;
         }
 
-        Row toRow(double frequency) {
+        Row<Color> toRow(double frequency) {
             return Row.of(Tags.of("color", name, "hex", hex), this, c -> frequency);
         }
     }


### PR DESCRIPTION
This PR changes to avoid using raw types in `MultiGauge` if possible. Unfortunately there's one use internally which seems to be inevitable to me.

See https://github.com/micrometer-metrics/micrometer/issues/1180#issuecomment-457519352