### PR TITLE
Use java-platform to configure platform instead of spring dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,21 +74,21 @@ subprojects {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true
         }
+    }
 
-        plugins.withId('maven-publish') {
-            publishing {
-                publications {
-                    nebula(MavenPublication) {
-                        // Nebula converts dynamic versions to static ones so it's ok.
-                        suppressPomMetadataWarningsFor('apiElements')
-                    }
+    plugins.withId('maven-publish') {
+        publishing {
+            publications {
+                nebula(MavenPublication) {
+                    // Nebula converts dynamic versions to static ones so it's ok.
+                    suppressPomMetadataWarningsFor('apiElements')
                 }
             }
+        }
 
-            // Nebula doesn't interface with Gradle's module format so just disable it for now.
-            tasks.withType(GenerateModuleMetadata) {
-                enabled = false
-            }
+        // Nebula doesn't interface with Gradle's module format so just disable it for now.
+        tasks.withType(GenerateModuleMetadata) {
+            enabled = false
         }
     }
 

--- a/micrometer-bom/build.gradle
+++ b/micrometer-bom/build.gradle
@@ -1,18 +1,17 @@
 plugins {
     id 'java-platform'
-    id 'io.spring.dependency-management' version '1.0.8.RELEASE'
 }
 
 description 'Micrometer BOM (Bill of Materials) for managing Micrometer artifact versions'
 
-dependencyManagement {
-    dependencies {
+dependencies {
+    constraints {
         rootProject.subprojects.findAll {
             !it.name.contains('sample') &&
                     !it.name.contains('benchmark') &&
                     !it.name.contains('micrometer-bom')
         }.each {
-            dependency(group: it.group,
+            api(group: it.group,
                     name: it.name,
                     version: it.version.toString())
         }


### PR DESCRIPTION
I noticed that spring dependencies plugin is being used to define a `java-platform`, even though `java-platform` comes with syntax to do it natively. So switched to native syntax.

Also fixed a bug from #1801 where the `maven-publish` configuration needs to be outside `if(project != 'micrometer-bom')` because the bom is also published. Currently, if it were published Gradle 6+ users would have a problem since the generated Gradle metadata does not interface with nebula and has no entries.

For reference: https://docs.gradle.org/current/userguide/java_platform_plugin.html