### PR TITLE
Fix object name for query in Tomcat metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -227,7 +227,7 @@ public class TomcatMetrics implements MeterBinder {
     private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject, boolean hasName) {
         if (getJmxDomain() != null) {
             try {
-                String name = getJmxDomain() + ":" + key + "=" + value + (hasName ? ",name=*" : "");
+                String name = getJmxDomain() + ":" + key + "=" + value + (hasName ? ",name=*,*" : "");
                 Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(name), null);
                 if (!objectNames.isEmpty()) {
                     // MBean is present, so we can register metrics now.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -228,6 +228,7 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.threads.current").gauge().value()).isGreaterThan(0.0);
         assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);
+        assertThat(registry.get("tomcat.servlet.error").functionCounter().count()).isEqualTo(0.0);
     }
 
     private void checkMbeansAfterRequests(long expectedSentBytes) {
@@ -242,5 +243,6 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.threads.current").gauge().value()).isGreaterThan(0.0);
         assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);
+        assertThat(registry.get("tomcat.servlet.error").functionCounter().count()).isEqualTo(1.0);
     }
 }


### PR DESCRIPTION
This PR fixes object name for query in Tomcat metrics.

Closes gh-1754