### PR TITLE
Eat RuntimeExceptions in DataDog-EHCache transmissions to avoid errors

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -207,7 +207,13 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                 .map(ms -> {
                     Meter.Id id = m.getId().withTag(ms.getStatistic());
                     addToMetadataList(metadata, id, null, ms.getStatistic(), null);
-                    return writeMetric(id, null, wallTime, ms.getValue());
+                    double value = 0d;
+                    try {
+                        value = ms.getValue();
+                    } catch (RuntimeException e) {
+                        // eat it
+                    }
+                    return writeMetric(id, null, wallTime, value);
                 });
     }
 


### PR DESCRIPTION
This fixes issue Micrometer with ehcache and datadog throws InvocationTargetException #1543