### PR TITLE
Use internal logging for LoggingMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -51,7 +51,7 @@ import static java.util.stream.Collectors.joining;
  */
 @Incubating(since = "1.1.0")
 public class LoggingMeterRegistry extends StepMeterRegistry {
-    private final static InternalLogger log = InternalLoggerFactory.getInstance(PushMeterRegistry.class);
+    private final static InternalLogger log = InternalLoggerFactory.getInstance(LoggingMeterRegistry.class);
 
     private final LoggingRegistryConfig config;
     private final Consumer<String> loggingSink;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -25,14 +25,15 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.push.PushMeterRegistry;
 import io.micrometer.core.instrument.step.StepDistributionSummary;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.step.StepTimer;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.micrometer.core.util.internal.logging.InternalLogger;
+import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
@@ -50,6 +51,8 @@ import static java.util.stream.Collectors.joining;
  */
 @Incubating(since = "1.1.0")
 public class LoggingMeterRegistry extends StepMeterRegistry {
+    private final static InternalLogger log = InternalLoggerFactory.getInstance(PushMeterRegistry.class);
+
     private final LoggingRegistryConfig config;
     private final Consumer<String> loggingSink;
 
@@ -58,7 +61,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
     }
 
     public LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock) {
-        this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), defaultLoggingSink());
+        this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), log::info);
     }
 
     private LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock, ThreadFactory threadFactory, Consumer<String> loggingSink) {
@@ -67,23 +70,6 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
         this.loggingSink = loggingSink;
         config().namingConvention(NamingConvention.dot);
         start(threadFactory);
-    }
-
-    private static Consumer<String> defaultLoggingSink() {
-        try {
-            Class<?> slf4jLogger = Class.forName("org.slf4j.LoggerFactory");
-            Object logger = slf4jLogger.getMethod("getLogger", Class.class).invoke(null, LoggingMeterRegistry.class);
-            final Method loggerInfo = logger.getClass().getMethod("info", String.class);
-            return stmt -> {
-                try {
-                    loggerInfo.invoke(logger, stmt);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    throw new RuntimeException(e); // should never happen
-                }
-            };
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            return System.out::println;
-        }
     }
 
     @Override
@@ -253,7 +239,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
 
         private Clock clock = Clock.SYSTEM;
         private ThreadFactory threadFactory = new NamedThreadFactory("logging-metrics-publisher");
-        private Consumer<String> loggingSink = defaultLoggingSink();
+        private Consumer<String> loggingSink = log::info;
 
         Builder(LoggingRegistryConfig config) {
             this.config = config;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -25,7 +25,6 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.instrument.push.PushMeterRegistry;
 import io.micrometer.core.instrument.step.StepDistributionSummary;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.step.StepTimer;


### PR DESCRIPTION
Now that we have proper internal logging, it'd be good to use internal logging in `LoggingMeterRegistry` for consistency.