### PR TITLE
Removes pcollections from statsd implementations

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -6,7 +6,6 @@ dependencies {
     compile project(':micrometer-core')
     compile 'io.projectreactor:reactor-core:3.2.12.RELEASE'
     compile 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
-    compile 'org.pcollections:pcollections:latest.release'
 
     testCompile project(':micrometer-test')
     testCompile 'io.projectreactor:reactor-test:latest.release'
@@ -20,13 +19,11 @@ shadowJar {
         include(dependency('io.projectreactor.netty:'))
         include(dependency('org.reactivestreams:reactive-streams'))
         include(dependency('io.netty:'))
-        include(dependency('org.pcollections:'))
     }
     relocate 'reactor', 'io.micrometer.shaded.reactor'
     relocate 'org.reactivestreams', 'io.micrometer.shaded.org.reactorstreams'
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
     exclude 'META-INF/native/libnetty_transport_native_epoll_x86_64.so'
-    relocate 'org.pcollections', 'io.micrometer.shaded.statsd.org.pcollections'
 }
 
 jar.enabled = false
@@ -40,7 +37,7 @@ publishing {
                         .dependencies
                         .dependency
                         .findAll {
-                    ['reactor-core', 'reactor-netty', 'pcollections'].contains(it.artifactId.text())
+                    ['reactor-core', 'reactor-netty'].contains(it.artifactId.text())
                 }
                 .each { it.parent().remove(it) }
             }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
@@ -20,14 +20,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.lang.Nullable;
-import org.pcollections.HashTreePMap;
-import org.pcollections.PMap;
-
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
-    private final Object tagsLock = new Object();
+    private final Object conventionTagsLock = new Object();
     @SuppressWarnings({"NullableProblems", "unused"})
     private volatile NamingConvention namingConvention;
     @SuppressWarnings("NullableProblems")
@@ -36,7 +35,7 @@ public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private volatile String conventionTags;
     @SuppressWarnings("NullableProblems")
     private volatile String tagsNoStat;
-    private volatile PMap<Statistic, String> tags = HashTreePMap.empty();
+    private final ConcurrentMap<Statistic, String> tags = new ConcurrentHashMap<>();
 
     private static final Pattern NAME_WHITELIST = Pattern.compile("[^\\w._]");
 
@@ -55,12 +54,14 @@ public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
         if (this.namingConvention != next) {
             this.namingConvention = next;
             this.name = sanitize(next.name(id.getName(), id.getType(), id.getBaseUnit()));
-            this.tags = HashTreePMap.empty();
-            this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
-                    id.getConventionTags(this.namingConvention).stream()
-                            .map(t -> sanitize(t.getKey()) + "=" + sanitize(t.getValue()))
-                            .collect(Collectors.joining(","))
-                    : null;
+            synchronized (conventionTagsLock) {
+                this.tags.clear();
+                this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
+                        id.getConventionTags(this.namingConvention).stream()
+                                .map(t -> sanitize(t.getKey()) + "=" + sanitize(t.getValue()))
+                                .collect(Collectors.joining(","))
+                        : null;
+            }
             this.tagsNoStat = tags(null, conventionTags, "=", "#");
         }
     }
@@ -70,23 +71,12 @@ public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
     }
 
     private String tagsByStatistic(@Nullable Statistic stat) {
-        if (stat == null) {
-            return tagsNoStat;
-        }
+        return stat == null ? tagsNoStat : tags.computeIfAbsent(stat, this::sysdigTag);
+    }
 
-        String tagString = tags.get(stat);
-        if (tagString != null)
-            return tagString;
-
-        synchronized (tagsLock) {
-            tagString = tags.get(stat);
-            if (tagString != null) {
-                return tagString;
-            }
-
-            tagString = tags(stat, conventionTags, "=", "#");
-            tags = tags.plus(stat, tagString);
-            return tagString;
+    private String sysdigTag(@Nullable Statistic stat) {
+        synchronized (conventionTagsLock) {
+            return tags(stat, conventionTags, "=", "#");
         }
     }
 }


### PR DESCRIPTION
This continues from #1794 and completes removing pcollections and its
MIT license attribution concerns, from the build.

This approach is to use `ConcurrentMap.computeIfAbsent` instead of the
former pcollections types. A side effect of this is more readable code.

Fixes #1785