### PR TITLE
Prevent race condition when updating tags for StatsD Telegraf flavor

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
@@ -65,12 +65,14 @@ public class TelegrafStatsdLineBuilder extends FlavorStatsdLineBuilder {
             }
 
             this.name = telegrafEscape(next.name(id.getName(), id.getType(), id.getBaseUnit()));
-            this.tags = HashTreePMap.empty();
-            this.conventionTags = id.getTags().iterator().hasNext() ?
-                    id.getConventionTags(this.namingConvention).stream()
-                            .map(t -> telegrafEscape(t.getKey()) + "=" + telegrafEscape(t.getValue()))
-                            .collect(Collectors.joining(","))
-                    : null;
+            synchronized (tagsLock) {
+                this.tags = HashTreePMap.empty();
+                this.conventionTags = id.getTags().iterator().hasNext() ?
+                        id.getConventionTags(this.namingConvention).stream()
+                                .map(t -> telegrafEscape(t.getKey()) + "=" + telegrafEscape(t.getValue()))
+                                .collect(Collectors.joining(","))
+                        : null;
+            }
             this.tagsNoStat = tags(null, conventionTags, "=", ",");
         }
     }

--- a/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compile.lockfile
@@ -54,6 +54,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/compileClasspath.lockfile
@@ -54,6 +54,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/default.lockfile
@@ -54,6 +54,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtime.lockfile
@@ -54,6 +54,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/micrometer-spring-legacy/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -54,6 +54,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1

--- a/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
+++ b/samples/micrometer-samples-boot1/gradle/dependency-locks/compileClasspath.lockfile
@@ -55,6 +55,7 @@ io.prometheus:simpleclient_pushgateway:0.2.0
 io.reactivex:rxjava:1.2.0
 javax.annotation:javax.annotation-api:1.2
 javax.cache:cache-api:1.0.0
+javax.inject:javax.inject:1
 javax.servlet:javax.servlet-api:3.1.0
 javax.validation:validation-api:1.1.0.Final
 javax.ws.rs:javax.ws.rs-api:2.0.1


### PR DESCRIPTION
This PR prevents race condition when updating tags for StatsD Telegraf flavor.

This PR also contains a preceding commit updating dependency lockfiles to resolve build failures similar to done in https://github.com/micrometer-metrics/micrometer/pull/1174. I didn't include unversioned dependency lockfiles intentionally to reduce verbosity in diff and hope to be okay without them.

And I noticed `DatadogStatsdLineBuilder` has the same concern, so if this approach is okay, I'll prepare a similar one for it.

Closes gh-1389