### PR TITLE
Log4j2 metrics - Fix duplicate recording of log events when multiple non-additive loggers share logger configuration

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -132,11 +132,11 @@ class Log4j2MetricsTest {
         LoggerConfig loggerConfig = new LoggerConfig("com.test", Level.INFO, false);
         Configuration configuration = loggerContext.getConfiguration();
         configuration.addLogger("com.test", loggerConfig);
-        loggerContext.setConfiguration(configuration);
-        loggerContext.updateLoggers();
+        loggerContext.updateLoggers(configuration);
 
         Logger logger1 = loggerContext.getLogger("com.test.log1");
         loggerContext.getLogger("com.test.log2");
+        loggerContext.updateLoggers(configuration);
 
         new Log4j2Metrics(emptyList(), loggerContext).bindTo(registry);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -124,4 +124,24 @@ class Log4j2MetricsTest {
         log4j2Metrics.close();
         assertThat(loggerConfig.getFilter()).isNull();
     }
+
+    @Test
+    void noDuplicateLoggingCountWhenMultipleNonAdditiveLoggersShareConfig() {
+        LoggerContext loggerContext = new LoggerContext("test");
+
+        LoggerConfig loggerConfig = new LoggerConfig("com.test", Level.INFO, false);
+        Configuration configuration = loggerContext.getConfiguration();
+        configuration.addLogger("com.test", loggerConfig);
+        loggerContext.setConfiguration(configuration);
+        loggerContext.updateLoggers();
+
+        Logger logger1 = loggerContext.getLogger("com.test.log1");
+        loggerContext.getLogger("com.test.log2");
+
+        new Log4j2Metrics(emptyList(), loggerContext).bindTo(registry);
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+        logger1.info("Hello, world!");
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
**Log4j2 metrics - Fix duplicate recording of log events when multiple non-additive loggers share logger configuration**

**Issue:**
When multiple non-additive loggers share the same logging configuration in the Log4j2 configuration and Log4j2 metrics are enabled, the filter that records these metrics is added multiple times to the shared logging configuration. This causes duplicate recordings of log events (the counters per log level will be incremented multiple times for a single log event).

**Changes:**
Changed binding in Log4j2Metrics to iterate over logger configurations instead of each logger, and added checks to not add the MetricsFilter when it is already present in the logging configuration.

**Tests:**
Added minimal unit test for this change

This is my first pull request so am open to suggestions & remarks

Resolves #1862 