### PR TITLE
Log request body on errors for Elasticsearch meter registry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -129,23 +129,24 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
         for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
             try {
+                String requestBody = batch.stream()
+                        .map(m -> m.match(
+                                this::writeGauge,
+                                this::writeCounter,
+                                this::writeTimer,
+                                this::writeSummary,
+                                this::writeLongTaskTimer,
+                                this::writeTimeGauge,
+                                this::writeFunctionCounter,
+                                this::writeFunctionTimer,
+                                this::writeMeter))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(joining("\n", "", "\n"));
                 httpClient
                         .post(config.host() + "/" + indexName() + "/doc/_bulk")
                         .withBasicAuthentication(config.userName(), config.password())
-                        .withJsonContent(batch.stream()
-                                .map(m -> m.match(
-                                        this::writeGauge,
-                                        this::writeCounter,
-                                        this::writeTimer,
-                                        this::writeSummary,
-                                        this::writeLongTaskTimer,
-                                        this::writeTimeGauge,
-                                        this::writeFunctionCounter,
-                                        this::writeFunctionTimer,
-                                        this::writeMeter))
-                                .filter(Optional::isPresent)
-                                .map(Optional::get)
-                                .collect(joining("\n", "", "\n")))
+                        .withJsonContent(requestBody)
                         .send()
                         .onSuccess(response -> {
                             // It's not enough to look at response code. ES could return {"errors":true} in body:
@@ -157,7 +158,10 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                                 logger.debug("successfully sent {} metrics to elastic", batch.size());
                             }
                         })
-                        .onError(response -> logger.error("failed to send metrics to elastic: {}", response.body()));
+                        .onError(response -> {
+                            logger.error("failed to send metrics to elastic: {}", response.body());
+                            logger.debug("failed metrics payload: {}", requestBody);
+                        });
             } catch (Throwable e) {
                 logger.error("failed to send metrics to elastic", e);
             }


### PR DESCRIPTION
This PR changes to log request body on errors for Elasticsearch meter registry. This log could help track down the cause of #1370.