### PR TITLE
Add HibernateMetricsAutoConfiguration to spring.factories

### DIFF
--- a/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
+++ b/micrometer-spring-legacy/src/main/resources/META-INF/spring.factories
@@ -31,6 +31,7 @@ io.micrometer.spring.autoconfigure.export.wavefront.WavefrontMetricsExportAutoCo
 io.micrometer.spring.autoconfigure.jdbc.DataSourcePoolMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.jersey.JerseyServerMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.kafka.consumer.KafkaMetricsAutoConfiguration,\
+io.micrometer.spring.autoconfigure.orm.jpa.HibernateMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.web.client.RestTemplateMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.web.jetty.JettyMetricsAutoConfiguration,\
 io.micrometer.spring.autoconfigure.web.servlet.WebMvcMetricsAutoConfiguration,\


### PR DESCRIPTION
This PR adds `HibernateMetricsAutoConfiguration` to `spring.factories`.

Closes gh-1394