### PR TITLE
Use Elasticsearch 7.6.0 Docker image for integration tests

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
@@ -25,7 +25,7 @@ class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
 
     @Override
     protected String getVersion() {
-        return "7.5.2";
+        return "7.6.0";
     }
 
     @Override


### PR DESCRIPTION
This PR changes to use Elasticsearch latest version (7.6.0) Docker image for integration tests