### PR TITLE
Enable NewRelicMeterRegistry to publish via APM in addition to API (resolves #1761)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,6 +17,7 @@ def VERSIONS = [
         // <=1.5.11 or 1.5.18 doesn't break with Micrometer, but open metrics won't be correct necessarily.
         'com.netflix.hystrix:hystrix-core:1.5.12',
         'com.netflix.spectator:spectator-reg-atlas:latest.release',
+        'com.newrelic.agent.java:newrelic-api:latest.release',
         'com.signalfx.public:signalfx-java:latest.release',
         'com.squareup.okhttp3:okhttp:latest.release',
         'com.wavefront:wavefront-sdk-java:latest.release',
@@ -52,7 +53,8 @@ def VERSIONS = [
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:latest.release',
         'org.hsqldb:hsqldb:latest.release',
-        'org.jooq:jooq:latest.release',
+        // Pin version temporarily to restore builds. See gh-1852
+        'org.jooq:jooq:3.12.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
         'org.junit.jupiter:junit-jupiter:latest.release',
         'org.junit.platform:junit-platform-launcher:latest.release',

--- a/implementations/micrometer-registry-new-relic/build.gradle
+++ b/implementations/micrometer-registry-new-relic/build.gradle
@@ -2,6 +2,11 @@ dependencies {
     api project(':micrometer-core')
 
     implementation 'org.slf4j:slf4j-api'
+    implementation 'com.newrelic.agent.java:newrelic-api'
 
     testImplementation project(':micrometer-test')
+
+    testImplementation 'ch.qos.logback:logback-classic'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+    testImplementation 'com.google.guava:guava'
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicIntegration.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicIntegration.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.newrelic;
+
+import io.micrometer.core.lang.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Enum representing the possible NewRelic integration methods.
+ *
+ * @author Galen Schmidt
+ */
+public enum NewRelicIntegration {
+
+    /**
+     * API integration, in which the {@link NewRelicMeterRegistry}
+     * will directly call the NewRelic REST API to publish metrics.
+     */
+    API,
+
+    /**
+     * APM integration, in which the {@link NewRelicMeterRegistry}
+     * will use {@link com.newrelic.api.agent.Insights#recordCustomEvent(String, Map)} to publish metrics.
+     */
+    APM;
+
+    /**
+     * Returns the {@code NewRelicIntegration} for the given name (case insensitive),
+     * or {@link Optional#empty()} if none match.
+     *
+     * @param input The enum name, as returned by {@link #name()}
+     * @return The enum value with the given name, if one exists
+     */
+    public static Optional<NewRelicIntegration> fromString(@Nullable String input) {
+
+        for (NewRelicIntegration value : NewRelicIntegration.values()) {
+            if (value.name().equalsIgnoreCase(input)) {
+                return Optional.of(value);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,38 @@
  */
 package io.micrometer.newrelic;
 
-import io.micrometer.core.instrument.*;
+import com.newrelic.api.agent.Insights;
+import com.newrelic.api.agent.NewRelic;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.InvalidConfigurationException;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
-import io.micrometer.core.instrument.util.*;
+import io.micrometer.core.instrument.util.DoubleFormat;
+import io.micrometer.core.instrument.util.MeterPartition;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringUtils;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
-
+import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,28 +54,38 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micrometer.core.instrument.util.StringEscapeUtils.escapeJson;
+import static io.micrometer.newrelic.NewRelicIntegration.API;
+import static io.micrometer.newrelic.NewRelicIntegration.APM;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Publishes metrics to New Relic Insights.
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Galen Schmidt
  * @since 1.0.0
  */
 public class NewRelicMeterRegistry extends StepMeterRegistry {
+
+    private static final Logger logger = LoggerFactory.getLogger(NewRelicMeterRegistry.class);
+
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("new-relic-metrics-publisher");
+
     private final NewRelicConfig config;
+
     private final HttpSender httpClient;
-    private final Logger logger = LoggerFactory.getLogger(NewRelicMeterRegistry.class);
+
+    private final Insights insights;
+
+    private final Runnable publisher;
 
     /**
      * @param config Configuration options for the registry that are describable as properties.
      * @param clock  The clock to use for timings.
      */
-    @SuppressWarnings("deprecation")
     public NewRelicMeterRegistry(NewRelicConfig config, Clock clock) {
-        this(config, clock, DEFAULT_THREAD_FACTORY,
-                new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()));
+        this(config, clock, DEFAULT_THREAD_FACTORY);
     }
 
     /**
@@ -66,32 +95,41 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
      * @deprecated Use {@link #builder(NewRelicConfig)} instead.
      */
     @Deprecated
+    @SuppressWarnings("DeprecatedIsStillUsed")
     public NewRelicMeterRegistry(NewRelicConfig config, Clock clock, ThreadFactory threadFactory) {
-        this(config, clock, threadFactory, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()));
+        this(config, clock, threadFactory, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), NewRelic.getAgent().getInsights());
     }
 
-    // VisibleForTesting
-    NewRelicMeterRegistry(NewRelicConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient) {
-        super(config, clock);
-
-        if (!config.meterNameEventTypeEnabled() && StringUtils.isEmpty(config.eventType())) {
-            throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
-        }
-        if (StringUtils.isEmpty(config.accountId())) {
-            throw new MissingRequiredConfigurationException("accountId must be set to report metrics to New Relic");
-        }
-        if (StringUtils.isEmpty(config.apiKey())) {
-            throw new MissingRequiredConfigurationException("apiKey must be set to report metrics to New Relic");
-        }
-        if (StringUtils.isEmpty(config.uri())) {
-            throw new MissingRequiredConfigurationException("uri must be set to report metrics to New Relic");
-        }
+    private NewRelicMeterRegistry(NewRelicConfig config, Clock clock, ThreadFactory threadFactory, HttpSender httpClient, Insights insights) {
+        super(requireNonNull(config, "config"), requireNonNull(clock, "clock"));
 
         this.config = config;
         this.httpClient = httpClient;
+        this.insights = insights;
+
+        NewRelicIntegration integration = requireNonEmpty("integration", config.integration());
+
+        if (API.equals(integration)) {
+            requireNonEmpty("accountId", config.accountId());
+            requireNonEmpty("apiKey", config.apiKey());
+            requireNonEmpty("uri", config.uri());
+            requireNonNull(httpClient, "httpClient");
+            publisher = this::publishViaApi;
+        } else if (APM.equals(integration)) {
+            requireNonNull(insights, "insights");
+            publisher = this::publishViaApm;
+        } else {
+            // the only way it's possible to get here is if a value is added to the enum,
+            // without adding a branch to the if/else tree
+            throw new InvalidConfigurationException("Unsupported New Relic integration " + integration);
+        }
+
+        if (!config.meterNameEventTypeEnabled()) {
+            requireNonEmpty("eventType", config.eventType());
+        }
 
         config().namingConvention(new NewRelicNamingConvention());
-        start(threadFactory);
+        start(requireNonNull(threadFactory, "threadFactory"));
     }
 
     public static Builder builder(NewRelicConfig config) {
@@ -100,163 +138,180 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
     @Override
     public void start(ThreadFactory threadFactory) {
+
         if (config.enabled()) {
             logger.info("publishing metrics to new relic every " + TimeUtils.format(config.step()));
+        } else {
+            logger.debug("publishing metrics to new relic is disabled");
         }
+
         super.start(threadFactory);
     }
 
     @Override
     protected void publish() {
-        String insightsEndpoint = config.uri() + "/v1/accounts/" + config.accountId() + "/events";
-
-        // New Relic's Insights API limits us to 1000 events per call
-        // 1:1 mapping between Micrometer meters and New Relic events
-        for (List<Meter> batch : MeterPartition.partition(this, Math.min(config.batchSize(), 1000))) {
-            sendEvents(insightsEndpoint, batch.stream().flatMap(meter -> meter.match(
-                    this::writeGauge,
-                    this::writeCounter,
-                    this::writeTimer,
-                    this::writeSummary,
-                    this::writeLongTaskTimer,
-                    this::writeTimeGauge,
-                    this::writeFunctionCounter,
-                    this::writeFunctionTimer,
-                    this::writeMeter)));
-        }
+        publisher.run();
     }
 
-    private Stream<String> writeLongTaskTimer(LongTaskTimer ltt) {
-        return Stream.of(
-                event(ltt.getId(),
-                        new Attribute("activeTasks", ltt.activeTasks()),
-                        new Attribute("duration", ltt.duration(getBaseTimeUnit())),
-                        new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase()))
-        );
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.SECONDS;
     }
 
     // VisibleForTesting
-    Stream<String> writeFunctionCounter(FunctionCounter counter) {
+    @Nullable
+    NewRelicEvent eventFor(Meter meter) {
+        return meter.match(
+                this::toEvent, // Gauge
+                this::toEvent, // Counter
+                this::toEvent, // Timer
+                this::toEvent, // DistributionSummary
+                this::toEvent, // LongTaskTimer
+                this::toEvent, // TimeGauge
+                this::toEvent, // FunctionCounter
+                this::toEvent, // FunctionTimer
+                this::toEvent  // Meter
+        );
+    }
+
+    @Nullable
+    private NewRelicEvent toEvent(Gauge gauge) {
+        double value = gauge.value();
+
+        if (!Double.isFinite(value)) {
+            return null;
+        }
+
+        return newEvent(gauge.getId(),
+                "value", value
+        );
+    }
+
+    private NewRelicEvent toEvent(Counter counter) {
+        return newEvent(counter.getId(),
+                "throughput", counter.count()
+        );
+    }
+
+    private NewRelicEvent toEvent(Timer timer) {
+        return newEvent(timer.getId(),
+                "count", timer.count(),
+                "avg", timer.mean(getBaseTimeUnit()),
+                "totalTime", timer.totalTime(getBaseTimeUnit()),
+                "max", timer.max(getBaseTimeUnit()),
+                "timeUnit", getBaseTimeUnit().name().toLowerCase()
+        );
+    }
+
+    private NewRelicEvent toEvent(DistributionSummary summary) {
+        return newEvent(summary.getId(),
+                "count", summary.count(),
+                "avg", summary.mean(),
+                "total", summary.totalAmount(),
+                "max", summary.max()
+        );
+    }
+
+    private NewRelicEvent toEvent(LongTaskTimer ltt) {
+        return newEvent(ltt.getId(),
+                "activeTasks", ltt.activeTasks(),
+                "duration", ltt.duration(getBaseTimeUnit()),
+                "timeUnit", getBaseTimeUnit().name().toLowerCase()
+        );
+    }
+
+    @Nullable
+    private NewRelicEvent toEvent(TimeGauge gauge) {
+        double value = gauge.value(getBaseTimeUnit());
+
+        if (!Double.isFinite(value)) {
+            return null;
+        }
+
+        return newEvent(gauge.getId(),
+                "value", value,
+                "timeUnit", getBaseTimeUnit().name().toLowerCase()
+        );
+    }
+
+    @Nullable
+    private NewRelicEvent toEvent(FunctionCounter counter) {
         double count = counter.count();
-        if (Double.isFinite(count)) {
-            return Stream.of(event(counter.getId(), new Attribute("throughput", count)));
+
+        if (!Double.isFinite(count)) {
+            return null;
         }
-        return Stream.empty();
-    }
 
-    private Stream<String> writeCounter(Counter counter) {
-        return Stream.of(event(counter.getId(), new Attribute("throughput", counter.count())));
-    }
-
-    // VisibleForTesting
-    Stream<String> writeGauge(Gauge gauge) {
-        Double value = gauge.value();
-        if (Double.isFinite(value)) {
-            return Stream.of(event(gauge.getId(), new Attribute("value", value)));
-        }
-        return Stream.empty();
-    }
-
-    // VisibleForTesting
-    Stream<String> writeTimeGauge(TimeGauge gauge) {
-        Double value = gauge.value(getBaseTimeUnit());
-        if (Double.isFinite(value)) {
-            return Stream.of(
-                    event(gauge.getId(), 
-                            new Attribute("value", value),
-                            new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase())));
-        }
-        return Stream.empty();
-    }
-
-    private Stream<String> writeSummary(DistributionSummary summary) {
-        return Stream.of(
-                event(summary.getId(),
-                        new Attribute("count", summary.count()),
-                        new Attribute("avg", summary.mean()),
-                        new Attribute("total", summary.totalAmount()),
-                        new Attribute("max", summary.max())
-                )
+        return newEvent(counter.getId(),
+                "throughput", count
         );
     }
 
-    private Stream<String> writeTimer(Timer timer) {
-        return Stream.of(event(timer.getId(),
-                new Attribute("count", timer.count()),
-                new Attribute("avg", timer.mean(getBaseTimeUnit())),
-                new Attribute("totalTime", timer.totalTime(getBaseTimeUnit())),
-                new Attribute("max", timer.max(getBaseTimeUnit())),
-                new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase())
-        ));
-    }
-
-    private Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        return Stream.of(
-                event(timer.getId(),
-                        new Attribute("count", timer.count()),
-                        new Attribute("avg", timer.mean(getBaseTimeUnit())),
-                        new Attribute("totalTime", timer.totalTime(getBaseTimeUnit())),
-                        new Attribute("timeUnit", getBaseTimeUnit().name().toLowerCase())
-                )
+    private NewRelicEvent toEvent(FunctionTimer timer) {
+        return newEvent(timer.getId(),
+                "count", timer.count(),
+                "avg", timer.mean(getBaseTimeUnit()),
+                "totalTime", timer.totalTime(getBaseTimeUnit()),
+                "timeUnit", getBaseTimeUnit().name().toLowerCase()
         );
     }
 
-    // VisibleForTesting
-    Stream<String> writeMeter(Meter meter) {
+    @Nullable
+    private NewRelicEvent toEvent(Meter meter) {
+        Map<String, Double> attributes = new HashMap<>();
+
         // Snapshot values should be used throughout this method as there are chances for values to be changed in-between.
-        Map<String, Attribute> attributes = new HashMap<>();
         for (Measurement measurement : meter.measure()) {
             double value = measurement.getValue();
+
             if (!Double.isFinite(value)) {
                 continue;
             }
-            String name = measurement.getStatistic().getTagValueRepresentation();
-            attributes.put(name, new Attribute(name, value));
+
+            attributes.put(measurement.getStatistic().getTagValueRepresentation(), value);
         }
+
         if (attributes.isEmpty()) {
-            return Stream.empty();
+            return null;
         }
-        return Stream.of(event(meter.getId(), attributes.values().toArray(new Attribute[0])));
+
+        // array representation of the attributes.
+        // Entries with odd indices are map keys, and entries with even indices are map values.
+        Object[] attributeArray = attributes.entrySet().stream()
+                .flatMap(entry -> Stream.of(entry.getKey(), entry.getValue()))
+                .toArray(Object[]::new);
+
+        return newEvent(meter.getId(), attributeArray);
     }
 
-    private String event(Meter.Id id, Attribute... attributes) {
+    private NewRelicEvent newEvent(Meter.Id id, Object... attributeArray) {
+        Map<String, Object> attributes = new HashMap<>();
+
+        // only inject metadata if we're not using the metric name as the event type
         if (!config.meterNameEventTypeEnabled()) {
-            // Include contextual attributes when publishing all metrics under a single categorical eventType,
-            // NOT when publishing an eventType per Meter/metric name
-            int size = attributes.length;
-            Attribute[] newAttrs = Arrays.copyOf(attributes, size + 2);
-
-            String name = id.getConventionName(config().namingConvention());
-            newAttrs[size] = new Attribute("metricName", name);
-            newAttrs[size + 1] = new Attribute("metricType", id.getType().toString());
-
-            return event(id, Tags.empty(), newAttrs);
+            attributes.put("metricName", id.getConventionName(config().namingConvention()));
+            attributes.put("metricType", String.valueOf(id.getType()));
         }
-        return event(id, Tags.empty(), attributes);
-    }
-
-    private String event(Meter.Id id, Iterable<Tag> extraTags, Attribute... attributes) {
-        StringBuilder tagsJson = new StringBuilder();
 
         for (Tag tag : getConventionTags(id)) {
-            tagsJson.append(",\"").append(escapeJson(tag.getKey())).append("\":\"").append(escapeJson(tag.getValue())).append("\"");
+            attributes.put(tag.getKey(), tag.getValue());
         }
 
         NamingConvention convention = config().namingConvention();
-        for (Tag tag : extraTags) {
-            tagsJson.append(",\"").append(escapeJson(convention.tagKey(tag.getKey())))
-                    .append("\":\"").append(escapeJson(convention.tagValue(tag.getValue()))).append("\"");
+
+        for (int i = 0; i < attributeArray.length; i += 2) {
+            String key = convention.tagKey(String.valueOf(attributeArray[i]));
+            Object value = attributeArray[i + 1];
+
+            // ensure the attribute value is either a Number or a String
+            if (!(value instanceof Number)) {
+                value = convention.tagValue(String.valueOf(value));
+            }
+
+            attributes.put(key, value);
         }
 
-        String eventType = getEventType(id);
-        
-        return Arrays.stream(attributes)
-                .map(attr ->
-                        (attr.getValue() instanceof Number)
-                            ? ",\"" + attr.getName() + "\":" + DoubleFormat.wholeOrDecimal(((Number)attr.getValue()).doubleValue())
-                            : ",\"" + attr.getName() + "\":\"" + convention.tagValue(attr.getValue().toString()) + "\""
-                )
-                .collect(Collectors.joining("", "{\"eventType\":\"" + escapeJson(eventType) + "\"", tagsJson + "}"));
+        return new NewRelicEvent(getEventType(id), attributes);
     }
 
     private String getEventType(Meter.Id id) {
@@ -266,37 +321,79 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             return config.eventType();
         }
     }
-    
-    private void sendEvents(String insightsEndpoint, Stream<String> events) {
-        try {
-            AtomicInteger totalEvents = new AtomicInteger();
 
-            httpClient.post(insightsEndpoint)
-                    .withHeader("X-Insert-Key", config.apiKey())
-                    .withJsonContent(events.peek(ev -> totalEvents.incrementAndGet()).collect(Collectors.joining(",", "[", "]")))
-                    .send()
-                    .onSuccess(response -> logger.debug("successfully sent {} metrics to New Relic.", totalEvents))
-                    .onError(response -> logger.error("failed to send metrics to new relic: http {} {}", response.code(), response.body()));
-        } catch (Throwable e) {
-            logger.warn("failed to send metrics to new relic", e);
-        }
+    private Stream<Stream<NewRelicEvent>> batchMetrics() {
+        // New Relic's Insights API limits us to 1000 events per call
+        // 1:1 mapping between Micrometer meters and New Relic events
+        return MeterPartition.partition(this, Math.min(config.batchSize(), 1000)).stream()
+                .map(meters -> meters.stream().map(this::eventFor).filter(Objects::nonNull));
     }
 
-    @Override
-    protected TimeUnit getBaseTimeUnit() {
-        return TimeUnit.SECONDS;
+    private void publishViaApm() {
+        batchMetrics().forEach(batch -> {
+            try {
+                AtomicInteger count = new AtomicInteger();
+
+                batch.peek(e -> count.incrementAndGet()).forEach(event -> insights.recordCustomEvent(event.getEventType(), event.getAttributes()));
+
+                logger.debug("successfully sent {} metrics to New Relic.", count);
+
+            } catch (Throwable e) {
+                logger.warn("failed to send metrics to New Relic", e);
+            }
+        });
+    }
+
+    private void publishViaApi() {
+        String insightsEndpoint = config.uri() + "/v1/accounts/" + config.accountId() + "/events";
+
+        batchMetrics().forEach(batch -> {
+            try {
+
+                AtomicInteger count = new AtomicInteger();
+
+                String json = batch.peek(e -> count.incrementAndGet())
+                        .map(NewRelicEvent::toJson)
+                        .collect(Collectors.joining(",", "[", "]"));
+
+                httpClient.post(insightsEndpoint)
+                        .withHeader("X-Insert-Key", config.apiKey())
+                        .withJsonContent(json)
+                        .send()
+                        .onSuccess(response -> logger.debug("successfully sent {} metrics to New Relic.", count))
+                        .onError(response -> logger.error("failed to send metrics to new relic: http {} {}", response.code(), response.body()));
+
+            } catch (Throwable e) {
+                logger.warn("failed to send metrics to New Relic", e);
+            }
+
+        });
+    }
+
+    private <T> T requireNonEmpty(String name, @Nullable T value) {
+
+        if (StringUtils.isEmpty(Objects.toString(value, null))) {
+            throw new MissingRequiredConfigurationException(name + " must be set to report metrics to New Relic");
+        }
+
+        return value;
     }
 
     public static class Builder {
+
         private final NewRelicConfig config;
 
         private Clock clock = Clock.SYSTEM;
+
         private ThreadFactory threadFactory = DEFAULT_THREAD_FACTORY;
+
         private HttpSender httpClient;
+
+        private Insights insights = NewRelic.getAgent().getInsights();
 
         @SuppressWarnings("deprecation")
         Builder(NewRelicConfig config) {
-            this.config = config;
+            this.config = requireNonNull(config, "config");
             this.httpClient = new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout());
         }
 
@@ -315,26 +412,78 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
             return this;
         }
 
+        public Builder insights(Insights insights) {
+            this.insights = insights;
+            return this;
+        }
+
         public NewRelicMeterRegistry build() {
-            return new NewRelicMeterRegistry(config, clock, threadFactory, httpClient);
+            return new NewRelicMeterRegistry(config, clock, threadFactory, httpClient, insights);
         }
     }
 
-    private class Attribute {
-        private final String name;
-        private final Object value;
+    /**
+     * POJO representation of an Insights event.
+     */
+    // VisibleForTesting
+    static class NewRelicEvent {
 
-        private Attribute(String name, Object value) {
-            this.name = name;
-            this.value = value;
+        private final String eventType;
+
+        private final Map<String, Object> attributes;
+
+        /**
+         * Create a new {@link NewRelicEvent}.
+         * All values provided should <b>NOT</b> be JSON escaped, {@link #toJson()} will perform JSON escaping.
+         *
+         * @param eventType  The event type
+         * @param attributes Attributes for the event
+         */
+        private NewRelicEvent(String eventType, Map<String, Object> attributes) {
+            this.eventType = eventType;
+            this.attributes = attributes;
         }
 
-        public String getName() {
-            return name;
+        public String getEventType() {
+            return this.eventType;
         }
 
-        public Object getValue() {
-            return value;
+        public Map<String, Object> getAttributes() {
+            return this.attributes;
+        }
+
+        /**
+         * Convert this event into a JSON payload suitable for use with the NewRelic Insights API
+         *
+         * @return The JSON representation of this event
+         */
+        public String toJson() {
+            final StringBuilder json = new StringBuilder();
+
+            json.append("{\"eventType\":\"");
+            json.append(escapeJson(getEventType()));
+            json.append("\"");
+
+            getAttributes().forEach((key, value) -> {
+
+                json.append(",\"");
+                json.append(escapeJson(key));
+                json.append("\":");
+
+                // the only supported attribute values are Numbers and Strings
+                if (value instanceof Number) {
+                    json.append(DoubleFormat.wholeOrDecimal(((Number) value).doubleValue()));
+                } else {
+                    json.append("\"");
+                    json.append(escapeJson(String.valueOf(value)));
+                    json.append("\"");
+                }
+            });
+
+            json.append("}");
+
+            return json.toString();
         }
     }
+
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicNamingConvention.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package io.micrometer.newrelic;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
-import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.lang.Nullable;
+
 import java.util.regex.Pattern;
 
 /**
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
  * @since 1.0.0
  */
 public class NewRelicNamingConvention implements NamingConvention {
+
     private final NamingConvention delegate;
 
     private static final Pattern INVALID_CHARACTERS_PATTERN = Pattern.compile("[^\\w:]");
@@ -35,6 +36,7 @@ public class NewRelicNamingConvention implements NamingConvention {
     private static String toValidNewRelicString(String input) {
         return INVALID_CHARACTERS_PATTERN.matcher(input).replaceAll("_");
     }
+
     public NewRelicNamingConvention() {
         this(NamingConvention.camelCase);
     }
@@ -45,16 +47,16 @@ public class NewRelicNamingConvention implements NamingConvention {
 
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        return StringEscapeUtils.escapeJson(toValidNewRelicString(delegate.name(name, type, baseUnit)));
+        return toValidNewRelicString(delegate.name(name, type, baseUnit));
     }
 
     @Override
     public String tagKey(String key) {
-        return StringEscapeUtils.escapeJson(toValidNewRelicString(delegate.tagKey(key)));
+        return toValidNewRelicString(delegate.tagKey(key));
     }
 
     @Override
     public String tagValue(String value) {
-        return StringEscapeUtils.escapeJson(delegate.tagValue(value));
+        return delegate.tagValue(value);
     }
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/package-info.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicIntegrationTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicIntegrationTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2019 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.newrelic;
+
+
+import io.micrometer.core.lang.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.micrometer.newrelic.NewRelicIntegration.API;
+import static io.micrometer.newrelic.NewRelicIntegration.APM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Galen Schmidt
+ */
+class NewRelicIntegrationTest {
+
+    private static Stream<Arguments> fromStringTestParameters() {
+        return Stream.of(
+                Arguments.of("API", API),
+                Arguments.of("APM", APM),
+
+                Arguments.of("api", API),
+                Arguments.of("apm", APM),
+
+                Arguments.of("Api", API),
+                Arguments.of("Apm", APM),
+
+                Arguments.of("INVALID", null),
+
+                Arguments.of("", null),
+                Arguments.of(null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromStringTestParameters")
+    void fromStringTest(String input, @Nullable NewRelicIntegration expected) {
+        Optional<NewRelicIntegration> maybeIntegration = NewRelicIntegration.fromString(input);
+
+        if (expected == null) {
+            assertThat(maybeIntegration).isEmpty();
+        } else {
+            assertThat(maybeIntegration).contains(expected);
+        }
+
+    }
+
+}

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryCompatibilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Pivotal Software, Inc.
+ * Copyright 2019 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,372 +15,903 @@
  */
 package io.micrometer.newrelic;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.junit.jupiter.api.Test;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.newrelic.api.agent.Insights;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.ipc.http.HttpSender;
+import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.NaN;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.util.Collections.emptyList;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Tests for {@link NewRelicMeterRegistry}.
  *
  * @author Johnny Lim
+ * @author Galen Schmidt
  */
+@SuppressWarnings("ConstantConditions")
 class NewRelicMeterRegistryTest {
 
-    private final NewRelicConfig config = new NewRelicConfig() {
-        
-        @Override
-        public String get(String key) {
-            return null;
-        }
-        
-        @Override
-        public String accountId() {
-            return "accountId";
-        }
-        
-        @Override
-        public String apiKey() {
-            return "apiKey";
-        }
-        
-    };
-   
-    private final NewRelicConfig meterNameEventTypeEnabledConfig = new NewRelicConfig() {
-        
+    private final NewRelicConfig meterNameEventTypeDisabledConfig = new MockNewRelicConfig() {
+
         @Override
         public boolean meterNameEventTypeEnabled() {
-            // Previous behavior for backward compatibility
+            return false; // note: false is the default value
+        }
+
+    };
+
+    private final NewRelicConfig meterNameEventTypeEnabledConfig = new MockNewRelicConfig() {
+
+        @Override
+        public boolean meterNameEventTypeEnabled() {
             return true;
         }
-        
-        @Override
-        public String get(String key) {
-            return null;
-        }
-        
-        @Override
-        public String accountId() {
-            return "accountId";
-        }
-        
-        @Override
-        public String apiKey() {
-            return "apiKey";
-        }
-        
+
     };
-    
+
+    private final Insights insights = Mockito.mock(Insights.class, RETURNS_DEFAULTS);
+
+    private final HttpSender httpSender = mock(HttpSender.class, CALLS_REAL_METHODS);
+
+    private final NamedThreadFactory threadFactory = new NamedThreadFactory(getClass().getSimpleName());
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
     private final MockClock clock = new MockClock();
+
     private final NewRelicMeterRegistry meterNameEventTypeEnabledRegistry = new NewRelicMeterRegistry(meterNameEventTypeEnabledConfig, clock);
-    private final NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock);
+
+    private final NewRelicMeterRegistry meterNameEventTypeDisabledRegistry = new NewRelicMeterRegistry(meterNameEventTypeDisabledConfig, clock);
 
     @Test
-    void writeGauge() {
-        writeGauge(this.meterNameEventTypeEnabledRegistry, "{\"eventType\":\"myGauge\",\"value\":1}");
-        writeGauge(this.registry,
-                "{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
+    void eventFor_Gauge() {
+        eventFor_Gauge(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myGauge")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Gauge(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("value", 1)
+                .build()
+        );
     }
 
-    private void writeGauge(NewRelicMeterRegistry meterRegistry, String expectedJson) {
-        meterRegistry.gauge("my.gauge", 1d);
-        Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        assertThat(meterRegistry.writeGauge(gauge)).containsExactly(expectedJson);
-    }
+    private void eventFor_Gauge(NewRelicMeterRegistry meterRegistry, Map<String, Object> expected) {
+        Gauge gauge = Gauge.builder("my.gauge", () -> 1d).register(meterRegistry);
 
-    @Test
-    void writeGaugeShouldDropNanValue() {
-        writeGaugeShouldDropNanValue(this.meterNameEventTypeEnabledRegistry);
-        writeGaugeShouldDropNanValue(this.registry);
-    }
-
-    private void writeGaugeShouldDropNanValue(NewRelicMeterRegistry meterRegistry) {
-        meterRegistry.gauge("my.gauge", Double.NaN);
-        Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        assertThat(meterRegistry.writeGauge(gauge)).isEmpty();
-    }
-
-    @Test
-    void writeGaugeShouldDropInfiniteValues() {
-        writeGaugeShouldDropInfiniteValues(this.meterNameEventTypeEnabledRegistry);
-        writeGaugeShouldDropInfiniteValues(this.registry);
-    }
-
-    private void writeGaugeShouldDropInfiniteValues(NewRelicMeterRegistry meterRegistry) {
-        meterRegistry.gauge("my.gauge", Double.POSITIVE_INFINITY);
-        Gauge gauge = meterRegistry.find("my.gauge").gauge();
-        assertThat(meterRegistry.writeGauge(gauge)).isEmpty();
-
-        meterRegistry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
-        gauge = meterRegistry.find("my.gauge").gauge();
-        assertThat(meterRegistry.writeGauge(gauge)).isEmpty();
+        assertThat(toMap(meterRegistry.eventFor(gauge))).isEqualTo(expected);
     }
 
     @Test
-    void writeGaugeWithTimeGauge() {
-        writeGaugeWithTimeGauge(this.meterNameEventTypeEnabledRegistry,
-                "{\"eventType\":\"myTimeGauge\",\"value\":1,\"timeUnit\":\"seconds\"}");
-        writeGaugeWithTimeGauge(this.registry,
-                "{\"eventType\":\"MicrometerSample\",\"value\":1,\"timeUnit\":\"seconds\",\"metricName\":\"myTimeGauge\",\"metricType\":\"GAUGE\"}");
+    void eventFor_Gauge_withRegistryLevelTags() {
+        eventFor_Gauge_withRegistryLevelTags(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myGauge")
+                .put("registry_tag_key", "registry_tag_value")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Gauge_withRegistryLevelTags(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("registry_tag_key", "registry_tag_value")
+                .put("value", 1)
+                .build()
+        );
     }
 
-    private void writeGaugeWithTimeGauge(NewRelicMeterRegistry meterRegistry, String expectedJson) {
+    private void eventFor_Gauge_withRegistryLevelTags(NewRelicMeterRegistry meterRegistry, Map<String, Object> expected) {
+        meterRegistry.config().commonTags("registry_tag_key", "registry_tag_value");
+        Gauge gauge = Gauge.builder("my.gauge", () -> 1d).register(meterRegistry);
+
+        assertThat(toMap(meterRegistry.eventFor(gauge))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Gauge_withMeterLevelTags() {
+        eventFor_Gauge_withMeterLevelTags(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myGauge")
+                .put("meter_tag_key", "meter_tag_value")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Gauge_withMeterLevelTags(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("meter_tag_key", "meter_tag_value")
+                .put("value", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Gauge_withMeterLevelTags(NewRelicMeterRegistry meterRegistry, Map<String, Object> expected) {
+        Gauge gauge = Gauge.builder("my.gauge", () -> 1d)
+                .tag("meter_tag_key", "meter_tag_value")
+                .register(meterRegistry);
+
+        assertThat(toMap(meterRegistry.eventFor(gauge))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Gauge_withBothLevelTags() {
+        eventFor_Gauge_withBothLevelTags(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myGauge")
+                .put("meter_tag_key", "meter_tag_value")
+                .put("registry_tag_key", "registry_tag_value")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Gauge_withBothLevelTags(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("meter_tag_key", "meter_tag_value")
+                .put("registry_tag_key", "registry_tag_value")
+                .put("value", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Gauge_withBothLevelTags(NewRelicMeterRegistry meterRegistry, Map<String, Object> expected) {
+        meterRegistry.config().commonTags("registry_tag_key", "registry_tag_value");
+        Gauge gauge = Gauge.builder("my.gauge", () -> 1d)
+                .tag("meter_tag_key", "meter_tag_value")
+                .register(meterRegistry);
+
+        assertThat(toMap(meterRegistry.eventFor(gauge))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Gauge_nanValuesDropped() {
+        eventFor_Gauge_nanValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_Gauge_nanValuesDropped(this.meterNameEventTypeDisabledRegistry);
+    }
+
+    private void eventFor_Gauge_nanValuesDropped(NewRelicMeterRegistry registry) {
+        Gauge gauge = Gauge.builder("my.gauge.nan", () -> NaN).register(registry);
+
+        assertThat(registry.eventFor(gauge)).isNull();
+    }
+
+    @Test
+    void eventFor_Gauge_infiniteValuesDropped() {
+        eventFor_Gauge_infiniteValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_Gauge_infiniteValuesDropped(this.meterNameEventTypeDisabledRegistry);
+    }
+
+    private void eventFor_Gauge_infiniteValuesDropped(NewRelicMeterRegistry registry) {
+        Gauge positive = Gauge.builder("my.gauge.positive", () -> POSITIVE_INFINITY).register(registry);
+        assertThat(registry.eventFor(positive)).isNull();
+
+        Gauge negative = Gauge.builder("my.gauge.negative", () -> NEGATIVE_INFINITY).register(registry);
+        assertThat(registry.eventFor(negative)).isNull();
+    }
+
+    @Test
+    void eventFor_Counter() {
+        eventFor_Counter(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myCounter")
+                .put("throughput", 1)
+                .build()
+        );
+
+        eventFor_Counter(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myCounter")
+                .put("metricType", "COUNTER")
+                .put("throughput", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Counter(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        Counter counter = registry.counter("my.counter");
+
+        counter.increment();
+        clock.add(meterNameEventTypeDisabledConfig.step());
+
+        assertThat(toMap(registry.eventFor(counter))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Timer() {
+        eventFor_Timer(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myTimer")
+                .put("timeUnit", "seconds")
+                .put("count", 1)
+                .put("avg", 1)
+                .put("max", 1)
+                .put("totalTime", 1)
+                .build()
+        );
+
+        eventFor_Timer(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myTimer")
+                .put("metricType", "TIMER")
+                .put("timeUnit", "seconds")
+                .put("count", 1)
+                .put("avg", 1)
+                .put("max", 1)
+                .put("totalTime", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Timer(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        Timer timer = registry.timer("my.timer");
+
+        timer.record(Duration.ofSeconds(1));
+        clock.add(meterNameEventTypeDisabledConfig.step());
+
+        assertThat(toMap(registry.eventFor(timer))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_DistributionSummary() {
+        eventFor_DistributionSummary(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "mySummary")
+                .put("count", 1)
+                .put("avg", 1)
+                .put("max", 1)
+                .put("total", 1)
+                .build()
+        );
+
+        eventFor_DistributionSummary(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "mySummary")
+                .put("metricType", "DISTRIBUTION_SUMMARY")
+                .put("count", 1)
+                .put("avg", 1)
+                .put("max", 1)
+                .put("total", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_DistributionSummary(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        DistributionSummary summary = DistributionSummary.builder("my.summary")
+                .publishPercentileHistogram()
+                .register(registry);
+
+        summary.record(1);
+        clock.add(meterNameEventTypeDisabledConfig.step());
+
+        assertThat(toMap(registry.eventFor(summary))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_LongTaskTimer() {
+        eventFor_LongTaskTimer(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myLongTaskTimer")
+                .put("timeUnit", "seconds")
+                .put("duration", 60)
+                .put("activeTasks", 1)
+                .build()
+        );
+
+        eventFor_LongTaskTimer(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myLongTaskTimer")
+                .put("metricType", "LONG_TASK_TIMER")
+                .put("timeUnit", "seconds")
+                .put("duration", 60)
+                .put("activeTasks", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_LongTaskTimer(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        LongTaskTimer timer = LongTaskTimer.builder("my.long.task.timer")
+                .register(registry);
+
+        timer.start();
+        clock.add(meterNameEventTypeDisabledConfig.step());
+
+        assertThat(toMap(registry.eventFor(timer))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_TimeGauge() {
+        eventFor_TimeGauge(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myTimeGauge")
+                .put("timeUnit", "seconds")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_TimeGauge(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myTimeGauge")
+                .put("metricType", "GAUGE")
+                .put("timeUnit", "seconds")
+                .put("value", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_TimeGauge(NewRelicMeterRegistry registry, Map<String, Object> expected) {
         AtomicReference<Double> obj = new AtomicReference<>(1d);
-        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
-        assertThat(meterRegistry.writeTimeGauge(timeGauge)).containsExactly(expectedJson);
+        TimeGauge timeGauge = registry.more().timeGauge("my.time.gauge", Tags.empty(), obj, SECONDS, AtomicReference::get);
+
+        assertThat(toMap(registry.eventFor(timeGauge))).isEqualTo(expected);
     }
 
     @Test
-    void writeGaugeWithTimeGaugeShouldDropNanValue() {
-        writeGaugeWithTimeGaugeShouldDropNanValue(this.meterNameEventTypeEnabledRegistry);
-        writeGaugeWithTimeGaugeShouldDropNanValue(this.registry);
+    void eventFor_TimeGauge_nanValuesDropped() {
+        eventFor_TimeGauge_nanValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_TimeGauge_nanValuesDropped(this.meterNameEventTypeDisabledRegistry);
     }
 
-    private void writeGaugeWithTimeGaugeShouldDropNanValue(NewRelicMeterRegistry meterRegistry) {
-        AtomicReference<Double> obj = new AtomicReference<>(Double.NaN);
-        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
-        assertThat(meterRegistry.writeTimeGauge(timeGauge)).isEmpty();
-    }
+    private void eventFor_TimeGauge_nanValuesDropped(NewRelicMeterRegistry registry) {
+        AtomicReference<Double> obj = new AtomicReference<>(NaN);
+        TimeGauge timeGauge = registry.more().timeGauge("my.time.gauge.nan", Tags.empty(), obj, SECONDS, AtomicReference::get);
 
-    @Test
-    void writeGaugeWithTimeGaugeShouldDropInfiniteValues() {
-        writeGaugeWithTimeGaugeShouldDropInfiniteValues(this.meterNameEventTypeEnabledRegistry);
-        writeGaugeWithTimeGaugeShouldDropInfiniteValues(this.registry);
-    }
-
-    private void writeGaugeWithTimeGaugeShouldDropInfiniteValues(NewRelicMeterRegistry meterRegistry) {
-        AtomicReference<Double> obj = new AtomicReference<>(Double.POSITIVE_INFINITY);
-        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        TimeGauge timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
-        assertThat(meterRegistry.writeTimeGauge(timeGauge)).isEmpty();
-
-        obj = new AtomicReference<>(Double.NEGATIVE_INFINITY);
-        meterRegistry.more().timeGauge("my.timeGauge", Tags.empty(), obj, TimeUnit.SECONDS, AtomicReference::get);
-        timeGauge = meterRegistry.find("my.timeGauge").timeGauge();
-        assertThat(meterRegistry.writeTimeGauge(timeGauge)).isEmpty();
+        assertThat(registry.eventFor(timeGauge)).isNull();
     }
 
     @Test
-    void writeCounterWithFunctionCounter() {
-        writeCounterWithFunctionCounter(this.meterNameEventTypeEnabledRegistry,
-                "{\"eventType\":\"myCounter\",\"throughput\":1}");
-        writeCounterWithFunctionCounter(this.registry,
-                "{\"eventType\":\"MicrometerSample\",\"throughput\":1,\"metricName\":\"myCounter\",\"metricType\":\"COUNTER\"}");
+    void eventFor_TimeGauge_infiniteValuesDropped() {
+        eventFor_TimeGauge_infiniteValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_TimeGauge_infiniteValuesDropped(this.meterNameEventTypeDisabledRegistry);
     }
 
-    private void writeCounterWithFunctionCounter(NewRelicMeterRegistry meterRegistry, String expectedJson) {
-        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(meterRegistry);
-        clock.add(config.step());
-        assertThat(meterRegistry.writeFunctionCounter(counter)).containsExactly(expectedJson);
-    }
+    private void eventFor_TimeGauge_infiniteValuesDropped(NewRelicMeterRegistry registry) {
+        AtomicReference<Double> positiveInfinity = new AtomicReference<>(POSITIVE_INFINITY);
+        TimeGauge positive = registry.more().timeGauge("my.time.gauge.positive", Tags.empty(), positiveInfinity, SECONDS, AtomicReference::get);
 
-    @Test
-    void writeCounterWithFunctionCounterShouldDropInfiniteValues() {
-        writeCounterWithFunctionCounterShouldDropInfiniteValues(this.meterNameEventTypeEnabledRegistry);
-        writeCounterWithFunctionCounterShouldDropInfiniteValues(this.registry);
-    }
+        assertThat(registry.eventFor(positive)).isNull();
 
-    private void writeCounterWithFunctionCounterShouldDropInfiniteValues(NewRelicMeterRegistry meterRegistry) {
-        FunctionCounter counter = FunctionCounter.builder("myCounter", Double.POSITIVE_INFINITY, Number::doubleValue)
-                .register(meterRegistry);
-        clock.add(config.step());
-        assertThat(meterRegistry.writeFunctionCounter(counter)).isEmpty();
 
-        counter = FunctionCounter.builder("myCounter", Double.NEGATIVE_INFINITY, Number::doubleValue)
-                .register(meterRegistry);
-        clock.add(config.step());
-        assertThat(meterRegistry.writeFunctionCounter(counter)).isEmpty();
+        AtomicReference<Double> negativeInfinity = new AtomicReference<>(NEGATIVE_INFINITY);
+        TimeGauge negative = registry.more().timeGauge("my.time.gauge.negative", Tags.empty(), negativeInfinity, SECONDS, AtomicReference::get);
+
+        assertThat(registry.eventFor(negative)).isNull();
     }
 
     @Test
-    void writeMeterWhenCustomMeterHasOnlyNonFiniteValuesShouldNotBeWritten() {
-        writeMeterWhenCustomMeterHasOnlyNonFiniteValuesShouldNotBeWritten(this.meterNameEventTypeEnabledRegistry);
-        writeMeterWhenCustomMeterHasOnlyNonFiniteValuesShouldNotBeWritten(this.registry);
+    void eventFor_FunctionCounter() {
+        eventFor_FunctionCounter(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myFunctionCounter")
+                .put("throughput", 1)
+                .build()
+        );
+
+        eventFor_FunctionCounter(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myFunctionCounter")
+                .put("metricType", "COUNTER")
+                .put("throughput", 1)
+                .build()
+        );
     }
 
-    private void writeMeterWhenCustomMeterHasOnlyNonFiniteValuesShouldNotBeWritten(
-            NewRelicMeterRegistry meterRegistry) {
-        Measurement measurement1 = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
-        Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
-        Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
-        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(meterRegistry);
-        assertThat(meterRegistry.writeMeter(meter)).isEmpty();
-    }
+    private void eventFor_FunctionCounter(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        FunctionCounter counter = FunctionCounter.builder("my.function.counter", 1d, Number::doubleValue).register(registry);
+        clock.add(meterNameEventTypeDisabledConfig.step());
 
-    @Test
-    void writeMeterWhenCustomMeterHasMixedFiniteAndNonFiniteValuesShouldSkipOnlyNonFiniteValues() {
-        writeMeterWhenCustomMeterHasMixedFiniteAndNonFiniteValuesShouldSkipOnlyNonFiniteValues(
-                this.meterNameEventTypeEnabledRegistry, "{\"eventType\":\"myMeter\",\"value\":1}");
-        writeMeterWhenCustomMeterHasMixedFiniteAndNonFiniteValuesShouldSkipOnlyNonFiniteValues(
-                this.registry,
-                "{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myMeter\",\"metricType\":\"GAUGE\"}");
-    }
-
-    private void writeMeterWhenCustomMeterHasMixedFiniteAndNonFiniteValuesShouldSkipOnlyNonFiniteValues(
-            NewRelicMeterRegistry meterRegistry, String expectedJson) {
-        Measurement measurement1 = new Measurement(() -> Double.POSITIVE_INFINITY, Statistic.VALUE);
-        Measurement measurement2 = new Measurement(() -> Double.NEGATIVE_INFINITY, Statistic.VALUE);
-        Measurement measurement3 = new Measurement(() -> Double.NaN, Statistic.VALUE);
-        Measurement measurement4 = new Measurement(() -> 1d, Statistic.VALUE);
-        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3, measurement4);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(meterRegistry);
-        assertThat(meterRegistry.writeMeter(meter)).containsExactly(expectedJson);
+        assertThat(toMap(registry.eventFor(counter))).isEqualTo(expected);
     }
 
     @Test
-    void writeMeterWhenCustomMeterHasDuplicatesKeysShouldWriteOnlyLastValue() {
-        Measurement measurement1 = new Measurement(() -> 3d, Statistic.VALUE);
-        Measurement measurement2 = new Measurement(() -> 1d, Statistic.VALUE);
-        Measurement measurement3 = new Measurement(() -> 2d, Statistic.VALUE);
-        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
-        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
-        assertThat(registry.writeMeter(meter)).containsExactly("{\"eventType\":\"MicrometerSample\",\"value\":2,\"metricName\":\"myMeter\",\"metricType\":\"GAUGE\"}");
+    void eventFor_FunctionCounter_infiniteValuesDropped() {
+        eventFor_FunctionCounter_infiniteValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_FunctionCounter_infiniteValuesDropped(this.meterNameEventTypeDisabledRegistry);
+    }
+
+    private void eventFor_FunctionCounter_infiniteValuesDropped(NewRelicMeterRegistry registry) {
+        FunctionCounter positive = FunctionCounter.builder("my.function.counter.positive", POSITIVE_INFINITY, Number::doubleValue)
+                .register(registry);
+
+        clock.add(meterNameEventTypeDisabledConfig.step());
+        assertThat(registry.eventFor(positive)).isNull();
+
+        FunctionCounter negative = FunctionCounter.builder("my.function.counter.negative", NEGATIVE_INFINITY, Number::doubleValue)
+                .register(registry);
+
+        clock.add(meterNameEventTypeDisabledConfig.step());
+        assertThat(registry.eventFor(negative)).isNull();
     }
 
     @Test
-    void publish() {
-        MockHttpSender mockHttpSender = new MockHttpSender();
-        NewRelicMeterRegistry registry = new NewRelicMeterRegistry(config, clock, new NamedThreadFactory("new-relic-test"), mockHttpSender);
-        
-        registry.gauge("my.gauge", 1d);
-        Gauge gauge = registry.find("my.gauge").gauge();
-        assertThat(gauge).isNotNull();
-        
+    void eventFor_FunctionTimer() {
+        eventFor_FunctionTimer(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myFunctionTimer")
+                .put("timeUnit", "seconds")
+                .put("totalTime", 2)
+                .put("count", 1)
+                .put("avg", 2)
+                .build()
+        );
+
+        eventFor_FunctionTimer(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myFunctionTimer")
+                .put("metricType", "TIMER")
+                .put("timeUnit", "seconds")
+                .put("totalTime", 2)
+                .put("count", 1)
+                .put("avg", 2)
+                .build()
+        );
+    }
+
+    private void eventFor_FunctionTimer(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        FunctionTimer timer = registry.more().timer("my.function.timer", emptyList(), new Object(), o -> 1L, o -> 2.0, registry.getBaseTimeUnit());
+
+        clock.add(meterNameEventTypeDisabledConfig.step());
+
+        assertThat(toMap(registry.eventFor(timer))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Meter() {
+        eventFor_Meter(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myMeter")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Meter(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myMeter")
+                .put("metricType", "GAUGE")
+                .put("value", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Meter(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        List<Measurement> measurements = Collections.singletonList(new Measurement(() -> 1d, Statistic.VALUE));
+
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(registry);
+
+        assertThat(toMap(registry.eventFor(meter))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Meter_nanAndInfiniteValuesDropped() {
+        eventFor_Meter_nanAndInfiniteValuesDropped(this.meterNameEventTypeEnabledRegistry);
+        eventFor_Meter_nanAndInfiniteValuesDropped(this.meterNameEventTypeDisabledRegistry);
+    }
+
+    private void eventFor_Meter_nanAndInfiniteValuesDropped(NewRelicMeterRegistry registry) {
+        List<Measurement> measurements = Arrays.asList(
+                new Measurement(() -> POSITIVE_INFINITY, Statistic.VALUE),
+                new Measurement(() -> NEGATIVE_INFINITY, Statistic.VALUE),
+                new Measurement(() -> NaN, Statistic.VALUE)
+        );
+
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(registry);
+
+        assertThat(registry.eventFor(meter)).isNull();
+    }
+
+    @Test
+    void eventFor_Meter_nanAndInfiniteValuesDropped_finiteValuesKept() {
+        eventFor_Meter_nanAndInfiniteValuesDropped_finiteValuesKept(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myMeter")
+                .put("value", 1)
+                .build()
+        );
+
+        eventFor_Meter_nanAndInfiniteValuesDropped_finiteValuesKept(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myMeter")
+                .put("metricType", "GAUGE")
+                .put("value", 1)
+                .build()
+        );
+    }
+
+    private void eventFor_Meter_nanAndInfiniteValuesDropped_finiteValuesKept(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        List<Measurement> measurements = Arrays.asList(
+                new Measurement(() -> POSITIVE_INFINITY, Statistic.VALUE),
+                new Measurement(() -> NEGATIVE_INFINITY, Statistic.VALUE),
+                new Measurement(() -> NaN, Statistic.VALUE),
+                new Measurement(() -> 1d, Statistic.VALUE)
+        );
+
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(registry);
+
+        assertThat(toMap(registry.eventFor(meter))).isEqualTo(expected);
+    }
+
+    @Test
+    void eventFor_Meter_onlyLastValueKeptForDuplicateKeys() {
+        eventFor_Meter_onlyLastValueKeptForDuplicateKeys(this.meterNameEventTypeEnabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "myMeter")
+                .put("value", 2)
+                .build()
+        );
+
+        eventFor_Meter_onlyLastValueKeptForDuplicateKeys(this.meterNameEventTypeDisabledRegistry, ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myMeter")
+                .put("metricType", "GAUGE")
+                .put("value", 2)
+                .build()
+        );
+    }
+
+    private void eventFor_Meter_onlyLastValueKeptForDuplicateKeys(NewRelicMeterRegistry registry, Map<String, Object> expected) {
+        List<Measurement> measurements = Arrays.asList(
+                new Measurement(() -> 3d, Statistic.VALUE),
+                new Measurement(() -> 1d, Statistic.VALUE),
+                new Measurement(() -> 2d, Statistic.VALUE)
+        );
+
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(registry);
+
+        assertThat(toMap(registry.eventFor(meter))).isEqualTo(expected);
+    }
+
+    @Test
+    void publishViaApi() throws Throwable {
+        MockNewRelicConfig config = new MockNewRelicConfig() {
+
+            @Override
+            public NewRelicIntegration integration() {
+                return NewRelicIntegration.API;
+            }
+
+        };
+
+        ArgumentCaptor<HttpSender.Request> captor = ArgumentCaptor.forClass(HttpSender.Request.class);
+        doReturn(new HttpSender.Response(200, "body")).when(httpSender).send(captor.capture());
+
+        NewRelicMeterRegistry registry = NewRelicMeterRegistry.builder(config)
+                .clock(clock)
+                .threadFactory(threadFactory)
+                .httpClient(httpSender)
+                .insights(insights)
+                .build();
+
+        Gauge.builder("my.gauge", () -> 1d).register(registry);
+
         registry.publish();
-        
-        assertThat(new String(mockHttpSender.getRequest().getEntity()))
-            .contains("{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
+
+        List<Map<String, Object>> published = jsonListToMap(new String(captor.getValue().getEntity()));
+
+        assertThat(published).containsExactly(ImmutableMap.<String, Object>builder()
+                .put("eventType", "MicrometerSample")
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("value", 1)
+                .build()
+        );
+
+        verifyNoInteractions(insights);
     }
 
     @Test
-    void configMissingEventType() {
-        NewRelicConfig config = new NewRelicConfig() {
+    void publishViaApiFailure() throws Throwable {
+        MockNewRelicConfig config = new MockNewRelicConfig() {
+
+            @Override
+            public NewRelicIntegration integration() {
+                return NewRelicIntegration.API;
+            }
+
+        };
+
+        doThrow(new RuntimeException("BOOM!")).when(httpSender).send(any(HttpSender.Request.class));
+
+        NewRelicMeterRegistry registry = NewRelicMeterRegistry.builder(config)
+                .clock(clock)
+                .threadFactory(threadFactory)
+                .httpClient(httpSender)
+                .insights(insights)
+                .build();
+
+        Gauge.builder("my.gauge", () -> 1d).register(registry);
+
+        // verify it throws no exception, the test will fail if it does
+        registry.publish();
+
+        verify(httpSender).send(any(HttpSender.Request.class));
+        verifyNoInteractions(insights);
+    }
+
+    @Test
+    void publishViaApm() {
+        MockNewRelicConfig config = new MockNewRelicConfig() {
+
+            @Override
+            public NewRelicIntegration integration() {
+                return NewRelicIntegration.APM;
+            }
+
+        };
+
+        NewRelicMeterRegistry registry = NewRelicMeterRegistry.builder(config)
+                .clock(clock)
+                .threadFactory(threadFactory)
+                .httpClient(httpSender)
+                .insights(insights)
+                .build();
+
+        Gauge.builder("my.gauge", () -> 1d).register(registry);
+
+        registry.publish();
+
+        verify(insights).recordCustomEvent("MicrometerSample", ImmutableMap.<String, Object>builder()
+                .put("metricName", "myGauge")
+                .put("metricType", "GAUGE")
+                .put("value", 1d)
+                .build());
+
+        verifyNoInteractions(httpSender);
+    }
+
+    @Test
+    void publishViaApmFailure() {
+        MockNewRelicConfig config = new MockNewRelicConfig() {
+
+            @Override
+            public NewRelicIntegration integration() {
+                return NewRelicIntegration.APM;
+            }
+
+        };
+
+        doThrow(new RuntimeException("BOOM!")).when(insights).recordCustomEvent(anyString(), anyMap());
+
+        NewRelicMeterRegistry registry = NewRelicMeterRegistry.builder(config)
+                .clock(clock)
+                .threadFactory(threadFactory)
+                .httpClient(httpSender)
+                .insights(insights)
+                .build();
+
+        Gauge.builder("my.gauge", () -> 1d).register(registry);
+
+        // verify it throws no exception, the test will fail if it does
+        registry.publish();
+
+        verify(insights).recordCustomEvent(anyString(), anyMap());
+        verifyNoInteractions(httpSender);
+    }
+
+    @Test
+    void builder() {
+        NewRelicConfig config = new MockNewRelicConfig();
+
+        NewRelicMeterRegistry built = NewRelicMeterRegistry.builder(config)
+                .threadFactory(new NamedThreadFactory("MOCK"))
+                .insights(insights)
+                .clock(clock)
+                .httpClient(new HttpUrlConnectionSender())
+                .build();
+
+        assertThat(built).isNotNull();
+    }
+
+    @Test
+    void builder_nullConfig() {
+        assertThatThrownBy(() -> NewRelicMeterRegistry.builder(null))
+                .isExactlyInstanceOf(NullPointerException.class)
+                .hasMessageContaining("config");
+    }
+
+    @Test
+    void startDisabled() {
+        NewRelicConfig config = new MockNewRelicConfig() {
+
+            @Override
+            public boolean enabled() {
+                return false;
+            }
+        };
+
+        NewRelicMeterRegistry registry = NewRelicMeterRegistry.builder(config)
+                .clock(clock)
+                .threadFactory(threadFactory)
+                .httpClient(httpSender)
+                .insights(insights)
+                .build();
+
+        try {
+            registry.start(threadFactory);
+        } finally {
+            registry.close();
+        }
+
+        verifyNoInteractions(httpSender);
+        verifyNoInteractions(insights);
+    }
+
+    @Test
+    void configEmptyEventType() {
+        NewRelicConfig config = new MockNewRelicConfig() {
+
             @Override
             public String eventType() {
                 return "";
             }
-            @Override
-            public String get(String key) {
-                return null;
-            }
+
         };
-        
+
         assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
                 .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
                 .hasMessageContaining("eventType");
     }
 
     @Test
-    void configMissingAccountId() {
-        NewRelicConfig config = new NewRelicConfig() {
-            @Override
-            public String eventType() {
-                return "eventType";
-            }
+    void configInvalidAccountId() {
+        NewRelicConfig nullConfig = new MockNewRelicConfig() {
+
             @Override
             public String accountId() {
                 return null;
             }
-            @Override
-            public String get(String key) {
-                return null;
-            }
+
         };
 
-        assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
-                .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
-                .hasMessageContaining("accountId");
-    }
-    
-    @Test
-    void configMissingApiKey() {
-        NewRelicConfig config = new NewRelicConfig() {
-            @Override
-            public String eventType() {
-                return "eventType";
-            }
+        NewRelicConfig emptyConfig = new MockNewRelicConfig() {
+
             @Override
             public String accountId() {
-                return "accountId";
+                return "";
             }
+
+        };
+
+        for (NewRelicConfig config : new NewRelicConfig[]{nullConfig, emptyConfig}) {
+            assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
+                    .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+                    .hasMessageContaining("accountId");
+        }
+    }
+
+    @Test
+    void configInvalidApiKey() {
+        NewRelicConfig nullConfig = new MockNewRelicConfig() {
+
+            @Override
+            public String apiKey() {
+                return null;
+            }
+
+        };
+
+        NewRelicConfig emptyConfig = new MockNewRelicConfig() {
+
             @Override
             public String apiKey() {
                 return "";
             }
-            @Override
-            public String get(String key) {
-                return null;
-            }
+
         };
 
-        assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
-                .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
-                .hasMessageContaining("apiKey");
+        for (NewRelicConfig config : new NewRelicConfig[]{nullConfig, emptyConfig}) {
+            assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
+                    .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+                    .hasMessageContaining("apiKey");
+        }
     }
-    
+
     @Test
-    void configMissingUri() {
-        NewRelicConfig config = new NewRelicConfig() {
+    void configInvalidUri() {
+        NewRelicConfig nullConfig = new MockNewRelicConfig() {
+
             @Override
-            public String eventType() {
-                return "eventType";
+            public String uri() {
+                return null;
             }
-            @Override
-            public String accountId() {
-                return "accountId";
-            }
-            @Override
-            public String apiKey() {
-                return "apiKey";
-            }
+
+        };
+
+        NewRelicConfig emptyConfig = new MockNewRelicConfig() {
+
             @Override
             public String uri() {
                 return "";
             }
-            @Override
-            public String get(String key) {
-                return null;
-            }
+
         };
 
-        assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
-                .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
-                .hasMessageContaining("uri");
+        for (NewRelicConfig config : new NewRelicConfig[]{nullConfig, emptyConfig}) {
+            assertThatThrownBy(() -> new NewRelicMeterRegistry(config, clock))
+                    .isExactlyInstanceOf(MissingRequiredConfigurationException.class)
+                    .hasMessageContaining("uri");
+        }
     }
-    
-    static class MockHttpSender implements HttpSender {
-        
-        private Request request;
-        
+
+    private Map<String, Object> toMap(NewRelicMeterRegistry.NewRelicEvent event) {
+        return jsonObjectToMap(event.toJson());
+    }
+
+    private List<Map<String, Object>> jsonListToMap(String json) {
+        return readJson(json, new TypeReference<>() {
+            // this space intentionally left blank
+        });
+    }
+
+    private Map<String, Object> jsonObjectToMap(String json) {
+        return readJson(json, new TypeReference<>() {
+            // this space intentionally left blank
+        });
+    }
+
+    private <T> T readJson(String json, TypeReference<T> type) {
+        try {
+            return mapper.readValue(json, type);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse JSON string into " + type.getType() + ": " + json, e);
+        }
+    }
+
+    private static class MockNewRelicConfig implements NewRelicConfig {
+
         @Override
-        public Response send(Request request) {
-            this.request = request;
-            return new Response(200, "body");
+        public String get(String key) {
+            return null;
         }
-        
-        public Request getRequest() {
-            return request;
+
+        @Override
+        public String accountId() {
+            return "accountId";
         }
+
+        @Override
+        public String apiKey() {
+            return "apiKey";
+        }
+
     }
 
 }

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -876,13 +876,15 @@ class NewRelicMeterRegistryTest {
     }
 
     private List<Map<String, Object>> jsonListToMap(String json) {
-        return readJson(json, new TypeReference<>() {
+        //noinspection Convert2Diamond
+        return readJson(json, new TypeReference<List<Map<String, Object>>>() {
             // this space intentionally left blank
         });
     }
 
     private Map<String, Object> jsonObjectToMap(String json) {
-        return readJson(json, new TypeReference<>() {
+        //noinspection Convert2Diamond
+        return readJson(json, new TypeReference<Map<String, Object>>() {
             // this space intentionally left blank
         });
     }


### PR DESCRIPTION
https://github.com/micrometer-metrics/micrometer/issues/1761

I've done extensive testing of this with some of my own applications, and everything appears to be working correctly.

The scope of the changes are fairly large, but I've been very careful to ensure that all of the changes should be backwards compatible for existing clients.

Specifically, all existing configurations will continue working as before, and none of the generated JSON payloads to the Insights API should change.