### PR TITLE
Catch and log uncaught exceptions when calling PushMeterRegistry#publish

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -18,6 +18,8 @@ package io.micrometer.core.instrument.push;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.lang.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -25,6 +27,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 public abstract class PushMeterRegistry extends MeterRegistry {
+    private final static Logger logger = LoggerFactory.getLogger(PushMeterRegistry.class);
     private final PushRegistryConfig config;
 
     @Nullable
@@ -36,6 +39,17 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     }
 
     protected abstract void publish();
+
+    /**
+     * Catch uncaught exceptions thrown from {@link #publish()}.
+     */
+    private void publishSafely() {
+        try {
+            publish();
+        } catch (Throwable e) {
+            logger.warn("Unexpected exception thrown while publishing metrics for " + this.getClass().getSimpleName(), e);
+        }
+    }
 
     /**
      * @deprecated Use {@link #start(ThreadFactory)} instead.
@@ -51,7 +65,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
 
         if (config.enabled()) {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
-            scheduledExecutorService.scheduleAtFixedRate(this::publish, config.step()
+            scheduledExecutorService.scheduleAtFixedRate(this::publishSafely, config.step()
                     .toMillis(), config.step().toMillis(), TimeUnit.MILLISECONDS);
         }
     }
@@ -66,7 +80,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     @Override
     public void close() {
         if (config.enabled()) {
-            publish();
+            publishSafely();
         }
         stop();
         super.close();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.push;
+
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.step.StepRegistryConfig;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link PushMeterRegistry}.
+ */
+class PushMeterRegistryTest {
+
+    static ThreadFactory threadFactory = new NamedThreadFactory("PushMeterRegistryTest");
+    StepRegistryConfig config = new StepRegistryConfig() {
+        @Override
+        public Duration step() {
+            return Duration.ofMillis(10);
+        }
+
+        @Override
+        public String prefix() {
+            return null;
+        }
+
+        @Override
+        public String get(String key) {
+            return null;
+        }
+    };
+    CountDownLatch latch = new CountDownLatch(2);
+    PushMeterRegistry pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
+
+    @AfterEach
+    void cleanUp() {
+        pushMeterRegistry.close();
+    }
+
+    @Test
+    void whenUncaughtExceptionInPublish_taskStillScheduled() throws InterruptedException {
+        pushMeterRegistry.start(threadFactory);
+        assertThat(latch.await(50,TimeUnit.MILLISECONDS))
+                .as("publish should continue to be scheduled even if an uncaught exception is thrown")
+                .isTrue();
+    }
+
+    @Test
+    void whenUncaughtExceptionInPublish_closeRegistrySuccessful() {
+        assertThatCode(() -> pushMeterRegistry.close()).doesNotThrowAnyException();
+    }
+
+    static class ThrowingPushMeterRegistry extends StepMeterRegistry {
+
+        final CountDownLatch countDownLatch;
+
+        public ThrowingPushMeterRegistry(StepRegistryConfig config, CountDownLatch countDownLatch) {
+            super(config, new MockClock());
+            this.countDownLatch = countDownLatch;
+        }
+
+        @Override
+        protected void publish() {
+            countDownLatch.countDown();
+            throw new RuntimeException("in ur base");
+        }
+
+        @Override
+        protected TimeUnit getBaseTimeUnit() {
+            return TimeUnit.MICROSECONDS;
+        }
+    }
+}


### PR DESCRIPTION
Scheduled tasks that throw uncaught exceptions stop being scheduled by default and the exception will not be logged. This made it impossible for users to report the cause of failures without custom code/debugging, and it is even difficult to notice when this happens due to the lack of logs. Now calls to the `publish` method are guarded by a try-catch that logs the exception. Implementations of `publish` should still implement proper exception handling, but this acts as a final safety net for bugs in those implementations.

Resolves #1228