### PR TITLE
Add log for gauge's value function application failure

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -26,6 +26,8 @@ import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.util.internal.logging.InternalLogger;
+import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +41,8 @@ import java.util.function.ToLongFunction;
  * @author Johnny Lim
  */
 public abstract class DropwizardMeterRegistry extends MeterRegistry {
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(DropwizardMeterRegistry.class);
+
     private final MetricRegistry registry;
     private final HierarchicalNameMapper nameMapper;
     private final DropwizardClock dropwizardClock;
@@ -79,11 +83,16 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
                 try {
                     return valueFunction.applyAsDouble(obj2);
                 } catch (Throwable ex) {
-                    return nullGaugeValue();
+                    String message = "Failed to apply the value function for the gauge '" + id.getName() + "'";
+                    if (log.isDebugEnabled()) {
+                        log.warn(message + ".", ex);
+                    }
+                    else {
+                        log.warn(message + ": " + ex);
+                    }
                 }
-            } else {
-                return nullGaugeValue();
             }
+            return nullGaugeValue();
         };
         registry.register(hierarchicalName(id), gauge);
         return new DropwizardGauge(id, gauge);


### PR DESCRIPTION
This PR adds log for gauge's value function application failure in `DropwizardMeterRegistry`. For the verbosity concern from @shakuzen, I chose [an approach from Spring framework](https://github.com/spring-projects/spring-framework/blob/972337e8f9424051d90a20e4680eb61037fe5f36/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java#L261) to lower the verbosity, but I'm open to any suggestion. An approach suggested from @checketts in https://github.com/micrometer-metrics/micrometer/pull/1532#issuecomment-527944141 also seems good to me.

See gh-1532