### PR TITLE
Fix unknown unit handling for CloudWatch 2.x

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -282,12 +282,13 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             return config().namingConvention().name(name, id.getType(), id.getBaseUnit());
         }
 
-        private StandardUnit toStandardUnit(@Nullable String unit) {
+        // VisibleForTesting
+        StandardUnit toStandardUnit(@Nullable String unit) {
             if (unit == null) {
                 return StandardUnit.NONE;
             }
             StandardUnit standardUnit = STANDARD_UNIT_BY_LOWERCASE_VALUE.get(unit.toLowerCase());
-            return standardUnit != null ? standardUnit : StandardUnit.UNKNOWN_TO_SDK_VERSION;
+            return standardUnit != null ? standardUnit : StandardUnit.NONE;
         }
 
         private List<Dimension> toDimensions(List<Tag> tags) {

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -204,7 +205,7 @@ class CloudWatchMeterRegistryTest {
     }
 
     @Test
-    public void batchSizeShouldWorkOnMetricDatum() throws InterruptedException {
+    void batchSizeShouldWorkOnMetricDatum() throws InterruptedException {
         List<Meter> meters = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             Timer timer = Timer.builder("timer." + i).register(this.registry);
@@ -218,6 +219,11 @@ class CloudWatchMeterRegistryTest {
         List<List<MetricDatum>> allValues = argumentCaptor.getAllValues();
         assertThat(allValues.get(0)).hasSize(20);
         assertThat(allValues.get(1)).hasSize(20);
+    }
+
+    @Test
+    void batchToStandardUnitWhenUnitIsUnknownShouldReturnNone() {
+        assertThat(this.registry.new Batch().toStandardUnit("unknownUnit")).isEqualTo(StandardUnit.NONE);
     }
 
     private Predicate<MetricDatum> hasAvgMetric(Id id) {


### PR DESCRIPTION
This PR fixes unknown unit handling for CloudWatch 2.x.

Closes gh-1645