### PR TITLE
Use MetricDatum for batches in CloudWatchMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/MetricDatumPartition.java
@@ -13,26 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.util;
+package io.micrometer.cloudwatch;
 
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import io.micrometer.core.instrument.util.AbstractPartition;
 
 import java.util.List;
 
 /**
- * {@link AbstractPartition} for {@link Meter}.
+ * {@link AbstractPartition} for {@link MetricDatum}.
  *
  * @author Jon Schneider
  */
-public class MeterPartition extends AbstractPartition<Meter> {
+class MetricDatumPartition extends AbstractPartition<MetricDatum> {
 
-    public MeterPartition(MeterRegistry registry, int partitionSize) {
-        super(registry.getMeters(), partitionSize);
+    MetricDatumPartition(List<MetricDatum> list, int partitionSize) {
+        super(list, partitionSize);
     }
 
-    public static List<List<Meter>> partition(MeterRegistry registry, int partitionSize) {
-        return new MeterPartition(registry, partitionSize);
+    static List<List<MetricDatum>> partition(List<MetricDatum> list, int partitionSize) {
+        return new MetricDatumPartition(list, partitionSize);
     }
 
 }

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -18,7 +18,9 @@ package io.micrometer.cloudwatch;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -32,8 +34,7 @@ import static io.micrometer.core.instrument.Meter.Id;
 import static io.micrometer.core.instrument.Meter.Type;
 import static io.micrometer.core.instrument.Meter.Type.DISTRIBUTION_SUMMARY;
 import static io.micrometer.core.instrument.Meter.Type.TIMER;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link CloudWatchMeterRegistry}.
@@ -55,13 +56,13 @@ class CloudWatchMeterRegistryTest {
     };
 
     private final MockClock clock = new MockClock();
-    private final CloudWatchMeterRegistry registry = new CloudWatchMeterRegistry(config, clock, null);
+    private final CloudWatchMeterRegistry registry = spy(new CloudWatchMeterRegistry(config, clock, null));
     private CloudWatchMeterRegistry.Batch registryBatch = registry.new Batch();
 
     @Test
     void metricData() {
         registry.gauge("gauge", 1d);
-        List<MetricDatum> metricDatumStream = registry.metricData(registry.getMeters());
+        List<MetricDatum> metricDatumStream = registry.metricData();
         assertThat(metricDatumStream.size()).isEqualTo(1);
     }
 
@@ -72,7 +73,7 @@ class CloudWatchMeterRegistryTest {
         AtomicReference<Double> value = new AtomicReference<>(Double.NaN);
         registry.more().timeGauge("time.gauge", Tags.empty(), value, TimeUnit.MILLISECONDS, AtomicReference::get);
 
-        List<MetricDatum> metricDatumStream = registry.metricData(registry.getMeters());
+        List<MetricDatum> metricDatumStream = registry.metricData();
         assertThat(metricDatumStream.size()).isEqualTo(0);
     }
 
@@ -200,6 +201,23 @@ class CloudWatchMeterRegistryTest {
 
         assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
         assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    public void batchSizeShouldWorkOnMetricDatum() throws InterruptedException {
+        List<Meter> meters = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Timer timer = Timer.builder("timer." + i).register(this.registry);
+            meters.add(timer);
+        }
+        when(this.registry.getMeters()).thenReturn(meters);
+        doNothing().when(this.registry).sendMetricData(any());
+        this.registry.publish();
+        ArgumentCaptor<List<MetricDatum>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(this.registry, times(2)).sendMetricData(argumentCaptor.capture());
+        List<List<MetricDatum>> allValues = argumentCaptor.getAllValues();
+        assertThat(allValues.get(0)).hasSize(20);
+        assertThat(allValues.get(1)).hasSize(20);
     }
 
     private Predicate<MetricDatum> hasAvgMetric(Id id) {

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -19,7 +19,6 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
-import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.lang.Nullable;
@@ -104,9 +103,9 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
     protected void publish() {
         boolean interrupted = false;
         try {
-            for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
+            for (List<MetricDatum> batch : MetricDatumPartition.partition(metricData(), config.batchSize())) {
                 try {
-                    sendMetricData(metricData(batch));
+                    sendMetricData(batch);
                 } catch (InterruptedException ex) {
                     interrupted = true;
                 }
@@ -119,7 +118,8 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    private void sendMetricData(List<MetricDatum> metricData) throws InterruptedException {
+    // VisibleForTesting
+    void sendMetricData(List<MetricDatum> metricData) throws InterruptedException {
         PutMetricDataRequest putMetricDataRequest = PutMetricDataRequest.builder()
                 .namespace(config.namespace())
                 .metricData(metricData)
@@ -146,9 +146,9 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
     }
 
     //VisibleForTesting
-    List<MetricDatum> metricData(List<Meter> meters) {
+    List<MetricDatum> metricData() {
         Batch batch = new Batch();
-        return meters.stream().flatMap(m -> m.match(
+        return getMeters().stream().flatMap(m -> m.match(
                 batch::gaugeData,
                 batch::counterData,
                 batch::timerData,

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/MetricDatumPartition.java
@@ -13,26 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.util;
+package io.micrometer.cloudwatch2;
 
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.util.AbstractPartition;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 
 import java.util.List;
 
 /**
- * {@link AbstractPartition} for {@link Meter}.
+ * {@link AbstractPartition} for {@link MetricDatum}.
  *
  * @author Jon Schneider
  */
-public class MeterPartition extends AbstractPartition<Meter> {
+class MetricDatumPartition extends AbstractPartition<MetricDatum> {
 
-    public MeterPartition(MeterRegistry registry, int partitionSize) {
-        super(registry.getMeters(), partitionSize);
+    MetricDatumPartition(List<MetricDatum> list, int partitionSize) {
+        super(list, partitionSize);
     }
 
-    public static List<List<Meter>> partition(MeterRegistry registry, int partitionSize) {
-        return new MeterPartition(registry, partitionSize);
+    static List<List<MetricDatum>> partition(List<MetricDatum> list, int partitionSize) {
+        return new MetricDatumPartition(list, partitionSize);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/AbstractPartition.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/AbstractPartition.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.util;
+
+import java.util.AbstractList;
+import java.util.List;
+
+/**
+ * Base class for a partition.
+ *
+ * Modified from {@link com.google.common.collect.Lists#partition(List, int)}.
+ *
+ * @author Jon Schneider
+ * @since 1.2.2
+ */
+public abstract class AbstractPartition<T> extends AbstractList<List<T>> {
+    private final List<T> list;
+    private final int partitionSize;
+    private final int partitionCount;
+
+    protected AbstractPartition(List<T> list, int partitionSize) {
+        this.list = list;
+        this.partitionSize = partitionSize;
+        this.partitionCount = MathUtils.divideWithCeilingRoundingMode(list.size(), partitionSize);
+    }
+
+    @Override
+    public List<T> get(int index) {
+        int start = index * partitionSize;
+        int end = Math.min(start + partitionSize, list.size());
+        return list.subList(start, end);
+    }
+
+    @Override
+    public int size() {
+        return this.partitionCount;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+}


### PR DESCRIPTION
This PR changes to use `MetricDatum` for batches in `CloudWatchMeterRegistry`.

Closes gh-1596