### PR TITLE
Add Javadoc since tags to Stackdriver classes

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
@@ -18,6 +18,12 @@ package io.micrometer.stackdriver;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 
+/**
+ * {@link StepRegistryConfig} for Stackdriver.
+ *
+ * @author Jon Schneider
+ * @since 1.1.0
+ */
 public interface StackdriverConfig extends StepRegistryConfig {
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -57,6 +57,12 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.StreamSupport.stream;
 
+/**
+ * {@link StepMeterRegistry} for Stackdriver.
+ *
+ * @author Jon Schneider
+ * @since 1.1.0
+ */
 @Incubating(since = "1.1.0")
 public class StackdriverMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("stackdriver-metrics-publisher");

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
@@ -22,6 +22,12 @@ import io.micrometer.core.lang.Nullable;
 
 import java.util.regex.Pattern;
 
+/**
+ * {@link NamingConvention} for Stackdriver.
+ *
+ * @author Jon Schneider
+ * @since 1.1.0
+ */
 public class StackdriverNamingConvention implements NamingConvention {
     private static final int MAX_NAME_LENGTH = 200;
     private static final int MAX_TAG_KEY_LENGTH = 100;

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/util/ClearCustomMetricDescriptors.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/util/ClearCustomMetricDescriptors.java
@@ -32,6 +32,9 @@ import java.io.UncheckedIOException;
  *
  * @see <a href="https://cloud.google.com/monitoring/docs/reference/libraries#setting_up_authentication">Google Cloud authentication</a>
  * @see <a href="https://cloud.google.com/monitoring/access-control">Google Cloud access control</a>
+ *
+ * @author Jon Schneider
+ * @since 1.1.0
  */
 public class ClearCustomMetricDescriptors {
     public static void clearCustomMetricDescriptors(MetricServiceSettings settings, String projectId) {

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/stackdriver/StackdriverMetricsExportAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/stackdriver/StackdriverMetricsExportAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.core.io.Resource;
  * Configuration for exporting metrics to Stackdriver.
  *
  * @author Jon Schneider
+ * @since 1.1.0
  */
 @Configuration
 @AutoConfigureBefore({CompositeMeterRegistryAutoConfiguration.class,

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/stackdriver/StackdriverProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/stackdriver/StackdriverProperties.java
@@ -25,6 +25,7 @@ import java.time.Duration;
  * {@link ConfigurationProperties} for configuring metrics export to Stackdriver.
  *
  * @author Jon Schneider
+ * @since 1.1.0
  */
 @ConfigurationProperties(prefix = "management.metrics.export.stackdriver")
 public class StackdriverProperties extends StepRegistryProperties {


### PR DESCRIPTION
This PR adds Javadoc `@since` tags to Stackdriver classes.