### PR TITLE
Keep strong reference on Statistics in HibernateMetricsTest

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -32,7 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 /**
+ * Tests for {@link HibernateMetrics}.
+ *
  * @author Marten Deinum
+ * @author Johnny Lim
  */
 class HibernateMetricsTest {
 
@@ -59,7 +62,8 @@ class HibernateMetricsTest {
 
     @Test
     void shouldExposeMetricsWhenStatsEnabled() {
-        HibernateMetrics.monitor(registry, createEntityManagerFactoryMock(true), "entityManagerFactory");
+        EntityManagerFactory entityManagerFactory = createEntityManagerFactoryMock(true);
+        HibernateMetrics.monitor(registry, entityManagerFactory, "entityManagerFactory");
         assertThat(registry.get("hibernate.sessions.open").functionCounter().count()).isEqualTo(42.0);
         assertThat(registry.get("hibernate.sessions.closed").functionCounter().count()).isEqualTo(42.0);
 
@@ -109,7 +113,8 @@ class HibernateMetricsTest {
 
     @Test
     void shouldNotExposeMetricsWhenStatsNotEnabled() {
-        HibernateMetrics.monitor(registry, createEntityManagerFactoryMock(false), "entityManagerFactory");
+        EntityManagerFactory entityManagerFactory = createEntityManagerFactoryMock(false);
+        HibernateMetrics.monitor(registry, entityManagerFactory, "entityManagerFactory");
         assertThat(registry.find("hibernate.sessions.open").gauge()).isNull();
     }
 


### PR DESCRIPTION
This PR changes to keep strong reference on `Statistics` in `HibernateMetricsTest` as it seems that there's no strong reference, so it could be garbage-collected during the test. But I'm not 100% sure on this as I couldn't trigger this with `System.gc()`. I might miss something here.

Closes gh-1196