### PR TITLE
Batching logic was not following New Relic expectations

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -32,12 +32,12 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -106,23 +106,24 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
                 }
             }).collect(toList());
 
-            if (events.size() > batchSize) {
-                sendEvents(insightsEndpoint, events.subList(0, batchSize));
-                events = new ArrayList<>(events.subList(batchSize, events.size()));
-            } else if (events.size() == batchSize) {
-                sendEvents(insightsEndpoint, events);
-                events = new ArrayList<>();
-            }
+            sendInBatches(batchSize, events, batch -> sendEvents(insightsEndpoint, batch));
 
-            // drain the remaining event list
-            if (!events.isEmpty()) {
-                sendEvents(insightsEndpoint, events);
-            }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("malformed New Relic insights endpoint -- see the 'uri' configuration", e);
         } catch (Throwable t) {
             logger.warn("failed to send metrics", t);
         }
+    }
+
+    static void sendInBatches(int batchSize, List<String> events, Consumer<List<String>> sender) {
+        int fromIndex = 0;
+        int totalSize = events.size();
+        int toIndex;
+        do {
+            toIndex = Math.min(fromIndex+batchSize,totalSize);
+            if (toIndex>0) sender.accept(events.subList(fromIndex, toIndex));
+            fromIndex = toIndex;
+        } while (toIndex<totalSize);
     }
 
     private Stream<String> writeLongTaskTimer(LongTaskTimer ltt) {
@@ -230,6 +231,8 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         HttpURLConnection con = null;
 
         try {
+            logger.info("Sending {} events to New Relic", events.size());
+
             con = (HttpURLConnection) insightsEndpoint.openConnection();
             con.setConnectTimeout((int) config.connectTimeout().toMillis());
             con.setReadTimeout((int) config.readTimeout().toMillis());

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -120,10 +120,10 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         int totalSize = events.size();
         int toIndex;
         do {
-            toIndex = Math.min(fromIndex+batchSize,totalSize);
-            if (toIndex>0) sender.accept(events.subList(fromIndex, toIndex));
+            toIndex = Math.min(fromIndex + batchSize,totalSize);
+            if (toIndex > 0) sender.accept(events.subList(fromIndex, toIndex));
             fromIndex = toIndex;
-        } while (toIndex<totalSize);
+        } while (toIndex < totalSize);
     }
 
     private Stream<String> writeLongTaskTimer(LongTaskTimer ltt) {

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryUtilsTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryUtilsTest.java
@@ -1,0 +1,52 @@
+package io.micrometer.newrelic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NewRelicMeterRegistryUtilsTest {
+
+    private static class Checker<T> implements Consumer<List<T>> {
+        final int[] batches;
+        int position = 0;
+
+        Checker(int[] batches) {
+            this.batches = batches;
+        }
+
+        @Override
+        public void accept(List<T> t) {
+            System.out.println(t.size()+" "+t);
+            assertEquals(batches[position],t.size());
+            position+=1;
+        }
+
+        void checkComplete(){
+            assertEquals(batches.length,position);
+        }
+    }
+
+    @Test
+    void sendInBatches() {
+        Checker<String> oneChecker = new Checker<>(new int[]{1});
+        NewRelicMeterRegistry.sendInBatches(2, Collections.singletonList("0"),oneChecker);
+        oneChecker.checkComplete();
+
+        Checker<String> evenChecker = new Checker<>(new int[]{2, 2});
+        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0","1","2","3"),evenChecker);
+        evenChecker.checkComplete();
+
+        Checker<String> oddChecker = new Checker<>(new int[]{2, 1});
+        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0","1","2"),oddChecker);
+        oddChecker.checkComplete();
+
+        Checker<String> emptyChecker = new Checker<>(new int[]{});
+        NewRelicMeterRegistry.sendInBatches(2, Collections.emptyList(),emptyChecker);
+        emptyChecker.checkComplete();
+    }
+}

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryUtilsTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryUtilsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.newrelic;
 
 import org.junit.jupiter.api.Test;
@@ -9,6 +24,9 @@ import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * @author Denis Tazhkenov
+ */
 class NewRelicMeterRegistryUtilsTest {
 
     private static class Checker<T> implements Consumer<List<T>> {
@@ -21,32 +39,32 @@ class NewRelicMeterRegistryUtilsTest {
 
         @Override
         public void accept(List<T> t) {
-            System.out.println(t.size()+" "+t);
-            assertEquals(batches[position],t.size());
-            position+=1;
+            System.out.println(t.size() + " " + t);
+            assertEquals(batches[position], t.size());
+            position += 1;
         }
 
-        void checkComplete(){
-            assertEquals(batches.length,position);
+        void checkComplete() {
+            assertEquals(batches.length, position);
         }
     }
 
     @Test
     void sendInBatches() {
         Checker<String> oneChecker = new Checker<>(new int[]{1});
-        NewRelicMeterRegistry.sendInBatches(2, Collections.singletonList("0"),oneChecker);
+        NewRelicMeterRegistry.sendInBatches(2, Collections.singletonList("0"), oneChecker);
         oneChecker.checkComplete();
 
         Checker<String> evenChecker = new Checker<>(new int[]{2, 2});
-        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0","1","2","3"),evenChecker);
+        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0", "1", "2", "3"), evenChecker);
         evenChecker.checkComplete();
 
         Checker<String> oddChecker = new Checker<>(new int[]{2, 1});
-        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0","1","2"),oddChecker);
+        NewRelicMeterRegistry.sendInBatches(2, Arrays.asList("0", "1", "2"), oddChecker);
         oddChecker.checkComplete();
 
         Checker<String> emptyChecker = new Checker<>(new int[]{});
-        NewRelicMeterRegistry.sendInBatches(2, Collections.emptyList(),emptyChecker);
+        NewRelicMeterRegistry.sendInBatches(2, Collections.emptyList(), emptyChecker);
         emptyChecker.checkComplete();
     }
 }


### PR DESCRIPTION
A pack of 3000 events was broken into 1000 and 2000, which led to all events from the second part being thrown out. Large packs should be broken into batches of `batchSize` each, eg. 1000, 1000, 1000 in this example.

A log was also added which states the intent to send a certain number of events. Because without it it took us too long to identify the problem.