### PR TITLE
Declarative Annotation Based API for Counters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -19,8 +19,9 @@ import java.lang.annotation.*;
 
 /**
  * Annotated methods would expose a few counter metrics about their execution status.
- * By default, only failure attempts would be reported. Switching the {@link #successfulAttempts()}
- * to {@code true} would instruct the corresponding aspect to record successful attempts, too.
+ * By default, both failed and successful attempts would be reported. Switching the
+ * {@link #successfulAttempts()} to {@code false} would instruct the corresponding aspect
+ * to only record the failed attempts.
  *
  * @author Ali Dehghani
  * @see io.micrometer.core.aop.CountedAspect
@@ -39,8 +40,8 @@ public @interface Counted {
     String value() default "";
 
     /**
-     * By default, successful attempts won't be recorded. Switch it to {@code true} in order to
-     * record successful attempts alongside with failed attempts.
+     * By default, both failed and successful attempts are recorded. Switch it to {@code false} in
+     * order to only record failed attempts.
      *
      * @return Whether to report successful attempts or not.
      */

--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -31,11 +31,12 @@ import java.lang.annotation.*;
 public @interface Counted {
 
     /**
-     * Represents the metric name for the to-be-recorded counters.
+     * Represents the metric name for the to-be-recorded counters. The default value is
+     * {@code method.counted}.
      *
      * @return The metric name.
      */
-    String value();
+    String value() default "";
 
     /**
      * By default, successful attempts won't be recorded. Switch it to {@code true} in order to

--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -20,7 +20,7 @@ import java.lang.annotation.*;
 /**
  * Annotated methods would expose a few counter metrics about their execution status.
  * By default, both failed and successful attempts would be reported. Switching the
- * {@link #successfulAttempts()} to {@code false} would instruct the corresponding aspect
+ * {@link #recordFailuresOnly()} to {@code true} would instruct the corresponding aspect
  * to only record the failed attempts.
  *
  * @author Ali Dehghani
@@ -40,12 +40,12 @@ public @interface Counted {
     String value() default "";
 
     /**
-     * By default, both failed and successful attempts are recorded. Switch it to {@code false} in
+     * By default, both failed and successful attempts are recorded. Switch it to {@code true} in
      * order to only record failed attempts.
      *
-     * @return Whether to report successful attempts or not.
+     * @return Whether to only report failures.
      */
-    boolean successfulAttempts() default true;
+    boolean recordFailuresOnly() default false;
 
     /**
      * An optional description for what the underlying counter is going to record.

--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotated methods would expose a few counter metrics about their execution status.
+ * By default, only failure attempts would be reported. Switching the {@link #successfulAttempts()}
+ * to {@code true} would instruct the corresponding aspect to record successful attempts, too.
+ *
+ * @author Ali Dehghani
+ * @see io.micrometer.core.aop.CountedAspect
+ */
+@Inherited
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Counted {
+
+    /**
+     * Represents the metric name for the to-be-recorded counters.
+     *
+     * @return The metric name.
+     */
+    String value();
+
+    /**
+     * By default, successful attempts won't be recorded. Switch it to {@code true} in order to
+     * record successful attempts alongside with failed attempts.
+     *
+     * @return Whether to report successful attempts or not.
+     */
+    boolean successfulAttempts() default false;
+
+    /**
+     * An optional description for what the underlying counter is going to record.
+     *
+     * @return The counter description.
+     */
+    String description() default "";
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -44,7 +44,7 @@ public @interface Counted {
      *
      * @return Whether to report successful attempts or not.
      */
-    boolean successfulAttempts() default false;
+    boolean successfulAttempts() default true;
 
     /**
      * An optional description for what the underlying counter is going to record.

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -103,23 +103,22 @@ public class CountedAspect {
         try {
             Object result = pjp.proceed();
             if (!counted.recordFailuresOnly()) {
-                counter(pjp, counted)
-                        .tag(EXCEPTION_TAG, "None")
-                        .tag(RESULT_TAG, "success")
-                        .register(meterRegistry)
-                        .increment();
+                record(pjp, counted, "None", "success");
             }
 
             return result;
         } catch (Throwable e) {
-            counter(pjp, counted)
-                    .tag(EXCEPTION_TAG, e.getClass().getSimpleName())
-                    .tag(RESULT_TAG, "failure")
-                    .register(meterRegistry)
-                    .increment();
-
+            record(pjp, counted, e.getClass().getSimpleName(), "failure");
             throw e;
         }
+    }
+
+    private void record(ProceedingJoinPoint pjp, Counted counted, String exception, String result) {
+        counter(pjp, counted)
+                .tag(EXCEPTION_TAG, exception)
+                .tag(RESULT_TAG, result)
+                .register(meterRegistry)
+                .increment();
     }
 
     private Counter.Builder counter(ProceedingJoinPoint pjp, Counted counted) {

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -41,7 +41,7 @@ public class CountedAspect {
     /**
      * The tag name to encapsulate the method execution status.
      */
-    private static final String STATUS_TAG = "status";
+    private static final String RESULT_TAG = "result";
 
     /**
      * The tag name to encapsulate the exception thrown by the intercepted method.
@@ -103,14 +103,18 @@ public class CountedAspect {
         try {
             Object result = pjp.proceed();
             if (counted.successfulAttempts()) {
-                counter(pjp, counted).tag(STATUS_TAG, "succeed").register(meterRegistry).increment();
+                counter(pjp, counted)
+                        .tag(EXCEPTION_TAG, "None")
+                        .tag(RESULT_TAG, "success")
+                        .register(meterRegistry)
+                        .increment();
             }
 
             return result;
         } catch (Throwable e) {
             counter(pjp, counted)
                     .tag(EXCEPTION_TAG, e.getClass().getSimpleName())
-                    .tag(STATUS_TAG, "failed")
+                    .tag(RESULT_TAG, "failure")
                     .register(meterRegistry)
                     .increment();
 

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -103,7 +103,7 @@ public class CountedAspect {
         try {
             Object result = pjp.proceed();
             if (!counted.recordFailuresOnly()) {
-                record(pjp, counted, "None", "success");
+                record(pjp, counted, "none", "success");
             }
 
             return result;

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -49,6 +49,11 @@ public class CountedAspect {
     private static final String EXCEPTION_TAG = "exception";
 
     /**
+     * The default metric name.
+     */
+    private static final String DEFAULT_METRIC_NAME = "method.counted";
+
+    /**
      * Where we're going register metrics.
      */
     private final MeterRegistry meterRegistry;
@@ -114,7 +119,8 @@ public class CountedAspect {
     }
 
     private Counter.Builder counter(ProceedingJoinPoint pjp, Counted counted) {
-        return Counter.builder(counted.value()).
+        String metricName = counted.value().trim().isEmpty() ? DEFAULT_METRIC_NAME : counted.value();
+        return Counter.builder(metricName).
                 description(counted.description())
                 .tags(tagsBasedOnJoinPoint.apply(pjp));
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -89,7 +89,7 @@ public class CountedAspect {
     /**
      * Intercept methods annotated with the {@link Counted} annotation and expose a few counters about
      * their execution status. By default, this aspect records both failed and successful attempts. If the
-     * {@link Counted#successfulAttempts()} is set to {@code false}, then the aspect would record only
+     * {@link Counted#recordFailuresOnly()} is set to {@code true}, then the aspect would record only
      * failed attempts. In case of a failure, the aspect tags the counter with the simple name of the thrown
      * exception.
      *
@@ -102,7 +102,7 @@ public class CountedAspect {
     public Object interceptAndRecord(ProceedingJoinPoint pjp, Counted counted) throws Throwable {
         try {
             Object result = pjp.proceed();
-            if (counted.successfulAttempts()) {
+            if (!counted.recordFailuresOnly()) {
                 counter(pjp, counted)
                         .tag(EXCEPTION_TAG, "None")
                         .tag(RESULT_TAG, "success")

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -88,10 +88,10 @@ public class CountedAspect {
 
     /**
      * Intercept methods annotated with the {@link Counted} annotation and expose a few counters about
-     * their execution status. By default, this aspect records only failed attempts. If the
-     * {@link Counted#successfulAttempts()} is set to {@code true}, then the aspect would record all
-     * successful attempts, too. In case of a failure, the aspect tags the counter with the simple name
-     * of the thrown exception.
+     * their execution status. By default, this aspect records both failed and successful attempts. If the
+     * {@link Counted#successfulAttempts()} is set to {@code false}, then the aspect would record only
+     * failed attempts. In case of a failure, the aspect tags the counter with the simple name of the thrown
+     * exception.
      *
      * @param pjp     Encapsulates some information about the intercepted area.
      * @param counted The annotation.

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.lang.NonNullApi;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+import java.util.function.Function;
+
+/**
+ * Aspect responsible for intercepting all methods annotated with the {@link Counted}
+ * annotation and record a few counter metrics about their execution status.
+ *
+ * @author Ali Dehghani
+ * @see Counted
+ */
+@Aspect
+@NonNullApi
+public class CountedAspect {
+
+    /**
+     * The tag name to encapsulate the method execution status.
+     */
+    private static final String STATUS_TAG = "status";
+
+    /**
+     * The tag name to encapsulate the exception thrown by the intercepted method.
+     */
+    private static final String EXCEPTION_TAG = "exception";
+
+    /**
+     * Where we're going register metrics.
+     */
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * A function to produce additional tags for any given join point.
+     */
+    private final Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint;
+
+    /**
+     * Construct a new aspect with the given {@code meterRegistry} along with a default
+     * tags provider.
+     *
+     * @param meterRegistry Where we're going register metrics.
+     */
+    public CountedAspect(MeterRegistry meterRegistry) {
+        this(meterRegistry, pjp ->
+                Tags.of("class", pjp.getStaticPart().getSignature().getDeclaringTypeName(),
+                        "method", pjp.getStaticPart().getSignature().getName()));
+    }
+
+    /**
+     * Constructs a new aspect with the given {@code meterRegistry} and tags provider function.
+     *
+     * @param meterRegistry        Where we're going register metrics.
+     * @param tagsBasedOnJoinPoint A function to generate tags given a join point.
+     */
+    public CountedAspect(MeterRegistry meterRegistry, Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint) {
+        this.meterRegistry = meterRegistry;
+        this.tagsBasedOnJoinPoint = tagsBasedOnJoinPoint;
+    }
+
+    /**
+     * Intercept methods annotated with the {@link Counted} annotation and expose a few counters about
+     * their execution status. By default, this aspect records only failed attempts. If the
+     * {@link Counted#successfulAttempts()} is set to {@code true}, then the aspect would record all
+     * successful attempts, too. In case of a failure, the aspect tags the counter with the simple name
+     * of the thrown exception.
+     *
+     * @param pjp     Encapsulates some information about the intercepted area.
+     * @param counted The annotation.
+     * @return Whatever the intercepted method returns.
+     * @throws Throwable When the intercepted method throws one.
+     */
+    @Around("@annotation(counted)")
+    public Object interceptAndRecord(ProceedingJoinPoint pjp, Counted counted) throws Throwable {
+        try {
+            Object result = pjp.proceed();
+            if (counted.successfulAttempts()) {
+                counter(pjp, counted).tag(STATUS_TAG, "succeed").register(meterRegistry).increment();
+            }
+
+            return result;
+        } catch (Throwable e) {
+            counter(pjp, counted)
+                    .tag(EXCEPTION_TAG, e.getClass().getSimpleName())
+                    .tag(STATUS_TAG, "failed")
+                    .register(meterRegistry)
+                    .increment();
+
+            throw e;
+        }
+    }
+
+    private Counter.Builder counter(ProceedingJoinPoint pjp, Counted counted) {
+        return Counter.builder(counted.value()).
+                description(counted.description())
+                .tags(tagsBasedOnJoinPoint.apply(pjp));
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
@@ -51,7 +51,7 @@ class CountedAspectTest {
         Counter counter = meterRegistry.get("metric.success")
                 .tag("method", "succeedWithMetrics")
                 .tag("class", "io.micrometer.core.aop.CountedAspectTest$CountedService")
-                .tag("status", "succeed").counter();
+                .tag("result", "success").counter();
 
         assertThat(counter.count()).isOne();
     }
@@ -67,7 +67,7 @@ class CountedAspectTest {
                 .tag("method", "fail")
                 .tag("class", "io.micrometer.core.aop.CountedAspectTest$CountedService")
                 .tag("exception", "RuntimeException")
-                .tag("status", "failed").counter();
+                .tag("result", "failure").counter();
 
         assertThat(counter.count()).isOne();
     }
@@ -81,19 +81,19 @@ class CountedAspectTest {
         }
 
         assertThat(meterRegistry.get("method.counted").counters()).hasSize(2);
-        assertThat(meterRegistry.get("method.counted").tag("status", "succeed").counter().count()).isOne();
-        assertThat(meterRegistry.get("method.counted").tag("status", "failed").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("result", "success").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("result", "failure").counter().count()).isOne();
     }
 
 
     static class CountedService {
 
-        @Counted("metric.none")
+        @Counted(value = "metric.none", successfulAttempts = false)
         void succeedWithoutMetrics() {
 
         }
 
-        @Counted(value = "metric.success", successfulAttempts = true)
+        @Counted("metric.success")
         void succeedWithMetrics() {
 
         }
@@ -103,7 +103,7 @@ class CountedAspectTest {
             throw new RuntimeException("Failing always");
         }
 
-        @Counted(value = "", successfulAttempts = true)
+        @Counted
         void emptyMetricName() {
 
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
@@ -88,7 +88,7 @@ class CountedAspectTest {
 
     static class CountedService {
 
-        @Counted(value = "metric.none", successfulAttempts = false)
+        @Counted(value = "metric.none", recordFailuresOnly = true)
         void succeedWithoutMetrics() {
 
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for the {@link CountedAspect} aspect.
+ *
+ * @author Ali Dehghani
+ */
+class CountedAspectTest {
+
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final CountedService countedService = getAdvisedService();
+
+    @Test
+    void countedWithoutSuccessfulMetrics() {
+        countedService.succeedWithoutMetrics();
+
+        assertThatThrownBy(() -> meterRegistry.get("metric.none").counter())
+                .isInstanceOf(MeterNotFoundException.class);
+    }
+
+    @Test
+    void countedWithSuccessfulMetrics() {
+        countedService.succeedWithMetrics();
+
+        Counter counter = meterRegistry.get("metric.success")
+                .tag("method", "succeedWithMetrics")
+                .tag("class", "io.micrometer.core.aop.CountedAspectTest$CountedService")
+                .tag("status", "succeed").counter();
+
+        assertThat(counter.count()).isOne();
+    }
+
+    @Test
+    void countedWithFailure() {
+        try {
+            countedService.fail();
+        } catch (Exception ignored) {
+        }
+
+        Counter counter = meterRegistry.get("metric.failing")
+                .tag("method", "fail")
+                .tag("class", "io.micrometer.core.aop.CountedAspectTest$CountedService")
+                .tag("exception", "RuntimeException")
+                .tag("status", "failed").counter();
+
+        assertThat(counter.count()).isOne();
+    }
+
+    @Test
+    void countedWithEmptyOrBlankMetricNames() {
+        countedService.emptyMetricName();
+        try {
+            countedService.blankMetricName();
+        } catch (Exception ignored) {
+        }
+
+        assertThat(meterRegistry.get("method.counted").counters()).hasSize(2);
+        assertThat(meterRegistry.get("method.counted").tag("status", "succeed").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("status", "failed").counter().count()).isOne();
+    }
+
+
+    static class CountedService {
+
+        @Counted("metric.none")
+        void succeedWithoutMetrics() {
+
+        }
+
+        @Counted(value = "metric.success", successfulAttempts = true)
+        void succeedWithMetrics() {
+
+        }
+
+        @Counted(value = "metric.failing", description = "To record something")
+        void fail() {
+            throw new RuntimeException("Failing always");
+        }
+
+        @Counted(value = "", successfulAttempts = true)
+        void emptyMetricName() {
+
+        }
+
+        @Counted("  ")
+        void blankMetricName() {
+            throw new RuntimeException("This is it");
+        }
+
+
+    }
+
+    private CountedService getAdvisedService() {
+        AspectJProxyFactory proxyFactory = new AspectJProxyFactory(new CountedService());
+        proxyFactory.addAspect(new CountedAspect(meterRegistry));
+
+        return proxyFactory.getProxy();
+    }
+
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.spring;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Spring integration tests for {@link CountedAspect} aspect.
+ *
+ * @author Ali Dehghani
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = CountedAspectTest.TestCountedAspectConfig.class)
+public class CountedAspectTest {
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Autowired
+    private CountedService countedService;
+
+    @Autowired
+    private AbstractCountedService abstractCountedService;
+
+    @Test
+    public void countedWithoutSuccessfulMetrics() {
+        countedService.succeedWithoutMetrics();
+
+        assertThatThrownBy(() -> meterRegistry.get("metric.none").counter())
+                .isInstanceOf(MeterNotFoundException.class);
+    }
+
+    @Test
+    public void countedWithSuccessfulMetrics() {
+        String worked = countedService.succeedWithMetrics();
+
+        Counter counter = meterRegistry.get("metric.success")
+                .tag("method", "succeedWithMetrics")
+                .tag("status", "succeed").counter();
+
+        assertThat(worked).isEqualTo("Worked!");
+        assertThat(counter.count()).isOne();
+    }
+
+    @Test
+    public void countedWithFailure() {
+        try {
+            countedService.fail();
+        } catch (Exception ignored) {
+        }
+
+        Counter counter = meterRegistry.get("metric.failing")
+                .tag("method", "fail")
+                .tag("exception", "RuntimeException")
+                .tag("status", "failed").counter();
+
+        assertThat(counter.count()).isOne();
+    }
+
+    @Test
+    public void countedWithEmptyOrBlankMetricNames() {
+        countedService.emptyMetricName();
+        try {
+            countedService.blankMetricName();
+        } catch (Exception ignored) {
+        }
+
+        assertThat(meterRegistry.get("method.counted").counters()).hasSize(2);
+        assertThat(meterRegistry.get("method.counted").tag("status", "succeed").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("status", "failed").counter().count()).isOne();
+    }
+
+    @Test
+    public void countedShouldWorkWhenImplementingAnInterface() {
+        abstractCountedService.doCount();
+
+        Counter counter = meterRegistry.get("metric.interface")
+                .tag("method", "doCount")
+                .tag("status", "succeed").counter();
+
+        assertThat(counter.count()).isOne();
+    }
+
+
+    @Configuration
+    @EnableAspectJAutoProxy
+    @Import(CountedService.class)
+    static class TestCountedAspectConfig {
+
+        @Bean
+        public SimpleMeterRegistry simpleMeterRegistry() {
+            return new SimpleMeterRegistry();
+        }
+
+        @Bean
+        public CountedAspect countedAspect(MeterRegistry meterRegistry) {
+            return new CountedAspect(meterRegistry);
+        }
+
+        @Bean
+        public AbstractCountedService abstractCountedService() {
+            return new DefaultAbstractCountedService();
+        }
+    }
+
+    @Service
+    static class CountedService {
+
+        @Counted("metric.none")
+        void succeedWithoutMetrics() {
+
+        }
+
+        @Counted(value = "metric.success", successfulAttempts = true)
+        String succeedWithMetrics() {
+            return "Worked!";
+        }
+
+        @Counted(value = "metric.failing", description = "To record something")
+        void fail() {
+            throw new RuntimeException("Failing always");
+        }
+
+        @Counted(value = "", successfulAttempts = true)
+        void emptyMetricName() {
+
+        }
+
+        @Counted("  ")
+        void blankMetricName() {
+            throw new RuntimeException("This is it");
+        }
+    }
+
+    interface AbstractCountedService {
+
+        void doCount();
+    }
+
+    static class DefaultAbstractCountedService implements AbstractCountedService {
+
+        @Override
+        @Counted(value = "metric.interface", successfulAttempts = true)
+        public void doCount() {
+
+        }
+    }
+}

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
@@ -67,7 +67,8 @@ public class CountedAspectTest {
 
         Counter counter = meterRegistry.get("metric.success")
                 .tag("method", "succeedWithMetrics")
-                .tag("status", "succeed").counter();
+                .tag("result", "success")
+                .tag("exception", "None").counter();
 
         assertThat(worked).isEqualTo("Worked!");
         assertThat(counter.count()).isOne();
@@ -83,7 +84,7 @@ public class CountedAspectTest {
         Counter counter = meterRegistry.get("metric.failing")
                 .tag("method", "fail")
                 .tag("exception", "RuntimeException")
-                .tag("status", "failed").counter();
+                .tag("result", "failure").counter();
 
         assertThat(counter.count()).isOne();
     }
@@ -97,8 +98,8 @@ public class CountedAspectTest {
         }
 
         assertThat(meterRegistry.get("method.counted").counters()).hasSize(2);
-        assertThat(meterRegistry.get("method.counted").tag("status", "succeed").counter().count()).isOne();
-        assertThat(meterRegistry.get("method.counted").tag("status", "failed").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("result", "success").counter().count()).isOne();
+        assertThat(meterRegistry.get("method.counted").tag("result", "failure").counter().count()).isOne();
     }
 
     @Test
@@ -107,7 +108,7 @@ public class CountedAspectTest {
 
         Counter counter = meterRegistry.get("metric.interface")
                 .tag("method", "doCount")
-                .tag("status", "succeed").counter();
+                .tag("result", "success").counter();
 
         assertThat(counter.count()).isOne();
     }
@@ -137,12 +138,12 @@ public class CountedAspectTest {
     @Service
     static class CountedService {
 
-        @Counted("metric.none")
+        @Counted(value = "metric.none", successfulAttempts = false)
         void succeedWithoutMetrics() {
 
         }
 
-        @Counted(value = "metric.success", successfulAttempts = true)
+        @Counted(value = "metric.success")
         String succeedWithMetrics() {
             return "Worked!";
         }
@@ -152,7 +153,7 @@ public class CountedAspectTest {
             throw new RuntimeException("Failing always");
         }
 
-        @Counted(value = "", successfulAttempts = true)
+        @Counted
         void emptyMetricName() {
 
         }
@@ -171,7 +172,7 @@ public class CountedAspectTest {
     static class DefaultAbstractCountedService implements AbstractCountedService {
 
         @Override
-        @Counted(value = "metric.interface", successfulAttempts = true)
+        @Counted(value = "metric.interface")
         public void doCount() {
 
         }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
@@ -138,7 +138,7 @@ public class CountedAspectTest {
     @Service
     static class CountedService {
 
-        @Counted(value = "metric.none", successfulAttempts = false)
+        @Counted(value = "metric.none", recordFailuresOnly = true)
         void succeedWithoutMetrics() {
 
         }

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/CountedAspectTest.java
@@ -68,7 +68,7 @@ public class CountedAspectTest {
         Counter counter = meterRegistry.get("metric.success")
                 .tag("method", "succeedWithMetrics")
                 .tag("result", "success")
-                .tag("exception", "None").counter();
+                .tag("exception", "none").counter();
 
         assertThat(worked).isEqualTo("Worked!");
         assertThat(counter.count()).isOne();


### PR DESCRIPTION
A few points:
 - I thought there is no use case for making the `Counted` annotation a *Repeatable* one. If you guys think otherwise, please let me know.
 - Same argument for the `extraTags`. Are they useful for `Counted`?

Resolves #1435 