### PR TITLE
Polish zero-count bucket trimming logic in StackdriverMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -383,13 +383,18 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
                     .collect(toCollection(ArrayList::new));
 
             if (!bucketCounts.isEmpty()) {
+                int endIndex = bucketCounts.size() - 1;
                 // trim zero-count buckets on the right side of the domain
-                int lastNonzero = 0;
-                for (int i = 0; i < bucketCounts.size(); i++) {
-                    if (bucketCounts.get(i) > 0)
-                        lastNonzero = i;
+                if (bucketCounts.get(endIndex) == 0) {
+                    int lastNonZeroIndex = 0;
+                    for (int i = endIndex - 1; i >= 0; i--) {
+                        if (bucketCounts.get(i) > 0) {
+                            lastNonZeroIndex = i;
+                            break;
+                        }
+                    }
+                    bucketCounts = bucketCounts.subList(0, lastNonZeroIndex + 1);
                 }
-                bucketCounts = bucketCounts.subList(0, lastNonzero + 1);
             }
 
             // add the "+infinity" bucket, which does NOT have a corresponding bucket boundary


### PR DESCRIPTION
This PR polishes by:

- Not creating `SubList` if possible.
- Not iterating bucket count list fully if possible.