### PR TITLE
Add version to deprecated comments in StatsdMetrics

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -418,7 +418,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     }
 
     /**
-     * @deprecated queue size is no longer available
+     * @deprecated queue size is no longer available since 1.4.0
      */
     @Deprecated
     public int queueSize() {
@@ -426,7 +426,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     }
 
     /**
-     * @deprecated queue capacity is no longer available
+     * @deprecated queue capacity is no longer available since 1.4.0
      */
     @Deprecated
     public int queueCapacity() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMetrics.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMetrics.java
@@ -19,7 +19,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
 /**
- * @deprecated statsd metrics are no longer available
+ * @deprecated statsd metrics are no longer available since 1.4.0
  */
 @Deprecated
 public class StatsdMetrics implements MeterBinder {


### PR DESCRIPTION
This PR adds version to deprecated comments in `StatsdMetrics`.