### PR TITLE
Add illegal import check for Java6Assertions

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -14,6 +14,7 @@
         <!-- Imports -->
         <module name="IllegalImportCheck" >
             <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.slf4j.*"/>
+            <property name="illegalClasses" value="org\.assertj\.core\.api\.Java6Assertions\..*"/>
             <property name="regexp" value="true"/>
         </module>
         <module name="UnusedImports">


### PR DESCRIPTION
This PR adds a Checkstyle rule for `org.assertj.core.api.Java6Assertions`.

See https://github.com/micrometer-metrics/micrometer/pull/1729#discussion_r353007060