### PR TITLE
Use modern Gradle features for declaring classpath dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     }
     dependencies {
         classpath 'io.spring.gradle:spring-release-plugin:0.20.1'
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:3.2.0'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:3.4.0'
 
@@ -37,8 +36,27 @@ allprojects {
 
 subprojects {
     if (project.name != 'micrometer-bom') {
-        apply plugin: 'java'
+        apply plugin: 'java-library'
         apply plugin: 'checkstyle'
+
+        java {
+            // It is more idiomatic to define different features for different sets of optional
+            // dependencies, e.g., 'dropwizard' and 'reactor'. If this library published Gradle
+            // metadata, Gradle users would be able to use these feature names in their dependency
+            // declarations instead of understanding the actual required optional dependencies.
+            // But we don't publish Gradle metadata yet and this may be overkill so just have a
+            // single feature for now to correspond to any optional dependency.
+            registerFeature('optional') {
+                usingSourceSet(sourceSets.main)
+            }
+        }
+
+        // All projects use optional annotations, but since we don't expose them downstream we would
+        // have to add the dependency in every project, which is tedious so just do it here.
+        dependencies {
+            // JSR-305 only used for non-required meta-annotations
+            optionalApi "com.google.code.findbugs:jsr305:latest.release"
+        }
 
         tasks {
             compileJava {
@@ -81,7 +99,7 @@ subprojects {
             publications {
                 nebula(MavenPublication) {
                     // Nebula converts dynamic versions to static ones so it's ok.
-                    suppressPomMetadataWarningsFor('apiElements')
+                    suppressAllPomMetadataWarnings()
                 }
             }
         }

--- a/implementations/micrometer-registry-appoptics/build.gradle
+++ b/implementations/micrometer-registry-appoptics/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-atlas/build.gradle
+++ b/implementations/micrometer-registry-atlas/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'com.netflix.spectator:spectator-reg-atlas:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.netflix.spectator:spectator-reg-atlas:latest.release'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-azure-monitor/build.gradle
+++ b/implementations/micrometer-registry-azure-monitor/build.gradle
@@ -1,9 +1,10 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'com.microsoft.azure:applicationinsights-core:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.microsoft.azure:applicationinsights-core:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
     // required by jdk 9+
-    testRuntimeClasspath 'javax.xml.bind:jaxb-api:2.3.+'
+    testRuntimeOnly 'javax.xml.bind:jaxb-api:2.3.+'
 }

--- a/implementations/micrometer-registry-cloudwatch/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.amazonaws:aws-java-sdk-cloudwatch:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-cloudwatch2/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch2/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'software.amazon.awssdk:cloudwatch:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'software.amazon.awssdk:cloudwatch:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-datadog/build.gradle
+++ b/implementations/micrometer-registry-datadog/build.gradle
@@ -1,9 +1,8 @@
-apply plugin: 'nebula.optional-base'
-
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'org.apache.commons:commons-text:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'org.apache.commons:commons-text:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-dynatrace/build.gradle
+++ b/implementations/micrometer-registry-dynatrace/build.gradle
@@ -1,10 +1,9 @@
-apply plugin: 'nebula.optional-base'
-
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'org.apache.commons:commons-text:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
-    testCompile 'com.fasterxml.jackson.core:jackson-databind:latest.release'
+    api 'org.apache.commons:commons-text:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:latest.release'
 }

--- a/implementations/micrometer-registry-elastic/build.gradle
+++ b/implementations/micrometer-registry-elastic/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-ganglia/build.gradle
+++ b/implementations/micrometer-registry-ganglia/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'info.ganglia.gmetric4j:gmetric4j:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'info.ganglia.gmetric4j:gmetric4j:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    // Deprecated constructor references this which is otherwise unused.
+    compileOnly 'io.dropwizard.metrics:metrics-core:4.0.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-graphite/build.gradle
+++ b/implementations/micrometer-registry-graphite/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-graphite:4.1.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
-    testCompile 'io.projectreactor.netty:reactor-netty:latest.release'
+    api 'io.dropwizard.metrics:metrics-graphite:4.1.+'
+
+    testImplementation project(':micrometer-test')
+    testImplementation 'io.projectreactor.netty:reactor-netty:latest.release'
 }

--- a/implementations/micrometer-registry-humio/build.gradle
+++ b/implementations/micrometer-registry-humio/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-influx/build.gradle
+++ b/implementations/micrometer-registry-influx/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-jmx/build.gradle
+++ b/implementations/micrometer-registry-jmx/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'io.dropwizard.metrics:metrics-jmx:4.0.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'io.dropwizard.metrics:metrics-jmx:4.0.+'
+
+    testImplementation project(':micrometer-test')
+    testImplementation 'ch.qos.logback:logback-classic:1.2.+'
 }

--- a/implementations/micrometer-registry-kairos/build.gradle
+++ b/implementations/micrometer-registry-kairos/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-new-relic/build.gradle
+++ b/implementations/micrometer-registry-new-relic/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-prometheus/build.gradle
+++ b/implementations/micrometer-registry-prometheus/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'io.prometheus:simpleclient_common:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'io.prometheus:simpleclient_common:latest.release'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-signalfx/build.gradle
+++ b/implementations/micrometer-registry-signalfx/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'com.signalfx.public:signalfx-java:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.signalfx.public:signalfx-java:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-stackdriver/build.gradle
+++ b/implementations/micrometer-registry-stackdriver/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'com.google.cloud:google-cloud-monitoring:latest.release'
-    compile 'org.slf4j:slf4j-api:1.7.+'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.google.cloud:google-cloud-monitoring:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+    implementation 'ch.qos.logback:logback-classic:1.2.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -3,12 +3,14 @@ plugins {
 }
 
 dependencies {
-    compile project(':micrometer-core')
-    compile 'io.projectreactor:reactor-core:3.2.12.RELEASE'
-    compile 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
-    testCompile 'io.projectreactor:reactor-test:latest.release'
+    implementation 'io.projectreactor:reactor-core:3.2.12.RELEASE'
+    implementation 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
+
+    testImplementation project(':micrometer-test')
+    testImplementation 'io.projectreactor:reactor-test:latest.release'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.+'
 }
 
 shadowJar {

--- a/implementations/micrometer-registry-wavefront/build.gradle
+++ b/implementations/micrometer-registry-wavefront/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.slf4j:slf4j-api:1.7.+'
-    compile 'com.wavefront:wavefront-sdk-java:latest.release'
+    api project(':micrometer-core')
 
-    testCompile project(':micrometer-test')
+    api 'com.wavefront:wavefront-sdk-java:latest.release'
+    implementation 'org.slf4j:slf4j-api:1.7.+'
+
+    testImplementation project(':micrometer-test')
 }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -1,98 +1,93 @@
 plugins {
     id 'idea'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
-apply plugin: 'nebula.optional-base'
-
 dependencies {
-    // JSR-305 only used for non-required meta-annotations
-    compile "com.google.code.findbugs:jsr305:latest.release", optional
-
-    compile 'org.hdrhistogram:HdrHistogram:latest.release'
-    compile('org.latencyutils:LatencyUtils:latest.release') {
+    // TODO(anuraaga): HdrHistogram is exposed in the micrometer API but probably shouldn't be
+    api 'org.hdrhistogram:HdrHistogram:latest.release'
+    implementation('org.latencyutils:LatencyUtils:latest.release') {
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
     }
 
     // instrumentation options
-    compile 'io.dropwizard.metrics:metrics-core:4.0.+', optional
+    optionalApi 'io.dropwizard.metrics:metrics-core:4.0.+'
 
     // cache monitoring
-    compile 'com.google.guava:guava:latest.release', optional
-    compile 'com.github.ben-manes.caffeine:caffeine:latest.release', optional
-    compile 'net.sf.ehcache:ehcache:latest.release', optional
-    compile 'javax.cache:cache-api:latest.release', optional
-    compile 'com.hazelcast:hazelcast:3.+', optional
-    compile 'org.hibernate:hibernate-entitymanager:latest.release', optional
+    optionalApi 'com.google.guava:guava:latest.release'
+    optionalApi 'com.github.ben-manes.caffeine:caffeine:latest.release'
+    optionalApi 'net.sf.ehcache:ehcache:latest.release'
+    optionalApi 'javax.cache:cache-api:latest.release'
+    optionalApi 'com.hazelcast:hazelcast:3.+'
+    optionalApi 'org.hibernate:hibernate-entitymanager:latest.release'
 
     // server runtime monitoring
-    compile 'org.eclipse.jetty:jetty-server:9.+', optional
-    compile 'org.apache.tomcat.embed:tomcat-embed-core:8.+', optional
+    optionalApi 'org.eclipse.jetty:jetty-server:9.+'
+    optionalApi 'org.apache.tomcat.embed:tomcat-embed-core:8.+'
 
     // apache httpcomponents monitoring
-    compile 'org.apache.httpcomponents:httpclient:4.5.6', optional
-    compile 'org.apache.httpcomponents:httpasyncclient:4.1.4', optional
+    optionalApi 'org.apache.httpcomponents:httpclient:4.5.6'
+    optionalApi 'org.apache.httpcomponents:httpasyncclient:4.1.4'
 
     // hystrix monitoring
     // metrics are better with https://github.com/Netflix/Hystrix/pull/1568 introduced
     // in hystrix 1.5.12, but Netflix re-released 1.5.11 as 1.5.18 late in 2018.
     // <=1.5.11 or 1.5.18 doesn't break with Micrometer, but open metrics won't be correct necessarily.
-    compile 'com.netflix.hystrix:hystrix-core:1.5.12', optional
+    optionalApi 'com.netflix.hystrix:hystrix-core:1.5.12'
 
     // log monitoring
-    compile 'ch.qos.logback:logback-classic:1.2.+', optional
-    compile 'org.apache.logging.log4j:log4j-core:2.+', optional
+    optionalApi 'ch.qos.logback:logback-classic:1.2.+'
+    optionalApi 'org.apache.logging.log4j:log4j-core:2.+'
 
     // reactor
-    compile 'io.projectreactor:reactor-core:3.2.12.RELEASE', optional
-    compile 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE', optional
+    optionalApi 'io.projectreactor:reactor-core:3.2.12.RELEASE'
+    optionalApi 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
 
     // @Timed AOP
-    compile 'org.aspectj:aspectjweaver:1.8.+', optional
+    optionalApi 'org.aspectj:aspectjweaver:1.8.+'
 
-    compile 'com.squareup.okhttp3:okhttp:latest.release', optional
+    optionalApi 'com.squareup.okhttp3:okhttp:latest.release'
 
-    compile 'org.mongodb:mongo-java-driver:latest.release', optional
+    optionalApi 'org.mongodb:mongo-java-driver:latest.release'
 
-    compile 'org.jooq:jooq:latest.release', optional
+    optionalApi 'org.jooq:jooq:latest.release'
 
-    testCompile 'io.projectreactor:reactor-test:latest.release'
+    testImplementation 'io.projectreactor:reactor-test:latest.release'
 
     // JUnit 5
     testImplementation 'org.junit.jupiter:junit-jupiter:latest.release'
 
     // Eclipse still needs this (as of 4.7.1a)
-    testRuntime 'org.junit.platform:junit-platform-launcher:latest.release'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:latest.release'
 
-    testCompile 'org.mockito:mockito-core:latest.release'
+    testImplementation 'org.mockito:mockito-core:latest.release'
 
-    testCompile 'org.hsqldb:hsqldb:latest.release'
+    testImplementation 'org.hsqldb:hsqldb:latest.release'
 
-    testCompile 'org.eclipse.jetty:jetty-client:9.+', optional
+    testImplementation 'org.eclipse.jetty:jetty-client:9.+'
 
     // dependency injection tests
-    testCompile 'javax.inject:javax.inject:1'
-    testCompile 'org.springframework:spring-context:4.+'
-    testCompile 'org.springframework:spring-test:4.+'
-    testCompile 'com.google.inject:guice:4.1.0'
+    testImplementation 'javax.inject:javax.inject:1'
+    testImplementation 'org.springframework:spring-context:4.+'
+    testImplementation 'org.springframework:spring-test:4.+'
+    testImplementation 'com.google.inject:guice:4.1.0'
 
-    testCompile 'com.h2database:h2:latest.release'
+    testImplementation 'com.h2database:h2:latest.release'
 
     // Uncomment these if you are interested in testing injection with dagger in MeterRegistryInjectionTest
-//    testCompile 'com.google.dagger:dagger:2.11'
+//    testImplementation 'com.google.dagger:dagger:2.11'
 //    testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.11'
 
-    testCompile 'org.assertj:assertj-core:latest.release'
+    testImplementation 'org.assertj:assertj-core:latest.release'
 
-    testCompile 'org.ehcache:ehcache:latest.release'
+    testImplementation 'org.ehcache:ehcache:latest.release'
 
     // Pin version temporarily to restore builds.
-    testCompile 'org.apache.kafka:kafka-clients:2.3.1'
+    testImplementation 'org.apache.kafka:kafka-clients:2.3.1'
 
-    testCompile 'ru.lanwen.wiremock:wiremock-junit5:1.2.0', {
+    testImplementation 'ru.lanwen.wiremock:wiremock-junit5:1.2.0', {
         exclude group: 'com.github.tomakehurst', module: 'wiremock'
     }
-    testCompile 'com.github.tomakehurst:wiremock-jre8:latest.release'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:latest.release'
 
-    testCompile 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:latest.release'
+    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo:latest.release'
 }

--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -1,19 +1,18 @@
-apply plugin: 'nebula.optional-base'
-
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.glassfish.jersey.core:jersey-server:2.+', optional
-    runtime 'org.glassfish.jersey.inject:jersey-hk2:2.+'
+    api project(':micrometer-core')
 
-    testCompile 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+'
+    compileOnly 'org.glassfish.jersey.core:jersey-server:2.+'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:2.+'
+
+    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+'
 
     // required by jdk 9
-    testRuntime 'javax.xml.bind:jaxb-api:2.3.+'
+    testRuntimeOnly 'javax.xml.bind:jaxb-api:2.3.+'
 
-    testCompile 'org.assertj:assertj-core:3.+'
+    testImplementation 'org.assertj:assertj-core:3.+'
 
     // JERSEY-3662
     testImplementation 'junit:junit:4.12'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:latest.release'
-    testCompile 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.mockito:mockito-core:2.+'
 }

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -1,14 +1,25 @@
 dependencies {
-    compile project(':micrometer-core')
-    compile 'org.assertj:assertj-core:latest.release'
+    api project(':micrometer-core')
 
-    compile 'org.junit.jupiter:junit-jupiter:latest.release'
+    api 'org.assertj:assertj-core:latest.release'
 
-    compile 'ru.lanwen.wiremock:wiremock-junit5:latest.release', {
+    api 'org.junit.jupiter:junit-jupiter:latest.release'
+
+    api 'ru.lanwen.wiremock:wiremock-junit5:latest.release', {
         exclude group: 'com.github.tomakehurst', module: 'wiremock'
     }
-    compile 'com.github.tomakehurst:wiremock-jre8:latest.release'
-    compile 'org.mockito:mockito-core:latest.release'
+    api 'com.github.tomakehurst:wiremock-jre8:latest.release'
+    api 'org.mockito:mockito-core:latest.release'
 
-    testCompile 'org.jsr107.ri:cache-ri-impl:1.0.0'
+    testImplementation 'org.jsr107.ri:cache-ri-impl:1.0.0'
+
+    // We have tests for the many features that are optional dependencies, so add
+    // them here just like a user would need to.
+    testImplementation 'com.google.guava:guava:latest.release'
+    testImplementation 'com.github.ben-manes.caffeine:caffeine:latest.release'
+    testImplementation 'net.sf.ehcache:ehcache:latest.release'
+    testImplementation 'javax.cache:cache-api:latest.release'
+    testImplementation 'com.hazelcast:hazelcast:3.+'
+    testImplementation 'com.squareup.okhttp3:okhttp:latest.release'
+    testImplementation 'io.projectreactor.netty:reactor-netty:0.8.6.RELEASE'
 }


### PR DESCRIPTION
The biggest change is switching from `java` plugin, meant for applications, to `java-library` plugin, meant for libraries.

https://docs.gradle.org/current/userguide/java_library_plugin.html

The `java-library` plugin gives two configurations to replace `compile` - `api` and `implementation`. Dependencies declared in `api` are required by consumers to compile their code, which is needed when dependencies are exposed in the library's API. `implementation` are only required by consumers to run their code. These map to the Maven scopes `compile` and `runtime` and allow consumer builds to be a bit faster with less leakage of dependencies into the compile classpath.

For example, `micrometer-registry-azure-monitor` pom.xml

Before:
```
<dependencies>
    <dependency>
      <groupId>io.micrometer</groupId>
      <artifactId>micrometer-core</artifactId>
      <version>1.3.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.microsoft.azure</groupId>
      <artifactId>applicationinsights-core</artifactId>
      <version>2.5.0</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.28</version>
      <scope>compile</scope>
    </dependency>
  </dependencies>
```

After:
```
<dependencies>
    <dependency>
      <groupId>io.micrometer</groupId>
      <artifactId>micrometer-core</artifactId>
      <version>1.4.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.microsoft.azure</groupId>
      <artifactId>applicationinsights-core</artifactId>
      <version>2.6.0-BETA.2</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.30</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```

Notice, slf4j which is not exposed in the API (only a static field in the class) has `runtime` scope now instead of `compile`.

In addition, I've switched from nebula's `optional-base` plugin to using Gradle's native `registerFeature` for declaring optional dependencies.

`micrometer-core` pom.xml

Before
```
<dependencies>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.hdrhistogram</groupId>
      <artifactId>HdrHistogram</artifactId>
      <version>2.1.11</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.latencyutils</groupId>
      <artifactId>LatencyUtils</artifactId>
      <version>2.0.3</version>
      <scope>compile</scope>
      <exclusions>
        <exclusion>
          <artifactId>HdrHistogram</artifactId>
          <groupId>org.hdrhistogram</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>io.dropwizard.metrics</groupId>
      <artifactId>metrics-core</artifactId>
      <version>4.0.6</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>28.1-jre</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.github.ben-manes.caffeine</groupId>
      <artifactId>caffeine</artifactId>
      <version>2.8.0</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>net.sf.ehcache</groupId>
      <artifactId>ehcache</artifactId>
      <version>2.10.6</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>javax.cache</groupId>
      <artifactId>cache-api</artifactId>
      <version>1.1.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.hazelcast</groupId>
      <artifactId>hazelcast</artifactId>
      <version>3.12.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.hibernate</groupId>
      <artifactId>hibernate-entitymanager</artifactId>
      <version>5.4.6.Final</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.jetty</groupId>
      <artifactId>jetty-server</artifactId>
      <version>9.2.28.v20190418</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.tomcat.embed</groupId>
      <artifactId>tomcat-embed-core</artifactId>
      <version>8.5.46</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpclient</artifactId>
      <version>4.5.6</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.netflix.hystrix</groupId>
      <artifactId>hystrix-core</artifactId>
      <version>1.5.12</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>ch.qos.logback</groupId>
      <artifactId>logback-classic</artifactId>
      <version>1.2.3</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.logging.log4j</groupId>
      <artifactId>log4j-core</artifactId>
      <version>2.12.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>io.projectreactor</groupId>
      <artifactId>reactor-core</artifactId>
      <version>3.2.12.RELEASE</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>io.projectreactor.netty</groupId>
      <artifactId>reactor-netty</artifactId>
      <version>0.8.6.RELEASE</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.aspectj</groupId>
      <artifactId>aspectjweaver</artifactId>
      <version>1.8.14</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.squareup.okhttp3</groupId>
      <artifactId>okhttp</artifactId>
      <version>3.14.4</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.mongodb</groupId>
      <artifactId>mongo-java-driver</artifactId>
      <version>3.11.0</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
  </dependencies>
```

After:
```
<dependencies>
    <dependency>
      <groupId>org.hdrhistogram</groupId>
      <artifactId>HdrHistogram</artifactId>
      <version>2.1.12</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.latencyutils</groupId>
      <artifactId>LatencyUtils</artifactId>
      <version>2.0.3</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>HdrHistogram</artifactId>
          <groupId>org.hdrhistogram</groupId>
        </exclusion>
      </exclusions>
    </dependency>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>io.dropwizard.metrics</groupId>
      <artifactId>metrics-core</artifactId>
      <version>4.0.7</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>28.2-jre</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.github.ben-manes.caffeine</groupId>
      <artifactId>caffeine</artifactId>
      <version>2.8.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>net.sf.ehcache</groupId>
      <artifactId>ehcache</artifactId>
      <version>2.10.6</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>javax.cache</groupId>
      <artifactId>cache-api</artifactId>
      <version>1.1.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.hazelcast</groupId>
      <artifactId>hazelcast</artifactId>
      <version>3.12.5</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.hibernate</groupId>
      <artifactId>hibernate-entitymanager</artifactId>
      <version>6.0.0.Alpha4</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.eclipse.jetty</groupId>
      <artifactId>jetty-server</artifactId>
      <version>9.4.26.v20200117</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.tomcat.embed</groupId>
      <artifactId>tomcat-embed-core</artifactId>
      <version>8.5.50</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpclient</artifactId>
      <version>4.5.6</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.httpcomponents</groupId>
      <artifactId>httpasyncclient</artifactId>
      <version>4.1.4</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.netflix.hystrix</groupId>
      <artifactId>hystrix-core</artifactId>
      <version>1.5.12</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>ch.qos.logback</groupId>
      <artifactId>logback-classic</artifactId>
      <version>1.2.3</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.apache.logging.log4j</groupId>
      <artifactId>log4j-core</artifactId>
      <version>2.13.0</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>io.projectreactor</groupId>
      <artifactId>reactor-core</artifactId>
      <version>3.2.12.RELEASE</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>io.projectreactor.netty</groupId>
      <artifactId>reactor-netty</artifactId>
      <version>0.8.6.RELEASE</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.aspectj</groupId>
      <artifactId>aspectjweaver</artifactId>
      <version>1.8.14</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>com.squareup.okhttp3</groupId>
      <artifactId>okhttp</artifactId>
      <version>4.3.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.mongodb</groupId>
      <artifactId>mongo-java-driver</artifactId>
      <version>3.12.1</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
    <dependency>
      <groupId>org.jooq</groupId>
      <artifactId>jooq</artifactId>
      <version>3.12.3</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
  </dependencies>
```

Basically the same (except LatencyUtils which switches to `runtime` as it's declared `implementation` now).

In a couple of cases, I used `compileOnly` which corresponds to Maven's `provided`. While in practice, provided and optional are almost the same, I guess it feels fuzzy and warm to mark dependencies that are actually required (such as a jersey container) as provided instead of optional.

The end result of these two changes is that not only is usage of third-party plugins reduced, but `micrometer-core` optional dependencies do not leak into other modules. Nebula's `optional-base` is very old (at least the version we're using) and is not aware of Gradle's classpath separation mechanism. This means that all of `micrometer-core`'s optional dependencies were on the compile classpath for every other module - you will notice I added some dependencies to modules which were implicitly inheriting optional dependencies. With such classpath leakage, it becomes possible to e.g., use a `reactor` API inside a completely unrelated `micrometer-registry-jmx`. While code review would probably catch such mishaps, now it's not even possible as reactor classes are not accessible when compiling jmx. This provides safety and should improve build performance a little.