### PR TITLE
native-image.properties that adds the shaded artifact pcollections to initialize-at-build-time.

### DIFF
--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer.shaded.org.pcollections/pcollections/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer.shaded.org.pcollections/pcollections/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-build-time=io.micrometer.shaded.org.pcollections

--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer.shaded.org.pcollections/pcollections/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer.shaded.org.pcollections/pcollections/native-image.properties
@@ -1,1 +1,16 @@
+#
+# Copyright 2017 Pivotal Software, Inc.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 Args = --initialize-at-build-time=io.micrometer.shaded.org.pcollections


### PR DESCRIPTION
GraalVM's [native-image](https://www.graalvm.org/docs/reference-manual/native-image/) tool can create executable self-contained applications out of jar files by doing a lot of magic, like evaluating static initializers during the compilation, making a snapshot of the memory heap, etc. However sometimes some classes' initialization need to be deferred to run-time to pass the build. This PR adds the property file that is read by the native-image tool during the compilation and the arguments are appended to the build tool. It's harmless for the jar itself and will be ignored by all the other tools.

I know you are not owner of the `pcollections` artifact, however you are using the shading and changing its group id, hence the PR. I will be opening also the pr against the upstream repo soon.