### PR TITLE
Prevent race condition when updating tags for StatsD Datadog flavor

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -56,12 +56,14 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
         if (this.namingConvention != next) {
             this.namingConvention = next;
             this.name = next.name(sanitize(id.getName()), id.getType(), id.getBaseUnit()) + ":";
-            this.tags = HashTreePMap.empty();
-            this.conventionTags = id.getTags().iterator().hasNext() ?
-                    id.getConventionTags(this.namingConvention).stream()
-                            .map(t -> sanitize(t.getKey()) + ":" + sanitize(t.getValue()))
-                            .collect(Collectors.joining(","))
-                    : null;
+            synchronized (tagsLock) {
+                this.tags = HashTreePMap.empty();
+                this.conventionTags = id.getTags().iterator().hasNext() ?
+                        id.getConventionTags(this.namingConvention).stream()
+                                .map(t -> sanitize(t.getKey()) + ":" + sanitize(t.getValue()))
+                                .collect(Collectors.joining(","))
+                        : null;
+            }
             this.tagsNoStat = tags(null, conventionTags, ":", "|#");
         }
     }


### PR DESCRIPTION
This PR prevents race condition when updating tags for StatsD Datadog flavor. 

Similar to https://github.com/micrometer-metrics/micrometer/issues/1389, we have noticed unusual behavior when multiple threads interact with our counter. Although we can't prove that it is indeed a race condition yet, in https://github.com/micrometer-metrics/micrometer/pull/1391, the author mentions updates to `DatadogStatsdLineBuilder` which were never done. 

> And I noticed DatadogStatsdLineBuilder has the same concern, so if this approach is okay, I'll prepare a similar one for it.



