### PR TITLE
Add catch statement to CloudWatchMeterRegistry.publish

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -94,8 +94,9 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                     interrupted = true;
                 }
             }
-        }
-        finally {
+        } catch (Exception exception) {
+            logger.error("error publishing metric data.", exception);
+        } finally {
             if (interrupted) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
Fix for bug #1444

I added a catch statement to CloudWatchMeterRegistry.publish, so that in the case where a gauge throws an exception, the scheduled executor won't be halted.