### PR TITLE
Add Javadoc indicating that SLA units are nanoseconds when they are meant for a Timer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -199,7 +199,8 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     /**
      * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
      * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
-     * generate aggregable percentile approximations.
+     * generate aggregable percentile approximations.  If The {@link DistributionStatisticConfig} is meant for
+     * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds
      *
      * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
      */
@@ -246,7 +247,8 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
         /**
          * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
          * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
-         * generate aggregable percentile approximations.
+         * generate aggregable percentile approximations.  If The {@link DistributionStatisticConfig} is meant for
+         * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds
          *
          * @param sla The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
          * @return This builder.


### PR DESCRIPTION
Fixes #1414