### PR TITLE
Improve Graphite name sanitization

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
@@ -23,6 +23,12 @@ import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * {@link HierarchicalNameMapper} for Graphite.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public class GraphiteHierarchicalNameMapper implements HierarchicalNameMapper {
     private final List<String> tagsAsPrefix;
 
@@ -42,15 +48,11 @@ public class GraphiteHierarchicalNameMapper implements HierarchicalNameMapper {
         hierarchicalName.append(id.getConventionName(convention));
         for (Tag tag : id.getTagsAsIterable()) {
             if (!tagsAsPrefix.contains(tag.getKey())) {
-                hierarchicalName.append('.').append(sanitize(convention.tagKey(tag.getKey())))
-                        .append('.').append(sanitize(convention.tagValue(tag.getValue())));
+                hierarchicalName.append('.').append(convention.tagKey(tag.getKey()))
+                        .append('.').append(convention.tagValue(tag.getValue()));
             }
         }
         return hierarchicalName.toString();
-    }
-
-    private String sanitize(String value) {
-        return value.replace(" ", "_");
     }
 
 }

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
@@ -33,7 +33,8 @@ public class GraphiteNamingConvention implements NamingConvention {
      * A list that probably is blacklisted: https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/grammar.py#L48-L55.
      * Empirically, we have found others.
      */
-    private static final Pattern blacklistedChars = Pattern.compile("[{}(),=\\[\\]/]");
+    private static final Pattern PATTERN_NAME_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ ]");
+    private static final Pattern PATTERN_TAG_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ .]");
     private final NamingConvention delegate;
 
     public GraphiteNamingConvention() {
@@ -46,17 +47,17 @@ public class GraphiteNamingConvention implements NamingConvention {
 
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        return sanitize(this.delegate.name(normalize(name), type, baseUnit));
+        return sanitizeName(this.delegate.name(normalize(name), type, baseUnit));
     }
 
     @Override
     public String tagKey(String key) {
-        return sanitize(this.delegate.tagKey(normalize(key)));
+        return sanitizeTag(this.delegate.tagKey(normalize(key)));
     }
 
     @Override
     public String tagValue(String value) {
-        return sanitize(this.delegate.tagValue(normalize(value)));
+        return sanitizeTag(this.delegate.tagValue(normalize(value)));
     }
 
     /**
@@ -67,8 +68,12 @@ public class GraphiteNamingConvention implements NamingConvention {
         return Normalizer.normalize(name, Normalizer.Form.NFKD);
     }
 
-    private String sanitize(String delegated) {
-        return blacklistedChars.matcher(delegated).replaceAll("_");
+    private String sanitizeName(String delegated) {
+        return PATTERN_NAME_BLACKLISTED_CHARS.matcher(delegated).replaceAll("_");
+    }
+
+    private String sanitizeTag(String delegated) {
+        return PATTERN_TAG_BLACKLISTED_CHARS.matcher(delegated).replaceAll("_");
     }
 
 }

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteNamingConvention.java
@@ -33,8 +33,8 @@ public class GraphiteNamingConvention implements NamingConvention {
      * A list that probably is blacklisted: https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/render/grammar.py#L48-L55.
      * Empirically, we have found others.
      */
-    private static final Pattern PATTERN_NAME_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ ]");
-    private static final Pattern PATTERN_TAG_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ .]");
+    private static final Pattern PATTERN_NAME_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ ?:]");
+    private static final Pattern PATTERN_TAG_BLACKLISTED_CHARS = Pattern.compile("[{}(),=\\[\\]/ ?:.]");
     private final NamingConvention delegate;
 
     public GraphiteNamingConvention() {

--- a/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteHierarchicalNameMapperTest.java
+++ b/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteHierarchicalNameMapperTest.java
@@ -23,6 +23,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link GraphiteHierarchicalNameMapper}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class GraphiteHierarchicalNameMapperTest {
     private final GraphiteHierarchicalNameMapper nameMapper = new GraphiteHierarchicalNameMapper("stack", "app.name");
     private final Meter.Id id = new SimpleMeterRegistry().counter("my.name",
@@ -33,5 +39,13 @@ class GraphiteHierarchicalNameMapperTest {
     void tagsAsPrefix() {
         assertThat(nameMapper.toHierarchicalName(id, NamingConvention.camelCase))
                 .isEqualTo("PROD.MYAPP.myName.otherTag.value");
+    }
+
+    @Test
+    void toHierarchicalNameShouldSanitizeTagValueFromTagsAsPrefix() {
+        Meter.Id id = new SimpleMeterRegistry().counter("my.name",
+                "app.name", "MY APP", "stack", "PROD", "other.tag", "value").getId();
+        assertThat(nameMapper.toHierarchicalName(id, new GraphiteNamingConvention()))
+                .isEqualTo("PROD.MY_APP.myName.otherTag.value");
     }
 }

--- a/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
+++ b/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
@@ -46,26 +46,58 @@ class GraphiteNamingConventionTest {
 
         GraphiteNamingConvention convention = new GraphiteNamingConvention(delegateNamingConvention);
 
-        assertThat(convention.name("my.name", Meter.Type.TIMER)).isEqualTo("name: my.name");
-        assertThat(convention.tagKey("my.tag.key")).isEqualTo("key: my.tag.key");
-        assertThat(convention.tagValue("my.tag.value")).isEqualTo("value: my.tag.value");
+        assertThat(convention.name("my.name", Meter.Type.TIMER)).isEqualTo("name:my.name");
+        assertThat(convention.tagKey("my_tag_key")).isEqualTo("key:my_tag_key");
+        assertThat(convention.tagValue("my_tag_value")).isEqualTo("value:my_tag_value");
+    }
+
+    @Test
+    void nameShouldPreserveDot() {
+        GraphiteNamingConvention convention = new GraphiteNamingConvention(NamingConvention.identity);
+        assertThat(convention.name("my.counter", Meter.Type.COUNTER)).isEqualTo("my.counter");
+    }
+
+    @Test
+    void nameShouldSanitizeSpace() {
+        assertThat(convention.name("counter 1", Meter.Type.COUNTER)).isEqualTo("counter_1");
+    }
+
+    @Test
+    void tagKeyShouldSanitizeDot() {
+        GraphiteNamingConvention convention = new GraphiteNamingConvention(NamingConvention.identity);
+        assertThat(convention.tagKey("my.tag")).isEqualTo("my_tag");
+    }
+
+    @Test
+    void tagKeyShouldSanitizeSpace() {
+        assertThat(convention.tagKey("tag 1")).isEqualTo("tag_1");
+    }
+
+    @Test
+    void tagValueShouldSanitizeDot() {
+        assertThat(convention.tagValue("my.value")).isEqualTo("my_value");
+    }
+
+    @Test
+    void tagValueShouldSanitizeSpace() {
+        assertThat(convention.tagKey("value 1")).isEqualTo("value_1");
     }
 
     private static class CustomNamingConvention implements NamingConvention {
 
         @Override
         public String name(String name, Meter.Type type, String baseUnit) {
-            return "name: " + name;
+            return "name:" + name;
         }
 
         @Override
         public String tagKey(String key) {
-            return "key: " + key;
+            return "key:" + key;
         }
 
         @Override
         public String tagValue(String value) {
-            return "value: " + value;
+            return "value:" + value;
         }
 
     }

--- a/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
+++ b/implementations/micrometer-registry-graphite/src/test/java/io/micrometer/graphite/GraphiteNamingConventionTest.java
@@ -46,9 +46,9 @@ class GraphiteNamingConventionTest {
 
         GraphiteNamingConvention convention = new GraphiteNamingConvention(delegateNamingConvention);
 
-        assertThat(convention.name("my.name", Meter.Type.TIMER)).isEqualTo("name:my.name");
-        assertThat(convention.tagKey("my_tag_key")).isEqualTo("key:my_tag_key");
-        assertThat(convention.tagValue("my_tag_value")).isEqualTo("value:my_tag_value");
+        assertThat(convention.name("my.name", Meter.Type.TIMER)).isEqualTo("name-my.name");
+        assertThat(convention.tagKey("my_tag_key")).isEqualTo("key-my_tag_key");
+        assertThat(convention.tagValue("my_tag_value")).isEqualTo("value-my_tag_value");
     }
 
     @Test
@@ -63,6 +63,16 @@ class GraphiteNamingConventionTest {
     }
 
     @Test
+    void nameShouldSanitizeQuestionMark() {
+        assertThat(convention.name("counter?1", Meter.Type.COUNTER)).isEqualTo("counter_1");
+    }
+
+    @Test
+    void nameShouldSanitizeColon() {
+        assertThat(convention.name("counter:1", Meter.Type.COUNTER)).isEqualTo("counter_1");
+    }
+
+    @Test
     void tagKeyShouldSanitizeDot() {
         GraphiteNamingConvention convention = new GraphiteNamingConvention(NamingConvention.identity);
         assertThat(convention.tagKey("my.tag")).isEqualTo("my_tag");
@@ -71,6 +81,16 @@ class GraphiteNamingConventionTest {
     @Test
     void tagKeyShouldSanitizeSpace() {
         assertThat(convention.tagKey("tag 1")).isEqualTo("tag_1");
+    }
+
+    @Test
+    void tagKeyShouldSanitizeQuestionMark() {
+        assertThat(convention.tagKey("tag?1")).isEqualTo("tag_1");
+    }
+
+    @Test
+    void tagKeyShouldSanitizeColon() {
+        assertThat(convention.tagKey("tag:1")).isEqualTo("tag_1");
     }
 
     @Test
@@ -83,21 +103,31 @@ class GraphiteNamingConventionTest {
         assertThat(convention.tagKey("value 1")).isEqualTo("value_1");
     }
 
+    @Test
+    void tagValueShouldSanitizeQuestionMark() {
+        assertThat(convention.tagKey("value?1")).isEqualTo("value_1");
+    }
+
+    @Test
+    void tagValueShouldSanitizeColon() {
+        assertThat(convention.tagKey("value:1")).isEqualTo("value_1");
+    }
+
     private static class CustomNamingConvention implements NamingConvention {
 
         @Override
         public String name(String name, Meter.Type type, String baseUnit) {
-            return "name:" + name;
+            return "name-" + name;
         }
 
         @Override
         public String tagKey(String key) {
-            return "key:" + key;
+            return "key-" + key;
         }
 
         @Override
         public String tagValue(String value) {
-            return "value:" + value;
+            return "value-" + value;
         }
 
     }


### PR DESCRIPTION
This PR improves Graphite name sanitization by:

- sanitizing tag values from tagsAsPrefix.
- sanitizing spaces from meter names.
- sanitizing dots from tag keys and values.

Closes gh-1465