### PR TITLE
Use system-dependent line separator for logs

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -133,7 +133,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                         m -> writeMeter(m, metadataToSend))
                 ).collect(joining(",", "{\"series\":[", "]}"));
 
-                logger.trace("sending metrics batch to datadog:\n{}", body);
+                logger.trace("sending metrics batch to datadog:{}{}", System.lineSeparator(), body);
 
                 httpClient.post(datadogEndpoint)
                         .withJsonContent(

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -170,9 +170,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
                         .addAllTimeSeries(partition)
                         .build();
 
-                if (logger.isTraceEnabled()) {
-                    logger.trace("publishing batch to Stackdriver:\n{}", request);
-                }
+                logger.trace("publishing batch to Stackdriver:{}{}", System.lineSeparator(), request);
 
                 client.createTimeSeries(request);
                 logger.debug("successfully sent {} TimeSeries to Stackdriver", partition.size());
@@ -361,9 +359,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
                         .setMetricDescriptor(descriptor)
                         .build();
 
-                if (logger.isTraceEnabled()) {
-                    logger.trace("creating metric descriptor:\n{}", request);
-                }
+                logger.trace("creating metric descriptor:{}{}", System.lineSeparator(), request);
 
                 try {
                     client.createMetricDescriptor(request);


### PR DESCRIPTION
This PR changes to use system-dependent line separator for logs.

This PR also removes unnecessary trace-level guards.