### PR TITLE
Handle missing exceptions in WebMvcMetricsFilter

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilter.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
  * Intercepts incoming HTTP requests and records metrics about execution time and results.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 @NonNullApi
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)
@@ -120,6 +121,9 @@ public class WebMvcMetricsFilter extends OncePerRequestFilter {
             response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
             record(timingContext, response, request, handlerObject, e.getCause());
             throw e;
+        } catch (ServletException | IOException | RuntimeException ex) {
+            record(timingContext, response, request, handlerObject, ex);
+            throw ex;
         }
     }
 

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/web/servlet/WebMvcMetricsFilterTest.java
@@ -43,10 +43,12 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -66,7 +68,9 @@ import java.util.concurrent.CyclicBarrier;
 import static io.micrometer.spring.web.servlet.WebMvcMetricsFilterTest.RedirectAndNotFoundFilter.TEST_MISBEHAVE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -166,6 +170,16 @@ public class WebMvcMetricsFilterTest {
         assertThat(this.registry.get("http.server.requests")
                 .tags("exception", "RuntimeException")
                 .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    public void streamingError() throws Exception {
+        MvcResult result = this.mvc.perform(get("/api/c1/streamingError"))
+                .andExpect(request().asyncStarted()).andReturn();
+        assertThatCode(
+                () -> this.mvc.perform(asyncDispatch(result)).andExpect(status().isOk()));
+        assertThat(this.registry.get("http.server.requests")
+                .tags("exception", "IOException").timer().count()).isEqualTo(1L);
     }
 
     @Test
@@ -353,6 +367,14 @@ public class WebMvcMetricsFilterTest {
         @GetMapping("/unhandledError/{id}")
         public String alwaysThrowsUnhandledException(@PathVariable Long id) {
             throw new RuntimeException("Boom on " + id + "!");
+        }
+
+        @GetMapping("/streamingError")
+        public ResponseBodyEmitter streamingError() {
+            ResponseBodyEmitter emitter = new ResponseBodyEmitter();
+            emitter.completeWithError(
+                    new IOException("error while writing to the response"));
+            return emitter;
         }
 
         @Timed


### PR DESCRIPTION
This PR changes to handle missing exceptions in `WebMvcMetricsFilter` by backporting changes from spring-projects/spring-boot#16014.

Closes gh-1190