### PR TITLE
Disable other histogram metrics when sending Wavefront Histograms

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontDistributionSummary.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontDistributionSummary.java
@@ -57,4 +57,8 @@ public class WavefrontDistributionSummary extends StepDistributionSummary {
             return delegate.flushDistributions();
         }
     }
+
+    boolean isPublishingHistogram() {
+        return delegate != null;
+    }
 }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -127,18 +127,22 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
                              PauseDetector pauseDetector) {
-        Timer timer = new WavefrontTimer(id, clock, distributionStatisticConfig, pauseDetector,
+        WavefrontTimer timer = new WavefrontTimer(id, clock, distributionStatisticConfig, pauseDetector,
             getBaseTimeUnit(), config.step().toMillis());
-        HistogramGauges.registerWithCommonFormat(timer, this);
+        if (!timer.isPublishingHistogram()) {
+            HistogramGauges.registerWithCommonFormat(timer, this);
+        }
         return timer;
     }
 
     @Override
     protected DistributionSummary newDistributionSummary(
         Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
-        DistributionSummary summary = new WavefrontDistributionSummary(id, clock,
+        WavefrontDistributionSummary summary = new WavefrontDistributionSummary(id, clock,
             distributionStatisticConfig, scale, config.step().toMillis());
-        HistogramGauges.registerWithCommonFormat(summary, this);
+        if (!summary.isPublishingHistogram()) {
+            HistogramGauges.registerWithCommonFormat(summary, this);
+        }
         return summary;
     }
 
@@ -255,13 +259,18 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
         final long wallTime = clock.wallTime();
         final Stream.Builder<WavefrontMetricLineData> metrics = Stream.builder();
 
-        Meter.Id id = timer.getId();
+        final Meter.Id id = timer.getId();
+        final WavefrontTimer wfTimer = (WavefrontTimer) timer;
 
-        addMetric(metrics, id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
-        addMetric(metrics, id, "count", wallTime, timer.count());
-        addMetric(metrics, id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
-        addMetric(metrics, id, "max", wallTime, timer.max(getBaseTimeUnit()));
-        addDistribution(metrics, id, ((WavefrontTimer) timer).flushDistributions());
+        if (wfTimer.isPublishingHistogram()) {
+            addDistribution(metrics, id, wfTimer.flushDistributions());
+        } else {
+            addMetric(metrics, id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()));
+            addMetric(metrics, id, "count", wallTime, timer.count());
+            addMetric(metrics, id, "avg", wallTime, timer.mean(getBaseTimeUnit()));
+            addMetric(metrics, id, "max", wallTime, timer.max(getBaseTimeUnit()));
+        }
+
         return metrics.build();
     }
 
@@ -269,13 +278,17 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
         final long wallTime = clock.wallTime();
         final Stream.Builder<WavefrontMetricLineData> metrics = Stream.builder();
 
-        Meter.Id id = summary.getId();
+        final Meter.Id id = summary.getId();
+        final WavefrontDistributionSummary wfSummary = (WavefrontDistributionSummary) summary;
 
-        addMetric(metrics, id, "sum", wallTime, summary.totalAmount());
-        addMetric(metrics, id, "count", wallTime, summary.count());
-        addMetric(metrics, id, "avg", wallTime, summary.mean());
-        addMetric(metrics, id, "max", wallTime, summary.max());
-        addDistribution(metrics, id, ((WavefrontDistributionSummary) summary).flushDistributions());
+        if (wfSummary.isPublishingHistogram()) {
+            addDistribution(metrics, id, wfSummary.flushDistributions());
+        } else {
+            addMetric(metrics, id, "sum", wallTime, summary.totalAmount());
+            addMetric(metrics, id, "count", wallTime, summary.count());
+            addMetric(metrics, id, "avg", wallTime, summary.mean());
+            addMetric(metrics, id, "max", wallTime, summary.max());
+        }
 
         return metrics.build();
     }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontTimer.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontTimer.java
@@ -60,4 +60,8 @@ public class WavefrontTimer extends StepTimer {
             return delegate.flushDistributions();
         }
     }
+
+    boolean isPublishingHistogram() {
+        return delegate != null;
+    }
 }


### PR DESCRIPTION
When histograms are enabled for Wavefront timers or summaries, we don't need to send anything other than the histogram distributions.  The other metrics (sum, count, avg, max, etc.) can all be calculated using `hs()` queries in Wavefront.  Injecting these metrics would result in additional costs for the customer.