### PR TITLE
Fix metrics registration for StringCache

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -161,7 +161,7 @@ public class TomcatMetrics implements MeterBinder {
                     s -> safeDouble(() -> s.getAttribute(name, "hitCount")))
                     .tags(allTags)
                     .register(registry);
-        });
+        }, false);
     }
 
     private void registerServletMetrics(MeterRegistry registry) {
@@ -216,14 +216,19 @@ public class TomcatMetrics implements MeterBinder {
         });
     }
 
+    private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
+        registerMetricsEventually(key, value, perObject, true);
+    }
+
     /**
      * If the MBean already exists, register metrics immediately. Otherwise register an MBean registration listener
      * with the MBeanServer and register metrics when/if the MBean becomes available.
      */
-    private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
+    private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject, boolean hasName) {
         if (getJmxDomain() != null) {
             try {
-                Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(getJmxDomain() + ":" + key + "=" + value + ",name=*"), null);
+                String name = getJmxDomain() + ":" + key + "=" + value + (hasName ? ",name=*" : "");
+                Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(name), null);
                 if (!objectNames.isEmpty()) {
                     // MBean is present, so we can register metrics now.
                     objectNames.forEach(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -204,6 +204,8 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.threads.config.max").gauge().value()).isGreaterThan(0.0);
         assertThat(registry.get("tomcat.threads.busy").gauge().value()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.threads.current").gauge().value()).isGreaterThan(0.0);
+        assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
+        assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);
     }
 
     private void checkMbeansAfterRequests() {
@@ -216,5 +218,7 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.threads.config.max").gauge().value()).isGreaterThan(0.0);
         assertThat(registry.get("tomcat.threads.busy").gauge().value()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.threads.current").gauge().value()).isGreaterThan(0.0);
+        assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
+        assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);
     }
 }


### PR DESCRIPTION
This PR fixes metrics registration for `StringCache`.

Closes gh-1666