### PR TITLE
URL Cleanup

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryCompatibilityTest.java
@@ -36,7 +36,7 @@ public class DynatraceMeterRegistryCompatibilityTest extends MeterRegistryCompat
 
         @Override
         public String uri() {
-            return "http://doesnotmatter.com";
+            return "https://www.buydomains.com/lander/doesnotmatter.com?domain=doesnotmatter.com&utm_source=doesnotmatter.com&utm_medium=click&utm_campaign=TDFS-OO-BDLander&traffic_id=TDFS-OO-BDLander&traffic_type=tdfs&redirect=ono-redirect";
         }
 
         @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/DoubleFormat.java
@@ -29,7 +29,7 @@ public class DoubleFormat {
     /**
      * Because NumberFormat is not thread-safe we cannot share instances across threads. Use a ThreadLocal to
      * create one pre thread as this seems to offer a significant performance improvement over creating one per-thread:
-     * http://stackoverflow.com/a/1285297/2648
+     * https://stackoverflow.com/a/1285297/2648
      * https://github.com/indeedeng/java-dogstatsd-client/issues/4
      */
     private static final ThreadLocal<NumberFormat> DECIMAL_OR_NAN = ThreadLocal.withInitial(() -> {

--- a/scripts/spring-dash/grafana-datasource.yml
+++ b/scripts/spring-dash/grafana-datasource.yml
@@ -4,4 +4,4 @@ datasources:
 - name: prometheus
   type: prometheus
   access: direct
-  url: http://10.200.10.1:9090
+  url: https://10.200.10.1:9090


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://slack.micrometer.io (200) with 1 occurrences could not be migrated:  
   ([https](https://slack.micrometer.io) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://doesnotmatter.com (301) with 1 occurrences migrated to:  
  https://www.buydomains.com/lander/doesnotmatter.com?domain=doesnotmatter.com&utm_source=doesnotmatter.com&utm_medium=click&utm_campaign=TDFS-OO-BDLander&traffic_id=TDFS-OO-BDLander&traffic_type=tdfs&redirect=ono-redirect ([https](https://doesnotmatter.com) result ConnectTimeoutException).
* [ ] http://10.200.10.1:9090 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://10.200.10.1:9090 ([https](https://10.200.10.1:9090) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://stackoverflow.com/a/1285297/2648 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/1285297/2648 ([https](https://stackoverflow.com/a/1285297/2648) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 2 occurrences
* http://localhost/test/123 with 3 occurrences
* http://localhost:7101/api/v1/graph?q=name,ftimer,:eq,:dist-avg,name,timer,:eq,:dist-avg,1,:axis&s=e-5m&l=0 with 1 occurrences
* http://localhost:7101/api/v1/publish with 1 occurrences
* http://localhost:7101/lwc/api/v1/evaluate with 1 occurrences
* http://localhost:7101/lwc/api/v1/expressions/local-dev with 1 occurrences
* http://localhost:8080 with 1 occurrences
* http://localhost:8080/api/v1/datapoints with 2 occurrences
* http://localhost:8083/api/v1/datapoints with 1 occurrences
* http://localhost:8086 with 3 occurrences
* http://localhost:9200 with 2 occurrences