### PR TITLE
Allow infinities for Amazon CloudWatch again

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -149,10 +149,11 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         private long wallTime = clock.wallTime();
 
         private Stream<MetricDatum> gaugeData(Gauge gauge) {
-            double value = gauge.value();
-            if (!Double.isFinite(value))
+            MetricDatum metricDatum = metricDatum(gauge.getId(), "value", gauge.value());
+            if (metricDatum == null) {
                 return Stream.empty();
-            return Stream.of(metricDatum(gauge.getId(), "value", value));
+            }
+            return Stream.of(metricDatum);
         }
 
         private Stream<MetricDatum> counterData(Counter counter) {
@@ -188,19 +189,20 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         }
 
         private Stream<MetricDatum> timeGaugeData(TimeGauge gauge) {
-            double value = gauge.value(getBaseTimeUnit());
-            if (!Double.isFinite(value))
+            MetricDatum metricDatum = metricDatum(gauge.getId(), "value", gauge.value(getBaseTimeUnit()));
+            if (metricDatum == null) {
                 return Stream.empty();
-            return Stream.of(metricDatum(gauge.getId(), "value", value));
+            }
+            return Stream.of(metricDatum);
         }
 
         // VisibleForTesting
         Stream<MetricDatum> functionCounterData(FunctionCounter counter) {
-            double count = counter.count();
-            if (Double.isFinite(count)) {
-                return Stream.of(metricDatum(counter.getId(), "count", count));
+            MetricDatum metricDatum = metricDatum(counter.getId(), "count", counter.count());
+            if (metricDatum == null) {
+                return Stream.empty();
             }
-            return Stream.empty();
+            return Stream.of(metricDatum);
         }
 
         private Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
@@ -210,7 +212,8 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                     metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
         }
 
-        private Stream<MetricDatum> metricData(Meter m) {
+        // VisibleForTesting
+        Stream<MetricDatum> metricData(Meter m) {
             return stream(m.measure().spliterator(), false)
                     .map(ms -> metricDatum(m.getId().withTag(ms.getStatistic()), ms.getValue()))
                     .filter(Objects::nonNull);

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchUtils.java
@@ -30,7 +30,8 @@ final class CloudWatchUtils {
      * Maximum allowed value as specified by
      * {@link com.amazonaws.services.cloudwatch.model.MetricDatum#setValue(Double)}
      */
-    private static final double MAXIMUM_ALLOWED_VALUE = 1.174271e+108;
+    // VisibleForTesting
+    static final double MAXIMUM_ALLOWED_VALUE = 1.174271e+108;
 
     private CloudWatchUtils() {
     }


### PR DESCRIPTION
This PR changes to allow infinities for Amazon CloudWatch again as on the 1.0.x branch they are allowed and looking into `CloudWatchUtils`, clamping logic handles them already.