### PR TITLE
AppOptics Implementation - Set metric time to clock time.

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
@@ -65,6 +65,13 @@ public interface AppOpticsConfig extends StepRegistryConfig {
         return v == null ? "https://api.appoptics.com/v1/measurements" : v;
     }
 
+    /**
+     * @return whether or not to ship a floored time - synchronizes reporting across nodes
+     */
+    default boolean floorTimes() {
+        return get(prefix() + ".floorTimes") == "true";
+    }
+
     @Override
     default int batchSize() {
         String v = get(prefix() + ".batchSize");

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
@@ -69,7 +69,7 @@ public interface AppOpticsConfig extends StepRegistryConfig {
      * @return whether or not to ship a floored time - synchronizes reporting across nodes
      */
     default boolean floorTimes() {
-        return get(prefix() + ".floorTimes") == "true";
+        return Boolean.parseBoolean(get(prefix() + ".floorTimes"));
     }
 
     @Override

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsConfig.java
@@ -66,7 +66,7 @@ public interface AppOpticsConfig extends StepRegistryConfig {
     }
 
     /**
-     * @return whether or not to ship a floored time - synchronizes reporting across nodes
+     * @return whether or not to ship a floored time - floors time to the multiple of the {@link #step()}
      */
     default boolean floorTimes() {
         return Boolean.parseBoolean(get(prefix() + ".floorTimes"));

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -145,11 +145,10 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
     }
 
     /**
-     * Align times to caller's clock, and optionally floor for synchronizing across nodes
-     * Visible for testing
+     * Build body prefix with time based on the clock and flooring configuration.
      */
-    protected String getBodyMeasurementsPrefix() {
-
+    // VisibleForTesting
+    String getBodyMeasurementsPrefix() {
         final long stepSeconds = config.step().getSeconds();
         final long time = config.floorTimes() ? (clock.wallTime() / 1000 / stepSeconds * stepSeconds) : clock.wallTime() / 1000;
         return String.format(BODY_MEASUREMENTS_PREFIX, time);

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -51,7 +51,8 @@ import static java.util.stream.Collectors.joining;
  */
 public class AppOpticsMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("appoptics-metrics-publisher");
-    private static final String BODY_MEASUREMENTS_PREFIX = "{\"time\": %d, \"measurements\":[";
+    // Visible for testing
+    protected static final String BODY_MEASUREMENTS_PREFIX = "{\"time\": %d, \"measurements\":[";
     private static final String BODY_MEASUREMENTS_SUFFIX = "]}";
 
     private final Logger logger = LoggerFactory.getLogger(AppOpticsMeterRegistry.class);
@@ -64,7 +65,8 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
         this(config, clock, DEFAULT_THREAD_FACTORY, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()));
     }
 
-    private AppOpticsMeterRegistry(AppOpticsConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient) {
+    // Visible for testing
+    protected AppOpticsMeterRegistry(AppOpticsConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient) {
         super(config, clock);
 
         if (config.apiToken() == null) {
@@ -144,8 +146,9 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
 
     /**
      * Align times to caller's clock, and optionally floor for synchronizing across nodes
+     * Visible for testing
      */
-    private String getBodyMeasurementsPrefix() {
+    protected String getBodyMeasurementsPrefix() {
 
         final long stepSeconds = config.step().getSeconds();
         final long time = config.floorTimes() ? (clock.wallTime() / 1000 / stepSeconds * stepSeconds) : clock.wallTime() / 1000;

--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.util.DoubleFormat.decimal;
 import static io.micrometer.core.instrument.util.StringEscapeUtils.escapeJson;
@@ -50,9 +51,8 @@ import static java.util.stream.Collectors.joining;
  */
 public class AppOpticsMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("appoptics-metrics-publisher");
-    private static final String BODY_MEASUREMENTS_PREFIX = "{\"measurements\":[";
+    private static final String BODY_MEASUREMENTS_PREFIX = "{\"time\": %d, \"measurements\":[";
     private static final String BODY_MEASUREMENTS_SUFFIX = "]}";
-    private static final String BODY_MEASUREMENTS_NONE = BODY_MEASUREMENTS_PREFIX + BODY_MEASUREMENTS_SUFFIX;
 
     private final Logger logger = LoggerFactory.getLogger(AppOpticsMeterRegistry.class);
 
@@ -105,7 +105,7 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
     protected void publish() {
         try {
             for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-                String body = batch.stream()
+                final List<String> meters = batch.stream()
                         .map(meter -> meter.match(
                                 this::writeGauge,
                                 this::writeCounter,
@@ -119,13 +119,14 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
                         )
                         .filter(Optional::isPresent)
                         .map(Optional::get)
-                        .collect(joining(",", BODY_MEASUREMENTS_PREFIX, BODY_MEASUREMENTS_SUFFIX));
-                if (body.equals(BODY_MEASUREMENTS_NONE)) {
+                        .collect(Collectors.toList());
+                if (meters.isEmpty()) {
                     continue;
                 }
                 httpClient.post(config.uri())
                         .withBasicAuthentication(config.apiToken(), "")
-                        .withJsonContent(body)
+                        .withJsonContent(
+                                meters.stream().collect(joining(",", getBodyMeasurementsPrefix(), BODY_MEASUREMENTS_SUFFIX)))
                         .send()
                         .onSuccess(response -> {
                             if (!response.body().contains("\"failed\":0")) {
@@ -139,6 +140,16 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
         } catch (Throwable t) {
             logger.warn("failed to send metrics to appoptics", t);
         }
+    }
+
+    /**
+     * Align times to caller's clock, and optionally floor for synchronizing across nodes
+     */
+    private String getBodyMeasurementsPrefix() {
+
+        final long stepSeconds = config.step().getSeconds();
+        final long time = config.floorTimes() ? (clock.wallTime() / 1000 / stepSeconds * stepSeconds) : clock.wallTime() / 1000;
+        return String.format(BODY_MEASUREMENTS_PREFIX, time);
     }
 
     // VisibleForTesting


### PR DESCRIPTION
and provide the option to floor times to synchronize between nodes.

If no time is provided by the client AppOptics assumes the time upon receiving the metrics, which can lead to unwanted jitter in metrics.

This sets the time value to the nodes' clock time and provides the ability to floor the provided time to synchronize across nodes, which should help to fix charts like this: ![](http://snapshots.appoptics.com/chart/xr74uny5-275916.png)