### PR TITLE
Drop custom meters' non-finite measurements for Wavefront

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -189,7 +189,8 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
         return metrics.build();
     }
 
-    private Stream<String> writeMeter(Meter meter) {
+    // VisibleForTesting
+    Stream<String> writeMeter(Meter meter) {
         long wallTime = clock.wallTime();
         Stream.Builder<String> metrics = Stream.builder();
 
@@ -204,7 +205,7 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     void addMetric(Stream.Builder<String> metrics, Meter.Id id, @Nullable String suffix, long wallTime, double value) {
-        if (!Double.isNaN(value)) {
+        if (Double.isFinite(value)) {
             metrics.add(writeMetric(id, suffix, wallTime, value));
         }
     }


### PR DESCRIPTION
This PR changes to drop custom meters' non-finite measurements for Wavefront similar to #1374.

I noticed that [the code on the 1.1.x branch handles it already](https://github.com/micrometer-metrics/micrometer/blob/1.1.x/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java#L212) but it's out of sync in the 1.0.x branch somehow.