### PR TITLE
Log payload for failed metric posts

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -246,7 +246,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                                     postMessage.metricCount, postMessage.payload.getBytes(UTF_8).length);
                             }
                         })
-                        .onError(response -> logger.error("failed to send metrics to dynatrace: {}", response.body()));
+                        .onError(response -> logger.error("failed to send metrics to dynatrace: {} - requestPayload ({})", response.body(), postMessage.payload));
             }
         } catch (Throwable e) {
             logger.error("failed to send metrics to dynatrace", e);


### PR DESCRIPTION
We have seen "failed to send metrics to dynatrace" errors with not enough indication on the actual root cause. Logging the actual requestPayload will give us more troubleshooting insights in case this problem happens again