### PR TITLE
Make PushMeterRegistry work without slf4j-api

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -18,8 +18,8 @@ package io.micrometer.core.instrument.push;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.lang.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.micrometer.core.util.internal.logging.InternalLogger;
+import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -27,7 +27,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 public abstract class PushMeterRegistry extends MeterRegistry {
-    private final static Logger logger = LoggerFactory.getLogger(PushMeterRegistry.class);
+    private final static InternalLogger logger = InternalLoggerFactory.getInstance(PushMeterRegistry.class);
     private final PushRegistryConfig config;
 
     @Nullable

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/AbstractInternalLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/AbstractInternalLogger.java
@@ -1,0 +1,255 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * NOTE: This file has been copied and slightly modified from {io.netty.util.internal.logging}.
+ *
+ * A skeletal implementation of {@link InternalLogger}.  This class implements
+ * all methods that have a {@link InternalLogLevel} parameter by default to call
+ * specific logger methods such as {@link #info(String)} or {@link #isInfoEnabled()}.
+ */
+public abstract class AbstractInternalLogger implements InternalLogger, Serializable {
+
+    private static final long serialVersionUID = -6382972526573193470L;
+
+    static final String EXCEPTION_MESSAGE = "Unexpected exception:";
+
+    private final String name;
+
+    /**
+     * Creates a new instance.
+     */
+    protected AbstractInternalLogger(String name) {
+        requireNonNull(name, "name");
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean isEnabled(InternalLogLevel level) {
+        switch (level) {
+        case TRACE:
+            return isTraceEnabled();
+        case DEBUG:
+            return isDebugEnabled();
+        case INFO:
+            return isInfoEnabled();
+        case WARN:
+            return isWarnEnabled();
+        case ERROR:
+            return isErrorEnabled();
+        default:
+            throw new Error();
+        }
+    }
+
+    @Override
+    public void trace(Throwable t) {
+        trace(EXCEPTION_MESSAGE, t);
+    }
+
+    @Override
+    public void debug(Throwable t) {
+        debug(EXCEPTION_MESSAGE, t);
+    }
+
+    @Override
+    public void info(Throwable t) {
+        info(EXCEPTION_MESSAGE, t);
+    }
+
+    @Override
+    public void warn(Throwable t) {
+        warn(EXCEPTION_MESSAGE, t);
+    }
+
+    @Override
+    public void error(Throwable t) {
+        error(EXCEPTION_MESSAGE, t);
+    }
+
+    @Override
+    public void log(InternalLogLevel level, String msg, Throwable cause) {
+        switch (level) {
+        case TRACE:
+            trace(msg, cause);
+            break;
+        case DEBUG:
+            debug(msg, cause);
+            break;
+        case INFO:
+            info(msg, cause);
+            break;
+        case WARN:
+            warn(msg, cause);
+            break;
+        case ERROR:
+            error(msg, cause);
+            break;
+        default:
+            throw new Error();
+        }
+    }
+
+    @Override
+    public void log(InternalLogLevel level, Throwable cause) {
+        switch (level) {
+            case TRACE:
+                trace(cause);
+                break;
+            case DEBUG:
+                debug(cause);
+                break;
+            case INFO:
+                info(cause);
+                break;
+            case WARN:
+                warn(cause);
+                break;
+            case ERROR:
+                error(cause);
+                break;
+            default:
+                throw new Error();
+        }
+    }
+
+    @Override
+    public void log(InternalLogLevel level, String msg) {
+        switch (level) {
+        case TRACE:
+            trace(msg);
+            break;
+        case DEBUG:
+            debug(msg);
+            break;
+        case INFO:
+            info(msg);
+            break;
+        case WARN:
+            warn(msg);
+            break;
+        case ERROR:
+            error(msg);
+            break;
+        default:
+            throw new Error();
+        }
+    }
+
+    @Override
+    public void log(InternalLogLevel level, String format, Object arg) {
+        switch (level) {
+        case TRACE:
+            trace(format, arg);
+            break;
+        case DEBUG:
+            debug(format, arg);
+            break;
+        case INFO:
+            info(format, arg);
+            break;
+        case WARN:
+            warn(format, arg);
+            break;
+        case ERROR:
+            error(format, arg);
+            break;
+        default:
+            throw new Error();
+        }
+    }
+
+    @Override
+    public void log(InternalLogLevel level, String format, Object argA, Object argB) {
+        switch (level) {
+        case TRACE:
+            trace(format, argA, argB);
+            break;
+        case DEBUG:
+            debug(format, argA, argB);
+            break;
+        case INFO:
+            info(format, argA, argB);
+            break;
+        case WARN:
+            warn(format, argA, argB);
+            break;
+        case ERROR:
+            error(format, argA, argB);
+            break;
+        default:
+            throw new Error();
+        }
+    }
+
+    @Override
+    public void log(InternalLogLevel level, String format, Object... arguments) {
+        switch (level) {
+        case TRACE:
+            trace(format, arguments);
+            break;
+        case DEBUG:
+            debug(format, arguments);
+            break;
+        case INFO:
+            info(format, arguments);
+            break;
+        case WARN:
+            warn(format, arguments);
+            break;
+        case ERROR:
+            error(format, arguments);
+            break;
+        default:
+            throw new Error();
+        }
+    }
+
+    protected Object readResolve() throws ObjectStreamException {
+        return InternalLoggerFactory.getInstance(name());
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + '(' + name() + ')';
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/FormattingTuple.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/FormattingTuple.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package io.micrometer.core.util.internal.logging;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * Holds the results of formatting done by {@link MessageFormatter}.
+ */
+final class FormattingTuple {
+
+    private final String message;
+    private final Throwable throwable;
+
+    FormattingTuple(String message, Throwable throwable) {
+        this.message = message;
+        this.throwable = throwable;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogLevel.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogLevel.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * The log level that {@link InternalLogger} can log at.
+ */
+public enum InternalLogLevel {
+    /**
+     * 'TRACE' log level.
+     */
+    TRACE,
+    /**
+     * 'DEBUG' log level.
+     */
+    DEBUG,
+    /**
+     * 'INFO' log level.
+     */
+    INFO,
+    /**
+     * 'WARN' log level.
+     */
+    WARN,
+    /**
+     * 'ERROR' log level.
+     */
+    ERROR
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogger.java
@@ -1,0 +1,503 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package io.micrometer.core.util.internal.logging;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * <em>Internal-use-only</em> logger used by Micrometer.  <strong>DO NOT</strong>
+ * access this class outside of Micrometer.
+ */
+public interface InternalLogger {
+
+    /**
+     * Return the name of this {@link InternalLogger} instance.
+     *
+     * @return name of this logger instance
+     */
+    String name();
+
+    /**
+     * Is the logger instance enabled for the TRACE level?
+     *
+     * @return True if this Logger is enabled for the TRACE level,
+     *         false otherwise.
+     */
+    boolean isTraceEnabled();
+
+    /**
+     * Log a message at the TRACE level.
+     *
+     * @param msg the message string to be logged
+     */
+    void trace(String msg);
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void trace(String format, Object arg);
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the TRACE level. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void trace(String format, Object argA, Object argB);
+
+    /**
+     * Log a message at the TRACE level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the TRACE level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for TRACE. The variants taking {@link #trace(String, Object) one} and
+     * {@link #trace(String, Object, Object) two} arguments exist solely in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void trace(String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the TRACE level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void trace(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the TRACE level.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void trace(Throwable t);
+
+    /**
+     * Is the logger instance enabled for the DEBUG level?
+     *
+     * @return True if this Logger is enabled for the DEBUG level,
+     *         false otherwise.
+     */
+    boolean isDebugEnabled();
+
+    /**
+     * Log a message at the DEBUG level.
+     *
+     * @param msg the message string to be logged
+     */
+    void debug(String msg);
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void debug(String format, Object arg);
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the DEBUG level. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void debug(String format, Object argA, Object argB);
+
+    /**
+     * Log a message at the DEBUG level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the DEBUG level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for DEBUG. The variants taking
+     * {@link #debug(String, Object) one} and {@link #debug(String, Object, Object) two}
+     * arguments exist solely in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void debug(String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the DEBUG level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void debug(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the DEBUG level.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void debug(Throwable t);
+
+    /**
+     * Is the logger instance enabled for the INFO level?
+     *
+     * @return True if this Logger is enabled for the INFO level,
+     *         false otherwise.
+     */
+    boolean isInfoEnabled();
+
+    /**
+     * Log a message at the INFO level.
+     *
+     * @param msg the message string to be logged
+     */
+    void info(String msg);
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void info(String format, Object arg);
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the INFO level. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void info(String format, Object argA, Object argB);
+
+    /**
+     * Log a message at the INFO level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the INFO level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for INFO. The variants taking
+     * {@link #info(String, Object) one} and {@link #info(String, Object, Object) two}
+     * arguments exist solely in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void info(String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the INFO level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void info(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the INFO level.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void info(Throwable t);
+
+    /**
+     * Is the logger instance enabled for the WARN level?
+     *
+     * @return True if this Logger is enabled for the WARN level,
+     *         false otherwise.
+     */
+    boolean isWarnEnabled();
+
+    /**
+     * Log a message at the WARN level.
+     *
+     * @param msg the message string to be logged
+     */
+    void warn(String msg);
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void warn(String format, Object arg);
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the WARN level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for WARN. The variants taking
+     * {@link #warn(String, Object) one} and {@link #warn(String, Object, Object) two}
+     * arguments exist solely in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void warn(String format, Object... arguments);
+
+    /**
+     * Log a message at the WARN level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the WARN level. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void warn(String format, Object argA, Object argB);
+
+    /**
+     * Log an exception (throwable) at the WARN level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void warn(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the WARN level.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void warn(Throwable t);
+
+    /**
+     * Is the logger instance enabled for the ERROR level?
+     *
+     * @return True if this Logger is enabled for the ERROR level,
+     *         false otherwise.
+     */
+    boolean isErrorEnabled();
+
+    /**
+     * Log a message at the ERROR level.
+     *
+     * @param msg the message string to be logged
+     */
+    void error(String msg);
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void error(String format, Object arg);
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the ERROR level. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void error(String format, Object argA, Object argB);
+
+    /**
+     * Log a message at the ERROR level according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the ERROR level. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for ERROR. The variants taking
+     * {@link #error(String, Object) one} and {@link #error(String, Object, Object) two}
+     * arguments exist solely in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void error(String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the ERROR level with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void error(String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the ERROR level.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void error(Throwable t);
+
+    /**
+     * Is the logger instance enabled for the specified {@code level}?
+     *
+     * @return True if this Logger is enabled for the specified {@code level},
+     *         false otherwise.
+     */
+    boolean isEnabled(InternalLogLevel level);
+
+    /**
+     * Log a message at the specified {@code level}.
+     *
+     * @param msg the message string to be logged
+     */
+    void log(InternalLogLevel level, String msg);
+
+    /**
+     * Log a message at the specified {@code level} according to the specified format
+     * and argument.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the specified {@code level}. </p>
+     *
+     * @param format the format string
+     * @param arg    the argument
+     */
+    void log(InternalLogLevel level, String format, Object arg);
+
+    /**
+     * Log a message at the specified {@code level} according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous object creation when the logger
+     * is disabled for the specified {@code level}. </p>
+     *
+     * @param format the format string
+     * @param argA   the first argument
+     * @param argB   the second argument
+     */
+    void log(InternalLogLevel level, String format, Object argA, Object argB);
+
+    /**
+     * Log a message at the specified {@code level} according to the specified format
+     * and arguments.
+     * <p/>
+     * <p>This form avoids superfluous string concatenation when the logger
+     * is disabled for the specified {@code level}. However, this variant incurs the hidden
+     * (and relatively small) cost of creating an {@code Object[]} before invoking the method,
+     * even if this logger is disabled for the specified {@code level}. The variants taking
+     * {@link #log(InternalLogLevel, String, Object) one} and
+     * {@link #log(InternalLogLevel, String, Object, Object) two} arguments exist solely
+     * in order to avoid this hidden cost.</p>
+     *
+     * @param format    the format string
+     * @param arguments a list of 3 or more arguments
+     */
+    void log(InternalLogLevel level, String format, Object... arguments);
+
+    /**
+     * Log an exception (throwable) at the specified {@code level} with an
+     * accompanying message.
+     *
+     * @param msg the message accompanying the exception
+     * @param t   the exception (throwable) to log
+     */
+    void log(InternalLogLevel level, String msg, Throwable t);
+
+    /**
+     * Log an exception (throwable) at the specified {@code level}.
+     *
+     * @param t   the exception (throwable) to log
+     */
+    void log(InternalLogLevel level, Throwable t);
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLoggerFactory.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.micrometer.core.util.internal.logging;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * NOTE: This file has been copied and simplified from {io.netty.util.internal.logging}.
+ *
+ * Creates an {@link InternalLogger} or changes the default factory
+ * implementation.  This factory allows you to choose what logging framework
+ * Micrometer should use.  The default factory is {@link Slf4JLoggerFactory}.  If SLF4J
+ * is not available, {@link JdkLoggerFactory} is used.  You can change it to your preferred
+ * logging framework before other Micrometer classes are loaded:
+ * <pre>
+ * {@link InternalLoggerFactory}.setDefaultFactory({@link JdkLoggerFactory}.INSTANCE);
+ * </pre>
+ * Please note that the new default factory is effective only for the classes
+ * which were loaded after the default factory is changed.  Therefore,
+ * {@link #setDefaultFactory(InternalLoggerFactory)} should be called as early
+ * as possible and shouldn't be called more than once.
+ */
+public abstract class InternalLoggerFactory {
+
+    private static volatile InternalLoggerFactory defaultFactory;
+
+    @SuppressWarnings("UnusedCatchParameter")
+    private static InternalLoggerFactory newDefaultFactory(String name) {
+        InternalLoggerFactory f;
+        try {
+            f = Slf4JLoggerFactory.INSTANCE;
+            f.newInstance(name).debug("Using SLF4J as the default logging framework");
+        } catch (Throwable ignored) {
+            f = JdkLoggerFactory.INSTANCE;
+            f.newInstance(name).debug("Using java.util.logging as the default logging framework");
+        }
+        return f;
+    }
+
+    /**
+     * Returns the default factory.
+     */
+    public static InternalLoggerFactory getDefaultFactory() {
+        if (defaultFactory == null) {
+            defaultFactory = newDefaultFactory(InternalLoggerFactory.class.getName());
+        }
+        return defaultFactory;
+    }
+
+    /**
+     * Changes the default factory.
+     */
+    public static void setDefaultFactory(InternalLoggerFactory defaultFactory) {
+        requireNonNull(defaultFactory, "defaultFactory");
+        InternalLoggerFactory.defaultFactory = defaultFactory;
+    }
+
+    /**
+     * Creates a new logger instance with the name of the specified class.
+     */
+    public static InternalLogger getInstance(Class<?> clazz) {
+        return getInstance(clazz.getName());
+    }
+
+    /**
+     * Creates a new logger instance with the specified name.
+     */
+    public static InternalLogger getInstance(String name) {
+        return getDefaultFactory().newInstance(name);
+    }
+
+    /**
+     * Creates a new logger instance with the specified name.
+     */
+    protected abstract InternalLogger newInstance(String name);
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLogger.java
@@ -1,0 +1,664 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package io.micrometer.core.util.internal.logging;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * <a href="http://java.sun.com/javase/6/docs/technotes/guides/logging/index.html">java.util.logging</a>
+ * logger.
+ */
+class JdkLogger extends AbstractInternalLogger {
+
+    private static final long serialVersionUID = -1767272577989225979L;
+
+    final transient Logger logger;
+
+    JdkLogger(Logger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    /**
+     * Is this logger instance enabled for the FINEST level?
+     *
+     * @return True if this Logger is enabled for level FINEST, false otherwise.
+     */
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isLoggable(Level.FINEST);
+    }
+
+    /**
+     * Log a message object at level FINEST.
+     *
+     * @param msg
+     *          - the message object to be logged
+     */
+    @Override
+    public void trace(String msg) {
+        if (logger.isLoggable(Level.FINEST)) {
+            log(SELF, Level.FINEST, msg, null);
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * argument.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for level FINEST.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    @Override
+    public void trace(String format, Object arg) {
+        if (logger.isLoggable(Level.FINEST)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINEST level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argA
+     *          the first argument
+     * @param argB
+     *          the second argument
+     */
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        if (logger.isLoggable(Level.FINEST)) {
+            FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINEST according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINEST level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    @Override
+    public void trace(String format, Object... argArray) {
+        if (logger.isLoggable(Level.FINEST)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.FINEST, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at level FINEST with an accompanying message.
+     *
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    @Override
+    public void trace(String msg, Throwable t) {
+        if (logger.isLoggable(Level.FINEST)) {
+            log(SELF, Level.FINEST, msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for the FINE level?
+     *
+     * @return True if this Logger is enabled for level FINE, false otherwise.
+     */
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isLoggable(Level.FINE);
+    }
+
+    /**
+     * Log a message object at level FINE.
+     *
+     * @param msg
+     *          - the message object to be logged
+     */
+    @Override
+    public void debug(String msg) {
+        if (logger.isLoggable(Level.FINE)) {
+            log(SELF, Level.FINE, msg, null);
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and argument.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for level FINE.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    @Override
+    public void debug(String format, Object arg) {
+        if (logger.isLoggable(Level.FINE)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINE level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argA
+     *          the first argument
+     * @param argB
+     *          the second argument
+     */
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        if (logger.isLoggable(Level.FINE)) {
+            FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level FINE according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the FINE level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    @Override
+    public void debug(String format, Object... argArray) {
+        if (logger.isLoggable(Level.FINE)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.FINE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at level FINE with an accompanying message.
+     *
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    @Override
+    public void debug(String msg, Throwable t) {
+        if (logger.isLoggable(Level.FINE)) {
+            log(SELF, Level.FINE, msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for the INFO level?
+     *
+     * @return True if this Logger is enabled for the INFO level, false otherwise.
+     */
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isLoggable(Level.INFO);
+    }
+
+    /**
+     * Log a message object at the INFO level.
+     *
+     * @param msg
+     *          - the message object to be logged
+     */
+    @Override
+    public void info(String msg) {
+        if (logger.isLoggable(Level.INFO)) {
+            log(SELF, Level.INFO, msg, null);
+        }
+    }
+
+    /**
+     * Log a message at level INFO according to the specified format and argument.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    @Override
+    public void info(String format, Object arg) {
+        if (logger.isLoggable(Level.INFO)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at the INFO level according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argA
+     *          the first argument
+     * @param argB
+     *          the second argument
+     */
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        if (logger.isLoggable(Level.INFO)) {
+            FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level INFO according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the INFO level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    @Override
+    public void info(String format, Object... argArray) {
+        if (logger.isLoggable(Level.INFO)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.INFO, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at the INFO level with an accompanying
+     * message.
+     *
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    @Override
+    public void info(String msg, Throwable t) {
+        if (logger.isLoggable(Level.INFO)) {
+            log(SELF, Level.INFO, msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for the WARNING level?
+     *
+     * @return True if this Logger is enabled for the WARNING level, false
+     *         otherwise.
+     */
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isLoggable(Level.WARNING);
+    }
+
+    /**
+     * Log a message object at the WARNING level.
+     *
+     * @param msg
+     *          - the message object to be logged
+     */
+    @Override
+    public void warn(String msg) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING, msg, null);
+        }
+    }
+
+    /**
+     * Log a message at the WARNING level according to the specified format and
+     * argument.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    @Override
+    public void warn(String format, Object arg) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at the WARNING level according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argA
+     *          the first argument
+     * @param argB
+     *          the second argument
+     */
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level WARNING according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the WARNING level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argArray
+     *          an array of arguments
+     */
+    @Override
+    public void warn(String format, Object... argArray) {
+        if (logger.isLoggable(Level.WARNING)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, argArray);
+            log(SELF, Level.WARNING, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at the WARNING level with an accompanying
+     * message.
+     *
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    @Override
+    public void warn(String msg, Throwable t) {
+        if (logger.isLoggable(Level.WARNING)) {
+            log(SELF, Level.WARNING, msg, t);
+        }
+    }
+
+    /**
+     * Is this logger instance enabled for level SEVERE?
+     *
+     * @return True if this Logger is enabled for level SEVERE, false otherwise.
+     */
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isLoggable(Level.SEVERE);
+    }
+
+    /**
+     * Log a message object at the SEVERE level.
+     *
+     * @param msg
+     *          - the message object to be logged
+     */
+    @Override
+    public void error(String msg) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.SEVERE, msg, null);
+        }
+    }
+
+    /**
+     * Log a message at the SEVERE level according to the specified format and
+     * argument.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arg
+     *          the argument
+     */
+    @Override
+    public void error(String format, Object arg) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.format(format, arg);
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at the SEVERE level according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param argA
+     *          the first argument
+     * @param argB
+     *          the second argument
+     */
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.format(format, argA, argB);
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log a message at level SEVERE according to the specified format and
+     * arguments.
+     *
+     * <p>
+     * This form avoids superfluous object creation when the logger is disabled
+     * for the SEVERE level.
+     * </p>
+     *
+     * @param format
+     *          the format string
+     * @param arguments
+     *          an array of arguments
+     */
+    @Override
+    public void error(String format, Object... arguments) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            FormattingTuple ft = MessageFormatter.arrayFormat(format, arguments);
+            log(SELF, Level.SEVERE, ft.getMessage(), ft.getThrowable());
+        }
+    }
+
+    /**
+     * Log an exception (throwable) at the SEVERE level with an accompanying
+     * message.
+     *
+     * @param msg
+     *          the message accompanying the exception
+     * @param t
+     *          the exception (throwable) to log
+     */
+    @Override
+    public void error(String msg, Throwable t) {
+        if (logger.isLoggable(Level.SEVERE)) {
+            log(SELF, Level.SEVERE, msg, t);
+        }
+    }
+
+    /**
+     * Log the message at the specified level with the specified throwable if any.
+     * This method creates a LogRecord and fills in caller date before calling
+     * this instance's JDK14 logger.
+     *
+     * See bug report #13 for more details.
+     */
+    private void log(String callerFQCN, Level level, String msg, Throwable t) {
+        // millis and thread are filled by the constructor
+        LogRecord record = new LogRecord(level, msg);
+        record.setLoggerName(name());
+        record.setThrown(t);
+        fillCallerData(callerFQCN, record);
+        logger.log(record);
+    }
+
+    static final String SELF = JdkLogger.class.getName();
+    static final String SUPER = AbstractInternalLogger.class.getName();
+
+    /**
+     * Fill in caller data if possible.
+     *
+     * @param record
+     *          The record to update
+     */
+    private static void fillCallerData(String callerFQCN, LogRecord record) {
+        StackTraceElement[] steArray = new Throwable().getStackTrace();
+
+        int selfIndex = -1;
+        for (int i = 0; i < steArray.length; i++) {
+            final String className = steArray[i].getClassName();
+            if (className.equals(callerFQCN) || className.equals(SUPER)) {
+                selfIndex = i;
+                break;
+            }
+        }
+
+        int found = -1;
+        for (int i = selfIndex + 1; i < steArray.length; i++) {
+            final String className = steArray[i].getClassName();
+            if (!(className.equals(callerFQCN) || className.equals(SUPER))) {
+                found = i;
+                break;
+            }
+        }
+
+        if (found != -1) {
+            StackTraceElement ste = steArray[found];
+            // setting the class name has the side effect of setting
+            // the needToInferCaller variable to false.
+            record.setSourceClassName(ste.getClassName());
+            record.setSourceMethodName(ste.getMethodName());
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLoggerFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import java.util.logging.Logger;
+
+/**
+ * NOTE: This file has been copied and slightly modified from {io.netty.util.internal.logging}.
+ *
+ * Logger factory which creates a
+ * <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/logging/">java.util.logging</a>
+ * logger.
+ */
+public class JdkLoggerFactory extends InternalLoggerFactory {
+
+    public static final InternalLoggerFactory INSTANCE = new JdkLoggerFactory();
+
+    private JdkLoggerFactory() {
+    }
+
+    @Override
+    public InternalLogger newInstance(String name) {
+        return new JdkLogger(Logger.getLogger(name));
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -1,0 +1,269 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import org.slf4j.spi.LocationAwareLogger;
+
+import static org.slf4j.spi.LocationAwareLogger.*;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * <a href="http://www.slf4j.org/">SLF4J</a> logger which is location aware and so will log the correct origin of the
+ * logging event by filter out the wrapper itself.
+ */
+final class LocationAwareSlf4JLogger extends AbstractInternalLogger {
+
+    // IMPORTANT: All our log methods first check if the log level is enabled before call the wrapped
+    // LocationAwareLogger.log(...) method. This is done to reduce GC creation that is caused by varargs.
+
+    static final String FQCN = LocationAwareSlf4JLogger.class.getName();
+    private static final long serialVersionUID = -8292030083201538180L;
+
+    private final transient LocationAwareLogger logger;
+
+    LocationAwareSlf4JLogger(LocationAwareLogger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    private void log(final int level, final String message) {
+        logger.log(null, FQCN, level, message, null, null);
+    }
+
+    private void log(final int level, final String message, Throwable cause) {
+        logger.log(null, FQCN, level, message, null, cause);
+    }
+
+    private void log(final int level, final org.slf4j.helpers.FormattingTuple tuple) {
+        logger.log(null, FQCN, level, tuple.getMessage(), tuple.getArgArray(), tuple.getThrowable());
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, msg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, org.slf4j.helpers.MessageFormatter.format(format, arg));
+        }
+    }
+
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, org.slf4j.helpers.MessageFormatter.format(format, argA, argB));
+        }
+    }
+
+    @Override
+    public void trace(String format, Object... argArray) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, org.slf4j.helpers.MessageFormatter.arrayFormat(format, argArray));
+        }
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        if (isTraceEnabled()) {
+            log(TRACE_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, msg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, org.slf4j.helpers.MessageFormatter.format(format, arg));
+        }
+    }
+
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, org.slf4j.helpers.MessageFormatter.format(format, argA, argB));
+        }
+    }
+
+    @Override
+    public void debug(String format, Object... argArray) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, org.slf4j.helpers.MessageFormatter.arrayFormat(format, argArray));
+        }
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        if (isDebugEnabled()) {
+            log(DEBUG_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, msg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, org.slf4j.helpers.MessageFormatter.format(format, arg));
+        }
+    }
+
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, org.slf4j.helpers.MessageFormatter.format(format, argA, argB));
+        }
+    }
+
+    @Override
+    public void info(String format, Object... argArray) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, org.slf4j.helpers.MessageFormatter.arrayFormat(format, argArray));
+        }
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        if (isInfoEnabled()) {
+            log(INFO_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(String msg) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, msg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, org.slf4j.helpers.MessageFormatter.format(format, arg));
+        }
+    }
+
+    @Override
+    public void warn(String format, Object... argArray) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, org.slf4j.helpers.MessageFormatter.arrayFormat(format, argArray));
+        }
+    }
+
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, org.slf4j.helpers.MessageFormatter.format(format, argA, argB));
+        }
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        if (isWarnEnabled()) {
+            log(WARN_INT, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(String msg) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, msg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, org.slf4j.helpers.MessageFormatter.format(format, arg));
+        }
+    }
+
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, org.slf4j.helpers.MessageFormatter.format(format, argA, argB));
+        }
+    }
+
+    @Override
+    public void error(String format, Object... argArray) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, org.slf4j.helpers.MessageFormatter.arrayFormat(format, argArray));
+        }
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        if (isErrorEnabled()) {
+            log(ERROR_INT, msg, t);
+        }
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
@@ -1,0 +1,414 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package io.micrometer.core.util.internal.logging;
+
+import java.text.MessageFormat;
+import java.util.HashSet;
+import java.util.Set;
+
+// contributors: lizongbo: proposed special treatment of array parameter values
+// Joern Huxhorn: pointed out double[] omission, suggested deep array copy
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * Formats messages according to very simple substitution rules. Substitutions
+ * can be made 1, 2 or more arguments.
+ * <p/>
+ * <p/>
+ * For example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;)
+ * </pre>
+ * <p/>
+ * will return the string "Hi there.".
+ * <p/>
+ * The {} pair is called the <em>formatting anchor</em>. It serves to designate
+ * the location where arguments need to be substituted within the message
+ * pattern.
+ * <p/>
+ * In case your message contains the '{' or the '}' character, you do not have
+ * to do anything special unless the '}' character immediately follows '{'. For
+ * example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Set {1,2,3} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "Set {1,2,3} is not equal to 1,2.".
+ * <p/>
+ * <p/>
+ * If for whatever reason you need to place the string "{}" in the message
+ * without its <em>formatting anchor</em> meaning, then you need to escape the
+ * '{' character with '\', that is the backslash character. Only the '{'
+ * character should be escaped. There is no need to escape the '}' character.
+ * For example,
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;Set \\{} is not equal to {}.&quot;, &quot;1,2&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "Set {} is not equal to 1,2.".
+ * <p/>
+ * <p/>
+ * The escaping behavior just described can be overridden by escaping the escape
+ * character '\'. Calling
+ * <p/>
+ * <pre>
+ * MessageFormatter.format(&quot;File name is C:\\\\{}.&quot;, &quot;file.zip&quot;);
+ * </pre>
+ * <p/>
+ * will return the string "File name is C:\file.zip".
+ * <p/>
+ * <p/>
+ * The formatting conventions are different than those of {@link MessageFormat}
+ * which ships with the Java platform. This is justified by the fact that
+ * SLF4J's implementation is 10 times faster than that of {@link MessageFormat}.
+ * This local performance difference is both measurable and significant in the
+ * larger context of the complete logging processing chain.
+ * <p/>
+ * <p/>
+ * See also {@link #format(String, Object)},
+ * {@link #format(String, Object, Object)} and
+ * {@link #arrayFormat(String, Object[])} methods for more details.
+ */
+final class MessageFormatter {
+    private static final String DELIM_STR = "{}";
+    private static final char ESCAPE_CHAR = '\\';
+
+    /**
+     * Performs single argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p/>
+     * For example,
+     * <p/>
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}.&quot;, &quot;there&quot;);
+     * </pre>
+     * <p/>
+     * will return the string "Hi there.".
+     * <p/>
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param arg            The argument to be substituted in place of the formatting anchor
+     * @return The formatted message
+     */
+    static FormattingTuple format(String messagePattern, Object arg) {
+        return arrayFormat(messagePattern, new Object[]{arg});
+    }
+
+    /**
+     * Performs a two argument substitution for the 'messagePattern' passed as
+     * parameter.
+     * <p/>
+     * For example,
+     * <p/>
+     * <pre>
+     * MessageFormatter.format(&quot;Hi {}. My name is {}.&quot;, &quot;Alice&quot;, &quot;Bob&quot;);
+     * </pre>
+     * <p/>
+     * will return the string "Hi Alice. My name is Bob.".
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param argA           The argument to be substituted in place of the first formatting
+     *                       anchor
+     * @param argB           The argument to be substituted in place of the second formatting
+     *                       anchor
+     * @return The formatted message
+     */
+    static FormattingTuple format(final String messagePattern,
+                                  Object argA, Object argB) {
+        return arrayFormat(messagePattern, new Object[]{argA, argB});
+    }
+
+    /**
+     * Same principle as the {@link #format(String, Object)} and
+     * {@link #format(String, Object, Object)} methods except that any number of
+     * arguments can be passed in an array.
+     *
+     * @param messagePattern The message pattern which will be parsed and formatted
+     * @param argArray       An array of arguments to be substituted in place of formatting
+     *                       anchors
+     * @return The formatted message
+     */
+    static FormattingTuple arrayFormat(final String messagePattern,
+                                       final Object[] argArray) {
+        if (argArray == null || argArray.length == 0) {
+            return new FormattingTuple(messagePattern, null);
+        }
+
+        int lastArrIdx = argArray.length - 1;
+        Object lastEntry = argArray[lastArrIdx];
+        Throwable throwable = lastEntry instanceof Throwable ? (Throwable) lastEntry : null;
+
+        if (messagePattern == null) {
+            return new FormattingTuple(null, throwable);
+        }
+
+        int j = messagePattern.indexOf(DELIM_STR);
+        if (j == -1) {
+            // this is a simple string
+            return new FormattingTuple(messagePattern, throwable);
+        }
+
+        StringBuilder sbuf = new StringBuilder(messagePattern.length() + 50);
+        int i = 0;
+        int L = 0;
+        do {
+            boolean notEscaped = j == 0 || messagePattern.charAt(j - 1) != ESCAPE_CHAR;
+            if (notEscaped) {
+                // normal case
+                sbuf.append(messagePattern, i, j);
+            } else {
+                sbuf.append(messagePattern, i, j - 1);
+                // check that escape char is not is escaped: "abc x:\\{}"
+                notEscaped = j >= 2 && messagePattern.charAt(j - 2) == ESCAPE_CHAR;
+            }
+
+            i = j + 2;
+            if (notEscaped) {
+                deeplyAppendParameter(sbuf, argArray[L], null);
+                L++;
+                if (L > lastArrIdx) {
+                    break;
+                }
+            } else {
+                sbuf.append(DELIM_STR);
+            }
+            j = messagePattern.indexOf(DELIM_STR, i);
+        } while (j != -1);
+
+        // append the characters following the last {} pair.
+        sbuf.append(messagePattern, i, messagePattern.length());
+        return new FormattingTuple(sbuf.toString(), L <= lastArrIdx ? throwable : null);
+    }
+
+    // special treatment of array values was suggested by 'lizongbo'
+    private static void deeplyAppendParameter(StringBuilder sbuf, Object o,
+                                              Set<Object[]> seenSet) {
+        if (o == null) {
+            sbuf.append("null");
+            return;
+        }
+        Class<?> objClass = o.getClass();
+        if (!objClass.isArray()) {
+            if (Number.class.isAssignableFrom(objClass)) {
+                // Prevent String instantiation for some number types
+                if (objClass == Long.class) {
+                    sbuf.append(((Long) o).longValue());
+                } else if (objClass == Integer.class || objClass == Short.class || objClass == Byte.class) {
+                    sbuf.append(((Number) o).intValue());
+                } else if (objClass == Double.class) {
+                    sbuf.append(((Double) o).doubleValue());
+                } else if (objClass == Float.class) {
+                    sbuf.append(((Float) o).floatValue());
+                } else {
+                    safeObjectAppend(sbuf, o);
+                }
+            } else {
+                safeObjectAppend(sbuf, o);
+            }
+        } else {
+            // check for primitive array types because they
+            // unfortunately cannot be cast to Object[]
+            sbuf.append('[');
+            if (objClass == boolean[].class) {
+                booleanArrayAppend(sbuf, (boolean[]) o);
+            } else if (objClass == byte[].class) {
+                byteArrayAppend(sbuf, (byte[]) o);
+            } else if (objClass == char[].class) {
+                charArrayAppend(sbuf, (char[]) o);
+            } else if (objClass == short[].class) {
+                shortArrayAppend(sbuf, (short[]) o);
+            } else if (objClass == int[].class) {
+                intArrayAppend(sbuf, (int[]) o);
+            } else if (objClass == long[].class) {
+                longArrayAppend(sbuf, (long[]) o);
+            } else if (objClass == float[].class) {
+                floatArrayAppend(sbuf, (float[]) o);
+            } else if (objClass == double[].class) {
+                doubleArrayAppend(sbuf, (double[]) o);
+            } else {
+                objectArrayAppend(sbuf, (Object[]) o, seenSet);
+            }
+            sbuf.append(']');
+        }
+    }
+
+    private static void safeObjectAppend(StringBuilder sbuf, Object o) {
+        try {
+            String oAsString = o.toString();
+            sbuf.append(oAsString);
+        } catch (Throwable t) {
+            System.err
+                    .println("SLF4J: Failed toString() invocation on an object of type ["
+                            + o.getClass().getName() + ']');
+            t.printStackTrace();
+            sbuf.append("[FAILED toString()]");
+        }
+    }
+
+    private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Set<Object[]> seenSet) {
+        if (a.length == 0) {
+            return;
+        }
+        if (seenSet == null) {
+            seenSet = new HashSet<>(a.length);
+        }
+        if (seenSet.add(a)) {
+            deeplyAppendParameter(sbuf, a[0], seenSet);
+            for (int i = 1; i < a.length; i++) {
+                sbuf.append(", ");
+                deeplyAppendParameter(sbuf, a[i], seenSet);
+            }
+            // allow repeats in siblings
+            seenSet.remove(a);
+        } else {
+            sbuf.append("...");
+        }
+    }
+
+    private static void booleanArrayAppend(StringBuilder sbuf, boolean[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void byteArrayAppend(StringBuilder sbuf, byte[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void charArrayAppend(StringBuilder sbuf, char[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void shortArrayAppend(StringBuilder sbuf, short[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void intArrayAppend(StringBuilder sbuf, int[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void longArrayAppend(StringBuilder sbuf, long[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void floatArrayAppend(StringBuilder sbuf, float[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private static void doubleArrayAppend(StringBuilder sbuf, double[] a) {
+        if (a.length == 0) {
+            return;
+        }
+        sbuf.append(a[0]);
+        for (int i = 1; i < a.length; i++) {
+            sbuf.append(", ");
+            sbuf.append(a[i]);
+        }
+    }
+
+    private MessageFormatter() {
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLogger.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import org.slf4j.Logger;
+
+/**
+ * NOTE: This file has been copied from {io.netty.util.internal.logging}.
+ *
+ * <a href="http://www.slf4j.org/">SLF4J</a> logger.
+ */
+final class Slf4JLogger extends AbstractInternalLogger {
+
+    private static final long serialVersionUID = 108038972685130825L;
+
+    private final transient Logger logger;
+
+    Slf4JLogger(Logger logger) {
+        super(logger.getName());
+        this.logger = logger;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        logger.trace(msg);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        logger.trace(format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object argA, Object argB) {
+        logger.trace(format, argA, argB);
+    }
+
+    @Override
+    public void trace(String format, Object... argArray) {
+        logger.trace(format, argArray);
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        logger.trace(msg, t);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public void debug(String msg) {
+        logger.debug(msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        logger.debug(format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object argA, Object argB) {
+        logger.debug(format, argA, argB);
+    }
+
+    @Override
+    public void debug(String format, Object... argArray) {
+        logger.debug(format, argArray);
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        logger.debug(msg, t);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        logger.info(format, arg);
+    }
+
+    @Override
+    public void info(String format, Object argA, Object argB) {
+        logger.info(format, argA, argB);
+    }
+
+    @Override
+    public void info(String format, Object... argArray) {
+        logger.info(format, argArray);
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        logger.info(msg, t);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public void warn(String msg) {
+        logger.warn(msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        logger.warn(format, arg);
+    }
+
+    @Override
+    public void warn(String format, Object... argArray) {
+        logger.warn(format, argArray);
+    }
+
+    @Override
+    public void warn(String format, Object argA, Object argB) {
+        logger.warn(format, argA, argB);
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        logger.warn(msg, t);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public void error(String msg) {
+        logger.error(msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        logger.error(format, arg);
+    }
+
+    @Override
+    public void error(String format, Object argA, Object argB) {
+        logger.error(format, argA, argB);
+    }
+
+    @Override
+    public void error(String format, Object... argArray) {
+        logger.error(format, argArray);
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        logger.error(msg, t);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLoggerFactory.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLoggerFactory;
+import org.slf4j.spi.LocationAwareLogger;
+
+/**
+ * NOTE: This file has been copied and slightly modified from {io.netty.util.internal.logging}.
+ *
+ * Logger factory which creates a <a href="http://www.slf4j.org/">SLF4J</a>
+ * logger.
+ */
+public class Slf4JLoggerFactory extends InternalLoggerFactory {
+
+    public static final InternalLoggerFactory INSTANCE = new Slf4JLoggerFactory();
+
+    private Slf4JLoggerFactory() {
+        if (LoggerFactory.getILoggerFactory() instanceof NOPLoggerFactory) {
+            throw new NoClassDefFoundError("NOPLoggerFactory not supported");
+        }
+    }
+
+    @Override
+    public InternalLogger newInstance(String name) {
+        return wrapLogger(LoggerFactory.getLogger(name));
+    }
+
+    // package-private for testing.
+    static InternalLogger wrapLogger(Logger logger) {
+        return logger instanceof LocationAwareLogger ?
+                new LocationAwareSlf4JLogger((LocationAwareLogger) logger) : new Slf4JLogger(logger);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2013 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * NOTE: This file has been copied and slightly modified from {io.netty.util.internal.logging}.
+ *
+ * <em>Internal-use-only</em> logging API which is not allowed to be used outside Micrometer.
+ */
+package io.micrometer.core.util.internal.logging;


### PR DESCRIPTION
`PushMeterRegistry` has references to classes (`Logger` and `LoggerFactory`) from `slf4j-api`, so without the dependency, the following error occurs:

```
java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory

	at io.micrometer.core.instrument.push.PushMeterRegistry.<clinit>(PushMeterRegistry.java:30)
```

This PR changes to make `PushMeterRegistry` work without `slf4j-api` by falling back to the standard output. If this fallback is not appropriate, another option might be logging nothing. I'm not sure if there's any better option for this. Maybe the easiest option might be just using a specific logging library like SLF4J explicitly.

`micrometer-core` has two more references in `JvmGcMetrics` and `MicrometerMetricsPublisherCommand`. If this PR finds a reasonable way, I'll prepare another PR for them or can update this to accommodate them.

I can see `implementations` has many references, so they already depends on SLF4J. So making Micrometer depend on SLF4j seems to be the easiest fix overall but IIRC @jkschneider doesn't want Micrometer to depend on any logging library.