### PR TITLE
Add log for gauge's value function application failure for DefaultGauge

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -26,8 +26,7 @@ import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.core.lang.Nullable;
-import io.micrometer.core.util.internal.logging.InternalLogger;
-import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +41,8 @@ import java.util.function.ToLongFunction;
  * @author Johnny Lim
  */
 public abstract class DropwizardMeterRegistry extends MeterRegistry {
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(DropwizardMeterRegistry.class);
+
+    private static final WarnThenDebugLogger logger = new WarnThenDebugLogger(DropwizardMeterRegistry.class);
 
     private final MetricRegistry registry;
     private final HierarchicalNameMapper nameMapper;
@@ -86,13 +86,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
                 try {
                     return valueFunction.applyAsDouble(obj2);
                 } catch (Throwable ex) {
-                    String message = "Failed to apply the value function for the gauge '" + id.getName() + "'.";
-                    if (this.warnLogged.compareAndSet(false, true)) {
-                        log.warn(message, ex);
-                    }
-                    else {
-                        log.debug(message, ex);
-                    }
+                    logger.log("Failed to apply the value function for the gauge '" + id.getName() + "'.", ex);
                 }
             }
             return nullGaugeValue();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 
 import java.lang.ref.WeakReference;
 import java.util.function.ToDoubleFunction;
@@ -33,6 +34,9 @@ import java.util.function.ToDoubleFunction;
  * @author Johnny Lim
  */
 public class DefaultGauge<T> extends AbstractMeter implements Gauge {
+
+    private static final WarnThenDebugLogger logger = new WarnThenDebugLogger(DefaultGauge.class);
+
     private final WeakReference<T> ref;
     private final ToDoubleFunction<T> value;
 
@@ -50,6 +54,7 @@ public class DefaultGauge<T> extends AbstractMeter implements Gauge {
                 return value.applyAsDouble(ref.get());
             }
             catch (Throwable ex) {
+                logger.log("Failed to apply the value function for the gauge '" + getId().getName() + "'.", ex);
             }
         }
         return Double.NaN;

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.util.internal.logging;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * {@link InternalLogger} which logs at warn level at first and then logs at debug level for the rest.
+ *
+ * @author Johnny Lim
+ * @since 1.1.8
+ */
+public class WarnThenDebugLogger {
+
+    private final InternalLogger log;
+    private final AtomicBoolean warnLogged = new AtomicBoolean();
+
+    public WarnThenDebugLogger(Class<?> clazz) {
+        this.log = InternalLoggerFactory.getInstance(clazz);
+    }
+
+    public void log(String message, Throwable ex) {
+        if (this.warnLogged.compareAndSet(false, true)) {
+            this.log.warn(message + " Note that subsequent logs will be logged at debug level.", ex);
+        }
+        else {
+            this.log.debug(message, ex);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds log for gauge's value function application failure for `DefaultGauge`. This PR also introduces `WarnThenDebugLogger` for convenience and consistency.

See https://github.com/micrometer-metrics/micrometer/pull/1582#issuecomment-529776555