### PR TITLE
Add Tomcat ThreadPool connectionCount metric.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
@@ -42,6 +42,11 @@ public final class BaseUnits {
      */
     public static final String THREADS = "threads";
 
+    /**
+     * For connections.
+     */
+    public static final String CONNECTIONS = "connections";
+
     private BaseUnits() {
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -147,6 +147,12 @@ public class TomcatMetrics implements MeterBinder {
                     .tags(allTags)
                     .baseUnit(BaseUnits.THREADS)
                     .register(registry);
+
+            Gauge.builder("tomcat.threads.active", mBeanServer,
+                    s -> safeLong(() -> s.getAttribute(name, "connectionCount")))
+                    .tags(allTags)
+                    .baseUnit(BaseUnits.CONNECTIONS)
+                    .register(registry);
         });
     }
 


### PR DESCRIPTION
This PR adds metric for connectionCount attribute from "Tomcat:name=*,type=ThreadPool" mBean.

Fixes #1598 