### PR TITLE
Counter value not getting updated correctly. It keeps printing count …

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
@@ -41,7 +41,7 @@ public class StatsdCounter extends AbstractMeter implements Counter {
     public void increment(double amount) {
         if (!shutdown && amount > 0) {
             count.add(amount);
-            subscriber.onNext(lineBuilder.count((long) amount));
+            subscriber.onNext(lineBuilder.count(count.longValue()));
         }
     }
 


### PR DESCRIPTION
…always 1 on counter.increment()

httpRequests.statistic.count.uri:1|c
httpRequests.statistic.count.uri:1|c
Fixed: onNext event to use count value rather than amount value. Because Amount is always fixed. After fix counter value increments correctly:
httpRequests.statistic.count.uri:1|c
httpRequests.statistic.count.uri:2|c