### PR TITLE
Remove org.ow2.asm:asm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'org.ow2.asm:asm:5.0.3'
         classpath 'io.spring.gradle:spring-release-plugin:0.20.1'
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.2.0'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'


### PR DESCRIPTION
This PR removes `org.ow2.asm:asm` as it doesn't seem to be used.