### PR TITLE
Use latest.release for org.awaitility:awaitility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -42,7 +42,7 @@ def VERSIONS = [
         'org.apache.tomcat.embed:tomcat-embed-core:8.+',
         'org.aspectj:aspectjweaver:1.8.+',
         'org.assertj:assertj-core:latest.release',
-        'org.awaitility:awaitility:4.+',
+        'org.awaitility:awaitility:latest.release',
         'org.eclipse.jetty:jetty-client:9.+',
         'org.eclipse.jetty:jetty-server:9.+',
         'org.ehcache:ehcache:latest.release',


### PR DESCRIPTION
This PR changes to use `latest.release` for `org.awaitility:awaitility` dependency.