### PR TITLE
Update javadocs for @Timed annotation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
@@ -29,6 +29,10 @@ public @interface Timed {
      */
     String value() default "";
 
+    /**
+     * A list of key-value pair arguments to supply the underlying Timer 
+     * {@link io.micrometer.core.instrument.Timer.Builder#tags(String...)} 
+     */
     String[] extraTags() default {};
 
     boolean longTask() default false;


### PR DESCRIPTION
extraTags{} should be supplied with an even key-value pair list, which isn't clear in the annotation comments.