### PR TITLE
Fix NewRelicMeterRegistry.writeMeter() publishing duplicate keys/metrics

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -148,8 +148,17 @@ class NewRelicMeterRegistryTest {
         Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
         Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
         Measurement measurement4 = new Measurement(() -> 1d, Statistic.VALUE);
-        Measurement measurement5 = new Measurement(() -> 2d, Statistic.VALUE);
-        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4, measurement5);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":1}");
+    }
+    
+    @Test
+    void writeMeterWhenCustomMeterHasDuplicatesKeysShouldWriteOnlyLastValue() {
+        Measurement measurement1 = new Measurement(() -> 3d, Statistic.VALUE);
+        Measurement measurement2 = new Measurement(() -> 1d, Statistic.VALUE);
+        Measurement measurement3 = new Measurement(() -> 2d, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
         assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":2}");
     }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -151,7 +151,7 @@ class NewRelicMeterRegistryTest {
         Measurement measurement5 = new Measurement(() -> 2d, Statistic.VALUE);
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4, measurement5);
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
-        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":1,\"value\":2}");
+        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":2}");
     }
 
 }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -163,4 +163,5 @@ class NewRelicMeterRegistryTest {
         assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":2}");
     }
 
+    
 }


### PR DESCRIPTION
New Relic Insights API docs (REST API and Java Agent) state that a
standard map of key value pairs (number, string) are expected and
Object/Array value types are not supported.

See Insights REST API (JSON Format Guidelines):
https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/send-custom-events-event-api

@shakuzen 
@breedx-nr