### PR TITLE
Fixate OkHttp 3.x

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     // @Timed AOP
     compile 'org.aspectj:aspectjweaver:1.8.+', optional
 
-    compile 'com.squareup.okhttp3:okhttp:latest.release', optional
+    compile 'com.squareup.okhttp3:okhttp:3.+', optional
 
     testCompile 'io.projectreactor:reactor-test:latest.release'
 


### PR DESCRIPTION
OkHttp 4.0.0-alpha01 has been released recently and the current build on the `master` branch is broken with the following compile error:

```
> Task :micrometer-core:compileJava FAILED
/Users/izeye/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/ipc/http/OkHttpSender.java:58: error: cannot access ByteString
            RequestBody body = RequestBody.create(mediaType, entity);
                                          ^
  class file for okio.ByteString not found
1 error
```

This PR fixates OkHttp to 3.x to have stable builds for now. I think we can prepare to support OkHttp 4.x around its GA.