### PR TITLE
Use JMX to expose tomcat sessions metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/Pair.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/Pair.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.tomcat;
+
+public class Pair<T, U> {
+
+    private T key;
+    private U value;
+
+    public Pair(T key, U value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public static <T,U>  Pair<T, U> pair(T key, U value) {
+        return new Pair<>(key, value);
+    }
+
+    public T getKey() {
+        return key;
+    }
+
+    public U getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
This avoid using the manager and allows to have sessions related metrics
even if the application is not a spring application.

This is a Work in progress.
If maintainers think it's a good idea I can work on that and:

- [ ] Replace Manager by JMX completely
- [ ] Update tests and add new test to verify the behavior with JMX
- [ ] Update the autoconfigurations