### PR TITLE
Added OSHI metrics support

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     compile 'com.hazelcast:hazelcast:latest.release', optional
     compile 'org.hibernate:hibernate-entitymanager:latest.release', optional
 
+    // oshi
+    compile 'com.github.oshi:oshi-core:3.13.0', optional
+
+
     // server runtime monitoring
     // 9.4+ are incompatible with the latest version of wiremock as of 1/4/2019
     compile 'org.eclipse.jetty:jetty-server:9.2.+', optional

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/JvmProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/JvmProcessorMetrics.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+import io.micrometer.core.lang.Nullable;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Record metrics related to the CPU, gathered by the JVM.
+ * <p>
+ * Supported JVM implementations:
+ * <ul>
+ *     <li>HotSpot</li>
+ *     <li>J9</li>
+ * </ul>
+ */
+@NonNullApi
+@NonNullFields
+class JvmProcessorMetrics implements MeterBinder {
+
+    /** List of public, exported interface class names from supported JVM implementations. */
+    private static final List<String> OPERATING_SYSTEM_BEAN_CLASS_NAMES = Arrays.asList(
+        "com.sun.management.OperatingSystemMXBean", // HotSpot
+        "com.ibm.lang.management.OperatingSystemMXBean" // J9
+    );
+
+    private final Iterable<Tag> tags;
+
+    private final OperatingSystemMXBean operatingSystemBean;
+
+    @Nullable
+    private final Class<?> operatingSystemBeanClass;
+
+    @Nullable
+    private final Method systemCpuUsage;
+
+    @Nullable
+    private final Method processCpuUsage;
+
+    public JvmProcessorMetrics() {
+        this(emptyList());
+    }
+
+    public JvmProcessorMetrics(Iterable<Tag> tags) {
+        this.tags = tags;
+        this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
+        this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
+        this.systemCpuUsage = detectMethod("getSystemCpuLoad");
+        this.processCpuUsage = detectMethod("getProcessCpuLoad");
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Runtime runtime = Runtime.getRuntime();
+        Gauge.builder("system.cpu.count", runtime, Runtime::availableProcessors)
+            .tags(tags)
+            .description("The number of processors available to the Java virtual machine")
+            .register(registry);
+
+        if (operatingSystemBean.getSystemLoadAverage() >= 0) {
+            Gauge.builder("system.load.average.1m", operatingSystemBean, OperatingSystemMXBean::getSystemLoadAverage)
+                .tags(tags)
+                .description("The sum of the number of runnable entities queued to available processors and the number " +
+                    "of runnable entities running on the available processors averaged over a period of time")
+                .register(registry);
+        }
+
+        if (systemCpuUsage != null) {
+            Gauge.builder("system.cpu.usage", operatingSystemBean, x -> invoke(systemCpuUsage))
+                .tags(tags)
+                .description("The \"recent cpu usage\" for the whole system")
+                .register(registry);
+        }
+
+        if (processCpuUsage != null) {
+            Gauge.builder("process.cpu.usage", operatingSystemBean, x -> invoke(processCpuUsage))
+                .tags(tags)
+                .description("The \"recent cpu usage\" for the Java Virtual Machine process")
+                .register(registry);
+        }
+    }
+
+    private double invoke(@Nullable Method method) {
+        try {
+            return method != null ? (double) method.invoke(operatingSystemBean) : Double.NaN;
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            return Double.NaN;
+        }
+    }
+
+    @Nullable
+    private Method detectMethod(String name) {
+        requireNonNull(name);
+        if (operatingSystemBeanClass == null) {
+            return null;
+        }
+        try {
+            // ensure the Bean we have is actually an instance of the interface
+            operatingSystemBeanClass.cast(operatingSystemBean);
+            return operatingSystemBeanClass.getDeclaredMethod(name);
+        } catch (ClassCastException | NoSuchMethodException | SecurityException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private Class<?> getFirstClassFound(List<String> classNames) {
+        for (String className : classNames) {
+            try {
+                return Class.forName(className);
+            } catch (ClassNotFoundException ignore) {
+            }
+        }
+        return null;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/MemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/MemoryMetrics.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import oshi.SystemInfo;
+import oshi.hardware.GlobalMemory;
+
+import java.util.Collections;
+
+/**
+ * Collects physical memory (RAM) metrics from host.
+ *
+ * For detailed info, checkout https://github.com/oshi/oshi.
+ *
+ * @author Johan Rask
+ */
+public class MemoryMetrics implements MeterBinder {
+
+    private final GlobalMemory memory;
+    private final Iterable<Tag> tags;
+
+    public MemoryMetrics() {
+        this(Collections.emptyList());
+    }
+
+    public MemoryMetrics(Iterable<Tag> tags) {
+        this.memory = new SystemInfo().getHardware().getMemory();
+
+        this.tags = tags;
+    }
+
+    public void bindTo(MeterRegistry meterRegistry) {
+
+        Gauge.builder("system.memory.available", () -> memory.getAvailable())
+            .tags(tags)
+            .baseUnit("bytes")
+            .description("Memory available")
+            .register(meterRegistry);
+
+
+        Gauge.builder("system.memory.total", () -> memory.getTotal())
+            .tags(tags)
+            .baseUnit("bytes")
+            .description("Memory available")
+            .register(meterRegistry);
+
+
+        Gauge.builder("system.memory.used", () -> memory.getTotal() - memory.getAvailable())
+            .tags(tags)
+            .baseUnit("bytes")
+            .description("Memory available")
+
+            .register(meterRegistry);
+
+        Gauge.builder("system.memory.swap.total", () -> memory.getSwapTotal())
+            .tags(tags)
+            .baseUnit("bytes")
+            .description("Memory Swap total")
+            .register(meterRegistry);
+
+        Gauge.builder("system.memory.swap.used", () -> memory.getSwapUsed())
+            .tags(tags)
+            .baseUnit("bytes")
+            .description("Memory Swap used")
+            .register(meterRegistry);
+
+    }
+
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/NetworkMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/NetworkMetrics.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import oshi.SystemInfo;
+import oshi.hardware.NetworkIF;
+
+import java.util.Collections;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Collects bytes and packets sent on all network interfaces an a machine.
+ *
+ * @author Johan Rask (jrask)
+ */
+public class NetworkMetrics implements MeterBinder {
+
+    public static final int MAX_REFRESH_TIME = 5_000;
+
+    public enum NetworkMetric {
+
+        BYTES_RECEIVED,
+        BYTES_SENT,
+        PACKETS_RECEIVED,
+        PACKETS_SENT
+    }
+
+    private final Iterable<Tag> tags;
+    private final CachedNetworkStats networkStats =
+        new CachedNetworkStats(new SystemInfo().getHardware().getNetworkIFs());
+
+    public NetworkMetrics() {
+        this(Collections.emptyList());
+    }
+
+    public NetworkMetrics(Iterable<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry meterRegistry) {
+
+        FunctionCounter.builder("system.network.bytes.received",
+            NetworkMetric.BYTES_RECEIVED, this::getNetworkMetricAsLong)
+            .tags(tags)
+            .baseUnit("bytes")
+            .register(meterRegistry);
+
+        FunctionCounter.builder("system.network.bytes.sent",
+            NetworkMetric.BYTES_SENT, this::getNetworkMetricAsLong)
+            .tags(tags)
+            .baseUnit("bytes")
+            .register(meterRegistry);
+
+        FunctionCounter.builder("system.network.packets.received",
+            NetworkMetric.PACKETS_RECEIVED, this::getNetworkMetricAsLong)
+            .tags(tags)
+            .register(meterRegistry);
+
+        FunctionCounter.builder("system.network.packets.sent",
+            NetworkMetric.PACKETS_SENT, this::getNetworkMetricAsLong)
+            .tags(tags)
+            .register(meterRegistry);
+    }
+
+    private long getNetworkMetricAsLong(NetworkMetric type) {
+        networkStats.refresh();
+
+        switch (type) {
+            case BYTES_SENT: return networkStats.bytesSent;
+            case PACKETS_SENT: return networkStats.packetsSent;
+            case BYTES_RECEIVED: return networkStats.bytesReceived;
+            case PACKETS_RECEIVED: return networkStats.packetsReceived;
+            default: throw new IllegalStateException("Unknown NetworkMetrics: " + type.name());
+        }
+    }
+
+    private static class CachedNetworkStats {
+
+        private final Lock lock = new ReentrantLock();
+
+        private final NetworkIF[] networks;
+        private long lastRefresh = 0;
+
+        public volatile long bytesReceived;
+        public volatile long bytesSent;
+        public volatile long packetsReceived;
+        public volatile long packetsSent;
+
+        public CachedNetworkStats(NetworkIF[] networkIFs) {
+            this.networks = networkIFs;
+        }
+
+        public  void refresh() {
+            if (lock.tryLock()) {
+                try {
+                    doRefresh();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+
+        private  void doRefresh() {
+
+            if (System.currentTimeMillis() - lastRefresh < MAX_REFRESH_TIME) {
+                return;
+            }
+
+            long bytesReceived = 0;
+            long bytesSent = 0;
+            long packetsReceived = 0;
+            long packetsSent = 0;
+
+            for (NetworkIF nif : networks) {
+                nif.updateNetworkStats();
+                bytesReceived += nif.getBytesRecv();
+                bytesSent += nif.getBytesSent();
+                packetsReceived += nif.getPacketsRecv();
+                packetsSent += nif.getPacketsSent();
+
+            }
+            this.bytesReceived = bytesReceived;
+            this.bytesSent = bytesSent;
+            this.packetsReceived = packetsReceived;
+            this.packetsSent = packetsSent;
+
+            this.lastRefresh = System.currentTimeMillis();
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/OshiProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/OshiProcessorMetrics.java
@@ -1,0 +1,396 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.system;
+
+import com.sun.jna.Platform;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.util.ExecutingCommand;
+import oshi.util.ParseUtil;
+
+import java.util.Collections;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static io.micrometer.core.instrument.binder.system.OshiProcessorMetrics.ProcessorMetric.*;
+
+/**
+ * Collects CPU (percent and/or time total) and system load (1m, 15m, 15m) from host.
+ *
+ * Time total is most useful for i.e prometheus while percent might be more useful for i.e
+ * influxdb or elastic.
+ *
+ * @author Johan Rask (jrask)
+ */
+class OshiProcessorMetrics implements MeterBinder {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(OshiProcessorMetrics.class);
+
+
+    public static final int MIN_REFRESH_INTERVAL = 2000;
+
+
+    public enum CpuSampleType {
+        ALL,
+        SECONDS_TOTAL,
+        PERCENT
+    }
+
+    protected enum ProcessorMetric {
+        USER_PERCENT,
+        NICE_PERCENT,
+        SYSTEM_PERCENT,
+        IDLE_PERCENT,
+        IOWAIT_PERCENT,
+        IRQ_PERCENT,
+        SOFTIRQ_PERCENT,
+        STEAL_PERCENT,
+
+        LOAD_1M,
+        LOAD_5M,
+        LOAD_15M,
+
+        USER_TIME_SECONDS_TOTAL,
+        NICE_TIME_SECONDS_TOTAL,
+        SYS_TIME_SECONDS_TOTAL,
+        IDLE_TIME_SECONDS_TOTAL,
+        IOWAIT_TIME_IN_SECONDS_TOTAL,
+        IRQ_TIME_IN_SECONDS_TOTAL,
+        SOFTIRQ_TIME_IN_SECONDS_TOTAL,
+        STEAL_TIME_IN_SECONDS_TOTAL
+    }
+
+
+
+    protected final Iterable<Tag> tags;
+
+    protected final CalculatedCpuMetrics calculatedCpuMetrics;
+
+    static long TICKS_PER_SEC = -1;
+
+    static {
+        if (Platform.isMac() || Platform.isLinux()) {
+            TICKS_PER_SEC = ParseUtil.parseLongOrDefault(ExecutingCommand.getFirstAnswer("getconf CLK_TCK"),
+                -1L);
+            if (TICKS_PER_SEC == -1) {
+                LOG.info("Unable to determine ticks per second, cumulative cpu time in seconds will be disabled");
+            }
+        } else {
+            LOG.info("Cumulative cpu time in seconds is unsupported on this platform");
+        }
+    }
+
+    public static boolean isCpuTotalSecondsSupported() {
+        return TICKS_PER_SEC != -1;
+    }
+
+    public OshiProcessorMetrics() {
+        this(Collections.emptyList(), CpuSampleType.ALL);
+    }
+
+    public OshiProcessorMetrics(Iterable<Tag> tags, CpuSampleType cpuSampleType) {
+        this.tags = tags;
+        this.calculatedCpuMetrics =
+            new CalculatedCpuMetrics(new SystemInfo().getHardware().getProcessor(), cpuSampleType);
+    }
+
+    public OshiProcessorMetrics(CpuSampleType type) {
+        this(Collections.emptyList(), type);
+    }
+
+    /**
+     * Read the value of a specific value. This method mainly exists
+     * to make sure that refresh() is invoked properly instead of invoking it in
+     * each Meter.
+     */
+    private double getCpuMetricAsDouble(ProcessorMetric type) {
+        calculatedCpuMetrics.refresh();
+
+        switch (type) {
+            case USER_PERCENT: return calculatedCpuMetrics.user;
+            case NICE_PERCENT: return calculatedCpuMetrics.nice;
+            case SYSTEM_PERCENT: return calculatedCpuMetrics.sys;
+            case IDLE_PERCENT: return calculatedCpuMetrics.idle;
+            case IOWAIT_PERCENT: return calculatedCpuMetrics.iowait;
+            case IRQ_PERCENT: return calculatedCpuMetrics.irq;
+            case SOFTIRQ_PERCENT: return calculatedCpuMetrics.softirq;
+            case STEAL_PERCENT: return calculatedCpuMetrics.steal;
+
+            case LOAD_1M: return calculatedCpuMetrics.load1m;
+            case LOAD_5M: return calculatedCpuMetrics.load5m;
+            case LOAD_15M: return calculatedCpuMetrics.load15m;
+
+            case USER_TIME_SECONDS_TOTAL: return calculatedCpuMetrics.userTimeSecondsTotal;
+            case NICE_TIME_SECONDS_TOTAL: return calculatedCpuMetrics.niceTimeInSecondsTotal;
+            case SYS_TIME_SECONDS_TOTAL: return calculatedCpuMetrics.sysTimeInSecondsTotal;
+            case IDLE_TIME_SECONDS_TOTAL: return calculatedCpuMetrics.idleTimeInSecondsTotal;
+            case IOWAIT_TIME_IN_SECONDS_TOTAL: return calculatedCpuMetrics.iowaitTimeInSecondsTotal;
+            case IRQ_TIME_IN_SECONDS_TOTAL: return calculatedCpuMetrics.irqTimeInSecondsTotal;
+            case SOFTIRQ_TIME_IN_SECONDS_TOTAL: return calculatedCpuMetrics.softirqTimeInSecondsTotal;
+            case STEAL_TIME_IN_SECONDS_TOTAL: return calculatedCpuMetrics.stealTimeInSecondsTotal;
+            default: return 0;
+        }
+    }
+
+    /**
+     * Calculates and caches CPU load, CPU percent and cumulative cpu time in seconds.
+     *
+     */
+    protected static class CalculatedCpuMetrics {
+
+        public final CpuSampleType cpuSampleType;
+
+        // Why not make it thread-safe?
+        private final Lock lock = new ReentrantLock();
+
+        private long refreshTime = 0;
+        private final CentralProcessor processor;
+
+        private long prevTicks[] = null;
+
+
+        private volatile double user;
+        private volatile double nice;
+        private volatile double sys;
+        private volatile double idle;
+        private volatile double iowait;
+        private volatile double irq;
+        private volatile double softirq;
+        private volatile double steal;
+
+        private volatile double load1m;
+        private volatile double load5m;
+        private volatile double load15m;
+
+        private volatile long userTimeSecondsTotal;
+        private volatile long niceTimeInSecondsTotal;
+        private volatile long sysTimeInSecondsTotal;
+        private volatile long idleTimeInSecondsTotal;
+        private volatile long iowaitTimeInSecondsTotal;
+        private volatile long irqTimeInSecondsTotal;
+        private volatile long softirqTimeInSecondsTotal;
+        private volatile long stealTimeInSecondsTotal;
+
+        public CalculatedCpuMetrics(CentralProcessor processor) {
+            this.processor = processor;
+            cpuSampleType = CpuSampleType.ALL;
+        }
+
+        public CalculatedCpuMetrics(CentralProcessor processor, CpuSampleType cpuSampleType) {
+            this.processor = processor;
+            this.cpuSampleType = cpuSampleType;
+        }
+
+
+        public  void refresh() {
+            if (lock.tryLock()) {
+                try {
+                    doRefresh();
+                } finally {
+                    lock.unlock();
+                }
+            }
+        }
+
+        // Not sure if there are any concurrent threads involved?
+        private  void doRefresh() {
+
+            // First invocation
+            if (prevTicks == null) {
+                prevTicks = processor.getSystemCpuLoadTicks();
+                return;
+            }
+
+            // quick and dirty to prevent multiple refreshes
+            if (System.currentTimeMillis() - refreshTime < MIN_REFRESH_INTERVAL) {
+                return;
+            }
+
+            double[] systemLoadAverage = processor.getSystemLoadAverage(3);
+            load1m = systemLoadAverage[0] < 0 ? 0 : systemLoadAverage[0];
+            load5m = systemLoadAverage[1] < 0 ? 0 : systemLoadAverage[1];
+            load15m = systemLoadAverage[2] < 0 ? 0 : systemLoadAverage[2];
+
+            long[] ticks = processor.getSystemCpuLoadTicks();
+
+            if (cpuSampleType == CpuSampleType.ALL || cpuSampleType == CpuSampleType.PERCENT) {
+                long user = ticks[CentralProcessor.TickType.USER.getIndex()] - prevTicks[CentralProcessor.TickType.USER.getIndex()];
+                long nice = ticks[CentralProcessor.TickType.NICE.getIndex()] - prevTicks[CentralProcessor.TickType.NICE.getIndex()];
+                long sys = ticks[CentralProcessor.TickType.SYSTEM.getIndex()] - prevTicks[CentralProcessor.TickType.SYSTEM.getIndex()];
+                long idle = ticks[CentralProcessor.TickType.IDLE.getIndex()] - prevTicks[CentralProcessor.TickType.IDLE.getIndex()];
+                long iowait = ticks[CentralProcessor.TickType.IOWAIT.getIndex()] - prevTicks[CentralProcessor.TickType.IOWAIT.getIndex()];
+                long irq = ticks[CentralProcessor.TickType.IRQ.getIndex()] - prevTicks[CentralProcessor.TickType.IRQ.getIndex()];
+                long softirq = ticks[CentralProcessor.TickType.SOFTIRQ.getIndex()] - prevTicks[CentralProcessor.TickType.SOFTIRQ.getIndex()];
+                long steal = ticks[CentralProcessor.TickType.STEAL.getIndex()] - prevTicks[CentralProcessor.TickType.STEAL.getIndex()];
+                long totalCpu = user + nice + sys + idle + iowait + irq + softirq + steal;
+
+                this.user = 100d * user / totalCpu;
+                this.nice = 100d * nice / totalCpu;
+                this.sys = 100d * sys / totalCpu;
+                this.idle = 100d * idle / totalCpu;
+                this.iowait = 100d * iowait / totalCpu;
+                this.irq = 100d * irq / totalCpu;
+                this.softirq = 100d * softirq / totalCpu;
+                this.steal = 100d * steal / totalCpu;
+            }
+
+            if (isCpuTotalSecondsSupported() && (cpuSampleType == CpuSampleType.ALL || cpuSampleType == CpuSampleType.SECONDS_TOTAL)) {
+                this.userTimeSecondsTotal = ticks[CentralProcessor.TickType.USER.getIndex()] / TICKS_PER_SEC;
+                this.niceTimeInSecondsTotal = ticks[CentralProcessor.TickType.NICE.getIndex()] / TICKS_PER_SEC;
+                this.sysTimeInSecondsTotal = ticks[CentralProcessor.TickType.SYSTEM.getIndex()] / TICKS_PER_SEC;
+                this.idleTimeInSecondsTotal = ticks[CentralProcessor.TickType.IDLE.getIndex()] / TICKS_PER_SEC;
+                this.iowaitTimeInSecondsTotal = ticks[CentralProcessor.TickType.IOWAIT.getIndex()] / TICKS_PER_SEC;
+                this.irqTimeInSecondsTotal = ticks[CentralProcessor.TickType.IRQ.getIndex()] / TICKS_PER_SEC;
+                this.softirqTimeInSecondsTotal = ticks[CentralProcessor.TickType.SOFTIRQ.getIndex()] / TICKS_PER_SEC;
+                this.stealTimeInSecondsTotal = ticks[CentralProcessor.TickType.STEAL.getIndex()] / TICKS_PER_SEC;
+            }
+
+            refreshTime = System.currentTimeMillis();
+            prevTicks = ticks;
+        }
+    }
+
+
+    @Override
+    public void bindTo(MeterRegistry meterRegistry) {
+        if (calculatedCpuMetrics.cpuSampleType == CpuSampleType.ALL ||
+            calculatedCpuMetrics.cpuSampleType == CpuSampleType.SECONDS_TOTAL) {
+            cpuUsageInSeconds(meterRegistry);
+        }
+        if (calculatedCpuMetrics.cpuSampleType == CpuSampleType.ALL ||
+            calculatedCpuMetrics.cpuSampleType == CpuSampleType.PERCENT) {
+            cpuUsagePercent(meterRegistry);
+        }
+        systemLoad(meterRegistry);
+    }
+
+
+    private void cpuUsagePercent(MeterRegistry meterRegistry) {
+
+
+        Gauge.builder("system.cpu.usage.pct", ProcessorMetric.USER_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "user")
+            .description("User cpu usage in percent")
+            .register(meterRegistry);
+
+        Gauge.builder("system.cpu.usage.pct", ProcessorMetric.SYSTEM_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "system")
+            .description("System cpu usage in percent")
+            .register(meterRegistry);
+
+        Gauge.builder("system.cpu.usage.pct",  ProcessorMetric.IDLE_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "idle")
+            .description("Idle cpu usage in percent")
+            .register(meterRegistry);
+
+        Gauge.builder("system.cpu.usage.pct",  ProcessorMetric.NICE_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "nice")
+            .description("Nice cpu usage in percent")
+            .register(meterRegistry);
+
+        Gauge.builder("system.cpu.usage.pct",  ProcessorMetric.IRQ_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "irq")
+            .description("IRQ cpu usage in percent")
+            .register(meterRegistry);
+
+        Gauge.builder("system.cpu.usage.pct",  ProcessorMetric.SOFTIRQ_PERCENT, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("mode", "irq")
+            .description("SOFTIRQ cpu usage in percent")
+            .register(meterRegistry);
+    }
+
+    private void systemLoad(MeterRegistry meterRegistry) {
+
+        int cpuCount = calculatedCpuMetrics.processor.getPhysicalProcessorCount();
+
+        Gauge.builder("system.load.1m",  ProcessorMetric.LOAD_1M, this::getCpuMetricAsDouble )
+            .tags(tags)
+            .tag("cpus", String.valueOf(cpuCount))
+            .description("System load 1m")
+            .register(meterRegistry);
+
+        Gauge.builder("system.load.5m",  ProcessorMetric.LOAD_5M, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("cpus", String.valueOf(cpuCount))
+            .description("System load 5m")
+            .register(meterRegistry);
+
+        Gauge.builder("system.load.15m",  ProcessorMetric.LOAD_15M, this::getCpuMetricAsDouble)
+            .tags(tags)
+            .tag("cpus", String.valueOf(cpuCount))
+            .description("System load 15m")
+            .register(meterRegistry);
+    }
+
+
+    private void cpuUsageInSeconds(MeterRegistry meterRegistry) {
+
+        if (isCpuTotalSecondsSupported()) {
+
+            FunctionCounter.builder("system.cpu.seconds.total", USER_TIME_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "user")
+                .description("User cpu usage in percent")
+                .register(meterRegistry);
+
+            FunctionCounter.builder("system.cpu.seconds.total", IDLE_TIME_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "idle")
+                .description("User cpu idle in percent")
+                .register(meterRegistry);
+
+            FunctionCounter.builder("system.cpu.seconds.total", SYS_TIME_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "system")
+                .description("User cpu usage in percent")
+                .register(meterRegistry);
+
+            FunctionCounter.builder("system.cpu.seconds.total", IRQ_TIME_IN_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "irq")
+                .description("User cpu irq in percent")
+                .register(meterRegistry);
+
+            FunctionCounter.builder("system.cpu.seconds.total", SOFTIRQ_TIME_IN_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "softirq")
+                .description("User cpu softirq in percent")
+                .register(meterRegistry);
+
+            FunctionCounter.builder("system.cpu.seconds.total", STEAL_TIME_IN_SECONDS_TOTAL, this::getCpuMetricAsDouble)
+                .tags(tags)
+                .tag("mode", "steal")
+                .description("User cpu steal in percent")
+                .register(meterRegistry);
+
+        } else {
+            LOG.info("Cunulative cpu seconds counter is unsupported on this platform");
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -15,130 +15,34 @@
  */
 package io.micrometer.core.instrument.binder.system;
 
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.lang.NonNullApi;
-import io.micrometer.core.lang.NonNullFields;
-import io.micrometer.core.lang.Nullable;
-
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-
-import static java.util.Collections.emptyList;
-import static java.util.Objects.requireNonNull;
 
 /**
- * Record metrics related to the CPU, gathered by the JVM.
- * <p>
- * Supported JVM implementations:
- * <ul>
- *     <li>HotSpot</li>
- *     <li>J9</li>
- * </ul>
+ * Delegates to either JvmProcessorMetrics or OshiProessorMetrics depending
+ * on OS support.
+ *
+ * @author Johan Rask
  */
-@NonNullApi
-@NonNullFields
 public class ProcessorMetrics implements MeterBinder {
 
-    /** List of public, exported interface class names from supported JVM implementations. */
-    private static final List<String> OPERATING_SYSTEM_BEAN_CLASS_NAMES = Arrays.asList(
-        "com.sun.management.OperatingSystemMXBean", // HotSpot
-        "com.ibm.lang.management.OperatingSystemMXBean" // J9
-    );
 
-    private final Iterable<Tag> tags;
+    // TODO - What should default be? Must be backwards compatible by default I guess.
+    // TODO - Determine which to use depending on operating system
 
-    private final OperatingSystemMXBean operatingSystemBean;
-
-    @Nullable
-    private final Class<?> operatingSystemBeanClass;
-
-    @Nullable
-    private final Method systemCpuUsage;
-
-    @Nullable
-    private final Method processCpuUsage;
+    final MeterBinder processorMetrics;
 
     public ProcessorMetrics() {
-        this(emptyList());
+        processorMetrics = new JvmProcessorMetrics();
     }
 
     public ProcessorMetrics(Iterable<Tag> tags) {
-        this.tags = tags;
-        this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
-        this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
-        this.systemCpuUsage = detectMethod("getSystemCpuLoad");
-        this.processCpuUsage = detectMethod("getProcessCpuLoad");
+        processorMetrics = new JvmProcessorMetrics(tags);
     }
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        Runtime runtime = Runtime.getRuntime();
-        Gauge.builder("system.cpu.count", runtime, Runtime::availableProcessors)
-            .tags(tags)
-            .description("The number of processors available to the Java virtual machine")
-            .register(registry);
-
-        if (operatingSystemBean.getSystemLoadAverage() >= 0) {
-            Gauge.builder("system.load.average.1m", operatingSystemBean, OperatingSystemMXBean::getSystemLoadAverage)
-                .tags(tags)
-                .description("The sum of the number of runnable entities queued to available processors and the number " +
-                    "of runnable entities running on the available processors averaged over a period of time")
-                .register(registry);
-        }
-
-        if (systemCpuUsage != null) {
-            Gauge.builder("system.cpu.usage", operatingSystemBean, x -> invoke(systemCpuUsage))
-                .tags(tags)
-                .description("The \"recent cpu usage\" for the whole system")
-                .register(registry);
-        }
-
-        if (processCpuUsage != null) {
-            Gauge.builder("process.cpu.usage", operatingSystemBean, x -> invoke(processCpuUsage))
-                .tags(tags)
-                .description("The \"recent cpu usage\" for the Java Virtual Machine process")
-                .register(registry);
-        }
-    }
-
-    private double invoke(@Nullable Method method) {
-        try {
-            return method != null ? (double) method.invoke(operatingSystemBean) : Double.NaN;
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            return Double.NaN;
-        }
-    }
-
-    @Nullable
-    private Method detectMethod(String name) {
-        requireNonNull(name);
-        if (operatingSystemBeanClass == null) {
-            return null;
-        }
-        try {
-            // ensure the Bean we have is actually an instance of the interface
-            operatingSystemBeanClass.cast(operatingSystemBean);
-            return operatingSystemBeanClass.getDeclaredMethod(name);
-        } catch (ClassCastException | NoSuchMethodException | SecurityException e) {
-            return null;
-        }
-    }
-
-    @Nullable
-    private Class<?> getFirstClassFound(List<String> classNames) {
-        for (String className : classNames) {
-            try {
-                return Class.forName(className);
-            } catch (ClassNotFoundException ignore) {
-            }
-        }
-        return null;
+        processorMetrics.bindTo(registry);
     }
 }


### PR DESCRIPTION
@checketts @jkschneider 

First version of OSHI metrics. This PR is incomplete since it simply delegates to the "old" jvm version always.

What I want to discuss is:

- metric naming, can we be backwards compatible by swapping jvm with oshi and only adding metrics and not removing any. Or should we use simply new names and always run both in parallell?

- (if not in parallell) We need to decide which to use depending on OS, I have not yet tried on windows only on mac and linux. Not sure if a first version would be ok to use oshi only on linux and mac until windows is tested. I know people run java on windows servers I am just not aware of any ;-)

- I guess I need to have some sanity tests as well.

Resolves #1274 