### PR TITLE
Handle exception for gauge value function in DropwizardMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -76,7 +76,11 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
         Gauge<Double> gauge = () -> {
             T obj2 = ref.get();
             if (obj2 != null) {
-                return valueFunction.applyAsDouble(obj2);
+                try {
+                    return valueFunction.applyAsDouble(obj2);
+                } catch (Throwable ex) {
+                    return nullGaugeValue();
+                }
             } else {
                 return nullGaugeValue();
             }


### PR DESCRIPTION
This PR changes to handle exception for gauge value function in `DropwizardMeterRegistry`. This will give other metrics a chance to be published although there's any exception from gauge functions. There's one caveat that the exception will be lost without any logging as there's no proper logging method for Micrometer core module yet.

See gh-1531