### PR TITLE
Wavefront cumulative values

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -16,7 +16,7 @@
 package io.micrometer.wavefront;
 
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
-import io.micrometer.core.instrument.step.StepRegistryConfig;
+import io.micrometer.core.instrument.push.PushRegistryConfig;
 import io.micrometer.core.lang.Nullable;
 
 import java.net.InetAddress;
@@ -31,7 +31,7 @@ import java.time.Duration;
  * @author Jon Schneider
  * @since 1.0.0
  */
-public interface WavefrontConfig extends StepRegistryConfig {
+public interface WavefrontConfig extends PushRegistryConfig {
     /**
      * Publishes to a wavefront sidecar running out of process.
      */

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontDistributionSummary.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontDistributionSummary.java
@@ -17,8 +17,8 @@ package io.micrometer.wavefront;
 
 import com.wavefront.sdk.entities.histograms.WavefrontHistogramImpl;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.cumulative.CumulativeDistributionSummary;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.step.StepDistributionSummary;
 import io.micrometer.core.lang.Nullable;
 
 import java.util.Collections;
@@ -29,14 +29,14 @@ import java.util.List;
  *
  * @author Han Zhang
  */
-class WavefrontDistributionSummary extends StepDistributionSummary {
+class WavefrontDistributionSummary extends CumulativeDistributionSummary {
     @Nullable
     private final WavefrontHistogramImpl delegate;
 
     WavefrontDistributionSummary(Id id, Clock clock,
                                  DistributionStatisticConfig distributionStatisticConfig,
-                                 double scale, long stepMillis) {
-        super(id, clock, distributionStatisticConfig, scale, stepMillis, false);
+                                 double scale) {
+        super(id, clock, distributionStatisticConfig, scale, false);
         delegate = distributionStatisticConfig.isPublishingHistogram() ?
             new WavefrontHistogramImpl(clock::wallTime) : null;
     }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -401,7 +401,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected TimeUnit getBaseTimeUnit() {
-        return TimeUnit.MILLISECONDS;
+        return TimeUnit.SECONDS;
     }
 
     @Override

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -401,7 +401,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected TimeUnit getBaseTimeUnit() {
-        return TimeUnit.SECONDS;
+        return TimeUnit.MILLISECONDS;
     }
 
     @Override

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontTimer.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontTimer.java
@@ -17,9 +17,9 @@ package io.micrometer.wavefront;
 
 import com.wavefront.sdk.entities.histograms.WavefrontHistogramImpl;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.cumulative.CumulativeTimer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.instrument.step.StepTimer;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.lang.Nullable;
 
@@ -32,14 +32,13 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Han Zhang
  */
-class WavefrontTimer extends StepTimer {
+class WavefrontTimer extends CumulativeTimer {
     @Nullable
     private final WavefrontHistogramImpl delegate;
 
     WavefrontTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-                   PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepMillis) {
-        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepMillis,
-            false);
+                   PauseDetector pauseDetector, TimeUnit baseTimeUnit) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, false);
         delegate = distributionStatisticConfig.isPublishingHistogram() ?
             new WavefrontHistogramImpl(clock::wallTime) : null;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeTimer.java
@@ -39,8 +39,8 @@ public class CumulativeTimer extends AbstractTimer {
     }
 
     public CumulativeTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-                           PauseDetector pauseDetector, TimeUnit baseTimeUnit, boolean suppportsAggregablePercentiles) {
-        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, suppportsAggregablePercentiles);
+                           PauseDetector pauseDetector, TimeUnit baseTimeUnit, boolean supportsAggregablePercentiles) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
         this.count = new AtomicLong();
         this.total = new AtomicLong();
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);


### PR DESCRIPTION
Updates to the Wavefront integration:

- Send cumulative values instead of aggregated rates, since the Wavefront query language provides `rate()` function.
- Update baseTimeUnit to be milliseconds instead of seconds.