### PR TITLE
Pin kafka-clients version to 2.3.1

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -83,7 +83,8 @@ dependencies {
 
     testCompile 'org.ehcache:ehcache:latest.release'
 
-    testCompile 'org.apache.kafka:kafka-clients:latest.release'
+    // Pin version temporarily to restore builds.
+    testCompile 'org.apache.kafka:kafka-clients:2.3.1'
 
     testCompile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0'
     testCompile 'com.github.tomakehurst:wiremock:latest.release'


### PR DESCRIPTION
`kafka-clients` 2.4.0 seems to be released recently, and it broke the builds on master. The client ID has been changed to include a group ID, which seems to be able to be fixed easily by changing the values in the tests. However, the clean-up logic doesn't seem to work somehow. It'd be better to pin its version to the previous version to restore builds before we figure out the cause.