### PR TITLE
adjust to recent spectator changes

### DIFF
--- a/implementations/micrometer-registry-atlas/build.gradle
+++ b/implementations/micrometer-registry-atlas/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     compile project(':micrometer-core')
-    // FIXME see https://github.com/micrometer-metrics/micrometer/issues/1545
-    compile 'com.netflix.spectator:spectator-reg-atlas:0.92.2'
+    compile 'com.netflix.spectator:spectator-reg-atlas:latest.release'
 
     testCompile project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -33,8 +33,6 @@ import io.micrometer.core.instrument.step.StepFunctionTimer;
 import io.micrometer.core.instrument.util.DoubleFormat;
 import io.micrometer.core.lang.Nullable;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
@@ -88,15 +86,6 @@ public class AtlasMeterRegistry extends MeterRegistry {
 
     @Override
     public void close() {
-        try {
-            @SuppressWarnings("JavaReflectionMemberAccess")
-            Method collectData = registry.getClass().getDeclaredMethod("collectData");
-            collectData.setAccessible(true);
-            collectData.invoke(registry);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            // oh well, we tried
-        }
-
         stop();
         super.close();
     }

--- a/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/AtlasMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/AtlasMeterRegistryCompatibilityTest.java
@@ -41,6 +41,11 @@ class AtlasMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit 
             public Duration step() {
                 return Duration.ofMinutes(1);
             }
+
+            @Override
+            public Duration lwcStep() {
+                return step();
+            }
         }, new MockClock());
     }
 

--- a/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/SpectatorTimerTest.java
+++ b/implementations/micrometer-registry-atlas/src/test/java/io/micrometer/atlas/SpectatorTimerTest.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.core.instrument.MockClock.clock;
@@ -28,7 +29,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SpectatorTimerTest {
     @Test
     void timerMax() {
-        AtlasConfig atlasConfig = k -> null;
+        AtlasConfig atlasConfig = new AtlasConfig() {
+            @Override
+            public String get(String k) {
+                return null;
+            }
+
+            @Override
+            public Duration lwcStep() {
+                return step();
+            }
+        };
         AtlasMeterRegistry registry = new AtlasMeterRegistry(atlasConfig, new MockClock());
         Timer timer = registry.timer("timer");
 


### PR DESCRIPTION
Two changes to fix tests that started breaking after recent
changes to AtlasRegistry:

1. Update AtlasConfig objects in tests to make the hi-res
   step used for on-demand streams match the publish step.
   When using tests with a synthetic clock this avoids
   missing some updates in the consolidated value published.
2. `AtlasMeterRegistryTest` was using reflection to call a
   private method that was renamed. This has been changed to
   just call stop on the AtlasRegistry. AtlasRegistry as of
   0.95.0 will handle the flush of the final interval.

Fixes #1545.