### PR TITLE
Make functionTimerUnits() pass in OpenJ9

### DIFF
--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -33,10 +33,17 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Base class for {@link MeterRegistry} compatibility tests.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  */
 @ExtendWith(RegistryResolver.class)
 public abstract class MeterRegistryCompatibilityKit {
+
+    // Retain this as a member field to prevent it to be garbage-collected in OpenJ9.
+    private final Object o = new Object();
+
     public abstract MeterRegistry registry();
     public abstract Duration step();
 
@@ -112,10 +119,8 @@ public abstract class MeterRegistryCompatibilityKit {
     @Test
     @DisplayName("function timers respect the base unit of an underlying registry")
     void functionTimerUnits(MeterRegistry registry) {
-        Object o = new Object();
-
         registry.more().timer("function.timer", emptyList(),
-            o, o2 -> 1, o2 -> 1, TimeUnit.MILLISECONDS);
+            this.o, o2 -> 1, o2 -> 1, TimeUnit.MILLISECONDS);
 
         FunctionTimer ft = registry.get("function.timer").functionTimer();
         clock(registry).add(step());


### PR DESCRIPTION
This PR adds a dummy assertion to the end of `MeterRegistryCompatibilityKit.functionTimerUnits()` to make it pass in OpenJ9 as OpenJ9 garbage-collects it eagerly.