### PR TITLE
Adding Custom Device Group name property to Dynatrace.

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -59,4 +59,8 @@ public interface DynatraceConfig extends StepRegistryConfig {
 
         return v;
     }
+
+    default String group() {
+        return get(prefix() + ".group");
+    }
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -15,7 +15,14 @@
  */
 package io.micrometer.dynatrace;
 
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
@@ -253,7 +260,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                         .onSuccess(response -> {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("successfully sent {} metrics to Dynatrace ({} bytes).",
-                                    postMessage.metricCount, postMessage.payload.getBytes(UTF_8).length);
+                                        postMessage.metricCount, postMessage.payload.getBytes(UTF_8).length);
                             }
                         })
                         .onError(response -> {
@@ -269,9 +276,9 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     // VisibleForTesting
     List<DynatraceBatchedPayload> createPostMessages(String type, String group, List<DynatraceTimeSeries> timeSeries) {
         final String header;
-        if(StringUtils.isNotBlank(group)){
+        if (StringUtils.isNotBlank(group)) {
             header = "{\"type\":\"" + type + '\"' + ",\"group\":\"" + group + '\"' + ",\"series\":[";
-        }else{
+        } else {
             header = "{\"type\":\"" + type + '\"' + ",\"series\":[";
         }
         final String footer = "]}";
@@ -297,7 +304,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                 continue;
             }
             if ((payload.length() == 0 && totalByteCount + jsonByteCount > maxSize) ||
-                (payload.length() > 0 && totalByteCount + jsonByteCount + 1 > maxSize)) {
+                    (payload.length() > 0 && totalByteCount + jsonByteCount + 1 > maxSize)) {
                 messages.add(new DynatraceBatchedPayload(payload.toString(), metricCount));
                 payload.setLength(0);
                 totalByteCount = 0;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -275,12 +275,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     List<DynatraceBatchedPayload> createPostMessages(String type, String group, List<DynatraceTimeSeries> timeSeries) {
-        final String header;
-        if (StringUtils.isNotBlank(group)) {
-            header = "{\"type\":\"" + type + '\"' + ",\"group\":\"" + group + '\"' + ",\"series\":[";
-        } else {
-            header = "{\"type\":\"" + type + '\"' + ",\"series\":[";
-        }
+        final String header = "{\"type\":\"" + type + (StringUtils.isNotBlank(group) ? '\"' + ",\"group\":\"" + group : "") + '\"' + ",\"series\":[";
         final String footer = "]}";
         final int headerFooterBytes = header.getBytes(UTF_8).length + footer.getBytes(UTF_8).length;
         final int maxMessageSize = MAX_MESSAGE_SIZE - headerFooterBytes;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
@@ -65,7 +65,7 @@ class DynatraceMetricDefinition {
         String displayName = description == null ? metricId : StringEscapeUtils.escapeJson(description);
         String body = "{\"displayName\":\"" + StringUtils.truncate(displayName, MAX_DISPLAY_NAME) + "\"";
 
-        if(StringUtils.isNotBlank(group))
+        if (StringUtils.isNotBlank(group))
             body += ",\"group\":\"" + StringUtils.truncate(group, MAX_GROUP_NAME) + "\"";
 
         if (unit != null)

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMetricDefinition.java
@@ -34,6 +34,7 @@ import static java.util.Arrays.stream;
 class DynatraceMetricDefinition {
 
     private static final int MAX_DISPLAY_NAME = 256;
+    private static final int MAX_GROUP_NAME = 256;
     private final String metricId;
     @Nullable
     private final String description;
@@ -43,14 +44,17 @@ class DynatraceMetricDefinition {
     private final Set<String> dimensions;
     // Guaranteed to be non-empty
     private final String[] technologyTypes;
+    @Nullable
+    private final String group;
 
     DynatraceMetricDefinition(String metricId, @Nullable String description, @Nullable DynatraceUnit unit, @Nullable Set<String> dimensions,
-                              String[] technologyTypes) {
+                              String[] technologyTypes, String group) {
         this.metricId = metricId;
         this.description = description;
         this.unit = unit;
         this.dimensions = dimensions;
         this.technologyTypes = technologyTypes;
+        this.group = group;
     }
 
     String getMetricId() {
@@ -60,6 +64,9 @@ class DynatraceMetricDefinition {
     String asJson() {
         String displayName = description == null ? metricId : StringEscapeUtils.escapeJson(description);
         String body = "{\"displayName\":\"" + StringUtils.truncate(displayName, MAX_DISPLAY_NAME) + "\"";
+
+        if(StringUtils.isNotBlank(group))
+            body += ",\"group\":\"" + StringUtils.truncate(group, MAX_GROUP_NAME) + "\"";
 
         if (unit != null)
             body += ",\"unit\":\"" + unit + "\"";

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMetricDefinitionTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMetricDefinitionTest.java
@@ -27,7 +27,7 @@ class DynatraceMetricDefinitionTest {
 
     @Test
     void usesMetricIdAsDescriptionWhenDescriptionIsNotAvailable() {
-        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", null, null, null, technologyTypes);
+        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", null, null, null, technologyTypes, null);
 
         assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"custom:test.metric\",\"types\":[\"java\"]}");
     }
@@ -37,14 +37,14 @@ class DynatraceMetricDefinitionTest {
         final DynatraceMetricDefinition metric = new DynatraceMetricDefinition(
                 "custom:test.metric",
                 "The /\"recent cpu usage\" for the Java Virtual Machine process",
-                null, null, technologyTypes);
+                null, null, technologyTypes, null);
 
         assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\",\"types\":[\"java\"]}");
     }
 
     @Test
     void addsUnitWhenAvailable() {
-        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", "my test metric", DynatraceMetricDefinition.DynatraceUnit.Count, null, technologyTypes);
+        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", "my test metric", DynatraceMetricDefinition.DynatraceUnit.Count, null, technologyTypes, null);
 
         assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"my test metric\",\"unit\":\"Count\",\"types\":[\"java\"]}");
     }
@@ -55,8 +55,14 @@ class DynatraceMetricDefinitionTest {
         dimensions.add("first");
         dimensions.add("second");
         dimensions.add("unknown");
-        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", "my test metric", null, dimensions, technologyTypes);
+        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", "my test metric", null, dimensions, technologyTypes, null);
 
         assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"my test metric\",\"dimensions\":[\"first\",\"second\",\"unknown\"],\"types\":[\"java\"]}");
+    }
+
+    @Test
+    void addsGroupWhenAvailable() {
+        final DynatraceMetricDefinition metric = new DynatraceMetricDefinition("custom:test.metric", "my test metric", DynatraceMetricDefinition.DynatraceUnit.Count, null, technologyTypes, "my test group");
+        assertThat(metric.asJson()).isEqualTo("{\"displayName\":\"my test metric\",\"group\":\"my test group\",\"unit\":\"Count\",\"types\":[\"java\"]}");
     }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatraceProperties.java
@@ -49,6 +49,11 @@ public class DynatraceProperties extends StepRegistryProperties {
      */
     private String uri;
 
+    /**
+     * Group for exported metrics. Used to name custom device group in the Dynatrace UI.
+     */
+    private String group;
+
     public String getApiToken() {
         return this.apiToken;
     }
@@ -81,4 +86,11 @@ public class DynatraceProperties extends StepRegistryProperties {
         this.uri = uri;
     }
 
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
 }

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatracePropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/dynatrace/DynatracePropertiesConfigAdapter.java
@@ -49,4 +49,10 @@ class DynatracePropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapt
     public String technologyType() {
         return get(DynatraceProperties::getTechnologyType, DynatraceConfig.super::technologyType);
     }
+
+    @Override
+    public String group() {
+        return get(DynatraceProperties::getGroup, DynatraceConfig.super::group);
+    }
+
 }


### PR DESCRIPTION
The group name property helps us to add custom device group name in Dynatrace from micrometer.

Resolves #1464