### PR TITLE
Use consistent value for count in CloudWatch meter registry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -169,26 +169,28 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         // VisibleForTesting
         Stream<MetricDatum> timerData(Timer timer) {
-            final Stream.Builder<MetricDatum> metrics = Stream.builder();
-
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
-            metrics.add(metricDatum(timer.getId(), "count", "count", timer.count()));
-
-            MetricDatum avg = metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit()));
-            MetricDatum max = metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit()));
-            return timer.count() > 0 ? metrics.add(avg).add(max).build() : metrics.build();
+            long count = timer.count();
+            metrics.add(metricDatum(timer.getId(), "count", "count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
+                metrics.add(metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
+            }
+            return metrics.build();
         }
 
         // VisibleForTesting
         Stream<MetricDatum> summaryData(DistributionSummary summary) {
-            final Stream.Builder<MetricDatum> metrics = Stream.builder();
-
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(summary.getId(), "sum", summary.totalAmount()));
-            metrics.add(metricDatum(summary.getId(), "count", summary.count()));
-
-            MetricDatum avg = metricDatum(summary.getId(), "avg", summary.mean());
-            MetricDatum max = metricDatum(summary.getId(), "max", summary.max());
-            return summary.count() > 0 ? metrics.add(avg).add(max).build() : metrics.build();
+            long count = summary.count();
+            metrics.add(metricDatum(summary.getId(), "count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(summary.getId(), "avg", summary.mean()));
+                metrics.add(metricDatum(summary.getId(), "max", summary.max()));
+            }
+            return metrics.build();
 
         }
 
@@ -218,11 +220,13 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         // VisibleForTesting
         Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
             // we can't know anything about max and percentiles originating from a function timer
-
-            MetricDatum count = metricDatum(timer.getId(),"count", timer.count());
-            MetricDatum avg = metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit()));
-
-            return timer.count() > 0 ? Stream.of(count, avg) : Stream.of(count);
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            double count = timer.count();
+            metrics.add(metricDatum(timer.getId(),"count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            }
+            return metrics.build();
         }
 
         // VisibleForTesting

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -162,27 +162,28 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         // VisibleForTesting
         Stream<MetricDatum> timerData(Timer timer) {
-            final Stream.Builder<MetricDatum> metrics = Stream.builder();
-
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
-            metrics.add(metricDatum(timer.getId(), "count", "count", timer.count()));
-
-            MetricDatum avg = metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit()));
-            MetricDatum max = metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit()));
-            return timer.count() > 0 ? metrics.add(avg).add(max).build() : metrics.build();
+            long count = timer.count();
+            metrics.add(metricDatum(timer.getId(), "count", "count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
+                metrics.add(metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
+            }
+            return metrics.build();
         }
 
         // VisibleForTesting
         Stream<MetricDatum> summaryData(DistributionSummary summary) {
-            final Stream.Builder<MetricDatum> metrics = Stream.builder();
-
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(summary.getId(), "sum", summary.totalAmount()));
-            metrics.add(metricDatum(summary.getId(), "count", summary.count()));
-
-            MetricDatum avg = metricDatum(summary.getId(), "avg", summary.mean());
-            MetricDatum max = metricDatum(summary.getId(), "max", summary.max());
-            return summary.count() > 0 ? metrics.add(avg).add(max).build() : metrics.build();
-
+            long count = summary.count();
+            metrics.add(metricDatum(summary.getId(), "count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(summary.getId(), "avg", summary.mean()));
+                metrics.add(metricDatum(summary.getId(), "max", summary.max()));
+            }
+            return metrics.build();
         }
 
         private Stream<MetricDatum> longTaskTimerData(LongTaskTimer longTaskTimer) {
@@ -211,11 +212,13 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         // VisibleForTesting
         Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
             // we can't know anything about max and percentiles originating from a function timer
-
-            MetricDatum count = metricDatum(timer.getId(),"count", timer.count());
-            MetricDatum avg = metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit()));
-
-            return timer.count() > 0 ? Stream.of(count, avg) : Stream.of(count);
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            double count = timer.count();
+            metrics.add(metricDatum(timer.getId(),"count", count));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            }
+            return metrics.build();
         }
 
         // VisibleForTesting


### PR DESCRIPTION
This PR changes to use consistent value for count in CloudWatch meter registry.

Along the way, this PR also changes to create `MetricDatum` objects only when they are used.