### PR TITLE
Handle when additivity for the root logger is false

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.logging;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.simple.SimpleConfig;
@@ -24,10 +25,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
 
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,29 +45,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class Log4j2MetricsTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
-    private final Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
-    private final Logger additivityDisabledLogger = LogManager.getLogger("additivityDisabledLogger");
 
-    @BeforeEach
-    void setUp() {
-        configureAdditivityDisabledLogger();
-
-        new Log4j2Metrics().bindTo(registry);
-    }
-
-    private void configureAdditivityDisabledLogger() {
-        Configurator.setLevel("additivityDisabledLogger", Level.INFO);
-
-        LoggerContext loggerContext = (LoggerContext) LogManager.getContext();
-        Configuration configuration = loggerContext.getConfiguration();
-        LoggerConfig loggerConfig = configuration.getLoggerConfig("additivityDisabledLogger");
-        loggerConfig.setAdditive(false);
+    @AfterEach
+    void cleanUp() {
+        LogManager.shutdown();
     }
 
     @Test
     void log4j2LevelMetrics() {
+        new Log4j2Metrics().bindTo(registry);
+
         assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
 
+        Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
         Configurator.setLevel(Log4j2MetricsTest.class.getName(), Level.INFO);
         logger.warn("warn");
         logger.error("error");
@@ -75,21 +69,52 @@ class Log4j2MetricsTest {
 
     @Test
     void filterWhenLoggerAdditivityIsFalseShouldWork() {
+        Logger additivityDisabledLogger = LogManager.getLogger("additivityDisabledLogger");
+        Configurator.setLevel("additivityDisabledLogger", Level.INFO);
+
+        LoggerContext loggerContext = (LoggerContext) LogManager.getContext();
+        Configuration configuration = loggerContext.getConfiguration();
+        LoggerConfig loggerConfig = configuration.getLoggerConfig("additivityDisabledLogger");
+        loggerConfig.setAdditive(false);
+
+        new Log4j2Metrics().bindTo(registry);
+
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
 
         additivityDisabledLogger.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
     }
 
+    @Issue("#1466")
+    @Test
+    void filterWhenRootLoggerAdditivityIsFalseShouldWork() throws IOException {
+        ConfigurationSource source = new ConfigurationSource(getClass().getResourceAsStream("/binder/logging/log4j2-root-logger-additivity-false.xml"));
+        Configurator.initialize(null, source);
+
+        Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
+
+        new Log4j2Metrics().bindTo(registry);
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+
+        logger.info("Hello, world!");
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
+    }
+
     @Test
     void isLevelEnabledDoesntContributeToCounts() {
+        new Log4j2Metrics().bindTo(registry);
+
+        Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
         logger.isErrorEnabled();
 
         assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(0.0);
     }
 
     @Test
-    void removeFilterFromLoggerContextOnClose() throws Exception {
+    void removeFilterFromLoggerContextOnClose() {
+        new Log4j2Metrics().bindTo(registry);
+
         LoggerContext loggerContext = new LoggerContext("test");
         Log4j2Metrics log4j2Metrics = new Log4j2Metrics(emptyList(), loggerContext);
         log4j2Metrics.bindTo(registry);

--- a/micrometer-core/src/test/resources/binder/logging/log4j2-root-logger-additivity-false.xml
+++ b/micrometer-core/src/test/resources/binder/logging/log4j2-root-logger-additivity-false.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2019 Pivotal Software, Inc.
+    <p>
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    <p>
+    https://www.apache.org/licenses/LICENSE-2.0
+    <p>
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR changes `Log4j2Metrics` to properly handle when additivity for the root logger is false.

Closes gh-1466