### PR TITLE
Add common metrics name prefix

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdConfig.java
@@ -162,4 +162,12 @@ public interface StatsdConfig extends MeterRegistryConfig {
         String v = get(prefix() + ".buffered");
         return v == null || Boolean.parseBoolean(v);
     }
+
+    /**
+     * @return Common prefix that will be added to every metric's name.
+     */
+    default String namePrefix() {
+        String v = get(prefix() + ".namePrefix");
+        return v == null ? "" : v;
+    }
 }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdHierarchicalNameMapper.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdHierarchicalNameMapper.java
@@ -1,0 +1,20 @@
+package io.micrometer.statsd;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+
+public class StatsdHierarchicalNameMapper implements HierarchicalNameMapper {
+
+    private final String prefix;
+
+    public StatsdHierarchicalNameMapper(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public String toHierarchicalName(Meter.Id id, NamingConvention convention) {
+        final String prefixToAppend = prefix == null ? "" : prefix + ".";
+        return prefixToAppend + DEFAULT.toHierarchicalName(id, convention);
+    }
+}

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -86,7 +86,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     private Consumer<String> lineSink;
 
     public StatsdMeterRegistry(StatsdConfig config, Clock clock) {
-        this(config, HierarchicalNameMapper.DEFAULT, clock);
+        this(config, new StatsdHierarchicalNameMapper(config.namePrefix()), clock);
     }
 
     /**


### PR DESCRIPTION
I was missing a possibility to set a common prefix that will be added to every metric's name.
That PR addresses that.
It's trivial and it's only purpose it to start a discussion about that. If it's a good idea to have such a functionality I'll be glad to take any comments and correct the code.