### PR TITLE
Remove SendOptions usage

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -33,7 +33,6 @@ import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.UnicastProcessor;
-import reactor.netty.NettyPipeline;
 import reactor.netty.udp.UdpClient;
 import reactor.netty.tcp.TcpClient;
 import reactor.util.concurrent.Queues;
@@ -223,7 +222,6 @@ public class StatsdMeterRegistry extends MeterRegistry {
                 .host(statsdConfig.host())
                 .port(statsdConfig.port())
                 .handle((in, out) -> out
-                        .options(NettyPipeline.SendOptions::flushOnEach)
                         .sendString(publisher)
                         .neverComplete()
                 )
@@ -241,7 +239,6 @@ public class StatsdMeterRegistry extends MeterRegistry {
                 .host(statsdConfig.host())
                 .port(statsdConfig.port())
                 .handle((in, out) -> out
-                        .options(NettyPipeline.SendOptions::flushOnEach)
                         .sendString(publisher)
                         .neverComplete())
                 .connect()


### PR DESCRIPTION
This PR removes `SendOptions` usage as it has been removed in https://github.com/reactor/reactor-netty/issues/766.