### PR TITLE
Upgrade to Gradle Wrapper 5.6.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = '5.6.1'
+    gradleVersion = '5.6.2'
 }
 
 defaultTasks 'build'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to Gradle Wrapper 5.6.2.