### PR TITLE
Upgrade the build to JDK 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:13.0
     steps:
 
       - checkout


### PR DESCRIPTION
This uses the new CircleCI convenience images for OpenJDK which are in public beta.

See https://github.com/CircleCI-Public/cimg-openjdk

Resolves #1809