### PR TITLE
Fix NamingConvention.upperCamelCase.tagKey()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
  * from Spring Web).
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public interface NamingConvention {
     NamingConvention identity = (name, type, baseUnit) -> name;
@@ -96,8 +97,12 @@ public interface NamingConvention {
     NamingConvention upperCamelCase = new NamingConvention() {
         @Override
         public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-            String lowerCamel = camelCase.name(name, type, baseUnit);
-            return capitalize(lowerCamel);
+            return capitalize(camelCase.name(name, type, baseUnit));
+        }
+
+        @Override
+        public String tagKey(String key) {
+            return capitalize(camelCase.tagKey(key));
         }
 
         private String capitalize(String name) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/NamingConventionTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/NamingConventionTest.java
@@ -20,22 +20,46 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+/**
+ * Tests for {@link NamingConvention}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class NamingConventionTest {
     @Test
-    void camelCase() {
+    void camelCaseName() {
         String name = NamingConvention.camelCase.name("a.Name.with.Words", Meter.Type.COUNTER);
         assertThat(name).isEqualTo("aNameWithWords");
     }
 
     @Test
-    void snakeCase() {
+    void camelCaseTagKey() {
+        String name = NamingConvention.camelCase.tagKey("a.Name.with.Words");
+        assertThat(name).isEqualTo("aNameWithWords");
+    }
+
+    @Test
+    void snakeCaseName() {
         String name = NamingConvention.snakeCase.name("a.Name.with.Words", Meter.Type.COUNTER);
         assertThat(name).isEqualTo("a_Name_with_Words");
     }
 
     @Test
-    void upperCamelCase() {
+    void snakeCaseTagKey() {
+        String name = NamingConvention.snakeCase.tagKey("a.Name.with.Words");
+        assertThat(name).isEqualTo("a_Name_with_Words");
+    }
+
+    @Test
+    void upperCamelCaseName() {
         String name = NamingConvention.upperCamelCase.name("a.name.with.words", Meter.Type.COUNTER);
+        assertThat(name).isEqualTo("ANameWithWords");
+    }
+
+    @Test
+    void upperCamelCaseTagKey() {
+        String name = NamingConvention.upperCamelCase.tagKey("a.name.with.words");
         assertThat(name).isEqualTo("ANameWithWords");
     }
 }


### PR DESCRIPTION
This PR fixes `NamingConvention.upperCamelCase.tagKey()`.