### PR TITLE
Add pcollections copyright and license to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,32 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+OTHER LICENSED CODE:
+
+The micrometer-core and micrometer-registry-statsd modules package a
+modified copy of the pcollections library, licensed under the MIT license.
+---------------------------------------------------------------------------
+MIT License
+
+Copyright 2008 Harold Cooper
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+---------------------------------------------------------------------------


### PR DESCRIPTION
While #1794 and #1794 replaced our usage of pcollections for the upcoming 1.4.0 release, maintenance branches still use it, so we need to include the MIT license from pcollections. This will be added for the `1.1.x` and `1.3.x` branches but not for the `master` branch where it does not apply.

See #1785

---

We shade the pcollections classes under a different group ID at build time for us in the micrometer-core and micrometer-registry-statsd modules. Since its license is not the Apache v2 license, its license and copyright should be mentioned in the LICENSE file.

---

This follows the instructions in [Apache's licensing how-to for permissively-licensed dependencies](https://www.apache.org/dev/licensing-howto.html#permissive-deps) opting to copy the short MIT license in-line rather than use a "pointer".