### PR TITLE
Use HTTPS for links in license headers

### DIFF
--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogConfigTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogConfigTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/AbstractInternalLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/AbstractInternalLogger.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/FormattingTuple.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/FormattingTuple.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogLevel.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogLevel.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLogger.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/InternalLoggerFactory.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLogger.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/JdkLoggerFactory.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/LocationAwareSlf4JLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/LocationAwareSlf4JLogger.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLogger.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLoggerFactory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/Slf4JLoggerFactory.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
@@ -20,7 +20,7 @@
  * version 2.0 (the "License"); you may not use this file except in compliance
  * with the License. You may obtain a copy of the License at:
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT


### PR DESCRIPTION
This PR changes to use HTTPS for links in license headers for consistency.