### PR TITLE
Use type parameter consistently for registerMeterIfNecessary methods

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -503,13 +503,13 @@ public abstract class MeterRegistry implements AutoCloseable {
         return gauge(name, tags, map, Map::size);
     }
 
-    private <M extends Meter> M registerMeterIfNecessary(Class<M> meterClass, Meter.Id id, Function<Meter.Id, Meter> builder,
+    private <M extends Meter> M registerMeterIfNecessary(Class<M> meterClass, Meter.Id id, Function<Meter.Id, M> builder,
                                                          Function<Meter.Id, M> noopBuilder) {
         return registerMeterIfNecessary(meterClass, id, null, (id2, conf) -> builder.apply(id2), noopBuilder);
     }
 
     private <M extends Meter> M registerMeterIfNecessary(Class<M> meterClass, Meter.Id id,
-                                                         @Nullable DistributionStatisticConfig config, BiFunction<Meter.Id, DistributionStatisticConfig, Meter> builder,
+                                                         @Nullable DistributionStatisticConfig config, BiFunction<Meter.Id, DistributionStatisticConfig, M> builder,
                                                          Function<Meter.Id, M> noopBuilder) {
         Meter.Id mappedId = id;
 
@@ -528,7 +528,7 @@ public abstract class MeterRegistry implements AutoCloseable {
     }
 
     private Meter getOrCreateMeter(@Nullable DistributionStatisticConfig config,
-                                   BiFunction<Id, /*Nullable Generic*/ DistributionStatisticConfig, Meter> builder,
+                                   BiFunction<Id, /*Nullable Generic*/ DistributionStatisticConfig, ? extends Meter> builder,
                                    Id originalId, Id mappedId, Function<Meter.Id, ? extends Meter> noopBuilder) {
         Meter m = meterMap.get(mappedId);
 


### PR DESCRIPTION
This PR changes to use type parameter consistently for `MeterRegistry.registerMeterIfNecessary()` methods as `noopBuilder` is using it but `builder` isn't.