### PR TITLE
Fix execution of ./gradlew :micrometer-benchmarks-core:jmh

### DIFF
--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -16,4 +16,6 @@ jmh {
     fork = 1
     warmupIterations = 1
     iterations = 1
+    duplicateClassesStrategy = 'exclude'
+    zip64 = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath 'org.ow2.asm:asm:5.0.3'
         classpath 'io.spring.gradle:spring-release-plugin:0.20.1'
         classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.2.0'
-        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:3.4.0'
     }
 


### PR DESCRIPTION
Main fix is to bump the `gradle-jmh-plugin` version (0.4.8 doesn't support Gradle 5.5+).  After that, found the need to exclude duplicates (due to java 9 dependencies, servlet) and enable big zips.