### PR TITLE
Manage mockito-core in micrometer-test module

### DIFF
--- a/implementations/micrometer-registry-appoptics/build.gradle
+++ b/implementations/micrometer-registry-appoptics/build.gradle
@@ -3,5 +3,4 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.+'
 
     testCompile project(':micrometer-test')
-    testCompile 'org.mockito:mockito-core:latest.release'
 }

--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -6,5 +6,4 @@ dependencies {
     compile 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
 
     testCompile project(':micrometer-test')
-    testCompile 'org.mockito:mockito-core:latest.release'
 }

--- a/implementations/micrometer-registry-cloudwatch2/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch2/build.gradle
@@ -6,5 +6,4 @@ dependencies {
     compile 'software.amazon.awssdk:cloudwatch:latest.release'
 
     testCompile project(':micrometer-test')
-    testCompile 'org.mockito:mockito-core:latest.release'
 }

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor:reactor-test:latest.release'
-    testCompile 'org.mockito:mockito-core:latest.release'
 }
 
 shadowJar {

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 
     compile 'ru.lanwen.wiremock:wiremock-junit5:latest.release'
     compile 'com.github.tomakehurst:wiremock:latest.release'
+    compile 'org.mockito:mockito-core:latest.release'
 
     testCompile 'org.jsr107.ri:cache-ri-impl:1.0.0'
 }


### PR DESCRIPTION
This PR changes to manage the `mockito-core` dependency in the `micrometer-test` module as it's generally useful for testing.