### PR TITLE
Signalfx source dimension

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
@@ -33,8 +33,6 @@ import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
  */
 public interface SignalFxConfig extends StepRegistryConfig {
 
-    String DEFAULT_SOURCE_TAG = "source";
-
     @Override
     default String prefix() {
         return "signalfx";
@@ -67,24 +65,6 @@ public interface SignalFxConfig extends StepRegistryConfig {
                 return "unknown";
             }
         });
-    }
-
-    /**
-     * @return if value of {@code source} property should be reported as dimension
-     */
-    default boolean includeSourceTag() {
-        String v = get(prefix() + ".includeSourceTag");
-        return v != null && Boolean.valueOf(v);
-    }
-
-    /**
-     * Name of source tag that should be used as dimension key.
-     *
-     * @see SignalFxConfig#DEFAULT_SOURCE_TAG
-     */
-    default String sourceTag() {
-        String v = get(prefix() + ".sourceTag");
-        return v == null ? DEFAULT_SOURCE_TAG : v;
     }
 
     @Override

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxConfig.java
@@ -33,6 +33,8 @@ import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
  */
 public interface SignalFxConfig extends StepRegistryConfig {
 
+    String DEFAULT_SOURCE_TAG = "source";
+
     @Override
     default String prefix() {
         return "signalfx";
@@ -65,6 +67,24 @@ public interface SignalFxConfig extends StepRegistryConfig {
                 return "unknown";
             }
         });
+    }
+
+    /**
+     * @return if value of {@code source} property should be reported as dimension
+     */
+    default boolean includeSourceTag() {
+        String v = get(prefix() + ".includeSourceTag");
+        return v != null && Boolean.valueOf(v);
+    }
+
+    /**
+     * Name of source tag that should be used as dimension key.
+     *
+     * @see SignalFxConfig#DEFAULT_SOURCE_TAG
+     */
+    default String sourceTag() {
+        String v = get(prefix() + ".sourceTag");
+        return v == null ? DEFAULT_SOURCE_TAG : v;
     }
 
     @Override

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -137,7 +137,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
         });
     }
 
-    private SignalFxProtocolBuffers.DataPoint.Builder addDatapoint(Meter meter, SignalFxProtocolBuffers.MetricType metricType, @Nullable String statSuffix, Number value) {
+    SignalFxProtocolBuffers.DataPoint.Builder addDatapoint(Meter meter, SignalFxProtocolBuffers.MetricType metricType, @Nullable String statSuffix, Number value) {
         SignalFxProtocolBuffers.Datum.Builder datumBuilder = SignalFxProtocolBuffers.Datum.newBuilder();
         SignalFxProtocolBuffers.Datum datum = (value instanceof Double ?
                 datumBuilder.setDoubleValue((Double) value) :
@@ -152,14 +152,23 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
                 .setMetricType(metricType)
                 .setValue(datum);
 
+        if (this.config.includeSourceTag()) {
+            String sourceTagValue = config().namingConvention().tagValue(this.config.source());
+            dataPointBuilder.addDimensions(dimension(this.config.sourceTag(), sourceTagValue));
+        }
+
         for (Tag tag : getConventionTags(meter.getId())) {
-            dataPointBuilder.addDimensions(SignalFxProtocolBuffers.Dimension.newBuilder()
-                    .setKey(tag.getKey())
-                    .setValue(tag.getValue())
-                    .build());
+            dataPointBuilder.addDimensions(dimension(tag.getKey(), tag.getValue()));
         }
 
         return dataPointBuilder;
+    }
+
+    private SignalFxProtocolBuffers.Dimension dimension(String key, String value) {
+        return SignalFxProtocolBuffers.Dimension.newBuilder()
+                .setKey(key)
+                .setValue(value)
+                .build();
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -152,10 +152,8 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
                 .setMetricType(metricType)
                 .setValue(datum);
 
-        if (this.config.includeSourceTag()) {
-            String sourceTagValue = config().namingConvention().tagValue(this.config.source());
-            dataPointBuilder.addDimensions(dimension(this.config.sourceTag(), sourceTagValue));
-        }
+        String sourceTagValue = config().namingConvention().tagValue(this.config.source());
+        dataPointBuilder.addDimensions(dimension("source", sourceTagValue));
 
         for (Tag tag : getConventionTags(meter.getId())) {
             dataPointBuilder.addDimensions(dimension(tag.getKey(), tag.getValue()));

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
@@ -57,15 +57,13 @@ class SignalFxMeterRegistryTest {
     }
 
     @Test
-    void sourceTagIsAddedToDimensionsIfEnabled() {
+    void sourceTagIsAddedToDimensions() {
         SignalFxProtocolBuffers.DataPoint dataPoint = whenDataPointGenerated(registry);
 
         assertThat(dataPoint.getDimensionsList()).hasSize(3)
-                .contains(dimension("source", "test-source"))
-                .contains(dimension("sample_tag", "value"))
-                .contains(dimension("normalized", "value1"))
-        ;
-        assertThat(dataPoint.getValue().getDoubleValue()).isEqualTo(0.0);
+                .containsExactlyInAnyOrder(dimension("source", "test-source"),
+                        dimension("sample_tag", "value"),
+                        dimension("normalized", "value1"));
     }
 
     private SignalFxProtocolBuffers.DataPoint whenDataPointGenerated(SignalFxMeterRegistry registry) {

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.signalfx;
 
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MockClock;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,10 @@ class SignalFxMeterRegistryTest {
             return "accessToken";
         }
 
+        @Override
+        public String source() {
+            return "test-source";
+        }
     };
 
     private final SignalFxMeterRegistry registry = new SignalFxMeterRegistry(this.config, new MockClock());
@@ -48,6 +54,29 @@ class SignalFxMeterRegistryTest {
     void addLongTaskTimer() {
         LongTaskTimer longTaskTimer = LongTaskTimer.builder("my.long.task.timer").register(this.registry);
         assertThat(this.registry.addLongTaskTimer(longTaskTimer)).hasSize(2);
+    }
+
+    @Test
+    void sourceTagIsAddedToDimensionsIfEnabled() {
+        SignalFxProtocolBuffers.DataPoint dataPoint = whenDataPointGenerated(registry);
+
+        assertThat(dataPoint.getDimensionsList()).hasSize(3)
+                .contains(dimension("source", "test-source"))
+                .contains(dimension("sample_tag", "value"))
+                .contains(dimension("normalized", "value1"))
+        ;
+        assertThat(dataPoint.getValue().getDoubleValue()).isEqualTo(0.0);
+    }
+
+    private SignalFxProtocolBuffers.DataPoint whenDataPointGenerated(SignalFxMeterRegistry registry) {
+        Counter counter = registry.counter("sample",
+                "sample_tag", "value", "sf_normalized", "value1");
+
+        return registry.addDatapoint(counter, SignalFxProtocolBuffers.MetricType.COUNTER, null, counter.count()).build();
+    }
+
+    private SignalFxProtocolBuffers.Dimension dimension(String name, String value) {
+        return SignalFxProtocolBuffers.Dimension.newBuilder().setKey(name).setValue(value).build();
     }
 
 }


### PR DESCRIPTION
micrometer-metrics/micrometer#1606 added support for dimension with source value.

Dimension is off by default to keep existing behavior, but can be enabled with `includeSourceTag` property as well as dimension name can be specified with `sourceTag` property (default - `source`)