### PR TITLE
Fix conditional on beans for HibernateMetricsAutoConfiguration

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/orm/jpa/HibernateMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/orm/jpa/HibernateMetricsAutoConfiguration.java
@@ -24,9 +24,11 @@ import org.hibernate.SessionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 
@@ -42,13 +44,14 @@ import java.util.Map;
  *
  * @author Rui Figueira
  * @author Stephane Nicoll
+ * @author Johnny Lim
  * @since 1.1.0
  */
 @Configuration
 @AutoConfigureAfter({MetricsAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
         SimpleMetricsExportAutoConfiguration.class})
 @ConditionalOnClass({EntityManagerFactory.class, SessionFactory.class, MeterRegistry.class})
-@ConditionalOnBean({EntityManagerFactory.class, MeterRegistry.class})
+@Conditional(HibernateMetricsAutoConfiguration.HibernateMetricsConditionalOnBeans.class)
 public class HibernateMetricsAutoConfiguration {
     private static final String ENTITY_MANAGER_FACTORY_SUFFIX = "entityManagerFactory";
 
@@ -87,4 +90,21 @@ public class HibernateMetricsAutoConfiguration {
         }
         return beanName;
     }
+
+    static class HibernateMetricsConditionalOnBeans extends AllNestedConditions {
+
+        HibernateMetricsConditionalOnBeans() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+
+        @ConditionalOnBean(MeterRegistry.class)
+        static class ConditionalOnMeterRegistryBean {
+        }
+
+        @ConditionalOnBean(EntityManagerFactory.class)
+        static class ConditionalOnEntityManagerFactoryBean {
+        }
+
+    }
+
 }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/orm/jpa/HibernateMetricsAutoConfigurationTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/orm/jpa/HibernateMetricsAutoConfigurationTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure.orm.jpa;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManagerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link HibernateMetricsAutoConfiguration}.
+ *
+ * @author Johnny Lim
+ */
+class HibernateMetricsAutoConfigurationTest {
+
+    private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+
+    @AfterEach
+    void cleanUp() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    void autoConfigureKicksIn() {
+        registerAndRefresh(
+            MeterRegistryConfiguration.class,
+            EntityManagerFactoryConfiguration.class,
+            HibernateMetricsAutoConfiguration.class);
+        assertThat(context.getBean(HibernateMetricsAutoConfiguration.class)).isNotNull();
+    }
+
+    @Test
+    void autoConfigureWhenMeterRegistryBeanIsNotPresentShouldBackOff() {
+        registerAndRefresh(
+            EntityManagerFactoryConfiguration.class,
+            HibernateMetricsAutoConfiguration.class);
+        assertThat(context.getBeansOfType(HibernateMetricsAutoConfiguration.class)).isEmpty();
+    }
+
+    @Test
+    void autoConfigureWhenEntityManagerFactoryBeanIsNotPresentShouldBackOff() {
+        registerAndRefresh(
+            MeterRegistryConfiguration.class,
+            HibernateMetricsAutoConfiguration.class);
+        assertThat(context.getBeansOfType(HibernateMetricsAutoConfiguration.class)).isEmpty();
+    }
+
+    private void registerAndRefresh(Class<?>... configurationClasses) {
+        this.context.register(configurationClasses);
+        this.context.refresh();
+    }
+
+    @Configuration
+    static class MeterRegistryConfiguration {
+
+        @Bean
+        public MeterRegistry meterRegistry() {
+            return mock(MeterRegistry.class);
+        }
+
+    }
+
+    @Configuration
+    static class EntityManagerFactoryConfiguration {
+
+        @Bean
+        public EntityManagerFactory entityManagerFactory() {
+            EntityManagerFactory entityManagerFactory = mock(EntityManagerFactory.class);
+            SessionFactory sessionFactory = mock(SessionFactory.class);
+            when(sessionFactory.getStatistics()).thenReturn(mock(Statistics.class));
+            when(entityManagerFactory.unwrap(SessionFactory.class)).thenReturn(sessionFactory);
+            return entityManagerFactory;
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR fixes `@ConditionalOnBean` usage for `HibernateMetricsAutoConfiguration` as elements in `@ConditionalOnBean` `value` array attribute are evaluated with "or" in Spring Boot 1.5 or prior whereas they are evaluated with "and" since 2.0.