### PR TITLE
Add support for Stackdriver resource labels

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
@@ -18,6 +18,9 @@ package io.micrometer.stackdriver;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * {@link StepRegistryConfig} for Stackdriver.
  *
@@ -41,5 +44,9 @@ public interface StackdriverConfig extends StepRegistryConfig {
     default String resourceType() {
         String resourceType = get(prefix() + ".resourceType");
         return resourceType == null ? "global" : resourceType;
+    }
+
+    default Map<String, String> resourceLabels() {
+        return Collections.emptyMap();
     }
 }

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -339,6 +339,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
                     .setResource(MonitoredResource.newBuilder()
                             .setType(config.resourceType())
                             .putLabels("project_id", config.projectId())
+                            .putAllLabels(config.resourceLabels())
                             .build())
                     .setMetricKind(MetricDescriptor.MetricKind.GAUGE) // https://cloud.google.com/monitoring/api/v3/metrics-details#metric-kinds
                     .setValueType(valueType)


### PR DESCRIPTION
Add support for defining arbitrary resource labels to the monitored
resource when configuring creating a time series.

Stackdriver enables associating metrics with different "monitored
resources", such as `k8s_container`. Monitored resources can specify
certain required "resource labels" (distinct from metric labels), such
as `pod_name` for `k8s_container`. Any metric submitted to that resource
type without all of the required resource labels will be rejected. By
enabling arbitrary resource labels to be defined in StackdriverConfig,
we'll enable more flexible integration with Stackdriver.