### PR TITLE
Backporting changes for issue #1282

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterRegistryConfigurer.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MeterRegistryConfigurer.java
@@ -18,6 +18,7 @@ package io.micrometer.spring.autoconfigure;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 
 import java.util.Collection;
@@ -41,14 +42,17 @@ class MeterRegistryConfigurer {
 
     private final boolean addToGlobalRegistry;
 
+    private final boolean hasCompositeMeterRegistry;
+
     MeterRegistryConfigurer(Collection<MeterBinder> binders,
                             Collection<MeterFilter> filters,
                             Collection<MeterRegistryCustomizer<?>> customizers,
-                            boolean addToGlobalRegistry) {
+                            boolean addToGlobalRegistry, boolean hasCompositeMeterRegistry) {
         this.binders = (binders != null ? binders : Collections.emptyList());
         this.filters = (filters != null ? filters : Collections.emptyList());
         this.customizers = (customizers != null ? customizers : Collections.emptyList());
         this.addToGlobalRegistry = addToGlobalRegistry;
+        this.hasCompositeMeterRegistry = hasCompositeMeterRegistry;
     }
 
     void configure(MeterRegistry registry) {
@@ -56,7 +60,10 @@ class MeterRegistryConfigurer {
         // tags or alter timer or summary configuration.
         customize(registry);
         addFilters(registry);
-        addBinders(registry);
+        if (!this.hasCompositeMeterRegistry
+                || registry instanceof CompositeMeterRegistry) {
+            addBinders(registry);
+        }
         if (this.addToGlobalRegistry && registry != Metrics.globalRegistry) {
             Metrics.addRegistry(registry);
         }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/MetricsAutoConfiguration.java
@@ -41,6 +41,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.SearchStrategy;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -82,8 +83,10 @@ public class MetricsAutoConfiguration {
             ObjectProvider<List<MeterBinder>> meterBinders,
             ObjectProvider<List<MeterFilter>> meterFilters,
             ObjectProvider<List<MeterRegistryCustomizer<?>>> meterRegistryCustomizers,
-            ObjectProvider<MetricsProperties> metricsProperties) {
-        return new MeterRegistryPostProcessor(meterBinders, meterFilters, meterRegistryCustomizers, metricsProperties);
+            ObjectProvider<MetricsProperties> metricsProperties,
+            ApplicationContext applicationContext) {
+        return new MeterRegistryPostProcessor(meterBinders, meterFilters, meterRegistryCustomizers, metricsProperties,
+                applicationContext);
     }
 
     @Bean

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeRegistryDoubleCountingTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/CompositeRegistryDoubleCountingTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = CompositeRegistryDoubleCountingTest.MetricsApp.class)
+@TestPropertySource(properties = {
+        "management.metrics.export.prometheus.enabled=true",
+        "management.metrics.export.prometheus.pushgateway.enabled=false",
+        "management.metrics.export.jmx.enabled=true",
+})
+public class CompositeRegistryDoubleCountingTest {
+    @Autowired
+    private MeterRegistry registry;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void compositeRegistryIsCreated() {
+        assertThat(registry).isInstanceOf(CompositeMeterRegistry.class);
+
+        assertThat(((CompositeMeterRegistry) registry).getRegistries())
+                .hasAtLeastOneElementOfType(JmxMeterRegistry.class)
+                .hasAtLeastOneElementOfType(PrometheusMeterRegistry.class);
+
+        assertThat(registry.config().clock()).isNotNull();
+    }
+
+    @Test
+    public void metricsAreNotCountedTwice() {
+        Logger logger = LoggerFactory.getLogger("test-logger");
+        logger.error("Error.");
+
+        Map<String, MeterRegistry> registriesByName = context
+                .getBeansOfType(MeterRegistry.class);
+        assertThat(registriesByName).hasSize(3);
+        registriesByName.forEach((name, registry) ->
+                assertThat(registry
+                        .get("logback.events")
+                        .tag("level", "error")
+                        .counter()
+                        .count())
+                        .isEqualTo(1));
+    }
+
+    @SpringBootApplication(scanBasePackages = "ignored")
+    static class MetricsApp {
+    }
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/SingleRegistryDoubleCountingTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/SingleRegistryDoubleCountingTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring.autoconfigure;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SingleRegistryDoubleCountingTest.MetricsApp.class)
+@TestPropertySource(properties = {
+        "management.metrics.export.prometheus.enabled=true",
+        "management.metrics.export.prometheus.pushgateway.enabled=false",
+})
+public class SingleRegistryDoubleCountingTest {
+    @Autowired
+    private MeterRegistry registry;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void singleRegistryIsCreated() {
+        assertThat(registry).isNotInstanceOf(CompositeMeterRegistry.class);
+
+        assertThat(registry.config().clock()).isNotNull();
+    }
+
+    @Test
+    public void metricsAreNotCountedTwice() {
+        Logger logger = LoggerFactory.getLogger("test-logger");
+        logger.error("Error.");
+
+        Map<String, MeterRegistry> registriesByName = context
+                .getBeansOfType(MeterRegistry.class);
+        assertThat(registriesByName).hasSize(1);
+        registriesByName.forEach((name, registry) ->
+                assertThat(registry
+                        .get("logback.events")
+                        .tag("level", "error")
+                        .counter()
+                        .count())
+                        .isEqualTo(1));
+    }
+
+    @SpringBootApplication(scanBasePackages = "ignored")
+    static class MetricsApp {
+    }
+}


### PR DESCRIPTION
For SpringBoot 2.x changes needs to be fixed from SpringBoot side and
they are proposed by izeye here: https://github.com/spring-projects/spring-boot/pull/16221

However, for SpringBoot 1.5.x micrometer-spring-legacy is in use and
changes shall be ported there. This is a goal of this PR.