### PR TITLE
Update default distribution port to match metrics port

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
 import io.micrometer.core.lang.Nullable;
 
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Duration;
 
@@ -90,13 +91,13 @@ public interface WavefrontConfig extends StepRegistryConfig {
 
     /**
      * @return The port to send to when sending histogram distributions to a Wavefront proxy.
-     * Default is 40000.
+     * The default is the port specified in the uri.
      * <p>For details on configuring the histogram proxy port, see
      * https://docs.wavefront.com/proxies_installing.html#configuring-proxy-ports-for-metrics-histograms-and-traces
      */
     default int distributionPort() {
         String v = get(prefix() + ".distributionPort");
-        return v == null ? 40000 : Integer.parseInt(v);
+        return v == null ? URI.create(uri()).getPort() : Integer.parseInt(v);
     }
 
     /**

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -65,6 +65,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
     private final WavefrontConfig config;
     private final HttpSender httpClient;
     private final URI uri;
+    private final int distributionPort;
     private final Set<HistogramGranularity> histogramGranularities;
 
     /**
@@ -99,6 +100,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
         }
         this.httpClient = httpClient;
         this.uri = URI.create(config.uri());
+        this.distributionPort = config.distributionPort();
 
         this.histogramGranularities = new HashSet<>();
         if (config.reportMinuteDistribution()) {
@@ -179,7 +181,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
                     "distributions", distributionCount.get());
             } else {
                 flushToProxy(metricStream, uri.getPort(), "metrics", batch.size());
-                flushToProxy(distributionStream, config.distributionPort(), "distributions",
+                flushToProxy(distributionStream, distributionPort, "distributions",
                     distributionCount.get());
             }
         }


### PR DESCRIPTION
Wavefront has optimized the metrics port for distributions as well, so we now recommend using the same port for metrics and distributions.