### PR TITLE
Changed Elastic Template source to true for Version 7 and above (#1629)

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -89,12 +89,10 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             "  }\n" +
             "}";
     private static final String TEMPLATE_BODY_BEFORE_VERSION_7 = "{\"template\":\"metrics*\",\"mappings\":{\"_default_\":{\"_all\":{\"enabled\":false}," + TEMPLATE_PROPERTIES + "}}}";
-    private static final String TEMPLATE_BODY_AFTER_VERSION_7 = "{\n" +
+    static final String TEMPLATE_BODY_AFTER_VERSION_7 = "{\n" +
             "  \"index_patterns\": [\"metrics*\"],\n" +
             "  \"mappings\": {\n" +
-            "    \"_source\": {\n" +
-            "      \"enabled\": false\n" +
-            "    },\n" + TEMPLATE_PROPERTIES +
+            "    \"_source\": {\"enabled\": true},\n" + TEMPLATE_PROPERTIES +
             "  }\n" +
             "}";
 

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -291,4 +291,10 @@ class ElasticMeterRegistryTest {
         assertThat(ElasticMeterRegistry.getMajorVersion(responseBody)).isEqualTo(5);
     }
 
+    @Issue("#1629")
+    @Test
+    void verifyTemplateSourceIsEnabledForVersion7() {
+        assertThat(ElasticMeterRegistry.TEMPLATE_BODY_AFTER_VERSION_7).contains("\"_source\": {\"enabled\": true}");
+    }
+
 }


### PR DESCRIPTION
After 7.3 the _source needs to be enabled for getting the fields visible on the index mapping. 
