### PR TITLE
Remove variability in ObjectName registered for Tomcat metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -26,6 +26,7 @@ import org.apache.catalina.Manager;
 import javax.management.*;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -236,7 +237,8 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
                 Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(name), null);
                 if (!objectNames.isEmpty()) {
                     // MBean is present, so we can register metrics now.
-                    objectNames.forEach(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));
+                    objectNames.stream().sorted(Comparator.reverseOrder()).findFirst()
+                            .ifPresent(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));
                     return;
                 }
             } catch (MalformedObjectNameException e) {


### PR DESCRIPTION
This ensures that when there are multiple `ObjectName` objects returned from the query, the same one is consistently used for Tomcat metrics. Previously, whichever one was returned from the Set first would be used, which added variability and made for flaky tests.

Fixes #1792

---

I'm not thrilled with this solution and it feels like we can/should do something better, but it nonetheless seems objectively better than what we are doing now.