### PR TITLE
Add support for categorical "MicrometerSample" eventType to publish New Relic metrics.

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
@@ -31,6 +31,18 @@ public interface NewRelicConfig extends StepRegistryConfig {
         return "newrelic";
     }
 
+    default boolean meterNameEventTypeEnabled() {
+    	String v = get(prefix() + ".meterNameEventTypeEnabled");
+    	return (v == null) ? false : new Boolean(v);
+    }
+    
+    default String eventType() {
+    	String v = get(prefix() + ".eventType");
+    	if (v == null)
+    		v = "MicrometerSample";
+    	return v;
+    }
+    
     default String apiKey() {
         String v = get(prefix() + ".apiKey");
         if (v == null)

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicConfig.java
@@ -32,15 +32,15 @@ public interface NewRelicConfig extends StepRegistryConfig {
     }
 
     default boolean meterNameEventTypeEnabled() {
-    	String v = get(prefix() + ".meterNameEventTypeEnabled");
-    	return (v == null) ? false : new Boolean(v);
+        String v = get(prefix() + ".meterNameEventTypeEnabled");
+        return (v == null) ? false : new Boolean(v);
     }
     
     default String eventType() {
-    	String v = get(prefix() + ".eventType");
-    	if (v == null)
-    		v = "MicrometerSample";
-    	return v;
+        String v = get(prefix() + ".eventType");
+        if (v == null)
+            v = "MicrometerSample";
+        return v;
     }
     
     default String apiKey() {

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -78,9 +78,9 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
     NewRelicMeterRegistry(NewRelicConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient) {
         super(config, clock);
 
-        if(config.meterNameEventTypeEnabled() == false
-        		&& (config.eventType() == null || config.eventType().isEmpty())) {
-        	throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
+        if (config.meterNameEventTypeEnabled() == false
+                && (config.eventType() == null || config.eventType().isEmpty())) {
+            throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
         }
         if (config.accountId() == null || config.accountId().isEmpty()) {
             throw new MissingRequiredConfigurationException("accountId must be set to report metrics to New Relic");
@@ -167,9 +167,10 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
     Stream<String> writeTimeGauge(TimeGauge gauge) {
         Double value = gauge.value(getBaseTimeUnit());
         if (Double.isFinite(value)) {
-            return Stream.of(event(gauge.getId(), 
-            					new Attribute("value", value),
-                    			new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase())));
+            return Stream.of(
+                    event(gauge.getId(), 
+                            new Attribute("value", value),
+                            new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase())));
         }
         return Stream.empty();
     }
@@ -224,19 +225,19 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
     }
 
     private String event(Meter.Id id, Attribute... attributes) {
-    	if(config.meterNameEventTypeEnabled() == false) {
-    		//Include contextual attributes when publishing all metrics under a single categorical eventType,
-    		//  NOT when publishing an eventType per Meter/metric name
-    		int size = attributes.length;
-    		Attribute[] newAttrs = Arrays.copyOf(attributes, size + 2);
-    		
-    		String name = id.getConventionName(config().namingConvention());
-    		newAttrs[size] = new Attribute("metricName", name);
-    		newAttrs[size+1] = new Attribute("metricType", id.getType().toString());
-    		
-    		return event(id, Tags.empty(), newAttrs);
+        if (config.meterNameEventTypeEnabled() == false) {
+            //Include contextual attributes when publishing all metrics under a single categorical eventType,
+            //  NOT when publishing an eventType per Meter/metric name
+            int size = attributes.length;
+            Attribute[] newAttrs = Arrays.copyOf(attributes, size + 2);
+            
+            String name = id.getConventionName(config().namingConvention());
+            newAttrs[size] = new Attribute("metricName", name);
+            newAttrs[size+1] = new Attribute("metricType", id.getType().toString());
+            
+            return event(id, Tags.empty(), newAttrs);
     	}
-    	
+        
         return event(id, Tags.empty(), attributes);
     }
 
@@ -256,24 +257,24 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         String eventType = getEventType(id, config, convention);
         
         return Arrays.stream(attributes)
-                .map(attr -> 
-	                	(attr.getValue() instanceof Number)
-		                	? ",\"" + attr.getName() + "\":" + DoubleFormat.wholeOrDecimal(((Number)attr.getValue()).doubleValue())
-		                	: ",\"" + attr.getName() + "\":\"" + convention.tagValue(((String)attr.getValue()).toString()) + "\""
-            		)
+                .map(attr ->
+                        (attr.getValue() instanceof Number)
+                            ? ",\"" + attr.getName() + "\":" + DoubleFormat.wholeOrDecimal(((Number)attr.getValue()).doubleValue())
+                            : ",\"" + attr.getName() + "\":\"" + convention.tagValue(((String)attr.getValue()).toString()) + "\""
+                )
                 .collect(Collectors.joining("", "{\"eventType\":\"" + escapeJson(eventType) + "\"", tagsJson + "}"));
     }
 
     String getEventType(Meter.Id id, NewRelicConfig config, NamingConvention convention) {
-    	String eventType = null;
-    	if(config.meterNameEventTypeEnabled()) {
-    		//meter/metric name event type
-    		eventType = id.getConventionName(convention);
-    	} else {
-    		//static eventType "category"
-    		eventType = config.eventType();
-    	}
-    	return eventType;
+        String eventType = null;
+        if (config.meterNameEventTypeEnabled()) {
+            //meter/metric name event type
+            eventType = id.getConventionName(convention);
+        } else {
+            //static eventType "category"
+            eventType = config.eventType();
+        }
+        return eventType;
     }
     
     private void sendEvents(String insightsEndpoint, Stream<String> events) {

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -233,11 +233,10 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             
             String name = id.getConventionName(config().namingConvention());
             newAttrs[size] = new Attribute("metricName", name);
-            newAttrs[size+1] = new Attribute("metricType", id.getType().toString());
+            newAttrs[size + 1] = new Attribute("metricType", id.getType().toString());
             
             return event(id, Tags.empty(), newAttrs);
-    	}
-        
+        }
         return event(id, Tags.empty(), attributes);
     }
 

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -26,7 +26,6 @@ import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,16 +79,16 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         super(config, clock);
 
         if(config.meterNameEventTypeEnabled() == false
-        		&& StringUtils.isEmpty(config.eventType())) {
+        		&& (config.eventType() == null || config.eventType().isEmpty())) {
         	throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
         }
-        if (StringUtils.isEmpty(config.accountId())) {
+        if (config.accountId() == null || config.accountId().isEmpty()) {
             throw new MissingRequiredConfigurationException("accountId must be set to report metrics to New Relic");
         }
-        if (StringUtils.isEmpty(config.apiKey())) {
+        if (config.apiKey() == null || config.apiKey().isEmpty()) {
             throw new MissingRequiredConfigurationException("apiKey must be set to report metrics to New Relic");
         }
-        if (StringUtils.isEmpty(config.uri())) {
+        if (config.uri() == null || config.uri().isEmpty()) {
             throw new MissingRequiredConfigurationException("uri must be set to report metrics to New Relic");
         }
 

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -259,7 +259,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
                 .map(attr ->
                         (attr.getValue() instanceof Number)
                             ? ",\"" + attr.getName() + "\":" + DoubleFormat.wholeOrDecimal(((Number)attr.getValue()).doubleValue())
-                            : ",\"" + attr.getName() + "\":\"" + convention.tagValue(((String)attr.getValue()).toString()) + "\""
+                            : ",\"" + attr.getName() + "\":\"" + convention.tagValue(attr.getValue().toString()) + "\""
                 )
                 .collect(Collectors.joining("", "{\"eventType\":\"" + escapeJson(eventType) + "\"", tagsJson + "}"));
     }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
@@ -28,9 +29,14 @@ import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.ipc.http.HttpSender;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link NewRelicMeterRegistry}.
@@ -42,6 +48,37 @@ class NewRelicMeterRegistryTest {
     private final NewRelicConfig config = new NewRelicConfig() {
 
         @Override
+		public boolean meterNameEventTypeEnabled() {
+        	//Default is false. Publish all metrics under a single eventType
+			return NewRelicConfig.super.meterNameEventTypeEnabled();
+		}
+
+		@Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public String accountId() {
+            return "accountId";
+        }
+
+        @Override
+        public String apiKey() {
+            return "apiKey";
+        }
+
+    };	
+	
+    private final NewRelicConfig meterNameEventTypeEnabledConfig = new NewRelicConfig() {
+
+        @Override
+		public boolean meterNameEventTypeEnabled() {
+        	//Previous behavior for backward compatibility
+			return true;
+		}
+
+		@Override
         public String get(String key) {
             return null;
         }
@@ -58,26 +95,46 @@ class NewRelicMeterRegistryTest {
 
     };
     private final MockClock clock = new MockClock();
+    private final NewRelicMeterRegistry meterNameEventTypeEnabledRegistry = new NewRelicMeterRegistry(meterNameEventTypeEnabledConfig, clock);
     private final NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock);
 
     @Test
     void writeGauge() {
+        meterNameEventTypeEnabledRegistry.gauge("my.gauge", 1d);
+        Gauge gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge(); 
+        Stream<String> streamResult = meterNameEventTypeEnabledRegistry.writeGauge(gauge);
+        assertThat(streamResult).contains("{\"eventType\":\"myGauge\",\"value\":1}");
+        
         registry.gauge("my.gauge", 1d);
-        Gauge gauge = registry.find("my.gauge").gauge();
-        assertThat(registry.writeGauge(gauge)).hasSize(1);
+        gauge = registry.find("my.gauge").gauge(); 
+        streamResult = registry.writeGauge(gauge);
+        assertThat(streamResult).contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
+        
     }
 
     @Test
     void writeGaugeShouldDropNanValue() {
+        meterNameEventTypeEnabledRegistry.gauge("my.gauge", Double.NaN);
+        Gauge gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeGauge(gauge)).isEmpty();
+        
         registry.gauge("my.gauge", Double.NaN);
-        Gauge gauge = registry.find("my.gauge").gauge();
+        gauge = registry.find("my.gauge").gauge();
         assertThat(registry.writeGauge(gauge)).isEmpty();
     }
 
     @Test
     void writeGaugeShouldDropInfiniteValues() {
+        meterNameEventTypeEnabledRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
+        Gauge gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeGauge(gauge)).isEmpty();
+
+        meterNameEventTypeEnabledRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
+        gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeGauge(gauge)).isEmpty();
+        
         registry.gauge("my.gauge", Double.POSITIVE_INFINITY);
-        Gauge gauge = registry.find("my.gauge").gauge();
+        gauge = registry.find("my.gauge").gauge();
         assertThat(registry.writeGauge(gauge)).isEmpty();
 
         registry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
@@ -88,24 +145,44 @@ class NewRelicMeterRegistryTest {
     @Test
     void writeGaugeWithTimeGauge() {
         AtomicReference<Double> obj = new AtomicReference<>(1d);
+        meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
+        Stream<String> streamResult = meterNameEventTypeEnabledRegistry.writeTimeGauge(timeGauge);
+        assertThat(streamResult).contains("{\"eventType\":\"myTimeGauge\",\"value\":1,\"timeUnit\":\"seconds\"}");
+        
         registry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = registry.find("my.timeGauge").timeGauge();
-        assertThat(registry.writeTimeGauge(timeGauge)).hasSize(1);
+        timeGauge = registry.find("my.timeGauge").timeGauge();
+        streamResult = registry.writeTimeGauge(timeGauge);
+        assertThat(streamResult).contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"timeUnit\":\"seconds\",\"metricName\":\"myTimeGauge\",\"metricType\":\"GAUGE\"}");
     }
 
     @Test
     void writeGaugeWithTimeGaugeShouldDropNanValue() {
         AtomicReference<Double> obj = new AtomicReference<>(Double.NaN);
+        meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeTimeGauge(timeGauge)).isEmpty();
+        
         registry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = registry.find("my.timeGauge").timeGauge();
+        timeGauge = registry.find("my.timeGauge").timeGauge();
         assertThat(registry.writeTimeGauge(timeGauge)).isEmpty();
     }
 
     @Test
     void writeGaugeWithTimeGaugeShouldDropInfiniteValues() {
         AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
+        meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        TimeGauge timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeTimeGauge(timeGauge)).isEmpty();
+
+        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
+        meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
+        timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
+        assertThat(meterNameEventTypeEnabledRegistry.writeTimeGauge(timeGauge)).isEmpty();
+        
+        obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
         registry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = registry.find("my.timeGauge").timeGauge();
+        timeGauge = registry.find("my.timeGauge").timeGauge();
         assertThat(registry.writeTimeGauge(timeGauge)).isEmpty();
 
         obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
@@ -116,14 +193,28 @@ class NewRelicMeterRegistryTest {
 
     @Test
     void writeCounterWithFunctionCounter() {
-        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(registry);
+        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(meterNameEventTypeEnabledRegistry);
         clock.add(config.step());
-        assertThat(registry.writeFunctionCounter(counter)).hasSize(1);
+        Stream<String> streamResult = meterNameEventTypeEnabledRegistry.writeFunctionCounter(counter);
+        assertThat(streamResult).contains("{\"eventType\":\"myCounter\",\"throughput\":1}");
+        
+        counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(registry);
+        clock.add(config.step());
+        streamResult = registry.writeFunctionCounter(counter);
+        assertThat(streamResult).contains("{\"eventType\":\"MicrometerSample\",\"throughput\":1,\"metricName\":\"myCounter\",\"metricType\":\"COUNTER\"}");
     }
 
     @Test
     void writeCounterWithFunctionCounterShouldDropInfiniteValues() {
-        FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(registry);
+        FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(meterNameEventTypeEnabledRegistry);
+        clock.add(config.step());
+        assertThat(meterNameEventTypeEnabledRegistry.writeFunctionCounter(counter)).isEmpty();
+
+        counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(meterNameEventTypeEnabledRegistry);
+        clock.add(config.step());
+        assertThat(meterNameEventTypeEnabledRegistry.writeFunctionCounter(counter)).isEmpty();
+        
+        counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(registry);
         clock.add(config.step());
         assertThat(registry.writeFunctionCounter(counter)).isEmpty();
 
@@ -138,7 +229,10 @@ class NewRelicMeterRegistryTest {
         Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
         Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.meterNameEventTypeEnabledRegistry);
+        assertThat(meterNameEventTypeEnabledRegistry.writeMeter(meter)).isEmpty();
+        
+        meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
         assertThat(registry.writeMeter(meter)).isEmpty();
     }
 
@@ -150,8 +244,149 @@ class NewRelicMeterRegistryTest {
         Measurement measurement4 = new Measurement(() -> 1d, Statistic.VALUE);
         Measurement measurement5 = new Measurement(() -> 2d, Statistic.VALUE);
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4, measurement5);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
-        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":1,\"value\":2}");
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.meterNameEventTypeEnabledRegistry);
+        assertThat(meterNameEventTypeEnabledRegistry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":1,\"value\":2}");
+        
+        meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"value\":2,\"metricName\":\"myMeter\",\"metricType\":\"GAUGE\"}");
+    }
+    
+    @Test
+    void publish() {
+    	MockHttpSender mockHttpSender = new MockHttpSender();
+    	NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock, new NamedThreadFactory("new-relic-test"), mockHttpSender);
+    	
+        registry.gauge("my.gauge", 1d);
+        Gauge gauge = registry.find("my.gauge").gauge();
+        assertThat(gauge).isNotNull();
+        
+        registry.publish();
+        
+        assertThat(new String(mockHttpSender.getRequest().getEntity()))
+        		.contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
+    	
+    }
+    
+    @Test
+    void configMissing() {
+    	try {
+    		NewRelicConfig missingEventTypeConfig = new NewRelicConfig() {
+				@Override
+				public  String eventType() {
+					return "";
+				}
+				@Override
+				public String get(String key) {
+					return null;
+				}
+			};
+			new NewRelicMeterRegistry(missingEventTypeConfig, clock);
+ 		
+    		assertTrue(false);	
+    	} catch(MissingRequiredConfigurationException mrce) {
+    		assertTrue(true);
+    	} catch (Exception e) {
+    		assertTrue(false);
+    	}
+    	
+    	try {
+    		NewRelicConfig missingAccountIdConfig = new NewRelicConfig() {
+				@Override
+				public  String eventType() {
+					return "eventType";
+				}
+    			@Override
+				public  String accountId() {
+					return null;
+				}
+				@Override
+				public String get(String key) {
+					return null;
+				}
+			};
+			new NewRelicMeterRegistry(missingAccountIdConfig, clock);
+ 		
+    		assertTrue(false);	
+    	} catch(MissingRequiredConfigurationException mrce) {
+    		assertTrue(true);
+    	} catch (Exception e) {
+    		assertTrue(false);
+    	}
+    	
+    	try {
+    		NewRelicConfig missingApiKeyConfig = new NewRelicConfig() {
+				@Override
+				public  String eventType() {
+					return "eventType";
+				}
+    			@Override
+				public  String accountId() {
+					return "accountId";
+				}
+    			@Override
+				public  String apiKey() {
+					return "";
+				}
+				@Override
+				public String get(String key) {
+					return null;
+				}
+			};
+			new NewRelicMeterRegistry(missingApiKeyConfig, clock);
+ 		
+    		assertTrue(false);	
+    	} catch(MissingRequiredConfigurationException mrce) {
+    		assertTrue(true);
+    	} catch (Exception e) {
+    		assertTrue(false);
+    	}
+    	
+    	try {
+    		NewRelicConfig missingUriConfig = new NewRelicConfig() {
+				@Override
+				public  String eventType() {
+					return "eventType";
+				}
+    			@Override
+				public  String accountId() {
+					return "accountId";
+				}
+    			@Override
+				public  String apiKey() {
+					return "apiKey";
+				}
+    			@Override
+				public  String uri() {
+					return "";
+				}
+				@Override
+				public String get(String key) {
+					return null;
+				}
+			};
+			new NewRelicMeterRegistry(missingUriConfig, clock);
+ 		
+    		assertTrue(false);	
+    	} catch(MissingRequiredConfigurationException mrce) {
+    		assertTrue(true);
+    	} catch (Exception e) {
+    		assertTrue(false);
+    	}     	
     }
 
+    class MockHttpSender implements HttpSender {
+
+    	private Request request;
+    	
+		@Override
+		public Response send(Request request) throws Throwable {
+			this.request=request;
+			return new Response(200, "body");
+		}
+
+		public Request getRequest() {
+			return request;
+		}
+    	
+    }
 }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -46,54 +46,55 @@ import static org.junit.Assert.assertTrue;
 class NewRelicMeterRegistryTest {
 
     private final NewRelicConfig config = new NewRelicConfig() {
-
+        
         @Override
-		public boolean meterNameEventTypeEnabled() {
-        	//Default is false. Publish all metrics under a single eventType
-			return NewRelicConfig.super.meterNameEventTypeEnabled();
-		}
-
-		@Override
+        public boolean meterNameEventTypeEnabled() {
+            //Default is false. Publish all metrics under a single eventType
+            return NewRelicConfig.super.meterNameEventTypeEnabled();
+        }
+        
+        @Override
         public String get(String key) {
             return null;
         }
-
+        
         @Override
         public String accountId() {
             return "accountId";
         }
-
+        
         @Override
         public String apiKey() {
             return "apiKey";
         }
-
-    };	
-	
-    private final NewRelicConfig meterNameEventTypeEnabledConfig = new NewRelicConfig() {
-
-        @Override
-		public boolean meterNameEventTypeEnabled() {
-        	//Previous behavior for backward compatibility
-			return true;
-		}
-
-		@Override
-        public String get(String key) {
-            return null;
-        }
-
-        @Override
-        public String accountId() {
-            return "accountId";
-        }
-
-        @Override
-        public String apiKey() {
-            return "apiKey";
-        }
-
+        
     };
+   
+    private final NewRelicConfig meterNameEventTypeEnabledConfig = new NewRelicConfig() {
+        
+        @Override
+        public boolean meterNameEventTypeEnabled() {
+            //Previous behavior for backward compatibility
+            return true;
+        }
+        
+        @Override
+        public String get(String key) {
+            return null;
+        }
+        
+        @Override
+        public String accountId() {
+            return "accountId";
+        }
+        
+        @Override
+        public String apiKey() {
+            return "apiKey";
+        }
+        
+    };
+    
     private final MockClock clock = new MockClock();
     private final NewRelicMeterRegistry meterNameEventTypeEnabledRegistry = new NewRelicMeterRegistry(meterNameEventTypeEnabledConfig, clock);
     private final NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock);
@@ -109,7 +110,6 @@ class NewRelicMeterRegistryTest {
         gauge = registry.find("my.gauge").gauge(); 
         streamResult = registry.writeGauge(gauge);
         assertThat(streamResult).contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
-        
     }
 
     @Test
@@ -128,7 +128,7 @@ class NewRelicMeterRegistryTest {
         meterNameEventTypeEnabledRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
         Gauge gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge();
         assertThat(meterNameEventTypeEnabledRegistry.writeGauge(gauge)).isEmpty();
-
+        
         meterNameEventTypeEnabledRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
         gauge = meterNameEventTypeEnabledRegistry.find("my.gauge").gauge();
         assertThat(meterNameEventTypeEnabledRegistry.writeGauge(gauge)).isEmpty();
@@ -136,7 +136,7 @@ class NewRelicMeterRegistryTest {
         registry.gauge("my.gauge", Double.POSITIVE_INFINITY);
         gauge = registry.find("my.gauge").gauge();
         assertThat(registry.writeGauge(gauge)).isEmpty();
-
+        
         registry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
         gauge = registry.find("my.gauge").gauge();
         assertThat(registry.writeGauge(gauge)).isEmpty();
@@ -174,7 +174,7 @@ class NewRelicMeterRegistryTest {
         meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
         TimeGauge timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
         assertThat(meterNameEventTypeEnabledRegistry.writeTimeGauge(timeGauge)).isEmpty();
-
+        
         obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
         meterNameEventTypeEnabledRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
         timeGauge = meterNameEventTypeEnabledRegistry.find("my.timeGauge").timeGauge();
@@ -184,7 +184,7 @@ class NewRelicMeterRegistryTest {
         registry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
         timeGauge = registry.find("my.timeGauge").timeGauge();
         assertThat(registry.writeTimeGauge(timeGauge)).isEmpty();
-
+        
         obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
         registry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
         timeGauge = registry.find("my.timeGauge").timeGauge();
@@ -209,7 +209,7 @@ class NewRelicMeterRegistryTest {
         FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(meterNameEventTypeEnabledRegistry);
         clock.add(config.step());
         assertThat(meterNameEventTypeEnabledRegistry.writeFunctionCounter(counter)).isEmpty();
-
+        
         counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(meterNameEventTypeEnabledRegistry);
         clock.add(config.step());
         assertThat(meterNameEventTypeEnabledRegistry.writeFunctionCounter(counter)).isEmpty();
@@ -217,7 +217,7 @@ class NewRelicMeterRegistryTest {
         counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue).register(registry);
         clock.add(config.step());
         assertThat(registry.writeFunctionCounter(counter)).isEmpty();
-
+        
         counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue).register(registry);
         clock.add(config.step());
         assertThat(registry.writeFunctionCounter(counter)).isEmpty();
@@ -250,12 +250,12 @@ class NewRelicMeterRegistryTest {
         meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
         assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"value\":2,\"metricName\":\"myMeter\",\"metricType\":\"GAUGE\"}");
     }
-    
+
     @Test
     void publish() {
-    	MockHttpSender mockHttpSender = new MockHttpSender();
-    	NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock, new NamedThreadFactory("new-relic-test"), mockHttpSender);
-    	
+        MockHttpSender mockHttpSender = new MockHttpSender();
+        NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock, new NamedThreadFactory("new-relic-test"), mockHttpSender);
+        
         registry.gauge("my.gauge", 1d);
         Gauge gauge = registry.find("my.gauge").gauge();
         assertThat(gauge).isNotNull();
@@ -263,130 +263,128 @@ class NewRelicMeterRegistryTest {
         registry.publish();
         
         assertThat(new String(mockHttpSender.getRequest().getEntity()))
-        		.contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
-    	
+            .contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
     }
-    
+
     @Test
     void configMissing() {
-    	try {
-    		NewRelicConfig missingEventTypeConfig = new NewRelicConfig() {
-				@Override
-				public  String eventType() {
-					return "";
-				}
-				@Override
-				public String get(String key) {
-					return null;
-				}
-			};
-			new NewRelicMeterRegistry(missingEventTypeConfig, clock);
- 		
-    		assertTrue(false);	
-    	} catch(MissingRequiredConfigurationException mrce) {
-    		assertTrue(true);
-    	} catch (Exception e) {
-    		assertTrue(false);
-    	}
-    	
-    	try {
-    		NewRelicConfig missingAccountIdConfig = new NewRelicConfig() {
-				@Override
-				public  String eventType() {
-					return "eventType";
-				}
-    			@Override
-				public  String accountId() {
-					return null;
-				}
-				@Override
-				public String get(String key) {
-					return null;
-				}
-			};
-			new NewRelicMeterRegistry(missingAccountIdConfig, clock);
- 		
-    		assertTrue(false);	
-    	} catch(MissingRequiredConfigurationException mrce) {
-    		assertTrue(true);
-    	} catch (Exception e) {
-    		assertTrue(false);
-    	}
-    	
-    	try {
-    		NewRelicConfig missingApiKeyConfig = new NewRelicConfig() {
-				@Override
-				public  String eventType() {
-					return "eventType";
-				}
-    			@Override
-				public  String accountId() {
-					return "accountId";
-				}
-    			@Override
-				public  String apiKey() {
-					return "";
-				}
-				@Override
-				public String get(String key) {
-					return null;
-				}
-			};
-			new NewRelicMeterRegistry(missingApiKeyConfig, clock);
- 		
-    		assertTrue(false);	
-    	} catch(MissingRequiredConfigurationException mrce) {
-    		assertTrue(true);
-    	} catch (Exception e) {
-    		assertTrue(false);
-    	}
-    	
-    	try {
-    		NewRelicConfig missingUriConfig = new NewRelicConfig() {
-				@Override
-				public  String eventType() {
-					return "eventType";
-				}
-    			@Override
-				public  String accountId() {
-					return "accountId";
-				}
-    			@Override
-				public  String apiKey() {
-					return "apiKey";
-				}
-    			@Override
-				public  String uri() {
-					return "";
-				}
-				@Override
-				public String get(String key) {
-					return null;
-				}
-			};
-			new NewRelicMeterRegistry(missingUriConfig, clock);
- 		
-    		assertTrue(false);	
-    	} catch(MissingRequiredConfigurationException mrce) {
-    		assertTrue(true);
-    	} catch (Exception e) {
-    		assertTrue(false);
-    	}     	
+        try {
+            NewRelicConfig missingEventTypeConfig = new NewRelicConfig() {
+                @Override
+                public String eventType() {
+                    return "";
+                }
+                @Override
+                public String get(String key) {
+                    return null;
+                }
+            };
+            new NewRelicMeterRegistry(missingEventTypeConfig, clock);
+            
+            assertTrue(false);
+        } catch (MissingRequiredConfigurationException mrce) {
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+        
+        try {
+            NewRelicConfig missingAccountIdConfig = new NewRelicConfig() {
+                @Override
+                public String eventType() {
+                    return "eventType";
+                }
+                @Override
+                public String accountId() {
+                    return null;
+                }
+                @Override
+                public String get(String key) {
+                    return null;
+                }
+            };
+            new NewRelicMeterRegistry(missingAccountIdConfig, clock);
+            
+            assertTrue(false);
+        } catch (MissingRequiredConfigurationException mrce) {
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+        
+        try {
+            NewRelicConfig missingApiKeyConfig = new NewRelicConfig() {
+                @Override
+                public String eventType() {
+                    return "eventType";
+                }
+                @Override
+                public String accountId() {
+                    return "accountId";
+                }
+                @Override
+                public String apiKey() {
+                    return "";
+                }
+                @Override
+                public String get(String key) {
+                    return null;
+                }
+            };
+            new NewRelicMeterRegistry(missingApiKeyConfig, clock);
+            
+            assertTrue(false);
+        } catch (MissingRequiredConfigurationException mrce) {
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+        
+        try {
+            NewRelicConfig missingUriConfig = new NewRelicConfig() {
+                @Override
+                public String eventType() {
+                    return "eventType";
+                }
+                @Override
+                public String accountId() {
+                    return "accountId";
+                }
+                @Override
+                public String apiKey() {
+                    return "apiKey";
+                }
+                @Override
+                public String uri() {
+                    return "";
+                }
+                @Override
+                public String get(String key) {
+                    return null;
+                }
+            };
+            new NewRelicMeterRegistry(missingUriConfig, clock);
+            
+            assertTrue(false);
+        } catch (MissingRequiredConfigurationException mrce) {
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
     }
 
     class MockHttpSender implements HttpSender {
-
-    	private Request request;
-    	
-		@Override
-		public Response send(Request request) throws Throwable {
-			this.request=request;
-			return new Response(200, "body");
-		}
-
-		public Request getRequest() {
-			return request;
-		}
-    	
+        
+        private Request request;
+        
+        @Override
+        public Response send(Request request) throws Throwable {
+            this.request=request;
+            return new Response(200, "body");
+        }
+        
+        public Request getRequest() {
+            return request;
+        }
     }
 }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -15,11 +15,16 @@
  */
 package io.micrometer.newrelic;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
 
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
@@ -32,11 +37,6 @@ import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.ipc.http.HttpSender;
-
-import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link NewRelicMeterRegistry}.
@@ -267,112 +267,105 @@ class NewRelicMeterRegistryTest {
     }
 
     @Test
-    void configMissing() {
-        try {
-            NewRelicConfig missingEventTypeConfig = new NewRelicConfig() {
-                @Override
-                public String eventType() {
-                    return "";
-                }
-                @Override
-                public String get(String key) {
-                    return null;
-                }
-            };
-            new NewRelicMeterRegistry(missingEventTypeConfig, clock);
-            
-            assertTrue(false);
-        } catch (MissingRequiredConfigurationException mrce) {
-            assertTrue(true);
-        } catch (Exception e) {
-            assertTrue(false);
-        }
+    void configMissingEventType() {
+        NewRelicConfig config = new NewRelicConfig() {
+            @Override
+            public String eventType() {
+                return "";
+            }
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
         
-        try {
-            NewRelicConfig missingAccountIdConfig = new NewRelicConfig() {
-                @Override
-                public String eventType() {
-                    return "eventType";
-                }
-                @Override
-                public String accountId() {
-                    return null;
-                }
-                @Override
-                public String get(String key) {
-                    return null;
-                }
-            };
-            new NewRelicMeterRegistry(missingAccountIdConfig, clock);
-            
-            assertTrue(false);
-        } catch (MissingRequiredConfigurationException mrce) {
-            assertTrue(true);
-        } catch (Exception e) {
-            assertTrue(false);
-        }
-        
-        try {
-            NewRelicConfig missingApiKeyConfig = new NewRelicConfig() {
-                @Override
-                public String eventType() {
-                    return "eventType";
-                }
-                @Override
-                public String accountId() {
-                    return "accountId";
-                }
-                @Override
-                public String apiKey() {
-                    return "";
-                }
-                @Override
-                public String get(String key) {
-                    return null;
-                }
-            };
-            new NewRelicMeterRegistry(missingApiKeyConfig, clock);
-            
-            assertTrue(false);
-        } catch (MissingRequiredConfigurationException mrce) {
-            assertTrue(true);
-        } catch (Exception e) {
-            assertTrue(false);
-        }
-        
-        try {
-            NewRelicConfig missingUriConfig = new NewRelicConfig() {
-                @Override
-                public String eventType() {
-                    return "eventType";
-                }
-                @Override
-                public String accountId() {
-                    return "accountId";
-                }
-                @Override
-                public String apiKey() {
-                    return "apiKey";
-                }
-                @Override
-                public String uri() {
-                    return "";
-                }
-                @Override
-                public String get(String key) {
-                    return null;
-                }
-            };
-            new NewRelicMeterRegistry(missingUriConfig, clock);
-            
-            assertTrue(false);
-        } catch (MissingRequiredConfigurationException mrce) {
-            assertTrue(true);
-        } catch (Exception e) {
-            assertTrue(false);
-        }
+        Exception exception = assertThrows(MissingRequiredConfigurationException.class, () -> {
+            new NewRelicMeterRegistry(config, clock);
+        });
+        assertThat(exception.getMessage()).contains("eventType");
     }
 
+    @Test
+    void configMissingAccountId() {
+        NewRelicConfig config = new NewRelicConfig() {
+            @Override
+            public String eventType() {
+                return "eventType";
+            }
+            @Override
+            public String accountId() {
+                return null;
+            }
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
+        
+        Exception exception = assertThrows(MissingRequiredConfigurationException.class, () -> {
+            new NewRelicMeterRegistry(config, clock);
+        });
+        assertThat(exception.getMessage()).contains("accountId");
+    }
+    
+    @Test
+    void configMissingApiKey() {
+        NewRelicConfig config = new NewRelicConfig() {
+            @Override
+            public String eventType() {
+                return "eventType";
+            }
+            @Override
+            public String accountId() {
+                return "accountId";
+            }
+            @Override
+            public String apiKey() {
+                return "";
+            }
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
+        
+        Exception exception = assertThrows(MissingRequiredConfigurationException.class, () -> {
+            new NewRelicMeterRegistry(config, clock);
+        });
+        assertThat(exception.getMessage()).contains("apiKey");
+    }
+    
+    @Test
+    void configMissingUri() {
+        NewRelicConfig config = new NewRelicConfig() {
+            @Override
+            public String eventType() {
+                return "eventType";
+            }
+            @Override
+            public String accountId() {
+                return "accountId";
+            }
+            @Override
+            public String apiKey() {
+                return "apiKey";
+            }
+            @Override
+            public String uri() {
+                return "";
+            }
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
+        
+        Exception exception = assertThrows(MissingRequiredConfigurationException.class, () -> {
+            new NewRelicMeterRegistry(config, clock);
+        });
+        assertThat(exception.getMessage()).contains("uri");
+    }
+    
     class MockHttpSender implements HttpSender {
         
         private Request request;

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -379,7 +379,7 @@ class NewRelicMeterRegistryTest {
         
         @Override
         public Response send(Request request) throws Throwable {
-            this.request=request;
+            this.request = request;
             return new Response(200, "body");
         }
         

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -257,7 +257,7 @@ class NewRelicMeterRegistryTest {
         Measurement measurement3 = new Measurement(() -> 2d, Statistic.VALUE);
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
-        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"myMeter\",\"value\":2}");
+        assertThat(registry.writeMeter(meter)).contains("{\"eventType\":\"MicrometerSample\",\"value\":2,\"metricName\":\"myMeter\",\"metricType\":\"GAUGE\"}");
     }
 
     @Test


### PR DESCRIPTION
Previous behavior was to publish an eventType per Meter/metric name
(still supported via meterNameEventTypeEnabled=true). NewRelic's own
agents publish metrics to eventTypes aligned with broader categories. To
align with their recommendation the default behavior is to publish
metrics under a "MicrometerSample" category. When doing so, additional
context is provided by including "metricName" and "metricType"
attributes. Also "timeUnit" is now provided as an attribute for all
Timer related metrics regardless, so Insights users can better
understand time-based metrics.
See: https://docs.newrelic.com/docs/insights/insights-data-sources/default-data/insights-default-data-other-new-relic-products

@shakuzen 
@breedx-nr