### PR TITLE
Fix running condition for ProcessorMetricsTest.hotspotCpuMetrics()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -41,6 +41,11 @@ import static java.util.Objects.requireNonNull;
  *     <li>HotSpot</li>
  *     <li>J9</li>
  * </ul>
+ *
+ * @author Jon Schneider
+ * @author Michael Weirauch
+ * @author Clint Checketts
+ * @author Tommy Ludwig
  */
 @NonNullApi
 @NonNullFields

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -22,6 +22,15 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+/**
+ * Tests for {@link ProcessorMetrics}.
+ *
+ * @author Jon Schneider
+ * @author Michael Weirauch
+ * @author Clint Checketts
+ * @author Tommy Ludwig
+ * @author Johnny Lim
+ */
 class ProcessorMetricsTest {
     @Test
     void cpuMetrics() {
@@ -39,7 +48,7 @@ class ProcessorMetricsTest {
 
     @Test
     void hotspotCpuMetrics() {
-        assumeTrue(classExists("com.sun.management.OperatingSystemMXBean"));
+        assumeTrue(!isOpenJ9());
 
         MeterRegistry registry = new SimpleMeterRegistry();
         new ProcessorMetrics().bindTo(registry);
@@ -50,7 +59,7 @@ class ProcessorMetricsTest {
 
     @Test
     void openJ9CpuMetrics() {
-        assumeTrue(classExists("com.ibm.lang.management.OperatingSystemMXBean"));
+        assumeTrue(isOpenJ9());
 
         MeterRegistry registry = new SimpleMeterRegistry();
         new ProcessorMetrics().bindTo(registry);
@@ -64,6 +73,10 @@ class ProcessorMetricsTest {
          */
         registry.get("system.cpu.usage").gauge();
         registry.get("process.cpu.usage").gauge();
+    }
+
+    private boolean isOpenJ9() {
+        return classExists("com.ibm.lang.management.OperatingSystemMXBean");
     }
 
     private boolean classExists(String className) {


### PR DESCRIPTION
OpenJ9 has `com.sun.management.OperatingSystemMXBean`, and `com.ibm.lang.management.OperatingSystemMXBean` actually extends `com.sun.management.OperatingSystemMXBean` as follows:

```
public interface OperatingSystemMXBean extends com.sun.management.OperatingSystemMXBean {
```

I used the following version of OpenJ9:

```
% java -version
openjdk version "1.8.0_232"
OpenJDK Runtime Environment (build 1.8.0_232-b09)
Eclipse OpenJ9 VM (build openj9-0.17.0, JRE 1.8.0 Mac OS X amd64-64-Bit Compressed References 20191101_372 (JIT enabled, AOT enabled)
OpenJ9   - 77c1cf708
OMR      - 20db4fbc1
JCL      - 3504dff40aa based on jdk8u232-b09)
%
```

I'm not sure if it has been changed at some point, but the lookup order needs to be reversed to work with the latest version of OpenJ9.