### PR TITLE
Use latest.release version for junit-jupiter-params dependency

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor:reactor-test:latest.release'
-    testCompile 'org.junit.jupiter:junit-jupiter-params:5.+'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:latest.release'
     testCompile 'org.mockito:mockito-core:latest.release'
 }
 


### PR DESCRIPTION
This PR changes to use `latest.release` version for `junit-jupiter-params` dependency for consistency as the other modules under `org.junit.jupiter` group from `micrometer-test` sub-project are using it.