### PR TITLE
Added an integration of ElasticSearch ingest pipelines

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -123,4 +123,26 @@ public interface ElasticConfig extends StepRegistryConfig {
         String v = get(prefix() + ".password");
         return v == null ? "" : v;
     }
+
+    /**
+     * The ingest pipeline name.
+     * Default is: "" (= do not pre-process events)
+     *
+     * @return ingest pipeline name
+     */
+    default String pipeline() {
+        String v = get(prefix() + ".pipeline");
+        return v == null ? "" : v;
+    }
+
+    /**
+     * The separator between the index name and the date part.
+     * Default is: "-"
+     *
+     * @return index name separator
+     */
+    default String indexDateSeparator() {
+        String v = get(prefix() + ".indexDateSeparator");
+        return v == null ? "-" : v;
+    }
 }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -76,9 +76,9 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         indexDateFormatter = DateTimeFormatter.ofPattern(config.indexDateFormat());
         this.httpClient = httpClient;
         start(threadFactory);
-        if(config.pipeline() != null && !config.pipeline().isEmpty()){
-            indexLine = "{ \"index\" : {\"pipeline\":\""+config.pipeline()+"\"} }\n";
-        } else{
+        if (config.pipeline() != null && !config.pipeline().isEmpty()) {
+            indexLine = "{ \"index\" : {\"pipeline\":\"" + config.pipeline() + "\"} }\n";
+        } else {
             indexLine = "{ \"index\" : {} }\n";
         }
     }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -59,7 +59,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     private final DateTimeFormatter indexDateFormatter;
 
-    private final String indexLine = "{ \"index\" : {} }\n";
+    private final String indexLine;
 
     private volatile boolean checkedForIndexTemplate = false;
 

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -51,7 +51,6 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("elastic-metrics-publisher");
     static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_INSTANT;
     private static final String ES_METRICS_TEMPLATE = "/_template/metrics_template";
-    private static final String INDEX_LINE = "{ \"index\" : {} }\n";
 
     private final Logger logger = LoggerFactory.getLogger(ElasticMeterRegistry.class);
 
@@ -59,6 +58,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     private final HttpSender httpClient;
 
     private final DateTimeFormatter indexDateFormatter;
+
+    private final String indexLine = "{ \"index\" : {} }\n";
 
     private volatile boolean checkedForIndexTemplate = false;
 
@@ -75,6 +76,11 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         indexDateFormatter = DateTimeFormatter.ofPattern(config.indexDateFormat());
         this.httpClient = httpClient;
         start(threadFactory);
+        if(config.pipeline() != null && !config.pipeline().isEmpty()){
+            indexLine = "{ \"index\" : {\"pipeline\":\""+config.pipeline()+"\"} }\n";
+        } else{
+            indexLine = "{ \"index\" : {} }\n";
+        }
     }
 
     public static Builder builder(ElasticConfig config) {
@@ -166,7 +172,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     private String indexName() {
         ZonedDateTime dt = ZonedDateTime.ofInstant(new Date(config().clock().wallTime()).toInstant(), ZoneOffset.UTC);
-        return config.index() + "-" + indexDateFormatter.format(dt);
+        return config.index() + config.indexDateSeparator() + indexDateFormatter.format(dt);
     }
 
     // VisibleForTesting
@@ -259,7 +265,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     String writeDocument(Meter meter, Consumer<StringBuilder> consumer) {
-        StringBuilder sb = new StringBuilder(INDEX_LINE);
+        StringBuilder sb = new StringBuilder(indexLine);
         String timestamp = TIMESTAMP_FORMATTER.format(Instant.ofEpochMilli(config().clock().wallTime()));
         String name = getConventionName(meter.getId());
         String type = meter.getId().getType().toString().toLowerCase();

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -63,4 +63,16 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
     public String password() {
         return get(ElasticProperties::getPassword, ElasticConfig.super::password);
     }
+
+    @Override
+    public String pipeline() {
+        String v = get(prefix() + ".pipeline");
+        return v == null ? "" : v;
+    }
+
+    @Override
+    public String indexDateSeparator() {
+        String v = get(prefix() + ".indexDateSeparator");
+        return v == null ? "-" : v;
+    }
 }


### PR DESCRIPTION
Changes:

- Added an integration of ElasticSearch [ingest pipelines](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/pipeline.html) to be able to pre-processes micrometer metrics
- Added a way to customize the separator between the index name and the date part (not all of us are using `-`)