### PR TITLE
Make JMX domain configurable for Tomcat meter binder

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -54,7 +54,7 @@ public class TomcatMetrics implements MeterBinder {
     private final MBeanServer mBeanServer;
     private final Iterable<Tag> tags;
 
-    private String jmxDomain;
+    private volatile String jmxDomain;
 
     public TomcatMetrics(@Nullable Manager manager, Iterable<Tag> tags) {
         this(manager, tags, getMBeanServer());
@@ -272,6 +272,20 @@ public class TomcatMetrics implements MeterBinder {
             }
         }
         return this.jmxDomain;
+    }
+
+    /**
+     * Set JMX domain. If unset, default values will be used as follows:
+     *
+     * <ul>
+     *     <li>Embedded Tomcat: "Tomcat"</li>
+     *     <li>Standalone Tomcat: "Catalina"</li>
+     * </ul>
+     *
+     * @param jmxDomain JMX domain to be used
+     */
+    public void setJmxDomain(String jmxDomain) {
+        this.jmxDomain = jmxDomain;
     }
 
     private boolean hasObjectName(String name) {


### PR DESCRIPTION
This PR changes JMX domain to be configurable for Tomcat meter binder.

Closes gh-1438

FTR I did the following to build successfully locally but didn't push the dependency lock changes as it could end up similar to c596caa4d0fc5bda106fd79b71a83ef23c2d5eb6:

```
$ ./gradlew clean check
...
> Task :micrometer-spring-legacy:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-spring-legacy:compileClasspath'.
> Dependency lock state for configuration 'compileClasspath' is out of date: Resolved 'javax.inject:javax.inject:1' which is not part of the lock state
...
$ ./gradlew :micrometer-spring-legacy:classes --update-locks javax.inject:javax.inject
...
$ ./gradlew clean check
...
> Task :micrometer-samples-boot1:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':micrometer-samples-boot1:compileClasspath'.
> Dependency lock state for configuration 'compileClasspath' is out of date: Resolved 'javax.inject:javax.inject:1' which is not part of the lock state
...
$ ./gradlew :micrometer-samples-boot1:classes --update-locks javax.inject:javax.inject
...
$ ./gradlew clean check
...
$
```