### PR TITLE
Add missing @Nullable for CallState constructor parameter

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -136,7 +136,7 @@ public class OkHttpMetricsEventListener extends EventListener {
         @Nullable
         IOException exception;
 
-        CallState(long startTime, Request request) {
+        CallState(long startTime, @Nullable Request request) {
             this.startTime = startTime;
             this.request = request;
         }


### PR DESCRIPTION
This PR adds missing `@Nullable` for `CallState` constructor parameter.