### PR TITLE
Provides ThreadFactory metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -27,6 +27,7 @@ import io.micrometer.core.lang.Nullable;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Arrays.asList;
 
@@ -209,6 +210,96 @@ public class ExecutorServiceMetrics implements MeterBinder {
                 .description("The current number of threads in the pool")
                 .baseUnit(BaseUnits.THREADS)
                 .register(registry);
+
+        monitorRejectedExecutionHandler(registry, tp);
+        monitorThreadFactory(registry, tp);
+    }
+
+    private void monitorThreadFactory(MeterRegistry registry, ThreadPoolExecutor tp) {
+        MonitoredThreadFactory tf = new MonitoredThreadFactory(tp.getThreadFactory());
+        tp.setThreadFactory(tf);
+
+        Gauge.builder("thread.factory.created", tf, MonitoredThreadFactory::getCreated)
+                .tags(tags)
+                .description("The approximate number of threads that create with thread factory")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
+        Gauge.builder("thread.factory.terminated", tf, MonitoredThreadFactory::getTerminated)
+                .tags(tags)
+                .description("The approximate number of threads that is finished execution")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
+        Gauge.builder("thread.factory.running", tf, MonitoredThreadFactory::getRunning)
+                .tags(tags)
+                .description("The approximate number of threads that are started executing, but not terminated")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
+    }
+
+    private void monitorRejectedExecutionHandler(MeterRegistry registry, ThreadPoolExecutor tp) {
+        MonitoredRejectedExecutionHandler mreh = new MonitoredRejectedExecutionHandler(tp.getRejectedExecutionHandler());
+        tp.setRejectedExecutionHandler(mreh);
+
+        Gauge.builder("executor.rejected", mreh, MonitoredRejectedExecutionHandler::getRejectedCount)
+                .tags(tags)
+                .description("The number of tasks that were not accepted for execution")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
+    }
+
+    static class MonitoredThreadFactory implements ThreadFactory {
+        private final ThreadFactory threadFactory;
+        private AtomicLong created = new AtomicLong();
+        private AtomicLong terminated = new AtomicLong();
+
+        MonitoredThreadFactory(ThreadFactory threadFactory) {
+            this.threadFactory = threadFactory;
+        }
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            return threadFactory.newThread(() -> {
+                created.incrementAndGet();
+                try {
+                    runnable.run();
+
+                } finally {
+                    terminated.decrementAndGet();
+                }
+            });
+        }
+
+        public long getCreated() {
+            return created.get();
+        }
+
+        public long getTerminated() {
+            return terminated.get();
+        }
+
+        public long getRunning() {
+            return created.get() - terminated.get();
+        }
+
+    }
+
+    static class MonitoredRejectedExecutionHandler implements RejectedExecutionHandler {
+        private final RejectedExecutionHandler wrappedRejectedExecutionHandler;
+        private AtomicLong count = new AtomicLong();
+
+        MonitoredRejectedExecutionHandler(RejectedExecutionHandler wrappedRejectedExecutionHandler) {
+            this.wrappedRejectedExecutionHandler = wrappedRejectedExecutionHandler;
+        }
+
+        @Override
+        public void rejectedExecution(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
+            wrappedRejectedExecutionHandler.rejectedExecution(runnable, threadPoolExecutor);
+            count.incrementAndGet();
+        }
+
+        public long getRejectedCount() {
+            return count.get();
+        }
     }
 
     private void monitor(MeterRegistry registry, ForkJoinPool fj) {


### PR DESCRIPTION
This implementation wraps `ThreadFactory` and `RejectedExecutionHandler` from user `ThreadPoolExecutor` to get metrics.

Closes #1665