### PR TITLE
Log custom meter names having leading numeric characters for Dynatrace

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceNamingConvention.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceNamingConvention.java
@@ -18,6 +18,7 @@ package io.micrometer.dynatrace;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 
 import java.util.regex.Pattern;
 
@@ -31,7 +32,10 @@ import java.util.regex.Pattern;
  */
 public class DynatraceNamingConvention implements NamingConvention {
 
+    private static final WarnThenDebugLogger logger = new WarnThenDebugLogger(DynatraceNamingConvention.class);
+
     private static final Pattern NAME_CLEANUP_PATTERN = Pattern.compile("[^\\w._-]");
+    private static final Pattern LEADING_NUMERIC_PATTERN = Pattern.compile("[._-]([\\d])+");
     private static final Pattern KEY_CLEANUP_PATTERN = Pattern.compile("[^\\w.-]");
 
     private final NamingConvention delegate;
@@ -53,7 +57,14 @@ public class DynatraceNamingConvention implements NamingConvention {
         if (name.equals("system.load.average.1m")) {
             return "system.load.average.oneminute";
         }
-        return NAME_CLEANUP_PATTERN.matcher(name).replaceAll("_");
+        String sanitized = NAME_CLEANUP_PATTERN.matcher(name).replaceAll("_");
+        if (LEADING_NUMERIC_PATTERN.matcher(sanitized).find()) {
+            logger.log("'" + sanitized + "' (original name: '" + name + "') is not a valid meter name. "
+                    + "Dynatrace doesn't allow leading numeric characters after non-alphabets. "
+                    + "Please rename it to conform to the constraints. "
+                    + "If it comes from a third party, please use MeterFilter to rename it.");
+        }
+        return sanitized;
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
@@ -25,20 +25,34 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class WarnThenDebugLogger {
 
-    private final InternalLogger log;
+    private final InternalLogger logger;
     private final AtomicBoolean warnLogged = new AtomicBoolean();
 
     public WarnThenDebugLogger(Class<?> clazz) {
-        this.log = InternalLoggerFactory.getInstance(clazz);
+        this.logger = InternalLoggerFactory.getInstance(clazz);
     }
 
     public void log(String message, Throwable ex) {
+        InternalLogLevel level;
+        String finalMessage;
         if (this.warnLogged.compareAndSet(false, true)) {
-            this.log.warn(message + " Note that subsequent logs will be logged at debug level.", ex);
+            level = InternalLogLevel.WARN;
+            finalMessage = message + " Note that subsequent logs will be logged at debug level.";
         }
         else {
-            this.log.debug(message, ex);
+            level = InternalLogLevel.DEBUG;
+            finalMessage = message;
         }
+        if (ex != null) {
+            this.logger.log(level, finalMessage, ex);
+        }
+        else {
+            this.logger.log(level, finalMessage);
+        }
+    }
+
+    public void log(String message) {
+        log(message, null);
     }
 
 }


### PR DESCRIPTION
This PR changes to sanitize meter names for Dynatrace.

Closes gh-1648