### PR TITLE
Remove unnecessary boxing

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogConfig.java
@@ -71,6 +71,6 @@ public interface DatadogConfig extends StepRegistryConfig {
      */
     default boolean descriptions() {
         String v = get(prefix() + ".descriptions");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 }

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -99,7 +99,7 @@ public interface ElasticConfig extends StepRegistryConfig {
      */
     default boolean autoCreateIndex() {
         String v = get(prefix() + ".autoCreateIndex");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**

--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaConfig.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaConfig.java
@@ -98,6 +98,6 @@ public interface GangliaConfig extends StepRegistryConfig {
      */
     default boolean enabled() {
         String v = get(prefix() + ".enabled");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 }

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
@@ -80,7 +80,7 @@ public interface GraphiteConfig extends DropwizardConfig {
      */
     default boolean enabled() {
         String v = get(prefix() + ".enabled");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxConfig.java
@@ -118,7 +118,7 @@ public interface InfluxConfig extends StepRegistryConfig {
      */
     default boolean compressed() {
         String v = get(prefix() + ".compressed");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**
@@ -127,6 +127,6 @@ public interface InfluxConfig extends StepRegistryConfig {
      */
     default boolean autoCreateDb() {
         String v = get(prefix() + ".autoCreateDb");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusConfig.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusConfig.java
@@ -41,7 +41,7 @@ public interface PrometheusConfig extends MeterRegistryConfig {
      */
     default boolean descriptions() {
         String v = get(prefix() + ".descriptions");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -60,7 +60,7 @@ public interface StatsdConfig extends MeterRegistryConfig {
      */
     default boolean enabled() {
         String v = get(prefix() + ".enabled");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**
@@ -150,7 +150,7 @@ public interface StatsdConfig extends MeterRegistryConfig {
      */
     default boolean publishUnchangedMeters() {
         String v = get(prefix() + ".publishUnchangedMeters");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**
@@ -160,6 +160,6 @@ public interface StatsdConfig extends MeterRegistryConfig {
      */
     default boolean buffered() {
         String v = get(prefix() + ".buffered");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -40,7 +40,7 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
      */
     default boolean enabled() {
         String v = get(prefix() + ".enabled");
-        return v == null || Boolean.valueOf(v);
+        return v == null || Boolean.parseBoolean(v);
     }
 
     /**


### PR DESCRIPTION
Tiny tiny change.
There is no point in using Booleans just to immediately unbox them to a boolean.