### PR TITLE
Constructors to customize InstrumentedQueuedThreadPool

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/InstrumentedQueuedThreadPool.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/InstrumentedQueuedThreadPool.java
@@ -19,12 +19,47 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
+import java.util.concurrent.BlockingQueue;
+
 public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
 
     private final MeterRegistry registry;
     private final Iterable<Tag> tags;
 
     public InstrumentedQueuedThreadPool(MeterRegistry registry, Iterable<Tag> tags) {
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    public InstrumentedQueuedThreadPool(MeterRegistry registry, Iterable<Tag> tags, int maxThreads) {
+        super(maxThreads);
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    public InstrumentedQueuedThreadPool(MeterRegistry registry, Iterable<Tag> tags, int maxThreads, int minThreads) {
+        super(maxThreads, minThreads);
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    public InstrumentedQueuedThreadPool(MeterRegistry registry,
+                                        Iterable<Tag> tags,
+                                        int maxThreads,
+                                        int minThreads,
+                                        int idleTimeout) {
+        super(maxThreads, minThreads, idleTimeout);
+        this.registry = registry;
+        this.tags = tags;
+    }
+
+    public InstrumentedQueuedThreadPool(MeterRegistry registry,
+                                        Iterable<Tag> tags,
+                                        int maxThreads,
+                                        int minThreads,
+                                        int idleTimeout,
+                                        BlockingQueue<Runnable> queue) {
+        super(maxThreads, minThreads, idleTimeout, queue);
         this.registry = registry;
         this.tags = tags;
     }


### PR DESCRIPTION
I decided to provide all possible constructors for convenience and further simplicity of using (although with one big constructor, people might figure out what to pass to the missing parameters, it's still not as good as plenty of 'native' options)

fixes #1639 