### PR TITLE
Remove unused import statements

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/TimedHandlerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/TimedHandlerTest.java
@@ -24,12 +24,9 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.AsyncEvent;
@@ -46,9 +43,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests ported from https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java


### PR DESCRIPTION
This PR removes unused `import` statements to restore builds on master.