### PR TITLE
Allow NaN for tomcat.threads.busy in tests

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -237,7 +237,7 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.global.request").functionTimer().totalTime(TimeUnit.MILLISECONDS)).isEqualTo(0.0);
         assertThat(registry.get("tomcat.global.request.max").timeGauge().value(TimeUnit.MILLISECONDS)).isEqualTo(0.0);
         assertThat(registry.get("tomcat.threads.config.max").gauge().value()).isGreaterThan(0.0);
-        assertThat(registry.get("tomcat.threads.busy").gauge().value()).isEqualTo(0.0);
+        assertThat(registry.get("tomcat.threads.busy").gauge().value()).isIn(Double.NaN, 0.0);
         assertThat(registry.get("tomcat.threads.current").gauge().value()).isGreaterThan(0.0);
         assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);


### PR DESCRIPTION
The initial value for `tomcat.threads.busy` seems to be 0 all the time in the 1.1.x branch which uses `org.apache.tomcat.embed:tomcat-embed-core:8.5.34`. However, it seems to be possible to be `Double.NaN` in the 1.3.x branch which uses `org.apache.tomcat.embed:tomcat-embed-core:8.5.46` due to the following exception:

```
javax.management.AttributeNotFoundException:  Cannot find attribute currentThreadsBusy for org.apache.tomcat.util.net.SocketProperties@198d6542
	at org.apache.tomcat.util.modeler.ManagedBean.getGetter(ManagedBean.java:435)
	at org.apache.tomcat.util.modeler.BaseModelMBean.getAttribute(BaseModelMBean.java:167)
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.getAttribute(DefaultMBeanServerInterceptor.java:647)
	at com.sun.jmx.mbeanserver.JmxMBeanServer.getAttribute(JmxMBeanServer.java:678)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetrics.lambda$null$2(TomcatMetrics.java:140)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetrics.safeDouble(TomcatMetrics.java:313)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetrics.lambda$null$3(TomcatMetrics.java:140)
	at io.micrometer.core.instrument.internal.DefaultGauge.value(DefaultGauge.java:54)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest.checkMbeansInitialState(TomcatMetricsTest.java:251)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest.lambda$mbeansAvailableBeforeBinder$3(TomcatMetricsTest.java:201)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest.runTomcat(TomcatMetricsTest.java:234)
	at io.micrometer.core.instrument.binder.tomcat.TomcatMetricsTest.mbeansAvailableBeforeBinder(TomcatMetricsTest.java:190)
...
```

This PR changes to allow it to be `Double.NaN` in addition to 0.