### PR TITLE
Remove the deprecated HumioConfig.repository()

### DIFF
--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioConfig.java
@@ -46,15 +46,6 @@ public interface HumioConfig extends StepRegistryConfig {
     }
 
     /**
-     * @return The repository name to write metrics to.
-     * @deprecated No longer used as repository is resolved from the api token
-     */
-    @Deprecated
-    default String repository() {
-        return "";
-    }
-
-    /**
      * Humio uses a concept called "tags" to decide which datasource to store metrics in. This concept
      * is distinct from Micrometer's notion of tags, which divides a metric along dimensional boundaries.
      * All metrics from this registry will be stored under a datasource defined by these tags.


### PR DESCRIPTION
This PR removes the deprecated `HumioConfig.repository()`.

See https://github.com/micrometer-metrics/micrometer/pull/1544#discussion_r317902015