### PR TITLE
Add Javadoc since to TomcatMetrics.setJmxDomain()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -283,6 +283,7 @@ public class TomcatMetrics implements MeterBinder {
      * </ul>
      *
      * @param jmxDomain JMX domain to be used
+     * @since 1.0.11
      */
     public void setJmxDomain(String jmxDomain) {
         this.jmxDomain = jmxDomain;


### PR DESCRIPTION
This PR adds Javadoc since tag to `TomcatMetrics.setJmxDomain()`.