### PR TITLE
Drop custom meters non-finite measurements for Elasticsearch

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -258,6 +258,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     Optional<String> writeMeter(Meter meter) {
         Iterable<Measurement> measurements = meter.measure();
         List<String> names = new ArrayList<>();
+        // Snapshot values should be used throughout this method as there are chances for values to be changed in-between.
         List<Double> values = new ArrayList<>();
         for (Measurement measurement : measurements) {
             double value = measurement.getValue();

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -20,7 +20,8 @@ import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,10 +124,26 @@ class ElasticMeterRegistryTest {
     }
 
     @Test
-    void writeMeterWhenCustomMeterIsInfinityShouldNotBeWritten() {
-        Measurement measurement = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, Collections.singletonList(measurement)).register(this.registry);
+    void writeMeterWhenCustomMeterHasOnlyNonFiniteValuesShouldNotBeWritten() {
+        Measurement measurement1 = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
+        Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
+        Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
         assertThat(registry.writeMeter(meter)).isNotPresent();
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterHasMixedFiniteAndNonFiniteValuesShouldSkipOnlyNonFiniteValues() {
+        Measurement measurement1 = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
+        Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
+        Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        Measurement measurement4 = new Measurement(() -> 1d, Statistic.VALUE);
+        Measurement measurement5 = new Measurement(() -> 2d, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4, measurement5);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.writeMeter(meter)).contains("{ \"index\" : {} }\n" +
+                "{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"my_meter\",\"type\":\"gauge\",\"value\":\"1.0\",\"value\":\"2.0\"}");
     }
 
     @Test

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +120,13 @@ class ElasticMeterRegistryTest {
         Timer timer = Timer.builder("myTimer").register(registry);
         assertThat(registry.writeMeter(timer))
                 .contains("{ \"index\" : {} }\n{\"@timestamp\":\"1970-01-01T00:00:00.001Z\",\"name\":\"myTimer\",\"type\":\"timer\",\"count\":\"0.0\",\"total\":\"0.0\",\"max\":\"0.0\"}");
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterIsInfinityShouldNotBeWritten() {
+        Measurement measurement = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, Collections.singletonList(measurement)).register(this.registry);
+        assertThat(registry.writeMeter(meter)).isNotPresent();
     }
 
     @Test


### PR DESCRIPTION
This PR drops custom meters having any non-finite measurement for Elasticsearch.

Closes gh-1370