### PR TITLE
Make DynatraceMeterRegistryTest.writeCustomMetrics() pass consistently

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
@@ -206,7 +206,8 @@ class DynatraceMeterRegistryTest {
 
     @Test
     void writeCustomMetrics() {
-        meterRegistry.gauge("my.gauge", 1d);
+        Double number = 1d;
+        meterRegistry.gauge("my.gauge", number);
         Gauge gauge = meterRegistry.find("my.gauge").gauge();
         Stream<DynatraceMeterRegistry.DynatraceCustomMetric> series = meterRegistry.writeMeter(gauge);
         List<DynatraceTimeSeries> timeSeries = series


### PR DESCRIPTION
This PR changes to make `DynatraceMeterRegistryTest.writeCustomMetrics()` pass consistently. If a GC happens between `MeterRegistry.gauge()` and `MeterRegistry.find()` in the test, it will fail like [this build](https://circleci.com/gh/micrometer-metrics/micrometer/4557) as the `DefaultGauge.ref` has been garbage-collected.