### PR TITLE
Add Javadoc since to default constructor in TimedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -58,6 +58,11 @@ public class TimedAspect {
     private final MeterRegistry registry;
     private final Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint;
 
+    /**
+     * Create a {@code TimedAspect} instance with {@link Metrics#globalRegistry}.
+     *
+     * @since 1.2.0
+     */
     public TimedAspect() {
         this(Metrics.globalRegistry);
     }


### PR DESCRIPTION
This PR adds Javadoc `@since` to the default constructor in the `TimedAspect`.