### PR TITLE
Add a note for the reference docs repo in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ dependencies {
 
 The build automatically calculates the "next" version for you when publishing snapshots.
 
+## Documentation
+
+The reference documentation is managed in [a separate GitHub repository](https://github.com/micrometer-metrics/micrometer-docs).
+
 -------------------------------------
 _Licensed under [Apache Software License 2.0](https://www.apache.org/licenses/LICENSE-2.0)_
 


### PR DESCRIPTION
It'd be good to have a pointer to the reference docs repo in the README file.