### PR TITLE
Fix flaky tests in HibernateMetricsTest due to GC

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.persistence.EntityManagerFactory;
@@ -39,7 +38,9 @@ import static org.mockito.Mockito.when;
  */
 class HibernateMetricsTest {
 
-    private MeterRegistry registry;
+    private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private final EntityManagerFactory entityManagerFactory = createMockEntityManagerFactory(true);
+    private final SessionFactory sessionFactory = createMockSessionFactory(true);
 
     private static EntityManagerFactory createMockEntityManagerFactory(boolean statsEnabled) {
         EntityManagerFactory emf = mock(EntityManagerFactory.class);
@@ -60,22 +61,15 @@ class HibernateMetricsTest {
         return sf;
     }
 
-    @BeforeEach
-    void setup() {
-        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
-    }
-
     @SuppressWarnings("deprecation")
     @Test
     void deprecatedMonitorShouldExposeMetricsWhenStatsEnabled() {
-        EntityManagerFactory entityManagerFactory = createMockEntityManagerFactory(true);
         HibernateMetrics.monitor(registry, entityManagerFactory, "entityManagerFactory");
         assertThatMonitorShouldExposeMetricsWhenStatsEnabled();
     }
 
     @Test
     void monitorShouldExposeMetricsWhenStatsEnabled() {
-        SessionFactory sessionFactory = createMockSessionFactory(true);
         HibernateMetrics.monitor(registry, sessionFactory, "sessionFactory");
         assertThatMonitorShouldExposeMetricsWhenStatsEnabled();
     }


### PR DESCRIPTION
This PR fixes some flaky tests in `HibernateMetricsTest` due to GC. It has been done in #1247 by changing them to be referenced by local variables, but it doesn't seem to be sufficient for OpenJ9.