### PR TITLE
Handle LongTaskTimer properly for SignalFx

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -47,7 +47,11 @@ import static com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType.G
 import static java.util.stream.StreamSupport.stream;
 
 /**
+ * {@link StepMeterRegistry} for SignalFx.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
+ * @since 1.0.0
  */
 public class SignalFxMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("signalfx-metrics-publisher");
@@ -151,7 +155,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
         SignalFxProtocolBuffers.Datum.Builder datumBuilder = SignalFxProtocolBuffers.Datum.newBuilder();
         SignalFxProtocolBuffers.Datum datum = (value instanceof Double ?
                 datumBuilder.setDoubleValue((Double) value) :
-                datumBuilder.setIntValue((Long) value)
+                datumBuilder.setIntValue(value.longValue())
         ).build();
 
         String metricName = config().namingConvention().name(statSuffix == null ? meter.getId().getName() : meter.getId().getName() + "." + statSuffix,
@@ -172,7 +176,8 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
         return dataPointBuilder;
     }
 
-    private Stream<SignalFxProtocolBuffers.DataPoint.Builder> addLongTaskTimer(LongTaskTimer longTaskTimer) {
+    // VisibleForTesting
+    Stream<SignalFxProtocolBuffers.DataPoint.Builder> addLongTaskTimer(LongTaskTimer longTaskTimer) {
         return Stream.of(
                 addDatapoint(longTaskTimer, GAUGE, "activeTasks", longTaskTimer.activeTasks()),
                 addDatapoint(longTaskTimer, COUNTER, "duration", longTaskTimer.duration(getBaseTimeUnit()))

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.signalfx;
+
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.MockClock;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link SignalFxMeterRegistry}.
+ *
+ * @author Johnny Lim
+ */
+class SignalFxMeterRegistryTest {
+
+    private final SignalFxConfig config = new SignalFxConfig() {
+
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public String accessToken() {
+            return "accessToken";
+        }
+
+    };
+
+    private final SignalFxMeterRegistry registry = new SignalFxMeterRegistry(this.config, new MockClock());
+
+    @Test
+    void addLongTaskTimer() {
+        LongTaskTimer longTaskTimer = LongTaskTimer.builder("my.long.task.timer").register(this.registry);
+        assertThat(this.registry.addLongTaskTimer(longTaskTimer)).hasSize(2);
+    }
+
+}


### PR DESCRIPTION
This PR changes to handle `LongTaskTimer` properly for SignalFx.

Closes gh-1690