### PR TITLE
Fix a Javadoc warning for Timed.value()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
@@ -24,6 +24,8 @@ import java.lang.annotation.*;
 public @interface Timed {
     /**
      * Name of the Timer metric.
+     *
+     * @return name of the Timer metric
      */
     String value() default "";
 


### PR DESCRIPTION
This PR fixes a Javadoc warning for `Timed.value()`.