### PR TITLE
Add Javadoc since tag for Counted.extraTags

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -52,6 +52,7 @@ public @interface Counted {
      *
      * @return key-value pair of tags
      * @see io.micrometer.core.instrument.Counter.Builder#tags(String...)
+     * @since 1.4.0
      */
     String[] extraTags() default {};
 


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for `Counted.extraTags`.

See gh-1757