### PR TITLE
#1340 Add Stackdriver batch size limit

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -140,7 +140,8 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
             return;
         }
 
-        for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
+        // Stackdriver's API limits us to less than 200 events per call
+        for (List<Meter> batch : MeterPartition.partition(this, Math.min(config.batchSize(), 199))) {
             Batch publishBatch = new Batch();
 
             Iterable<TimeSeries> series = batch.stream()


### PR DESCRIPTION
Stackdriver's API limits us to less than 200 events per call, see documentation below.

* https://cloud.google.com/monitoring/quotas