### PR TITLE
Fully initialize StatsD line builders during concurrent use.

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -50,17 +50,19 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private void updateIfNamingConventionChanged() {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
-            this.namingConvention = next;
-            this.name = next.name(sanitize(id.getName()), id.getType(), id.getBaseUnit()) + ":";
             synchronized (tagsLock) {
-                this.tags = HashTreePMap.empty();
-                this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
-                        id.getConventionTags(this.namingConvention).stream()
-                                .map(t -> sanitize(t.getKey()) + ":" + sanitize(t.getValue()))
-                                .collect(Collectors.joining(","))
-                        : null;
+                if (this.namingConvention != next) {
+                    this.name = next.name(sanitize(id.getName()), id.getType(), id.getBaseUnit()) + ":";
+                    this.tags = HashTreePMap.empty();
+                    this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
+                            id.getConventionTags(next).stream()
+                                    .map(t -> sanitize(t.getKey()) + ":" + sanitize(t.getValue()))
+                                    .collect(Collectors.joining(","))
+                            : null;
+                }
+                this.tagsNoStat = tags(null, conventionTags, ":", "|#");
+                this.namingConvention = next;
             }
-            this.tagsNoStat = tags(null, conventionTags, ":", "|#");
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
@@ -53,15 +53,19 @@ public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private void updateIfNamingConventionChanged() {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
-            this.namingConvention = next;
-            this.name = sanitize(next.name(id.getName(), id.getType(), id.getBaseUnit()));
-            this.tags = HashTreePMap.empty();
-            this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
-                    id.getConventionTags(this.namingConvention).stream()
-                            .map(t -> sanitize(t.getKey()) + "=" + sanitize(t.getValue()))
-                            .collect(Collectors.joining(","))
-                    : null;
-            this.tagsNoStat = tags(null, conventionTags, "=", "#");
+            synchronized (tagsLock) {
+                if (this.namingConvention != next) {
+                    this.name = sanitize(next.name(id.getName(), id.getType(), id.getBaseUnit()));
+                    this.tags = HashTreePMap.empty();
+                    this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
+                            id.getConventionTags(next).stream()
+                                    .map(t -> sanitize(t.getKey()) + "=" + sanitize(t.getValue()))
+                                    .collect(Collectors.joining(","))
+                            : null;
+                    this.tagsNoStat = tags(null, conventionTags, "=", "#");
+                    this.namingConvention = next;
+                }
+            }
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.statsd.internal;
 
+import com.google.common.util.concurrent.SettableFuture;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -22,6 +23,10 @@ import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +43,34 @@ class SysdigStatsdLineBuilderTest {
 
         registry.config().namingConvention(NamingConvention.camelCase);
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("myCounter#statistic=count,myTag=value:1|c");
+    }
+
+    @Test
+    void multiThreadLineCall() throws InterruptedException, TimeoutException, ExecutionException {
+        Counter c = registry.counter("my.counter", "my.tag", "value");
+        SysdigStatsdLineBuilder lb = new SysdigStatsdLineBuilder(c.getId(), registry.config());
+
+        SettableFuture<String> line1Future = SettableFuture.create();
+        SettableFuture<String> line2Future = SettableFuture.create();
+        Thread t1 = new Thread(() -> line1Future.set(lb.line("1", Statistic.COUNT, "c")));
+        Thread t2 = new Thread(() -> line2Future.set(lb.line("1", Statistic.COUNT, "c")));
+
+        t1.start();
+        t2.start();
+
+        String line1 = line1Future.get(100, TimeUnit.MILLISECONDS);
+        String line2 = line2Future.get(100, TimeUnit.MILLISECONDS);
+
+        assertThat(line1)
+                .contains("my_counter")
+                .contains("my_tag")
+                .contains("value")
+                .doesNotContain("null");
+        assertThat(line2)
+                .contains("my_counter")
+                .contains("my_tag")
+                .contains("value")
+                .doesNotContain("null");
     }
 
     @Issue("#739")


### PR DESCRIPTION
During (re)initialization of the Datadag and Sysdig StatsD line
builders, multiple threads accessing the same instance should see
updates from first thread due to happens-before semantics.
In addition, (re)initialization should only happen once per instance.

Addresses https://github.com/micrometer-metrics/micrometer/issues/1642