### PR TITLE
Fix description for httpcomponents.httpclient.pool.total.connections

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -76,7 +76,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
         Gauge.builder("httpcomponents.httpclient.pool.total.connections",
             connectionManager,
             (connectionManager) -> connectionManager.getTotalStats().getAvailable())
-            .description("The number of persistent and leased connections for all routes.")
+            .description("The number of persistent and available connections for all routes.")
             .tags(tags).tag("state", "available")
             .register(registry);
         Gauge.builder("httpcomponents.httpclient.pool.total.connections",

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -47,12 +47,6 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
     }
 
     @Test
-    void creationWithPoolingHttpClientIsOk() {
-        PoolingHttpClientConnectionManager connectionManager = mock(PoolingHttpClientConnectionManager.class);
-        new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
-    }
-
-    @Test
     void totalMax() {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getMax()).thenReturn(13);


### PR DESCRIPTION
This PR fixes the description for `httpcomponents.httpclient.pool.total.connections{state="available"}`. Along the way, this PR also removes a test in `PoolingHttpClientConnectionManagerMetricsBinderTest` which seems to be a duplicate of what the `setup()` method is already doing.