### PR TITLE
Add continuation indent size to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ root = true
 [*.java]
 indent_style = space
 indent_size = 4
+continuation_indent_size = 8


### PR DESCRIPTION
This PR adds continuation indent size for Java sources to the `.editorconfig` file.