### PR TITLE
Fix statistics disabled tests for HibernateMetrics

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -133,14 +133,14 @@ class HibernateMetricsTest {
     void deprecatedMonitorShouldNotExposeMetricsWhenStatsNotEnabled() {
         EntityManagerFactory entityManagerFactory = createMockEntityManagerFactory(false);
         HibernateMetrics.monitor(registry, entityManagerFactory, "entityManagerFactory");
-        assertThat(registry.find("hibernate.sessions.open").gauge()).isNull();
+        assertThat(registry.find("hibernate.sessions.open").functionCounter()).isNull();
     }
 
     @Test
     void monitorShouldNotExposeMetricsWhenStatsNotEnabled() {
-        SessionFactory sessionFactory = createMockSessionFactory(true);
+        SessionFactory sessionFactory = createMockSessionFactory(false);
         HibernateMetrics.monitor(registry, sessionFactory, "sessionFactory");
-        assertThat(registry.find("hibernate.sessions.open").gauge()).isNull();
+        assertThat(registry.find("hibernate.sessions.open").functionCounter()).isNull();
     }
 
 }


### PR DESCRIPTION
This PR fixes statistics disabled tests for `HibernateMetrics`.