### PR TITLE
Apply missing sanitization for SignalFx tag keys

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -79,7 +79,7 @@ public class SignalFxNamingConvention implements NamingConvention {
             conventionKey = "a" + conventionKey;
         }
         if (PATTERN_TAG_KEY_BLACKLISTED_PREFIX.matcher(conventionKey).matches()) {
-            logger.log("'" + conventionKey + "' (original name: '" + key + "') is not a valid meter name. "
+            logger.log("'" + conventionKey + "' (original name: '" + key + "') is not a valid tag key. "
                     + "Must not start with any of these prefixes: aws_, gcp_, or azure_. "
                     + "Please rename it to conform to the constraints. "
                     + "If it comes from a third party, please use MeterFilter to rename it.");

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -24,15 +24,20 @@ import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.lang.Nullable;
 
 /**
- * See https://developers.signalfx.com/reference#section-criteria-for-metric-and-dimension-names-and-values for criteria.
+ * {@link NamingConvention} for SignalFx.
+ *
+ * See https://developers.signalfx.com/metrics/data_ingest_overview.html#_criteria_for_metric_and_dimension_names_and_values
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 public class SignalFxNamingConvention implements NamingConvention {
 
     private static final Pattern START_UNDERSCORE_PATTERN = Pattern.compile("^_");
     private static final Pattern SF_PATTERN = Pattern.compile("^sf_");
     private static final Pattern START_LETTERS_PATTERN = Pattern.compile("^[a-zA-Z].*");
+    private static final Pattern PATTERN_TAG_KEY_BLACKLISTED_CHARS = Pattern.compile("[^\\w_\\-]");
+    private static final Pattern PATTERN_TAG_KEY_BLACKLISTED_PREFIX = Pattern.compile("^(aws|gcp|azure)_.*");
 
     private static final int NAME_MAX_LENGTH = 256;
     private static final int TAG_VALUE_MAX_LENGTH = 256;
@@ -66,7 +71,9 @@ public class SignalFxNamingConvention implements NamingConvention {
         conventionKey = START_UNDERSCORE_PATTERN.matcher(conventionKey).replaceAll(""); // 2
         conventionKey = SF_PATTERN.matcher(conventionKey).replaceAll(""); // 2
 
-        if (!START_LETTERS_PATTERN.matcher(conventionKey).matches()) { // 3
+        conventionKey = PATTERN_TAG_KEY_BLACKLISTED_CHARS.matcher(conventionKey).replaceAll("_");
+        if (PATTERN_TAG_KEY_BLACKLISTED_PREFIX.matcher(conventionKey).matches()
+                || !START_LETTERS_PATTERN.matcher(conventionKey).matches()) { // 3
             conventionKey = "a" + conventionKey;
         }
         return StringUtils.truncate(conventionKey, KEY_MAX_LENGTH); // 1

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
@@ -19,6 +19,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link SignalFxNamingConvention}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class SignalFxNamingConventionTest {
     private SignalFxNamingConvention convention = new SignalFxNamingConvention();
 
@@ -28,6 +34,18 @@ class SignalFxNamingConventionTest {
         assertThat(convention.tagKey("sf_boo")).isEqualTo("boo");
 
         assertThat(convention.tagKey("123")).isEqualTo("a123");
+    }
+
+    @Test
+    void tagKeyWhenKeyHasBlacklistedCharShouldSanitize() {
+        assertThat(convention.tagKey("a.b")).isEqualTo("a_b");
+    }
+
+    @Test
+    void tagKeyWhenKeyStartsWithBlacklistedPrefixShouldSanitize() {
+        assertThat(convention.tagKey("aws_a")).isEqualTo("aaws_a");
+        assertThat(convention.tagKey("gcp_a")).isEqualTo("agcp_a");
+        assertThat(convention.tagKey("azure_a")).isEqualTo("aazure_a");
     }
 
 }

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
@@ -41,11 +41,4 @@ class SignalFxNamingConventionTest {
         assertThat(convention.tagKey("a.b")).isEqualTo("a_b");
     }
 
-    @Test
-    void tagKeyWhenKeyStartsWithBlacklistedPrefixShouldSanitize() {
-        assertThat(convention.tagKey("aws_a")).isEqualTo("aaws_a");
-        assertThat(convention.tagKey("gcp_a")).isEqualTo("agcp_a");
-        assertThat(convention.tagKey("azure_a")).isEqualTo("aazure_a");
-    }
-
 }


### PR DESCRIPTION
This PR applies missing sanitization for SignalFx tag keys.

Closes gh-1746