### PR TITLE
Remove nebula.optional-base plugin from CloudWatch modules

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'nebula.optional-base'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'

--- a/implementations/micrometer-registry-cloudwatch2/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch2/build.gradle
@@ -1,5 +1,3 @@
-apply plugin: 'nebula.optional-base'
-
 dependencies {
     compile project(':micrometer-core')
     compile 'org.slf4j:slf4j-api:1.7.+'


### PR DESCRIPTION
This PR removes `nebula.optional-base` plugin from CloudWatch modules as it doesn't seem to be used.