### PR TITLE
Add Infinity Buckets to the StatsD MeterRegistry for Meters with an SLA

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -273,17 +273,54 @@ class StatsdMeterRegistryTest {
 
         Gauge summaryHist1 = registry.get("my.summary.histogram").tags("le", "1").gauge();
         Gauge summaryHist2 = registry.get("my.summary.histogram").tags("le", "2").gauge();
-        Gauge timerHist = registry.get("my.timer.histogram").tags("le", "1").gauge();
+        Gauge summaryHist3 = registry.get("my.summary.histogram").tags("le", "+Inf").gauge();
+        Gauge timerHist1 = registry.get("my.timer.histogram").tags("le", "1").gauge();
+        Gauge timerHist2 = registry.get("my.timer.histogram").tags("le", "+Inf").gauge();
 
         assertThat(summaryHist1.value()).isEqualTo(1);
         assertThat(summaryHist2.value()).isEqualTo(1);
-        assertThat(timerHist.value()).isEqualTo(1);
+        assertThat(summaryHist3.value()).isEqualTo(1);
+        assertThat(timerHist1.value()).isEqualTo(1);
+        assertThat(timerHist2.value()).isEqualTo(1);
 
         clock.add(config.step());
 
         assertThat(summaryHist1.value()).isEqualTo(0);
         assertThat(summaryHist2.value()).isEqualTo(0);
-        assertThat(timerHist.value()).isEqualTo(0);
+        assertThat(summaryHist3.value()).isEqualTo(0);
+        assertThat(timerHist1.value()).isEqualTo(0);
+        assertThat(timerHist2.value()).isEqualTo(0);
+    }
+
+    @Test
+    void timersWithSlasHaveInfBucket() {
+        StatsdMeterRegistry registry = new StatsdMeterRegistry(configWithFlavor(StatsdFlavor.ETSY), clock);
+        Timer timer = Timer.builder("my.timer").sla(Duration.ofMillis(1)).register(registry);
+
+        // A io.micrometer.core.instrument.search.MeterNotFoundException is thrown if the gauge isn't present
+        registry.get("my.timer.histogram").tag("le", "+Inf").gauge();
+    }
+
+    @Test
+    void distributionSummariesWithSlasHaveInfBucket() {
+        StatsdMeterRegistry registry = new StatsdMeterRegistry(configWithFlavor(StatsdFlavor.ETSY), clock);
+        DistributionSummary summary = DistributionSummary.builder("my.distribution").sla(1).register(registry);
+
+        // A io.micrometer.core.instrument.search.MeterNotFoundException is thrown if the gauge isn't present
+        registry.get("my.distribution.histogram").tag("le", "+Inf").gauge();
+    }
+
+    @Test
+    void infBucketEqualsCount() {
+        StatsdMeterRegistry registry = new StatsdMeterRegistry(configWithFlavor(StatsdFlavor.ETSY), clock);
+        Timer timer = Timer.builder("my.timer").sla(Duration.ofMillis(1)).register(registry);
+        timer.record(1, TimeUnit.MILLISECONDS);
+
+        Gauge timerHist = registry.get("my.timer.histogram").tags("le", "+Inf").gauge();
+        Long count = timer.takeSnapshot().count();
+
+       assertThat(timerHist.value()).isEqualTo(1);
+       assertThat(count).isEqualTo(1);
     }
 
     @Test

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -48,7 +48,9 @@ public class HistogramGauges {
                 percentile -> Tags.concat(id.getTags(), "phi", DoubleFormat.decimalOrNan(percentile.percentile())),
                 percentile -> percentile.value(timer.baseTimeUnit()),
                 bucket -> id.getName() + ".histogram",
-                bucket -> Tags.concat(id.getTags(), "le", DoubleFormat.decimalOrWhole(bucket.bucket(timer.baseTimeUnit()))));
+                // We look for Long.MAX_VALUE to ensure a sensible tag on our +Inf bucket
+                bucket -> Tags.concat(id.getTags(), "le", bucket.bucket() != Long.MAX_VALUE
+                        ? DoubleFormat.decimalOrWhole(bucket.bucket(timer.baseTimeUnit())) : "+Inf"));
     }
 
     public static HistogramGauges registerWithCommonFormat(DistributionSummary summary, MeterRegistry registry) {
@@ -58,7 +60,9 @@ public class HistogramGauges {
                 percentile -> Tags.concat(id.getTags(), "phi", DoubleFormat.decimalOrNan(percentile.percentile())),
                 ValueAtPercentile::value,
                 bucket -> id.getName() + ".histogram",
-                bucket -> Tags.concat(id.getTags(), "le", DoubleFormat.decimalOrWhole(bucket.bucket())));
+                // We look for Long.MAX_VALUE to ensure a sensible tag on our +Inf bucket
+                bucket -> Tags.concat(id.getTags(), "le", bucket.bucket() != Long.MAX_VALUE
+                        ? DoubleFormat.decimalOrWhole(bucket.bucket()) : "+Inf"));
     }
 
     public static HistogramGauges register(HistogramSupport meter, MeterRegistry registry,

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.distribution;
 
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -63,5 +64,25 @@ class HistogramGaugesTest {
 
         registry.get("MYPREFIX.my.timer.percentile").tag("phi", "0.95").gauge();
         registry.get("MYPREFIX.my.timer.histogram").tag("le", "0.001").gauge();
+    }
+
+    @Test
+    void histogramsContainLongMaxValue() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        Timer timer = Timer.builder("my.timer")
+                .sla(Duration.ofNanos(Long.MAX_VALUE))
+                .register(registry);
+
+        DistributionSummary distributionSummary = DistributionSummary.builder("my.distribution")
+                .sla(Long.MAX_VALUE)
+                .register(registry);
+
+        HistogramGauges distributionGauges = HistogramGauges.registerWithCommonFormat(distributionSummary, registry);
+
+        HistogramGauges timerGauges = HistogramGauges.registerWithCommonFormat(timer, registry);
+
+        assertThat(registry.get("my.distribution.histogram").tag("le", "+Inf").gauge()).isNotNull();
+        assertThat(registry.get("my.timer.histogram").tag("le", "+Inf").gauge()).isNotNull();
     }
 }


### PR DESCRIPTION
I'm a first-time contributor and don't write Java daily, so I'm more than happy to change anything here in favor of a more idiomatic solution, just let me know! I've ensured all existing tests pass while adding a few new ones.

### Problem
The rate at which StatsD reports metrics and expiration time on SLA histogram age buckets is not aligned. This can cause odd values to be observed on monitoring systems e.g. decimal values being reported from a single host or the SLA count exceeding the total count. One of the primary use cases for the SLA feature is to report on violations, this change aims to make that easier.

### Solution
This was discussed briefly in the Micrometer Slack channel. Aligning the registry's reporting time with the distribution statistic configuration isn't straightforward. So, instead we'll add `+Inf` (`Long.MAX_VALUE`) buckets to the underlying histograms on our user-defined buckets. That way we'll be able to calculate violations using the following - 

```
metric{le:+Inf} - metric{le:$sla}
```


