### PR TITLE
Add Javadoc since tags for Wavefront classes

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -28,6 +28,7 @@ import java.time.Duration;
  *
  * @author Howard Yoo
  * @author Jon Schneider
+ * @since 1.0.0
  */
 public interface WavefrontConfig extends StepRegistryConfig {
     /**

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -37,8 +37,11 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.StreamSupport.stream;
 
 /**
+ * {@link StepMeterRegistry} for Wavefront.
+ *
  * @author Jon Schneider
  * @author Howard Yoo
+ * @since 1.0.0
  */
 public class WavefrontMeterRegistry extends StepMeterRegistry {
     private final Logger logger = LoggerFactory.getLogger(WavefrontMeterRegistry.class);

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontNamingConvention.java
@@ -22,6 +22,12 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
 
+/**
+ * Naming convention for Wavefront.
+ *
+ * @author Jon Schneider
+ * @since 1.0.0
+ */
 public class WavefrontNamingConvention implements NamingConvention {
 
     private static final Pattern PATTERN_NAME_TO_SANITIZE = Pattern.compile("[^a-zA-Z0-9\\-_\\./,]");

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontMetricsExportAutoConfiguration.java
@@ -33,6 +33,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+/**
+ * Auto-configuration for Wavefront.
+ *
+ * @author Jon Schneider
+ * @since 1.0.0
+ */
 @Configuration
 @AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,
         SimpleMetricsExportAutoConfiguration.class})

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/wavefront/WavefrontProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * {@link ConfigurationProperties} for configuring Wavefront metrics export.
  *
  * @author Jon Schneider
+ * @since 1.0.0
  */
 @ConfigurationProperties("management.metrics.export.wavefront")
 public class WavefrontProperties extends StepRegistryProperties {


### PR DESCRIPTION
This PR adds Javadoc `@since` tags for Wavefront classes.