### PR TITLE
Replace deprecated DoubleFormat.decimalOrWhole() usages

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceTimeSeries.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceTimeSeries.java
@@ -41,7 +41,7 @@ class DynatraceTimeSeries {
 
     String asJson() {
         String body = "{\"timeseriesId\":\"" + metricId + "\"" +
-                ",\"dataPoints\":[[" + time + "," + DoubleFormat.decimalOrWhole(value) + "]]";
+                ",\"dataPoints\":[[" + time + "," + DoubleFormat.wholeOrDecimal(value) + "]]";
 
         if (dimensions != null && !dimensions.isEmpty()) {
             body += ",\"dimensions\":{" +

--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
@@ -291,7 +291,7 @@ public class HumioMeterRegistry extends StepMeterRegistry {
                     .append(escapeJson(name)).append('"');
 
             for (Attribute attribute : attributes) {
-                sb.append(",\"").append(attribute.name).append("\":").append(DoubleFormat.decimalOrWhole(attribute.value));
+                sb.append(",\"").append(attribute.name).append("\":").append(DoubleFormat.wholeOrDecimal(attribute.value));
             }
 
             List<Tag> tags = getConventionTags(meter.getId());

--- a/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
+++ b/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
@@ -222,7 +222,7 @@ public class KairosMeterRegistry extends StepMeterRegistry {
         }
 
         KairosMetricBuilder datapoints(long wallTime, double value) {
-            sb.append(",\"datapoints\":[[").append(wallTime).append(',').append(DoubleFormat.decimalOrWhole(value)).append("]]");
+            sb.append(",\"datapoints\":[[").append(wallTime).append(',').append(DoubleFormat.wholeOrDecimal(value)).append("]]");
             return this;
         }
 

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -315,7 +315,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
                     Arrays.stream(snapshot.percentileValues())
                             .map(valueAtP -> createTimeSeries(histogramSupport,
                                     timeDomain ? valueAtP.value(getBaseTimeUnit()) : valueAtP.value(),
-                                    "p" + DoubleFormat.decimalOrWhole(valueAtP.percentile() * 100)))
+                                    "p" + DoubleFormat.wholeOrDecimal(valueAtP.percentile() * 100)))
             );
         }
 


### PR DESCRIPTION
This PR replaces deprecated `DoubleFormat.decimalOrWhole()` usages.