### PR TITLE
Add Dropwizard metrics binder

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListener.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.*;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.util.StringUtils;
 
 import java.util.function.ToDoubleFunction;
 
@@ -38,7 +39,7 @@ public class MicrometerMetricRegistryListener extends MetricRegistryListener.Bas
     private String metricPrefix;
 
     public MicrometerMetricRegistryListener(MeterRegistry registry) {
-        this(registry, "dropwizard");
+        this(registry, "");
     }
 
     public MicrometerMetricRegistryListener(MeterRegistry registry, String metricPrefix) {
@@ -75,13 +76,18 @@ public class MicrometerMetricRegistryListener extends MetricRegistryListener.Bas
     }
 
     private <T> void registerGauge(String name, T obj, ToDoubleFunction<T> f) {
-        Gauge.builder(String.format("%s.%s", metricPrefix, name), obj, f)
+        Gauge.builder(getPrefixedMetricName(metricPrefix, name), obj, f)
                 .register(registry);
     }
 
     private <T> void registerCounter(String name, T obj, ToDoubleFunction<T> f) {
-        FunctionCounter.builder(String.format("%s.%s.count", metricPrefix, name), obj, f)
+        String prefixedMetricName = getPrefixedMetricName(metricPrefix, name);
+        FunctionCounter.builder(String.join(".", prefixedMetricName, "count"), obj, f)
                 .register(registry);
+    }
+
+    private static String getPrefixedMetricName(String prefix, String metric) {
+        return StringUtils.isBlank(prefix) ? metric : String.join(".", prefix, metric);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListener.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.dropwizard;
+
+import com.codahale.metrics.*;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Dropwizard {@link MetricRegistryListener} that binds Dropwizard's metrics with Micrometer Meters.
+ * Useful for third-party libraries that expose their metrics only through Dropwizard registries.
+ * Example use:
+ * <code>
+ *     metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry));
+ * </code>
+ *
+ * @author Christophe Bornet
+ */
+public class MicrometerMetricRegistryListener extends MetricRegistryListener.Base {
+
+    private final MeterRegistry registry;
+    private String metricPrefix;
+
+    public MicrometerMetricRegistryListener(MeterRegistry registry) {
+        this(registry, "dropwizard");
+    }
+
+    public MicrometerMetricRegistryListener(MeterRegistry registry, String metricPrefix) {
+        this.registry = registry;
+        this.metricPrefix = metricPrefix;
+    }
+
+    @Override
+    public void onGaugeAdded(String name, com.codahale.metrics.Gauge<?> gauge) {
+        if (gauge.getValue() instanceof Number) {
+            registerGauge(name, gauge, g -> ((Number) g.getValue()).doubleValue());
+        }
+    }
+
+    @Override
+    public void onCounterAdded(String name, Counter counter) {
+        // Using a Gauge since Dropwizard's counters are not monotonic.
+        registerGauge(name, counter, Counter::getCount);
+    }
+
+    @Override
+    public void onHistogramAdded(String name, Histogram histogram) {
+        registerCounter(name, histogram, Histogram::getCount);
+    }
+
+    @Override
+    public void onMeterAdded(String name, Meter meter) {
+        registerCounter(name, meter, Meter::getCount);
+    }
+
+    @Override
+    public void onTimerAdded(String name, Timer timer) {
+        registerCounter(name, timer, Timer::getCount);
+    }
+
+    private <T> void registerGauge(String name, T obj, ToDoubleFunction<T> f) {
+        Gauge.builder(String.format("%s.%s", metricPrefix, name), obj, f)
+                .register(registry);
+    }
+
+    private <T> void registerCounter(String name, T obj, ToDoubleFunction<T> f) {
+        FunctionCounter.builder(String.format("%s.%s.count", metricPrefix, name), obj, f)
+                .register(registry);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListenerTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.dropwizard;
+
+import com.codahale.metrics.*;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MicrometerMetricRegistryListenerTest {
+
+    private static final String METRIC_PREFIX = "prefix";
+    private static final String METRIC_NAME = "metric";
+    private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private MetricRegistry metricRegistry = new MetricRegistry();
+
+    @BeforeEach
+    void setUp() {
+        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry, METRIC_PREFIX));
+    }
+
+    @Test
+    void shouldBindGauge() {
+        AtomicInteger innerVal = new AtomicInteger();
+        Gauge<Integer> gauge = innerVal::get;
+        metricRegistry.register(METRIC_NAME, gauge);
+        innerVal.set(1);
+        innerVal.set(42);
+        assertEquals(42, meterRegistry.get(String.format("%s.%s", METRIC_PREFIX, METRIC_NAME)).gauge().value());
+    }
+
+    @Test
+    void shouldBindGaugeWithoutListenerPrefix() {
+        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry));
+        AtomicInteger innerVal = new AtomicInteger();
+        Gauge<Integer> gauge = innerVal::get;
+        metricRegistry.register(METRIC_NAME, gauge);
+        innerVal.set(1);
+        innerVal.set(42);
+        assertEquals(42, meterRegistry.get(String.format("%s.%s", "dropwizard", METRIC_NAME)).gauge().value());
+    }
+
+    @Test
+    void shouldBindCounter() {
+        Counter counter = new Counter();
+        metricRegistry.register(METRIC_NAME, counter);
+        counter.inc();
+        counter.inc(2);
+        assertEquals(3, meterRegistry.get(String.format("%s.%s", METRIC_PREFIX, METRIC_NAME)).gauge().value());
+    }
+
+    @Test
+    void shouldBindHistogram() {
+        Histogram histogram = new Histogram(new UniformReservoir());
+        metricRegistry.register(METRIC_NAME, histogram);
+        histogram.update(1);
+        histogram.update(42);
+        assertEquals(2, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+    }
+
+    @Test
+    void shouldBindMeter() {
+        Meter meter = new Meter();
+        metricRegistry.register(METRIC_NAME, meter);
+        meter.mark();
+        meter.mark(2);
+        assertEquals(3, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+    }
+
+    @Test
+    void shouldBindTimer() {
+        Timer timer = new Timer();
+        metricRegistry.register(METRIC_NAME, timer);
+        timer.update(5, TimeUnit.SECONDS);
+        timer.update(5, TimeUnit.SECONDS);
+        assertEquals(2, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/MicrometerMetricRegistryListenerTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class MicrometerMetricRegistryListenerTest {
 
@@ -35,7 +35,7 @@ class MicrometerMetricRegistryListenerTest {
 
     @BeforeEach
     void setUp() {
-        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry, METRIC_PREFIX));
+        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry));
     }
 
     @Test
@@ -45,18 +45,18 @@ class MicrometerMetricRegistryListenerTest {
         metricRegistry.register(METRIC_NAME, gauge);
         innerVal.set(1);
         innerVal.set(42);
-        assertEquals(42, meterRegistry.get(String.format("%s.%s", METRIC_PREFIX, METRIC_NAME)).gauge().value());
+        assertEquals(42, meterRegistry.get(METRIC_NAME).gauge().value());
     }
 
     @Test
-    void shouldBindGaugeWithoutListenerPrefix() {
-        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry));
+    void shouldBindGaugeWithListenerPrefix() {
+        metricRegistry.addListener(new MicrometerMetricRegistryListener(meterRegistry, METRIC_PREFIX));
         AtomicInteger innerVal = new AtomicInteger();
         Gauge<Integer> gauge = innerVal::get;
         metricRegistry.register(METRIC_NAME, gauge);
         innerVal.set(1);
         innerVal.set(42);
-        assertEquals(42, meterRegistry.get(String.format("%s.%s", "dropwizard", METRIC_NAME)).gauge().value());
+        assertEquals(42, meterRegistry.get(String.join(".", METRIC_PREFIX, METRIC_NAME)).gauge().value());
     }
 
     @Test
@@ -65,7 +65,7 @@ class MicrometerMetricRegistryListenerTest {
         metricRegistry.register(METRIC_NAME, counter);
         counter.inc();
         counter.inc(2);
-        assertEquals(3, meterRegistry.get(String.format("%s.%s", METRIC_PREFIX, METRIC_NAME)).gauge().value());
+        assertEquals(3, meterRegistry.get(METRIC_NAME).gauge().value());
     }
 
     @Test
@@ -74,7 +74,7 @@ class MicrometerMetricRegistryListenerTest {
         metricRegistry.register(METRIC_NAME, histogram);
         histogram.update(1);
         histogram.update(42);
-        assertEquals(2, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+        assertEquals(2, meterRegistry.get(METRIC_NAME + ".count").functionCounter().count());
     }
 
     @Test
@@ -83,7 +83,7 @@ class MicrometerMetricRegistryListenerTest {
         metricRegistry.register(METRIC_NAME, meter);
         meter.mark();
         meter.mark(2);
-        assertEquals(3, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+        assertEquals(3, meterRegistry.get(METRIC_NAME + ".count").functionCounter().count());
     }
 
     @Test
@@ -92,6 +92,6 @@ class MicrometerMetricRegistryListenerTest {
         metricRegistry.register(METRIC_NAME, timer);
         timer.update(5, TimeUnit.SECONDS);
         timer.update(5, TimeUnit.SECONDS);
-        assertEquals(2, meterRegistry.get(String.format("%s.%s.count", METRIC_PREFIX, METRIC_NAME)).functionCounter().count());
+        assertEquals(2, meterRegistry.get(METRIC_NAME + ".count").functionCounter().count());
     }
 }


### PR DESCRIPTION
Dropwizard `MetricRegistryListener` that binds Dropwizard's metrics with Micrometer Meters.
Useful for third-party libraries that expose their metrics only through Dropwizard registries.
Example with cassandra's driver:
```java
    cluster.getMetrics().getRegistry().addListener(new MicrometerMetricRegistryListener(meterRegistry, "cassandra"));

```