### PR TITLE
Run release script and maven central sync from CI for release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,21 @@ jobs:
           name: Deployment
           command: sh ./gradle/deploy.sh
 
+  maven-central-sync:
+    docker:
+      - image: circleci/openjdk:8-jdk
+    steps:
+      - checkout
+      - run:
+          name: Decrypt properties
+          command: openssl aes-256-cbc -d -in gradle.properties.enc -out gradle.properties -k $KEY -md md5
+      - deploy:
+          name: Maven Central sync
+          command: ./gradlew mavenCentralSync -Prelease.useLastTag=true -x bintrayPublish -x bintrayUpload -x bintrayCreateVersion -x bintrayCreatePackage
+
 workflows:
   version: 2
-  build_and_deploy:
+  build_prs_deploy_snapshots:
     jobs:
       - build
       - deploy:
@@ -66,5 +78,21 @@ workflows:
               only:
                 - master
                 - /\d+\.\d+\.x/
+  build_deploy_releases:
+    jobs:
+      - build:
+          filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
+      - deploy:
+          requires:
+            - build
+      - staging-approval:
+          type: approval
+          requires:
+            - deploy
+      - maven-central-sync:
+          requires:
+            - staging-approval


### PR DESCRIPTION
We had the build configuration and scripts available to do this already but the CI config was not setup for it. This makes it so maintainers do not have to run the release process locally and can instead make a release/tag in GitHub, which will start the new workflow. There is a manual approval stage between publishing to Jcenter and syncing to Maven Central so release artifacts can be consumed before final sync.

---

I also wrote a wiki page to explain the release process so it is documented and easier for anyone to understand/do it. See https://github.com/micrometer-metrics/micrometer/wiki/Releasing-Micrometer