### PR TITLE
Move to new Humio structered API.

### DIFF
--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
@@ -46,14 +46,6 @@ public interface HumioConfig extends StepRegistryConfig {
     }
 
     /**
-     * @return The repository name to write metrics to.
-     */
-    default String repository() {
-        String v = get(prefix() + ".repository");
-        return v == null ? "sandbox" : v;
-    }
-
-    /**
      * Humio uses a concept called "tags" to decide which datasource to store metrics in. This concept
      * is distinct from Micrometer's notion of tags, which divides a metric along dimensional boundaries.
      * All metrics from this registry will be stored under a datasource defined by these tags.

--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
@@ -46,6 +46,15 @@ public interface HumioConfig extends StepRegistryConfig {
     }
 
     /**
+     * @return The repository name to write metrics to.
+     * @deprecated No longer used as repository is resolved from the api token
+     */
+    @Deprecated
+    default String repository() {
+        return "";
+    }
+
+    /**
      * Humio uses a concept called "tags" to decide which datasource to store metrics in. This concept
      * is distinct from Micrometer's notion of tags, which divides a metric along dimensional boundaries.
      * All metrics from this registry will be stored under a datasource defined by these tags.

--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
@@ -91,7 +91,7 @@ public class HumioMeterRegistry extends StepMeterRegistry {
     protected void publish() {
         for (List<Meter> meters : MeterPartition.partition(this, config.batchSize())) {
             try {
-                HttpSender.Request.Builder post = httpClient.post(config.uri() + "/api/v1/dataspaces/" + config.repository() + "/ingest");
+                HttpSender.Request.Builder post = httpClient.post(config.uri() + "/api/v1/ingest/humio-structured");
                 String token = config.apiToken();
                 if (token != null) {
                     post.withHeader("Authorization", "Bearer " + token);

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -59,7 +59,7 @@ class HumioMeterRegistryTest {
 
         server.stubFor(any(anyUrl()));
         registry.publish();
-        server.verify(postRequestedFor(urlMatching("/api/v1/dataspaces/repo/ingest"))
+        server.verify(postRequestedFor(urlMatching("/api/v1/ingest/humio-structured"))
                 .withRequestBody(equalTo("[{\"events\": [{\"timestamp\":\"1970-01-01T00:00:00.001Z\",\"attributes\":{\"name\":\"my_timer\",\"count\":0,\"sum\":0,\"avg\":0,\"max\":0,\"status\":\"success\"}}]}]")));
     }
 
@@ -70,7 +70,7 @@ class HumioMeterRegistryTest {
 
         server.stubFor(any(anyUrl()));
         registry.publish();
-        server.verify(postRequestedFor(urlMatching("/api/v1/dataspaces/repo/ingest"))
+        server.verify(postRequestedFor(urlMatching("/api/v1/ingest/humio-structured"))
                 .withRequestBody(containing("\"tags\":{\"name\": \"micrometer\"}")));
     }
 
@@ -192,11 +192,6 @@ class HumioMeterRegistryTest {
             @Override
             public String uri() {
                 return server.baseUrl();
-            }
-
-            @Override
-            public String repository() {
-                return "repo";
             }
 
             @Override

--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/humio/HumioPropertiesConfigAdapter.java
@@ -43,11 +43,6 @@ class HumioPropertiesConfigAdapter extends StepRegistryPropertiesConfigAdapter<H
     }
 
     @Override
-    public String repository() {
-        return get(HumioProperties::getRepository, HumioConfig.super::repository);
-    }
-
-    @Override
     public Map<String, String> tags() {
         return get(HumioProperties::getTags, HumioConfig.super::tags);
     }


### PR DESCRIPTION
New structured API doesn't require a repo reference so was removed as well.

---
References

* [Ingest tokens](https://docs.humio.com/operations-guide/configuration/sending-data-to-humio/ingest-tokens/)
* [Ingest API](https://docs.humio.com/developer-resources/api/ingest-api/)