### PR TITLE
Truncate tag values > 1024 for Stackdriver

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -86,6 +86,7 @@ import static java.util.stream.StreamSupport.stream;
  */
 @Incubating(since = "1.1.0")
 public class StackdriverMeterRegistry extends StepMeterRegistry {
+    
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("stackdriver-metrics-publisher");
 
     /**

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -354,13 +354,6 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
             String metricType = metricType(id, statistic);
 
             Map<String, String> metricLabels = getConventionTags(id).stream()
-                    // label value cannot be more than 1024 characters. See https://cloud.google.com/monitoring/quotas#custom_metrics_quotas
-                    .peek(tag -> {
-                        if (tag.getValue().length() >= 1024) {
-                            logger.warn("Filtered out tag {}, for metric {}, because its value exceeded the max length of 1024 characters", tag.getKey(), metricType);
-                        }
-                    })
-                    .filter(tag -> tag.getValue().length() < 1024)
                     .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
 
             return TimeSeries.newBuilder()

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
@@ -24,17 +24,19 @@ import io.micrometer.core.lang.Nullable;
 
 /**
  * {@link NamingConvention} for Stackdriver.
- *
+ * 
  * Names are mapped to Stackdriver's metric type names and tag keys are mapped to its metric label names.
  *
- * @see <a href="https://cloud.google.com/monitoring/api/v3/metrics-details">"Naming rules" section on Stackdriver's reference documentation</a>
- * and 
- * @see <a href="https://cloud.google.com/monitoring/quotas#custom_metrics_quotas">"Custom Metrics" on the Stackdriver's Quotas and limits reference documentation</a>
  *
+ * @see <a href="https://cloud.google.com/monitoring/api/v3/metrics-details">"Naming rules" section on Stackdriver's reference documentation</a>
+ * and
+ * @see <a href="https://cloud.google.com/monitoring/quotas#custom_metrics_quotas">"Custom Metrics" on the Stackdriver's Quotas and limits reference documentation</a>
+ * 
  * @author Jon Schneider
  * @since 1.1.0
  */
 public class StackdriverNamingConvention implements NamingConvention {
+
     private static final int MAX_NAME_LENGTH = 200;
     private static final int MAX_TAG_KEY_LENGTH = 100;
     private static final int MAX_TAG_VALUE_LENGTH = 1024;

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
@@ -15,12 +15,12 @@
  */
 package io.micrometer.stackdriver;
 
+import java.util.regex.Pattern;
+
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.lang.Nullable;
-
-import java.util.regex.Pattern;
 
 /**
  * {@link NamingConvention} for Stackdriver.
@@ -28,6 +28,8 @@ import java.util.regex.Pattern;
  * Names are mapped to Stackdriver's metric type names and tag keys are mapped to its metric label names.
  *
  * @see <a href="https://cloud.google.com/monitoring/api/v3/metrics-details">"Naming rules" section on Stackdriver's reference documentation</a>
+ * and 
+ * @see <a href="https://cloud.google.com/monitoring/quotas#custom_metrics_quotas">"Custom Metrics" on the Stackdriver's Quotas and limits reference documentation</a>
  *
  * @author Jon Schneider
  * @since 1.1.0
@@ -35,6 +37,7 @@ import java.util.regex.Pattern;
 public class StackdriverNamingConvention implements NamingConvention {
     private static final int MAX_NAME_LENGTH = 200;
     private static final int MAX_TAG_KEY_LENGTH = 100;
+    private static final int MAX_TAG_VALUE_LENGTH = 1024;
     private static final Pattern NAME_BLACKLIST = Pattern.compile("[^\\w./_]");
     private static final Pattern TAG_KEY_BLACKLIST = Pattern.compile("[^\\w_]");
     private final NamingConvention nameDelegate;
@@ -61,5 +64,10 @@ public class StackdriverNamingConvention implements NamingConvention {
     @Override
     public String tagKey(String key) {
         return sanitize(tagKeyDelegate.tagKey(key), TAG_KEY_BLACKLIST, MAX_TAG_KEY_LENGTH);
+    }
+
+    @Override
+    public String tagValue(final String value) {
+        return StringUtils.truncate(value, MAX_TAG_VALUE_LENGTH);
     }
 }


### PR DESCRIPTION
Spit up from original PR-1724

This PR is about truncating the tag value of Stackdriver metric when >1024 chars according the documenation here:  https://cloud.google.com/monitoring/quotas