### PR TITLE
Auto-configure cache metrics

### DIFF
--- a/micrometer-spring-legacy/build.gradle
+++ b/micrometer-spring-legacy/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     compile 'org.springframework.boot:spring-boot', optional
     compile 'org.springframework.boot:spring-boot-actuator', optional
     compile 'org.springframework.boot:spring-boot-starter-aop', optional
+    compile 'org.springframework.boot:spring-boot-starter-cache', optional
     compile 'org.springframework.boot:spring-boot-starter-security', optional
     compile 'org.springframework:spring-webmvc', optional
     compile 'org.springframework:spring-web', optional
@@ -41,6 +42,8 @@ dependencies {
     compile project(":micrometer-jersey2"), optional
 
     compile 'org.springframework.integration:spring-integration-core', optional
+    
+    compile 'com.hazelcast:hazelcast-spring', optional
 
     annotationProcessor 'org.springframework.boot:spring-boot-autoconfigure-processor'
 

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMeterBinderProvidersConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMeterBinderProvidersConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.autoconfigure.cache;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.spring.cache.HazelcastCache;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.spring.cache.*;
+import net.sf.ehcache.Ehcache;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.ehcache.EhCacheCache;
+import org.springframework.cache.jcache.JCacheCache;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configure {@link CacheMeterBinderProvider} beans.
+ *
+ * @author Stephane Nicoll
+ */
+@Configuration
+@ConditionalOnClass(MeterBinder.class)
+class CacheMeterBinderProvidersConfiguration {
+
+    @Configuration
+    @ConditionalOnClass({CaffeineCache.class,
+            com.github.benmanes.caffeine.cache.Cache.class})
+    static class CaffeineCacheMeterBinderProviderConfiguration {
+
+        @Bean
+        public CaffeineCacheMeterBinderProvider caffeineCacheMeterBinderProvider() {
+            return new CaffeineCacheMeterBinderProvider();
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnClass({EhCacheCache.class, Ehcache.class})
+    static class EhCache2CacheMeterBinderProviderConfiguration {
+
+        @Bean
+        public EhCache2CacheMeterBinderProvider ehCache2CacheMeterBinderProvider() {
+            return new EhCache2CacheMeterBinderProvider();
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnClass({HazelcastCache.class, Hazelcast.class})
+    static class HazelcastCacheMeterBinderProviderConfiguration {
+
+        @Bean
+        public HazelcastCacheMeterBinderProvider hazelcastCacheMeterBinderProvider() {
+            return new HazelcastCacheMeterBinderProvider();
+        }
+
+    }
+
+    @Configuration
+    @ConditionalOnClass({JCacheCache.class, javax.cache.CacheManager.class})
+    static class JCacheCacheMeterBinderProviderConfiguration {
+
+        @Bean
+        public JCacheCacheMeterBinderProvider jCacheCacheMeterBinderProvider() {
+            return new JCacheCacheMeterBinderProvider();
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMetricsAutoConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.autoconfigure.cache;
+
+import io.micrometer.spring.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for metrics on all available
+ * {@link Cache caches}.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+@Configuration
+@AutoConfigureAfter({MetricsAutoConfiguration.class, CacheAutoConfiguration.class})
+@ConditionalOnBean(CacheManager.class)
+@Import({CacheMeterBinderProvidersConfiguration.class,
+        CacheMetricsRegistrarConfiguration.class})
+public class CacheMetricsAutoConfiguration {
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMetricsRegistrarConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/cache/CacheMetricsRegistrarConfiguration.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.autoconfigure.cache;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.spring.cache.CacheMeterBinderProvider;
+import io.micrometer.spring.cache.CacheMetricsRegistrar;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Configure a {@link CacheMetricsRegistrar} and register all available {@link Cache
+ * caches}.
+ *
+ * @author Stephane Nicoll
+ */
+@Configuration
+@ConditionalOnBean({CacheMeterBinderProvider.class, MeterRegistry.class})
+class CacheMetricsRegistrarConfiguration {
+
+    private static final String CACHE_MANAGER_SUFFIX = "cacheManager";
+
+    private final MeterRegistry registry;
+
+    private final CacheMetricsRegistrar cacheMetricsRegistrar;
+
+    private final Map<String, CacheManager> cacheManagers;
+
+    CacheMetricsRegistrarConfiguration(MeterRegistry registry,
+                                       Collection<CacheMeterBinderProvider<?>> binderProviders,
+                                       Map<String, CacheManager> cacheManagers) {
+        this.registry = registry;
+        this.cacheManagers = cacheManagers;
+        this.cacheMetricsRegistrar = new CacheMetricsRegistrar(this.registry,
+                binderProviders);
+    }
+
+    @Bean
+    public CacheMetricsRegistrar cacheMetricsRegistrar() {
+        return this.cacheMetricsRegistrar;
+    }
+
+    @PostConstruct
+    public void bindCachesToRegistry() {
+        this.cacheManagers.forEach(this::bindCacheManagerToRegistry);
+    }
+
+    private void bindCacheManagerToRegistry(String beanName, CacheManager cacheManager) {
+        cacheManager.getCacheNames().forEach((cacheName) -> bindCacheToRegistry(beanName,
+                cacheManager.getCache(cacheName)));
+    }
+
+    private void bindCacheToRegistry(String beanName, Cache cache) {
+        Tag cacheManagerTag = Tag.of("cacheManager", getCacheManagerName(beanName));
+        this.cacheMetricsRegistrar.bindCacheToRegistry(cache, cacheManagerTag);
+    }
+
+    /**
+     * Get the name of a {@link CacheManager} based on its {@code beanName}.
+     *
+     * @param beanName the name of the {@link CacheManager} bean
+     * @return a name for the given cache manager
+     */
+    private String getCacheManagerName(String beanName) {
+        if (beanName.length() > CACHE_MANAGER_SUFFIX.length()
+                && StringUtils.endsWithIgnoreCase(beanName, CACHE_MANAGER_SUFFIX)) {
+            return beanName.substring(0,
+                    beanName.length() - CACHE_MANAGER_SUFFIX.length());
+        }
+        return beanName;
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CacheMeterBinderProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CacheMeterBinderProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.springframework.cache.Cache;
+
+/**
+ * Provide a {@link MeterBinder} based on a {@link Cache}.
+ *
+ * @param <C> the cache type
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+@FunctionalInterface
+public interface CacheMeterBinderProvider<C extends Cache> {
+
+    /**
+     * Return the {@link MeterBinder} managing the specified {@link Cache} or {@code null}
+     * if the specified {@link Cache} is not supported.
+     *
+     * @param cache the cache to instrument
+     * @param tags  tags to apply to all recorded metrics
+     * @return a {@link MeterBinder} handling the specified {@link Cache} or {@code null}
+     */
+    MeterBinder getMeterBinder(C cache, Iterable<Tag> tags);
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CacheMetricsRegistrar.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CacheMetricsRegistrar.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.spring.util.LambdaSafe;
+import org.springframework.cache.Cache;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+import org.springframework.util.ClassUtils;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Register supported {@link Cache} to a {@link MeterRegistry}.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+public class CacheMetricsRegistrar {
+
+    private final MeterRegistry registry;
+
+    private final Collection<CacheMeterBinderProvider<?>> binderProviders;
+
+    /**
+     * Creates a new registrar.
+     *
+     * @param registry        the {@link MeterRegistry} to use
+     * @param binderProviders the {@link CacheMeterBinderProvider} instances that should
+     *                        be used to detect compatible caches
+     */
+    public CacheMetricsRegistrar(MeterRegistry registry,
+                                 Collection<CacheMeterBinderProvider<?>> binderProviders) {
+        this.registry = registry;
+        this.binderProviders = binderProviders;
+    }
+
+    /**
+     * Attempt to bind the specified {@link Cache} to the registry. Return {@code true} if
+     * the cache is supported and was bound to the registry, {@code false} otherwise.
+     *
+     * @param cache the cache to handle
+     * @param tags  the tags to associate with the metrics of that cache
+     * @return {@code true} if the {@code cache} is supported and was registered
+     */
+    public boolean bindCacheToRegistry(Cache cache, Tag... tags) {
+        MeterBinder meterBinder = getMeterBinder(unwrapIfNecessary(cache), Tags.of(tags));
+        if (meterBinder != null) {
+            meterBinder.bindTo(this.registry);
+            return true;
+        }
+        return false;
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private MeterBinder getMeterBinder(Cache cache, Tags tags) {
+        Tags cacheTags = tags.and(getAdditionalTags(cache));
+        return LambdaSafe
+                .callbacks(CacheMeterBinderProvider.class, this.binderProviders, cache)
+                .withLogger(CacheMetricsRegistrar.class)
+                .invokeAnd((binderProvider) -> binderProvider.getMeterBinder(cache,
+                        cacheTags))
+                .filter(Objects::nonNull).findFirst().orElse(null);
+    }
+
+    /**
+     * Return additional {@link Tag tags} to be associated with the given {@link Cache}.
+     *
+     * @param cache the cache
+     * @return a list of additional tags to associate to that {@code cache}.
+     */
+    protected Iterable<Tag> getAdditionalTags(Cache cache) {
+        return Tags.of("name", cache.getName());
+    }
+
+    private Cache unwrapIfNecessary(Cache cache) {
+        if (ClassUtils.isPresent(
+                "org.springframework.cache.transaction.TransactionAwareCacheDecorator",
+                getClass().getClassLoader())) {
+            return TransactionAwareCacheDecoratorHandler.unwrapIfNecessary(cache);
+        }
+        return cache;
+    }
+
+    private static class TransactionAwareCacheDecoratorHandler {
+
+        private static Cache unwrapIfNecessary(Cache cache) {
+            try {
+                if (cache instanceof TransactionAwareCacheDecorator) {
+                    return ((TransactionAwareCacheDecorator) cache).getTargetCache();
+                }
+            } catch (NoClassDefFoundError ex) {
+                // Ignore
+            }
+            return cache;
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CaffeineCacheMeterBinderProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/CaffeineCacheMeterBinderProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import org.springframework.cache.caffeine.CaffeineCache;
+
+/**
+ * {@link CacheMeterBinderProvider} implementation for Caffeine.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+public class CaffeineCacheMeterBinderProvider
+        implements CacheMeterBinderProvider<CaffeineCache> {
+
+    @Override
+    public MeterBinder getMeterBinder(CaffeineCache cache, Iterable<Tag> tags) {
+        return new CaffeineCacheMetrics(cache.getNativeCache(), cache.getName(), tags);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/EhCache2CacheMeterBinderProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/EhCache2CacheMeterBinderProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.EhCache2Metrics;
+import org.springframework.cache.ehcache.EhCacheCache;
+
+/**
+ * {@link CacheMeterBinderProvider} implementation for EhCache2.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+public class EhCache2CacheMeterBinderProvider
+        implements CacheMeterBinderProvider<EhCacheCache> {
+
+    @Override
+    public MeterBinder getMeterBinder(EhCacheCache cache, Iterable<Tag> tags) {
+        return new EhCache2Metrics(cache.getNativeCache(), tags);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/HazelcastCacheMeterBinderProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/HazelcastCacheMeterBinderProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.spring.cache.HazelcastCache;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.HazelcastCacheMetrics;
+
+/**
+ * {@link CacheMeterBinderProvider} implementation for Hazelcast.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+public class HazelcastCacheMeterBinderProvider
+        implements CacheMeterBinderProvider<HazelcastCache> {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public MeterBinder getMeterBinder(HazelcastCache cache, Iterable<Tag> tags) {
+        return new HazelcastCacheMetrics((IMap<Object, Object>) cache.getNativeCache(), tags);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/JCacheCacheMeterBinderProvider.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/cache/JCacheCacheMeterBinderProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.cache;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.JCacheMetrics;
+import org.springframework.cache.jcache.JCacheCache;
+
+/**
+ * {@link CacheMeterBinderProvider} implementation for JCache.
+ *
+ * @author Stephane Nicoll
+ * @since 1.2.0
+ */
+public class JCacheCacheMeterBinderProvider
+        implements CacheMeterBinderProvider<JCacheCache> {
+
+    @Override
+    public MeterBinder getMeterBinder(JCacheCache cache, Iterable<Tag> tags) {
+        return new JCacheMetrics(cache.getNativeCache(), tags);
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/util/LambdaSafe.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/util/LambdaSafe.java
@@ -1,0 +1,457 @@
+/*
+ * Copyright 2012-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.spring.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.ResolvableType;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Utility that can be used to invoke lambdas in a safe way. Primarily designed to help
+ * support generically typed callbacks where {@link ClassCastException class cast
+ * exceptions} need to be dealt with due to class erasure.
+ *
+ * @author Phillip Webb
+ * @since 1.2.0
+ */
+public final class LambdaSafe {
+
+    private static final Method CLASS_GET_MODULE;
+
+    private static final Method MODULE_GET_NAME;
+
+    static {
+        CLASS_GET_MODULE = ReflectionUtils.findMethod(Class.class, "getModule");
+        MODULE_GET_NAME = (CLASS_GET_MODULE != null)
+                ? ReflectionUtils.findMethod(CLASS_GET_MODULE.getReturnType(), "getName")
+                : null;
+    }
+
+    private LambdaSafe() {
+    }
+
+    /**
+     * Start a call to a single callback instance, dealing with common generic type
+     * concerns and exceptions.
+     *
+     * @param callbackType        the callback type (a {@link FunctionalInterface functional
+     *                            interface})
+     * @param callbackInstance    the callback instance (may be a lambda)
+     * @param argument            the primary argument passed to the callback
+     * @param additionalArguments any additional arguments passed to the callback
+     * @param <C>                 the callback type
+     * @param <A>                 the primary argument type
+     * @return a {@link Callback} instance that can be invoked.
+     */
+    public static <C, A> Callback<C, A> callback(Class<C> callbackType,
+                                                 C callbackInstance, A argument, Object... additionalArguments) {
+        Assert.notNull(callbackType, "CallbackType must not be null");
+        Assert.notNull(callbackInstance, "CallbackInstance must not be null");
+        return new Callback<>(callbackType, callbackInstance, argument,
+                additionalArguments);
+    }
+
+    /**
+     * Start a call to callback instances, dealing with common generic type concerns and
+     * exceptions.
+     *
+     * @param callbackType        the callback type (a {@link FunctionalInterface functional
+     *                            interface})
+     * @param callbackInstances   the callback instances (elements may be lambdas)
+     * @param argument            the primary argument passed to the callbacks
+     * @param additionalArguments any additional arguments passed to the callbacks
+     * @param <C>                 the callback type
+     * @param <A>                 the primary argument type
+     * @return a {@link Callbacks} instance that can be invoked.
+     */
+    public static <C, A> Callbacks<C, A> callbacks(Class<C> callbackType,
+                                                   Collection<? extends C> callbackInstances, A argument,
+                                                   Object... additionalArguments) {
+        Assert.notNull(callbackType, "CallbackType must not be null");
+        Assert.notNull(callbackInstances, "CallbackInstances must not be null");
+        return new Callbacks<>(callbackType, callbackInstances, argument,
+                additionalArguments);
+    }
+
+    /**
+     * Abstract base class for lambda safe callbacks.
+     */
+    private abstract static class LambdaSafeCallback<C, A, SELF extends LambdaSafeCallback<C, A, SELF>> {
+
+        private final Class<C> callbackType;
+
+        private final A argument;
+
+        private final Object[] additionalArguments;
+
+        private Log logger;
+
+        private Filter<C, A> filter = new GenericTypeFilter<>();
+
+        protected LambdaSafeCallback(Class<C> callbackType, A argument,
+                                     Object[] additionalArguments) {
+            this.callbackType = callbackType;
+            this.argument = argument;
+            this.additionalArguments = additionalArguments;
+            this.logger = LogFactory.getLog(callbackType);
+        }
+
+        /**
+         * Use the specified logger source to report any lambda failures.
+         *
+         * @param loggerSource the logger source to use
+         * @return this instance
+         */
+        public SELF withLogger(Class<?> loggerSource) {
+            return withLogger(LogFactory.getLog(loggerSource));
+        }
+
+        /**
+         * Use the specified logger to report any lambda failures.
+         *
+         * @param logger the logger to use
+         * @return this instance
+         */
+        public SELF withLogger(Log logger) {
+            Assert.notNull(logger, "Logger must not be null");
+            this.logger = logger;
+            return self();
+        }
+
+        /**
+         * Use a specific filter to determine when a callback should apply. If no explicit
+         * filter is set filter will be attempted using the generic type on the callback
+         * type.
+         *
+         * @param filter the filter to use
+         * @return this instance
+         */
+        public SELF withFilter(Filter<C, A> filter) {
+            Assert.notNull(filter, "Filter must not be null");
+            this.filter = filter;
+            return self();
+        }
+
+        protected final <R> InvocationResult<R> invoke(C callbackInstance,
+                                                       Supplier<R> supplier) {
+            if (this.filter.match(this.callbackType, callbackInstance, this.argument,
+                    this.additionalArguments)) {
+                try {
+                    return InvocationResult.of(supplier.get());
+                } catch (ClassCastException ex) {
+                    if (!isLambdaGenericProblem(ex)) {
+                        throw ex;
+                    }
+                    logNonMatchingType(callbackInstance, ex);
+                }
+            }
+            return InvocationResult.noResult();
+        }
+
+        private boolean isLambdaGenericProblem(ClassCastException ex) {
+            return (ex.getMessage() == null
+                    || startsWithArgumentClassName(ex.getMessage()));
+        }
+
+        private boolean startsWithArgumentClassName(String message) {
+            Predicate<Object> startsWith = (argument) -> startsWithArgumentClassName(
+                    message, argument);
+            return startsWith.test(this.argument)
+                    || Stream.of(this.additionalArguments).anyMatch(startsWith);
+        }
+
+        private boolean startsWithArgumentClassName(String message, Object argument) {
+            if (argument == null) {
+                return false;
+            }
+            Class<?> argumentType = argument.getClass();
+            // On Java 8, the message starts with the class name: "java.lang.String cannot
+            // be cast..."
+            if (message.startsWith(argumentType.getName())) {
+                return true;
+            }
+            // On Java 11, the message starts with "class ..." a.k.a. Class.toString()
+            if (message.startsWith(argumentType.toString())) {
+                return true;
+            }
+            // On Java 9, the message used to contain the module name:
+            // "java.base/java.lang.String cannot be cast..."
+            int moduleSeparatorIndex = message.indexOf('/');
+            if (moduleSeparatorIndex != -1 && message.startsWith(argumentType.getName(),
+                    moduleSeparatorIndex + 1)) {
+                return true;
+            }
+            if (CLASS_GET_MODULE != null) {
+                Object module = ReflectionUtils.invokeMethod(CLASS_GET_MODULE,
+                        argumentType);
+                Object moduleName = ReflectionUtils.invokeMethod(MODULE_GET_NAME, module);
+                return message.startsWith(moduleName + "/" + argumentType.getName());
+            }
+            return false;
+        }
+
+        private void logNonMatchingType(C callback, ClassCastException ex) {
+            if (this.logger.isDebugEnabled()) {
+                Class<?> expectedType = ResolvableType.forClass(this.callbackType)
+                        .resolveGeneric();
+                String expectedTypeName = (expectedType != null)
+                        ? ClassUtils.getShortName(expectedType) + " type" : "type";
+                String message = "Non-matching " + expectedTypeName + " for callback "
+                        + ClassUtils.getShortName(this.callbackType) + ": " + callback;
+                this.logger.debug(message, ex);
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        private SELF self() {
+            return (SELF) this;
+        }
+
+    }
+
+    /**
+     * Represents a single callback that can be invoked in a lambda safe way.
+     *
+     * @param <C> the callback type
+     * @param <A> the primary argument type
+     */
+    public static final class Callback<C, A>
+            extends LambdaSafeCallback<C, A, Callback<C, A>> {
+
+        private final C callbackInstance;
+
+        private Callback(Class<C> callbackType, C callbackInstance, A argument,
+                         Object[] additionalArguments) {
+            super(callbackType, argument, additionalArguments);
+            this.callbackInstance = callbackInstance;
+        }
+
+        /**
+         * Invoke the callback instance where the callback method returns void.
+         *
+         * @param invoker the invoker used to invoke the callback
+         */
+        public void invoke(Consumer<C> invoker) {
+            invoke(this.callbackInstance, () -> {
+                invoker.accept(this.callbackInstance);
+                return null;
+            });
+        }
+
+        /**
+         * Invoke the callback instance where the callback method returns a result.
+         *
+         * @param invoker the invoker used to invoke the callback
+         * @param <R>     the result type
+         * @return the result of the invocation (may be {@link InvocationResult#noResult}
+         * if the callback was not invoked)
+         */
+        public <R> InvocationResult<R> invokeAnd(Function<C, R> invoker) {
+            return invoke(this.callbackInstance,
+                    () -> invoker.apply(this.callbackInstance));
+        }
+
+    }
+
+    /**
+     * Represents a collection of callbacks that can be invoked in a lambda safe way.
+     *
+     * @param <C> the callback type
+     * @param <A> the primary argument type
+     */
+    public static final class Callbacks<C, A>
+            extends LambdaSafeCallback<C, A, Callbacks<C, A>> {
+
+        private final Collection<? extends C> callbackInstances;
+
+        private Callbacks(Class<C> callbackType,
+                          Collection<? extends C> callbackInstances, A argument,
+                          Object[] additionalArguments) {
+            super(callbackType, argument, additionalArguments);
+            this.callbackInstances = callbackInstances;
+        }
+
+        /**
+         * Invoke the callback instances where the callback method returns void.
+         *
+         * @param invoker the invoker used to invoke the callback
+         */
+        public void invoke(Consumer<C> invoker) {
+            this.callbackInstances.forEach((callbackInstance) -> {
+                invoke(callbackInstance, () -> {
+                    invoker.accept(callbackInstance);
+                    return null;
+                });
+            });
+        }
+
+        /**
+         * Invoke the callback instances where the callback method returns a result.
+         *
+         * @param invoker the invoker used to invoke the callback
+         * @param <R>     the result type
+         * @return the results of the invocation (may be an empty stream if no callbacks
+         * could be called)
+         */
+        public <R> Stream<R> invokeAnd(Function<C, R> invoker) {
+            Function<C, InvocationResult<R>> mapper = (callbackInstance) -> invoke(
+                    callbackInstance, () -> invoker.apply(callbackInstance));
+            return this.callbackInstances.stream().map(mapper)
+                    .filter(InvocationResult::hasResult).map(InvocationResult::get);
+        }
+
+    }
+
+    /**
+     * A filter that can be used to restrict when a callback is used.
+     *
+     * @param <C> the callback type
+     * @param <A> the primary argument type
+     */
+    @FunctionalInterface
+    interface Filter<C, A> {
+
+        /**
+         * Determine if the given callback matches and should be invoked.
+         *
+         * @param callbackType        the callback type (the functional interface)
+         * @param callbackInstance    the callback instance (the implementation)
+         * @param argument            the primary argument
+         * @param additionalArguments any additional arguments
+         * @return if the callback matches and should be invoked
+         */
+        boolean match(Class<C> callbackType, C callbackInstance, A argument,
+                      Object[] additionalArguments);
+
+        /**
+         * Return a {@link Filter} that allows all callbacks to be invoked.
+         *
+         * @param <C> the callback type
+         * @param <A> the primary argument type
+         * @return an "allow all" filter
+         */
+        static <C, A> Filter<C, A> allowAll() {
+            return (callbackType, callbackInstance, argument,
+                    additionalArguments) -> true;
+        }
+
+    }
+
+    /**
+     * {@link Filter} that matches when the callback has a single generic and primary
+     * argument is an instance of it.
+     */
+    private static class GenericTypeFilter<C, A> implements Filter<C, A> {
+
+        @Override
+        public boolean match(Class<C> callbackType, C callbackInstance, A argument,
+                             Object[] additionalArguments) {
+            ResolvableType type = ResolvableType.forClass(callbackType,
+                    callbackInstance.getClass());
+            if (type.getGenerics().length == 1 && type.resolveGeneric() != null) {
+                return type.resolveGeneric().isInstance(argument);
+            }
+
+            return true;
+        }
+
+    }
+
+    /**
+     * The result of a callback which may be a value, {@code null} or absent entirely if
+     * the callback wasn't suitable. Similar in design to {@link Optional} but allows for
+     * {@code null} as a valid value.
+     *
+     * @param <R> the result type
+     */
+    public static final class InvocationResult<R> {
+
+        private static final InvocationResult<?> NONE = new InvocationResult<>(null);
+
+        private final R value;
+
+        private InvocationResult(R value) {
+            this.value = value;
+        }
+
+        /**
+         * Return true if a result in present.
+         *
+         * @return if a result is present
+         */
+        public boolean hasResult() {
+            return this != NONE;
+        }
+
+        /**
+         * Return the result of the invocation or {@code null} if the callback wasn't
+         * suitable.
+         *
+         * @return the result of the invocation or {@code null}
+         */
+        public R get() {
+            return this.value;
+        }
+
+        /**
+         * Return the result of the invocation or the given fallback if the callback
+         * wasn't suitable.
+         *
+         * @param fallback the fallback to use when there is no result
+         * @return the result of the invocation or the fallback
+         */
+        public R get(R fallback) {
+            return (this != NONE) ? this.value : fallback;
+        }
+
+        /**
+         * Create a new {@link InvocationResult} instance with the specified value.
+         *
+         * @param value the value (may be {@code null})
+         * @param <R>   the result type
+         * @return an {@link InvocationResult}
+         */
+        public static <R> InvocationResult<R> of(R value) {
+            return new InvocationResult<>(value);
+        }
+
+        /**
+         * Return an {@link InvocationResult} instance representing no result.
+         *
+         * @param <R> the result type
+         * @return an {@link InvocationResult}
+         */
+        @SuppressWarnings("unchecked")
+        public static <R> InvocationResult<R> noResult() {
+            return (InvocationResult<R>) NONE;
+        }
+
+    }
+
+}

--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -8,6 +8,7 @@ io.micrometer.spring.autoconfigure.Log4J2MetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.LogbackMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.MetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.SystemMetricsAutoConfiguration,\
+io.micrometer.spring.autoconfigure.cache.CacheMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.appoptics.AppOpticsMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.atlas.AtlasMetricsExportAutoConfiguration,\
 io.micrometer.spring.autoconfigure.export.azuremonitor.AzureMonitorMetricsExportAutoConfiguration,\


### PR DESCRIPTION
This PR adds auto-configuration for cache metrics by backporting from Spring Boot 2.x support. This has been supported since Spring Boot 2.0.0.RELEASE but missed to backport to Spring Boot 1.5.x support.