### PR TITLE
Apply illegal import Checkstyle rule for SLF4J

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC
+		"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+	<suppress files="io[\\/]micrometer[\\/]core[\\/]instrument[\\/]binder[\\/]logging[\\/].+" checks="IllegalImport" />
+	<suppress files="io[\\/]micrometer[\\/]core[\\/]util[\\/]internal[\\/]logging[\\/].+" checks="IllegalImport" />
+	<suppress files="implementations[\\/].+" checks="IllegalImport" />
+	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
+	<suppress files="micrometer-spring-legacy[\\/]src[\\/]test[\\/].+" checks="IllegalImport" />
+</suppressions>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -3,13 +3,17 @@
         "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
+    <!-- Suppressions -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
+    </module>
 
     <!-- TreeWalker Checks -->
     <module name="TreeWalker">
 
         <!-- Imports -->
         <module name="IllegalImportCheck" >
-            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*"/>
+            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.slf4j.*"/>
             <property name="regexp" value="true"/>
         </module>
         <module name="UnusedImports">

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
@@ -21,8 +21,8 @@ import com.netflix.hystrix.strategy.metrics.HystrixMetricsPublisherCommand;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.micrometer.core.util.internal.logging.InternalLogger;
+import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 @NonNullApi
 @NonNullFields
 public class MicrometerMetricsPublisherCommand implements HystrixMetricsPublisherCommand {
-    private static final Logger LOG = LoggerFactory.getLogger(MicrometerMetricsPublisherCommand.class);
+    private static final InternalLogger LOG = InternalLoggerFactory.getInstance(MicrometerMetricsPublisherCommand.class);
 
     private static final String NAME_HYSTRIX_CIRCUIT_BREAKER_OPEN = "hystrix.circuit.breaker.open";
     private static final String NAME_HYSTRIX_EXECUTION = "hystrix.execution";


### PR DESCRIPTION
This PR applies illegal import Checkstyle rule for SLF4J. Along the way, this PR also replaces SLF4J with internal logging for Hystrix so that internal logging is used consistently.

See https://github.com/micrometer-metrics/micrometer/pull/1475#issuecomment-536362046