### PR TITLE
Add BaseUnits.MILLISECONDS

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
@@ -67,6 +67,11 @@ public final class BaseUnits {
      */
     public static final String SESSIONS = "sessions";
 
+    /**
+     * For milliseconds.
+     */
+    public static final String MILLISECONDS = "ms";
+
     private BaseUnits() {
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmCompilationMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmCompilationMetrics.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
@@ -53,7 +54,7 @@ public class JvmCompilationMetrics implements MeterBinder {
             FunctionCounter.builder("jvm.compilation.time", compilationBean, CompilationMXBean::getTotalCompilationTime)
                     .tags(Tags.concat(tags, "compiler", compilationBean.getName()))
                     .description("The approximate accumulated elapsed time spent in compilation")
-                    .baseUnit("ms")
+                    .baseUnit(BaseUnits.MILLISECONDS)
                     .register(registry);
         }
     }


### PR DESCRIPTION
This PR adds `BaseUnits.MILLISECONDS` and changes to use it in `JvmCompilationMetrics`.