### PR TITLE
Polish Elasticsearch ingest pipeline and index separator support

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -129,6 +129,7 @@ public interface ElasticConfig extends StepRegistryConfig {
      * Default is: "" (= do not pre-process events)
      *
      * @return ingest pipeline name
+     * @since 1.2.0
      */
     default String pipeline() {
         String v = get(prefix() + ".pipeline");
@@ -140,6 +141,7 @@ public interface ElasticConfig extends StepRegistryConfig {
      * Default is: "-"
      *
      * @return index name separator
+     * @since 1.2.0
      */
     default String indexDateSeparator() {
         String v = get(prefix() + ".indexDateSeparator");

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -170,7 +170,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private String indexName() {
+    // VisibleForTesting
+    String indexName() {
         ZonedDateTime dt = ZonedDateTime.ofInstant(new Date(config().clock().wallTime()).toInstant(), ZoneOffset.UTC);
         return config.index() + config.indexDateSeparator() + indexDateFormatter.format(dt);
     }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -163,4 +163,32 @@ class ElasticMeterRegistryTest {
         TimeGauge gauge = TimeGauge.builder("myGauge", Double.NEGATIVE_INFINITY, TimeUnit.MILLISECONDS, Number::doubleValue).register(registry);
         assertThat(registry.writeTimeGauge(gauge)).isNotPresent();
     }
+
+    @Issue("#987")
+    @Test
+    void indexNameSupportsIndexNameWithoutDateSuffix() {
+        ElasticMeterRegistry registry = new ElasticMeterRegistry(new ElasticConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String index() {
+                return "my-metrics";
+            }
+
+            @Override
+            public String indexDateFormat() {
+                return "";
+            }
+
+            @Override
+            public String indexDateSeparator() {
+                return "";
+            }
+        }, clock);
+        assertThat(registry.indexName()).isEqualTo("my-metrics");
+    }
+
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticProperties.java
@@ -63,6 +63,16 @@ public class ElasticProperties extends StepRegistryProperties {
      */
     private String password = "";
 
+    /**
+     * Ingest pipeline name.
+     */
+    private String pipeline = "";
+
+    /**
+     * Separator between the index name and the date part.
+     */
+    private String indexDateSeparator = "-";
+
     public String getHost() {
         return this.host;
     }
@@ -117,6 +127,22 @@ public class ElasticProperties extends StepRegistryProperties {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getPipeline() {
+        return this.pipeline;
+    }
+
+    public void setPipeline(String pipeline) {
+        this.pipeline = pipeline;
+    }
+
+    public String getIndexDateSeparator() {
+        return this.indexDateSeparator;
+    }
+
+    public void setIndexDateSeparator(String indexDateSeparator) {
+        this.indexDateSeparator = indexDateSeparator;
     }
 
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/elastic/ElasticPropertiesConfigAdapter.java
@@ -66,13 +66,12 @@ class ElasticPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter
 
     @Override
     public String pipeline() {
-        String v = get(prefix() + ".pipeline");
-        return v == null ? "" : v;
+        return get(ElasticProperties::getPipeline, ElasticConfig.super::pipeline);
     }
 
     @Override
     public String indexDateSeparator() {
-        String v = get(prefix() + ".indexDateSeparator");
-        return v == null ? "-" : v;
+        return get(ElasticProperties::getIndexDateSeparator, ElasticConfig.super::indexDateSeparator);
     }
+
 }


### PR DESCRIPTION
This PR polishes Elasticsearch ingest pipeline and index separator support.

This PR also adds a test showing that gh-987 is supported now.

See gh-1244
Closes gh-987
Closes gh-988