### PR TITLE
Adds NOTICE file for copy/paste/modified code

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,26 @@
+Micrometer
+
+Copyright 2017-2020 Pivotal Software, Inc.
+
+-------------------------------------------------------------------------------
+
+This product contains a modified portion of 'io.netty.util.internal.logging',
+in the Netty/Common library distributed by The Netty Project:
+
+  * Copyright 2013 The Netty Project
+  * License: Apache License v2.0
+  * Homepage: https://netty.io
+
+This product contains a modified portion of 'StringUtils.isBlank()',
+in the Commons Lang library distributed by The Apache Software Foundation:
+
+  * Copyright 2001-2019 The Apache Software Foundation
+  * License: Apache License v2.0
+  * Homepage: https://commons.apache.org/proper/commons-lang/
+
+This product contains a modified portion of 'JsonUtf8Writer',
+in the Moshi library distributed by Square, Inc:
+
+  * Copyright 2010 Google Inc.
+  * License: Apache License v2.0
+  * Homepage: https://github.com/square/moshi


### PR DESCRIPTION
This adds NOTICE citations for copyright declarations from the headers of ASL 2.0 licensed source fragments copied into this project, which were later modified.

See https://www.apache.org/dev/licensing-howto.html#mod-notice

Fixes #1786