### PR TITLE
Use name of Meter.Id.Type for metric_type in InfluxDB's Line Protocol

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -162,7 +162,8 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         if (fields.isEmpty()) {
             return Stream.empty();
         }
-        return Stream.of(influxLineProtocol(m.getId(), "unknown", fields.stream()));
+        Meter.Id id = m.getId();
+        return Stream.of(influxLineProtocol(id, id.getType().name().toLowerCase(), fields.stream()));
     }
 
     private Stream<String> writeLongTaskTimer(LongTaskTimer timer) {

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
@@ -124,7 +124,7 @@ class InfluxMeterRegistryTest {
 
     @Test
     void writeCustomMeter() {
-        String expectedInfluxLine = "my_custom,metric_type=unknown value=23,value=13,total=5 1";
+        String expectedInfluxLine = "my_custom,metric_type=other value=23,value=13,total=5 1";
 
         Measurement m1 = new Measurement(() -> 23d, Statistic.VALUE);
         Measurement m2 = new Measurement(() -> 13d, Statistic.VALUE);
@@ -153,6 +153,6 @@ class InfluxMeterRegistryTest {
         Measurement measurement5 = new Measurement(() -> 2d, Statistic.VALUE);
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4, measurement5);
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.meterRegistry);
-        assertThat(meterRegistry.writeMeter(meter)).containsExactly("my_meter,metric_type=unknown value=1,value=2 1");
+        assertThat(meterRegistry.writeMeter(meter)).containsExactly("my_meter,metric_type=gauge value=1,value=2 1");
     }
 }


### PR DESCRIPTION
This PR changes to use name of `Meter.Id.Type` for `metric_type` in InfluxDB's Line Protocol.

Closes gh-1327