### PR TITLE
Fix a race condition in MeterRegistry.getOrCreateMeter()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -573,7 +573,6 @@ public abstract class MeterRegistry {
                     }
 
                     m = builder.apply(mappedId, config);
-                    meterMap = meterMap.plus(mappedId, m);
 
                     Id synAssoc = originalId.syntheticAssociation();
                     if (synAssoc != null) {
@@ -584,6 +583,7 @@ public abstract class MeterRegistry {
                     for (Consumer<Meter> onAdd : meterAddedListeners) {
                         onAdd.accept(m);
                     }
+                    meterMap = meterMap.plus(mappedId, m);
                 }
             }
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -468,7 +468,7 @@ class CompositeMeterRegistryTest {
             });
         }
         executor.shutdown();
-        assertThat(executor.awaitTermination(1L, TimeUnit.DAYS)).isTrue();
+        assertThat(executor.awaitTermination(1L, TimeUnit.SECONDS)).isTrue();
         for (int i = 0; i < tagCount; i++) {
             assertThat(this.composite.find(meterName).tag(tagName, String.valueOf(i)).counter().count())
                     .isEqualTo(count / tagCount);


### PR DESCRIPTION
This PR resolves a race condition between meter addition and
composite meter's children addition via meter-added event listener in `MeterRegistry.getOrCreateMeter()`.

Closes gh-1622