### PR TITLE
Allow base units from meters to be used in CloudWatch meter registry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -34,7 +34,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadFactory;
@@ -53,6 +56,19 @@ import static java.util.stream.StreamSupport.stream;
  * @author Pierre-Yves B.
  */
 public class CloudWatchMeterRegistry extends StepMeterRegistry {
+
+    private static final Map<String, StandardUnit> STANDARD_UNIT_BY_LOWERCASE_VALUE;
+
+    static {
+        Map<String, StandardUnit> standardUnitByLowercaseValue = new HashMap<>();
+        for (StandardUnit standardUnit : StandardUnit.values()) {
+            if (standardUnit != StandardUnit.UNKNOWN_TO_SDK_VERSION) {
+                standardUnitByLowercaseValue.put(standardUnit.toString().toLowerCase(), standardUnit);
+            }
+        }
+        STANDARD_UNIT_BY_LOWERCASE_VALUE = Collections.unmodifiableMap(standardUnitByLowercaseValue);
+    }
+
     private final CloudWatchConfig config;
     private final CloudWatchAsyncClient cloudWatchAsyncClient;
     private final Logger logger = LoggerFactory.getLogger(CloudWatchMeterRegistry.class);
@@ -158,7 +174,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         }
 
         private Stream<MetricDatum> counterData(Counter counter) {
-            return Stream.of(metricDatum(counter.getId(), "count", "count", counter.count()));
+            return Stream.of(metricDatum(counter.getId(), "count", StandardUnit.COUNT, counter.count()));
         }
 
         // VisibleForTesting
@@ -166,7 +182,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
             long count = timer.count();
-            metrics.add(metricDatum(timer.getId(), "count", "count", count));
+            metrics.add(metricDatum(timer.getId(), "count", StandardUnit.COUNT, count));
             if (count > 0) {
                 metrics.add(metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
                 metrics.add(metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
@@ -179,7 +195,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             Stream.Builder<MetricDatum> metrics = Stream.builder();
             metrics.add(metricDatum(summary.getId(), "sum", summary.totalAmount()));
             long count = summary.count();
-            metrics.add(metricDatum(summary.getId(), "count", "count", count));
+            metrics.add(metricDatum(summary.getId(), "count", StandardUnit.COUNT, count));
             if (count > 0) {
                 metrics.add(metricDatum(summary.getId(), "avg", summary.mean()));
                 metrics.add(metricDatum(summary.getId(), "max", summary.max()));
@@ -203,7 +219,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         // VisibleForTesting
         Stream<MetricDatum> functionCounterData(FunctionCounter counter) {
-            MetricDatum metricDatum = metricDatum(counter.getId(), "count", "count", counter.count());
+            MetricDatum metricDatum = metricDatum(counter.getId(), "count", StandardUnit.COUNT, counter.count());
             if (metricDatum == null) {
                 return Stream.empty();
             }
@@ -215,7 +231,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             // we can't know anything about max and percentiles originating from a function timer
             Stream.Builder<MetricDatum> metrics = Stream.builder();
             double count = timer.count();
-            metrics.add(metricDatum(timer.getId(), "count", "count", count));
+            metrics.add(metricDatum(timer.getId(), "count", StandardUnit.COUNT, count));
             if (count > 0) {
                 metrics.add(metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
             }
@@ -231,16 +247,21 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         @Nullable
         private MetricDatum metricDatum(Meter.Id id, double value) {
-            return metricDatum(id, null, null, value);
+            return metricDatum(id, null, id.getBaseUnit(), value);
         }
 
         @Nullable
         private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, double value) {
-            return metricDatum(id, suffix, null, value);
+            return metricDatum(id, suffix, id.getBaseUnit(), value);
         }
 
         @Nullable
         private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, @Nullable String unit, double value) {
+            return metricDatum(id, suffix, toStandardUnit(unit), value);
+        }
+
+        @Nullable
+        private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, StandardUnit standardUnit, double value) {
             if (Double.isNaN(value)) {
                 return null;
             }
@@ -251,7 +272,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                     .dimensions(toDimensions(tags))
                     .timestamp(timestamp)
                     .value(CloudWatchUtils.clampMetricValue(value))
-                    .unit(toStandardUnit(unit))
+                    .unit(standardUnit)
                     .build();
         }
 
@@ -265,18 +286,9 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             if (unit == null) {
                 return StandardUnit.NONE;
             }
-            switch (unit.toLowerCase()) {
-                case "bytes":
-                    return StandardUnit.BYTES;
-                case "milliseconds":
-                    return StandardUnit.MILLISECONDS;
-                case "count":
-                    return StandardUnit.COUNT;
-                default:
-                    return StandardUnit.NONE;
-            }
+            StandardUnit standardUnit = STANDARD_UNIT_BY_LOWERCASE_VALUE.get(unit.toLowerCase());
+            return standardUnit != null ? standardUnit : StandardUnit.UNKNOWN_TO_SDK_VERSION;
         }
-
 
         private List<Dimension> toDimensions(List<Tag> tags) {
             return tags.stream()


### PR DESCRIPTION
This PR changes to allow base units from meters to be used in CloudWatch meter registry.

Closes gh-1494