### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 An application metrics facade for the most popular monitoring tools. Instrument your code with dimensional metrics with a
 vendor neutral interface and decide on the monitoring backend at the last minute.
 
-More info and the user manual are available on [micrometer.io](http://micrometer.io).
+More info and the user manual are available on [micrometer.io](https://micrometer.io).
 
 Micrometer is the instrumentation library underpinning Spring Boot 2.0's metrics collection.
 
@@ -49,4 +49,4 @@ The build automatically calculates the "next" version for you when publishing sn
 -------------------------------------
 _Licensed under [Apache Software License 2.0](www.apache.org/licenses/LICENSE-2.0)_
 
-_Sponsored by [Pivotal](http://pivotal.io)_
+_Sponsored by [Pivotal](https://pivotal.io)_

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
@@ -29,7 +29,7 @@ public class DoubleFormat {
     /**
      * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
      * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
-     * http://stackoverflow.com/a/1285297/2648
+     * https://stackoverflow.com/a/1285297/2648
      * https://github.com/indeedeng/java-dogstatsd-client/issues/4
      */
     private static final ThreadLocal<NumberFormat> DECIMAL_OR_NAN = ThreadLocal.withInitial(() -> {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://slack.micrometer.io (200) with 1 occurrences could not be migrated:  
   ([https](https://slack.micrometer.io) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://micrometer.io with 1 occurrences migrated to:  
  https://micrometer.io ([https](https://micrometer.io) result 200).
* [ ] http://pivotal.io with 1 occurrences migrated to:  
  https://pivotal.io ([https](https://pivotal.io) result 200).
* [ ] http://stackoverflow.com/a/1285297/2648 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/1285297/2648 ([https](https://stackoverflow.com/a/1285297/2648) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences
* http://localhost/test/123 with 3 occurrences
* http://localhost:3036 with 1 occurrences
* http://localhost:7101/api/v1/graph?q=name,ftimer,:eq,:dist-avg,name,timer,:eq,:dist-avg,1,:axis&s=e-5m&l=0 with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8086 with 2 occurrences