### PR TITLE
Fix warnings in TomcatMetricsTest

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -203,8 +203,8 @@ class TomcatMetricsTest {
             server.setPort(this.port);
             server.start();
 
-            Context context = server.addContext("/", null);
-            server.addServlet("/", "servletname", servlet);
+            Context context = server.addContext("", null);
+            server.addServlet("", "servletname", servlet);
             context.addServletMappingDecoded("/", "servletname");
 
             doWithTomcat.call();


### PR DESCRIPTION
Running tests in `TomcatMetricsTest` prints the following warning:

```
WARNING: A context path must either be an empty string or start with a '/' and do not end with a '/'. The path [/] does not meet these criteria and has been changed to []
```

This PR fixes it by changing the context path to an empty string.