### PR TITLE
Move GcGenerationAge into JvmGcMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -44,32 +44,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import static java.util.Collections.emptyList;
 
 /**
- * Generalization of which parts of the heap are considered "young" or "old" for multiple GC implementations
- */
-@NonNullApi
-enum GcGenerationAge {
-    OLD,
-    YOUNG,
-    UNKNOWN;
-
-    private static Map<String, GcGenerationAge> knownCollectors = new HashMap<String, GcGenerationAge>() {{
-        put("ConcurrentMarkSweep", OLD);
-        put("Copy", YOUNG);
-        put("G1 Old Generation", OLD);
-        put("G1 Young Generation", YOUNG);
-        put("MarkSweepCompact", OLD);
-        put("PS MarkSweep", OLD);
-        put("PS Scavenge", YOUNG);
-        put("ParNew", YOUNG);
-    }};
-
-    static GcGenerationAge fromName(String name) {
-        GcGenerationAge t = knownCollectors.get(name);
-        return (t == null) ? UNKNOWN : t;
-    }
-}
-
-/**
  * Record metrics that report a number of statistics related to garbage
  * collection emanating from the MXBean and also adds information about GC causes.
  *
@@ -239,6 +213,32 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
     @Override
     public void close() {
         notificationListenerCleanUpRunnables.forEach(Runnable::run);
+    }
+
+    /**
+     * Generalization of which parts of the heap are considered "young" or "old" for multiple GC implementations
+     */
+    @NonNullApi
+    enum GcGenerationAge {
+        OLD,
+        YOUNG,
+        UNKNOWN;
+
+        private static Map<String, GcGenerationAge> knownCollectors = new HashMap<String, GcGenerationAge>() {{
+            put("ConcurrentMarkSweep", OLD);
+            put("Copy", YOUNG);
+            put("G1 Old Generation", OLD);
+            put("G1 Young Generation", YOUNG);
+            put("MarkSweepCompact", OLD);
+            put("PS MarkSweep", OLD);
+            put("PS Scavenge", YOUNG);
+            put("ParNew", YOUNG);
+        }};
+
+        static GcGenerationAge fromName(String name) {
+            GcGenerationAge t = knownCollectors.get(name);
+            return (t == null) ? UNKNOWN : t;
+        }
     }
 
 }


### PR DESCRIPTION
This PR moves `GcGenerationAge` into `JvmGcMetrics` as having two top-level entities in a single source file doesn't seem to be usual.