### PR TITLE
Use the latest version of JUnit Jupiter on master

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -60,10 +60,10 @@ dependencies {
     testCompile 'io.projectreactor:reactor-test:latest.release'
 
     // JUnit 5
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.4.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter:latest.release'
 
     // Eclipse still needs this (as of 4.7.1a)
-    testRuntime 'org.junit.platform:junit-platform-launcher:1.4.+'
+    testRuntime 'org.junit.platform:junit-platform-launcher:latest.release'
 
     testCompile 'org.mockito:mockito-core:latest.release'
 

--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 
     // JERSEY-3662
     testImplementation 'junit:junit:4.12'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.4.+'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:latest.release'
     testCompile 'org.mockito:mockito-core:2.+'
 }

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -2,8 +2,7 @@ dependencies {
     compile project(':micrometer-core')
     compile 'org.assertj:assertj-core:latest.release'
 
-    // JUnit 5
-    compile 'org.junit.jupiter:junit-jupiter:5.4.+'
+    compile 'org.junit.jupiter:junit-jupiter:latest.release'
 
     compile 'ru.lanwen.wiremock:wiremock-junit5:latest.release'
     compile 'com.github.tomakehurst:wiremock:latest.release'


### PR DESCRIPTION
This PR changes to use the latest version of JUnit Jupiter on the `master` branch as it doesn't seem to have any reason to fixate the version for now.