### PR TITLE
Added instrumentation for Apache HttpComponents HttpRequestExecutor

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     compile 'org.eclipse.jetty:jetty-server:9.2.+', optional
     compile 'org.apache.tomcat.embed:tomcat-embed-core:8.+', optional
 
+    // apache httpcomponents monitoring
+    compile 'org.apache.httpcomponents:httpclient:4.5.6', optional
+
     // hystrix monitoring
     // metrics are better with https://github.com/Netflix/Hystrix/pull/1568 introduced
     // in hystrix 1.5.12, but Netflix re-released 1.5.11 as 1.5.18 late in 2018.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.http.*;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestExecutor;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+/**
+ * This HttpRequestExecutor tracks the request duration of every request, that
+ * goes through a {@link org.apache.http.client.HttpClient}. It must be
+ * registered as request executor when creating the HttpClient instance.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @since 1.2.0
+ */
+public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
+
+    public static final String DEFAULT_METER_NAME = "httpcomponents.httpclient.request";
+    public static final String DEFAULT_URI_PATTERN_HEADER = "URI_PATTERN";
+
+    private final MeterRegistry registry;
+    private final String requestsMetricName;
+    private final Function<HttpRequest, String> uriMapper;
+    private final Iterable<Tag> extraTags;
+    private final boolean exportTagsForRoute;
+
+    /**
+     * Use {@link #builder(MeterRegistry)} to create an instance of this class.
+     */
+    private MicrometerHttpRequestExecutor(int waitForContinue,
+                                          MeterRegistry registry,
+                                          String requestsMetricName,
+                                          Function<HttpRequest, String> uriMapper,
+                                          Iterable<Tag> extraTags,
+                                          boolean exportTagsForRoute) {
+        super(waitForContinue);
+        this.registry = registry;
+        this.requestsMetricName = requestsMetricName;
+        this.uriMapper = uriMapper;
+        this.extraTags = extraTags;
+        this.exportTagsForRoute = exportTagsForRoute;
+    }
+
+    /**
+     * Use this method to create an instance of {@link MicrometerHttpRequestExecutor}.
+     *
+     * @param registry The registry to register the metrics to. Will be the
+     *                 global registry in most cases.
+     * @return An instance of the builder, which allows further configuration of
+     * the request executor.
+     */
+    public static Builder builder(MeterRegistry registry) {
+        return new Builder(registry);
+    }
+
+    @Override
+    public HttpResponse execute(HttpRequest request, HttpClientConnection conn, HttpContext context) throws IOException, HttpException {
+        long startTime = registry.config().clock().monotonicTime();
+
+        Optional<HttpRequest> req = Optional.ofNullable(request);
+        String method = req.map(HttpRequest::getRequestLine).map(RequestLine::getMethod).orElse("unknown");
+        String uri = req.isPresent() ? uriMapper.apply(req.get()) : "unknown";
+        String status = "unknown";
+
+        Tags routeTags = exportTagsForRoute ? generateTagsForRoute(context) : Tags.empty();
+
+        try {
+            HttpResponse response = super.execute(request, conn, context);
+            status = Optional.ofNullable(response).map(HttpResponse::getStatusLine).map(StatusLine::getStatusCode).map(String::valueOf).orElse("unknown");
+            return response;
+        } catch (IOException | HttpException | RuntimeException e) {
+            status = "exception";
+            throw e;
+        } finally {
+            long endTime = registry.config().clock().monotonicTime();
+
+            Iterable<Tag> tags = Tags.of(extraTags).and(routeTags).and(
+                    "method", method,
+                    "uri", uri,
+                    "status", status
+            );
+
+            Timer.builder(this.requestsMetricName)
+                    .description("Duration of Apache HttpClient execution")
+                    .tags(tags)
+                    .register(registry)
+                    .record(endTime - startTime, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private Tags generateTagsForRoute(HttpContext context) {
+        Optional<HttpHost> route = Optional.ofNullable(context)
+                .map(ctx -> ctx.getAttribute("http.route"))
+                .filter(o -> o instanceof HttpRoute)
+                .map(o -> (HttpRoute) o)
+                .map(HttpRoute::getTargetHost);
+        String targetScheme = route.map(HttpHost::getSchemeName).orElse("unknown");
+        String targetHost = route.map(HttpHost::getHostName).orElse("unknown");
+        String targetPort = route.map(HttpHost::getPort).map(String::valueOf).orElse("unknown");
+        return Tags.of(
+                "target.scheme", targetScheme,
+                "target.host", targetHost,
+                "target.port", targetPort
+        );
+    }
+
+    public static class Builder {
+        private final MeterRegistry registry;
+        private int waitForContinue = HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE;
+        private String name = DEFAULT_METER_NAME;
+        private Iterable<Tag> tags = Collections.emptyList();
+        private Function<HttpRequest, String> uriMapper = new DefaultUriMapper();
+        private boolean exportTagsForRoute = false;
+
+        Builder(MeterRegistry registry) {
+            this.registry = registry;
+        }
+
+        /**
+         * @param waitForContinue Overrides the wait for continue time for this
+         *                        request executor. See {@link HttpRequestExecutor}
+         *                        for details.
+         * @return This builder instance.
+         */
+        public Builder waitForContinue(int waitForContinue) {
+            this.waitForContinue = waitForContinue;
+            return this;
+        }
+
+        /**
+         * @param name The name of the metric. By default {@link #DEFAULT_METER_NAME}.
+         * @return This builder instance.
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * @param tags Additional tags which should be exposed with every value.
+         * @return This builder instance.
+         */
+        public Builder tags(Iterable<Tag> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        /**
+         * Allows to register a mapping function for exposing request URIs. Be
+         * careful, exposing request URIs could result in a huge number of tag
+         * values, which could cause problems in your meter registry.
+         *
+         * By default, this feature is almost disabled. It only exposes values
+         * of the {@link #DEFAULT_URI_PATTERN_HEADER} HTTP header.
+         *
+         * @param uriMapper A mapper that allows mapping and exposing request
+         *                  paths. By default this feature is completely
+         * @return This builder instance.
+         * @see DefaultUriMapper
+         */
+        public Builder uriMapper(Function<HttpRequest, String> uriMapper) {
+            this.uriMapper = uriMapper;
+            return this;
+        }
+
+        /**
+         * Allows to expose the target scheme, host and port with every metric.
+         * Be careful with enabling this feature: If your client accesses a huge
+         * number of remote servers, this would result in a huge number of tag
+         * values, which could cause problems in your meter registry.
+         *
+         * By default, this feature is disabled.
+         *
+         * @param exportTagsForRoute Set this to true, if the metrics should be
+         *                           tagged with the target route.
+         * @return This builder instance.
+         */
+        public Builder exportTagsForRoute(boolean exportTagsForRoute) {
+            this.exportTagsForRoute = exportTagsForRoute;
+            return this;
+        }
+
+        /**
+         * @return Creates an instance of {@link MicrometerHttpRequestExecutor}
+         * with all the configured properties.
+         */
+        public MicrometerHttpRequestExecutor build() {
+            return new MicrometerHttpRequestExecutor(waitForContinue, registry, name, uriMapper, tags, exportTagsForRoute);
+        }
+    }
+
+    /**
+     * Extracts the pattern from the request header of the request if available.
+     */
+    private static class DefaultUriMapper implements Function<HttpRequest, String> {
+        @Override
+        public String apply(HttpRequest httpRequest) {
+            if (httpRequest != null) {
+                Header uriPattern = httpRequest.getLastHeader(DEFAULT_URI_PATTERN_HEADER);
+                if (uriPattern != null && uriPattern.getValue() != null) {
+                    return uriPattern.getValue();
+                } else {
+                    return "other";
+                }
+            } else {
+                return "none";
+            }
+        }
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -34,6 +34,15 @@ import java.util.function.Function;
  * This HttpRequestExecutor tracks the request duration of every request, that
  * goes through a {@link org.apache.http.client.HttpClient}. It must be
  * registered as request executor when creating the HttpClient instance.
+ * For example:
+ *
+ * <code><pre>
+ *     HttpClientBuilder.create()
+ *         .setRequestExecutor(MicrometerHttpRequestExecutor
+ *                 .builder(meterRegistry)
+ *                 .build())
+ *         .build();
+ * </pre></code>
  *
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
  * @author Tommy Ludwig

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -59,10 +59,10 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
                                           Iterable<Tag> extraTags,
                                           boolean exportTagsForRoute) {
         super(waitForContinue);
-        this.registry = registry;
-        this.requestsMetricName = requestsMetricName;
-        this.uriMapper = uriMapper;
-        this.extraTags = extraTags;
+        this.registry = Optional.ofNullable(registry).orElseThrow(() -> new IllegalArgumentException("registry is required but has been initialized with null"));
+        this.requestsMetricName = Optional.ofNullable(requestsMetricName).orElseThrow(() -> new IllegalArgumentException("requestMetricName is required but has been initialized with null"));
+        this.uriMapper = Optional.ofNullable(uriMapper).orElseThrow(() -> new IllegalArgumentException("uriMapper is required but has been initialized with null"));
+        this.extraTags = Optional.ofNullable(extraTags).orElse(Collections.emptyList());
         this.exportTagsForRoute = exportTagsForRoute;
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
@@ -210,6 +210,42 @@ public class MicrometerHttpRequestExecutorTest {
         assertThrows(MeterNotFoundException.class, () -> registry.get(EXPECTED_METER_NAME).timer());
     }
 
+    @Test
+    void settingNullRegistryThrowsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MicrometerHttpRequestExecutor.builder(null)
+                        .build());
+    }
+
+    @Test
+    void overridingNameWithNullThrowsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MicrometerHttpRequestExecutor.builder(registry)
+                        .name(null)
+                        .build()
+        );
+    }
+
+    @Test
+    void overridingUriMapperWithNullThrowsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MicrometerHttpRequestExecutor.builder(registry)
+                        .uriMapper(null)
+                        .build()
+        );
+    }
+
+    @Test
+    void overrideExtraTagsDoesNotThrowAnException(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .tags(null)
+                .build();
+        HttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)).isNotNull();
+    }
+
     private HttpClient client(HttpRequestExecutor executor) {
         return HttpClientBuilder.create()
                 .setRequestExecutor(executor)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link MicrometerHttpRequestExecutor}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+@ExtendWith(WiremockResolver.class)
+public class MicrometerHttpRequestExecutorTest {
+
+    private static final String EXPECTED_METER_NAME = "httpcomponents.httpclient.request";
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    private void setup() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    }
+
+    @Test
+    void timeSuccessful(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void httpMethodIsTagged(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpPost(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "POST")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void httpStatusCodeIsTagged(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(urlEqualTo("/ok")).willReturn(aResponse().withStatus(200)));
+        server.stubFor(any(urlEqualTo("/notfound")).willReturn(aResponse().withStatus(404)));
+        HttpClient client = client(executor(false));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/ok")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/ok")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/notfound")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET", "status", "200")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET", "status", "404")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void uriIsOtherByDefault(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/someuri")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/otheruri")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "other")
+                .timer().count()).isEqualTo(3L);
+    }
+
+    @Test
+    void uriIsReadFromHttpHeader(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        HttpGet getWithHeader = new HttpGet(server.baseUrl());
+        getWithHeader.addHeader("URI_PATTERN", "/some/pattern");
+        EntityUtils.consume(client.execute(getWithHeader).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/some/pattern")
+                .timer().count()).isEqualTo(1L);
+        assertThrows(MeterNotFoundException.class, () -> registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "other")
+                .timer());
+    }
+
+    @Test
+    void routeNotTaggedByDefault(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME)
+                .timer().getId().getTags().stream()
+                .map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).doesNotContain("target.scheme", "target.host", "target.port");
+        assertThat(tagKeys).contains("status", "method");
+    }
+
+    @Test
+    void routeTaggedIfEnabled(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(true));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME)
+                .timer().getId().getTags().stream()
+                .map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).contains("target.scheme", "target.host", "target.port");
+    }
+
+    @Test
+    void waitForContinueGetsPassedToSuper() {
+        // We cannot see the private variable inside the HttpRequestExecutor,
+        // but we can see, if its constructor fails because of an illegal value.
+        assertThrows(IllegalArgumentException.class, () -> MicrometerHttpRequestExecutor.builder(registry)
+                    .waitForContinue(-7654)
+                    .build());
+    }
+
+    @Test
+    void uriMapperWorksAsExpected(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .uriMapper(request -> request.getRequestLine().getUri())
+                .build();
+        HttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/foo")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/bar")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/foo")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/")
+                .timer().count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/foo")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/bar")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void additionalTagsAreExposed(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .tags(Tags.of("foo", "bar", "some.key", "value"))
+                .exportTagsForRoute(true)
+                .build();
+        HttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("foo", "bar", "some.key", "value", "target.host", "localhost")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void nameCanBeOverridden(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .name("some.other.metric.name")
+                .build();
+        HttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get("some.other.metric.name").timer().count()).isEqualTo(1L);
+        assertThrows(MeterNotFoundException.class, () -> registry.get(EXPECTED_METER_NAME).timer());
+    }
+
+    private HttpClient client(HttpRequestExecutor executor) {
+        return HttpClientBuilder.create()
+                .setRequestExecutor(executor)
+                .build();
+    }
+
+    private HttpRequestExecutor executor(boolean exportRoutes) {
+        return MicrometerHttpRequestExecutor.builder(registry)
+                .exportTagsForRoute(exportRoutes)
+                .build();
+    }
+
+}


### PR DESCRIPTION
The `MicrometerHttpRequestExecutor` can be used to monitor the execution time
of all requests going through a `HttpClient`. It collects metrics by HTTP
method and HTTP status.

In addition, it allows to tag the metrics by remote scheme, host and port and
also to tag the requested URLs (or URL patterns).

A feature for #533 