### PR TITLE
Add idle timings to ExecutorService monitoring

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
@@ -32,12 +32,16 @@ import static java.util.stream.Collectors.toList;
  * @author Jon Schneider
  */
 public class TimedExecutorService implements ExecutorService {
+    private final MeterRegistry registry;
     private final ExecutorService delegate;
-    private final Timer timer;
+    private final Timer executionTimer;
+    private final Timer idleTimer;
 
     public TimedExecutorService(MeterRegistry registry, ExecutorService delegate, String executorServiceName, Iterable<Tag> tags) {
+        this.registry = registry;
         this.delegate = delegate;
-        this.timer = registry.timer("executor", Tags.concat(tags ,"name", executorServiceName));
+        this.executionTimer = registry.timer("executor", Tags.concat(tags, "name", executorServiceName));
+        this.idleTimer = registry.timer("executor.idle", Tags.concat(tags, "name", executorServiceName));
     }
 
     @Override
@@ -67,17 +71,17 @@ public class TimedExecutorService implements ExecutorService {
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(timer.wrap(task));
+        return delegate.submit(wrap(task));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(() -> timer.record(task), result);
+        return delegate.submit(wrap(task), result);
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(() -> timer.record(task));
+        return delegate.submit(wrap(task));
     }
 
     @Override
@@ -102,10 +106,18 @@ public class TimedExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        delegate.execute(timer.wrap(command));
+        delegate.execute(wrap(command));
+    }
+
+    private Runnable wrap(Runnable task) {
+        return new TimedRunnable(registry, executionTimer, idleTimer, task);
+    }
+
+    private <T> Callable<T> wrap(Callable<T> task) {
+        return new TimedCallable<>(registry, executionTimer, idleTimer, task);
     }
 
     private <T> Collection<? extends Callable<T>> wrapAll(Collection<? extends Callable<T>> tasks) {
-        return tasks.stream().map(timer::wrap).collect(toList());
+        return tasks.stream().map(this::wrap).collect(toList());
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedRunnable.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,36 @@
 package io.micrometer.core.instrument.internal;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 
-import java.util.concurrent.Executor;
-
 /**
- * An {@link Executor} that is timed
+ * A wrapper for a Runnable with idle and execution timings
+ *
+ * @author Sebastian Lövdahl
  */
-public class TimedExecutor implements Executor {
+class TimedRunnable implements Runnable {
     private final MeterRegistry registry;
-    private final Executor delegate;
     private final Timer executionTimer;
     private final Timer idleTimer;
+    private final Runnable command;
+    private final Timer.Sample idleSample;
 
-    public TimedExecutor(MeterRegistry registry, Executor delegate, String executorName, Iterable<Tag> tags) {
+    TimedRunnable(MeterRegistry registry, Timer executionTimer, Timer idleTimer, Runnable command) {
         this.registry = registry;
-        this.delegate = delegate;
-        this.executionTimer = registry.timer("executor.execution", Tags.concat(tags, "name", executorName));
-        this.idleTimer = registry.timer("executor.idle", Tags.concat(tags, "name", executorName));
+        this.executionTimer = executionTimer;
+        this.idleTimer = idleTimer;
+        this.command = command;
+        this.idleSample = Timer.start(registry);
     }
 
     @Override
-    public void execute(Runnable command) {
-        delegate.execute(new TimedRunnable(registry, executionTimer, idleTimer, command));
+    public void run() {
+        idleSample.stop(idleTimer);
+        Timer.Sample executionSample = Timer.start(registry);
+        try {
+            command.run();
+        } finally {
+            executionSample.stop(executionTimer);
+        }
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -102,6 +102,7 @@ class ExecutorServiceMetricsTest {
         pool.awaitTermination(1, TimeUnit.SECONDS);
 
         assertThat(registry.get("executor").tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get("executor.idle").tags(userTags).timer().count()).isEqualTo(2L);
         assertThat(registry.get("executor.queued").tags(userTags).gauge().value()).isEqualTo(0.0);
     }
 
@@ -111,6 +112,7 @@ class ExecutorServiceMetricsTest {
         registry.get("executor.queue.remaining").tags(userTags).tag("name", executorName).gauge();
         registry.get("executor.active").tags(userTags).tag("name", executorName).gauge();
         registry.get("executor.pool.size").tags(userTags).tag("name", executorName).gauge();
+        registry.get("executor.idle").tags(userTags).tag("name", executorName).timer();
         registry.get("executor").tags(userTags).tag("name", executorName).timer();
     }
 }


### PR DESCRIPTION
Idle timings were implemented in #763, but only if the input is an `Executor`. This change implements idle timings if the input is an `ExecutorService` instance.