### PR TITLE
Fix method tag in TimedAspectTest.timeMethodFailureWithLongTaskTimer()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -104,7 +104,7 @@ class TimedAspectTest {
         assertThatExceptionOfType(MeterNotFoundException.class).isThrownBy(() -> {
             failingRegistry.get("longCall")
                     .tag("class", "io.micrometer.core.aop.TimedAspectTest$TimedService")
-                    .tag("method", "call")
+                    .tag("method", "longCall")
                     .tag("extra", "tag")
                     .longTaskTimer();
         });


### PR DESCRIPTION
This PR fixes "method" tag in `TimedAspectTest.timeMethodFailureWithLongTaskTimer()`.