### PR TITLE
Log request data when error occurs

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -113,7 +113,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                 if (exception instanceof AbortedException) {
                     logger.warn("sending metric data was aborted: {}", exception.getMessage());
                 } else {
-                    logger.error("error sending metric data.", exception);
+                    logger.error("error sending metric data:{}", putMetricDataRequest, exception);
                 }
                 latch.countDown();
             }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -140,7 +140,9 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                                 body)
                         .send()
                         .onSuccess(response -> logger.debug("successfully sent {} metrics to datadog", batch.size()))
-                        .onError(response -> logger.error("failed to send metrics to datadog: {}", response.body()));
+                        .onError(response
+                                -> logger.error("failed to send metrics to datadog. Request body:{} Response body:{}",
+                                body, response.body()));
             }
         } catch (Throwable e) {
             logger.warn("failed to send metrics to datadog", e);

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -167,8 +167,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                             }
                         })
                         .onError(response -> {
-                            logger.error("failed to send metrics to elastic: {}", response.body());
-                            logger.debug("failed metrics payload: {}", requestBody);
+                            logger.error("failed to send metrics to elastic: Request body:{} Response body:{} ",
+                                    requestBody, response.body());
                         });
             } catch (Throwable e) {
                 logger.error("failed to send metrics to elastic", e);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -233,12 +233,14 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         try {
             AtomicInteger totalEvents = new AtomicInteger();
 
+            String body = events.peek(ev -> totalEvents.incrementAndGet()).collect(Collectors.joining(",", "[", "]"));
             httpClient.post(insightsEndpoint)
                     .withHeader("X-Insert-Key", config.apiKey())
-                    .withJsonContent(events.peek(ev -> totalEvents.incrementAndGet()).collect(Collectors.joining(",", "[", "]")))
+                    .withJsonContent(body)
                     .send()
                     .onSuccess(response -> logger.debug("successfully sent {} metrics to New Relic.", totalEvents))
-                    .onError(response -> logger.error("failed to send metrics to new relic: http {} {}", response.code(), response.body()));
+                    .onError(response -> logger.error("failed to send metrics to new relic: Response code:{} Request body:{} Response body:{}",
+                            response.code(), body, response.body()));
         } catch (Throwable e) {
             logger.warn("failed to send metrics to new relic", e);
         }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -193,13 +193,15 @@ public class WavefrontMeterRegistry extends StepMeterRegistry {
         }
         try {
             String originalPath = uri.getPath() != null && !uri.getPath().equals("/") ? uri.getPath() : "";
+            String body = stream.collect(joining());
             httpClient.post(new URL(uri.getScheme(), uri.getHost(), uri.getPort(), originalPath + "/report?f=" + format).toString())
                 .withHeader("Authorization", "Bearer " + config.apiToken())
-                .withContent("application/octet-stream", stream.collect(joining()))
+                .withContent("application/octet-stream", body)
                 .compress()
                 .send()
                 .onSuccess(response -> logSuccessfulMetricsSent(description, count))
-                .onError(response -> logger.error("failed to send {} to Wavefront: {}", description, response.body()));
+                .onError(response -> logger.error("failed to send {} to Wavefront: Request body:{} Response body:{}",
+                        description, body, response.body()));
         } catch (Throwable e) {
             logger.error("failed to send " + description + " to Wavefront", e);
         }


### PR DESCRIPTION
Related to:

https://github.com/micrometer-metrics/micrometer/issues/1396

I think it makes sense to log the request/response data when an error occurs. Hence the removal of debug for the elastic registry.