### PR TITLE
StepTimer#max should always return max of last period.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -88,7 +88,7 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
 
     @Override
     public long count() {
-        return (long) count.poll();
+        return count.poll();
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
@@ -34,16 +34,16 @@ public class StepDouble extends StepValue<Double> {
     }
 
     @Override
-    public Supplier<Double> valueSupplier() {
+    protected Supplier<Double> valueSupplier() {
         return current::sumThenReset;
+    }
+
+    @Override
+    protected Double noValue() {
+        return 0.0;
     }
 
     public DoubleAdder getCurrent() {
         return current;
-    }
-
-    @Override
-    public Double noValue() {
-        return 0.0;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
@@ -17,8 +17,8 @@ package io.micrometer.core.instrument.step;
 
 import io.micrometer.core.instrument.Clock;
 
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
+import java.util.function.Supplier;
 
 /**
  * Subtly different from {@code com.netflix.spectator.impl.StepDouble} in that we want to be able
@@ -26,40 +26,24 @@ import java.util.concurrent.atomic.DoubleAdder;
  *
  * @author Jon Schneider
  */
-public class StepDouble {
-    private final Clock clock;
-    private final long stepMillis;
+public class StepDouble extends StepValue<Double> {
     private final DoubleAdder current = new DoubleAdder();
-    private final AtomicLong lastInitPos;
-    private volatile double previous = 0.0;
 
     public StepDouble(Clock clock, long stepMillis) {
-        this.clock = clock;
-        this.stepMillis = stepMillis;
-        lastInitPos = new AtomicLong(clock.wallTime() / stepMillis);
+        super(clock, stepMillis);
     }
 
-    private void rollCount(long now) {
-        final long stepTime = now / stepMillis;
-        final long lastInit = lastInitPos.get();
-        if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
-            final double v = current.sumThenReset();
-            // Need to check if there was any activity during the previous step interval. If there was
-            // then the init position will move forward by 1, otherwise it will be older. No activity
-            // means the previous interval should be set to the `init` value.
-            previous = (lastInit == stepTime - 1) ? v : 0.0;
-        }
+    @Override
+    public Supplier<Double> valueSupplier() {
+        return current::sumThenReset;
     }
 
     public DoubleAdder getCurrent() {
         return current;
     }
 
-    /**
-     * @return The value for the last completed interval.
-     */
-    public double poll() {
-        rollCount(clock.wallTime());
-        return previous;
+    @Override
+    public Double noValue() {
+        return 0.0;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
@@ -28,12 +28,12 @@ public class StepLong extends StepValue<Long> {
     }
 
     @Override
-    public Supplier<Long> valueSupplier() {
+    protected Supplier<Long> valueSupplier() {
         return current::sumThenReset;
     }
 
     @Override
-    public Long noValue() {
+    protected Long noValue() {
         return 0L;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLongMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLongMax.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Clock;
+
+/**
+ * A class similar to {@link StepLong}, but records the maximum <b>positive</b>
+ * value recorded in steps as opposed accumulated values.
+ */
+class StepLongMax extends StepValue<Long> {
+    private final AtomicLong current = new AtomicLong(0);
+
+    public StepLongMax(Clock clock, long stepMillis) {
+        super(clock, stepMillis);
+    }
+
+    @Override
+    public Supplier<Long> valueSupplier() {
+        return () -> current.getAndSet(0L);
+    }
+
+    /**
+     * Record a positive amount.
+     *
+     * @throws {@link IllegalArgumentException} if the amount is negative.
+     */
+    void record(final long amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("Only positive values can be recorded.");
+        }
+        current.updateAndGet(curr -> Math.max(curr, amount));
+    }
+
+    @Override
+    public Long noValue() {
+        return 0L;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLongMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLongMax.java
@@ -32,8 +32,13 @@ class StepLongMax extends StepValue<Long> {
     }
 
     @Override
-    public Supplier<Long> valueSupplier() {
+    protected Supplier<Long> valueSupplier() {
         return () -> current.getAndSet(0L);
+    }
+
+    @Override
+    protected Long noValue() {
+        return 0L;
     }
 
     /**
@@ -48,8 +53,4 @@ class StepLongMax extends StepValue<Long> {
         current.updateAndGet(curr -> Math.max(curr, amount));
     }
 
-    @Override
-    public Long noValue() {
-        return 0L;
-    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -31,6 +31,17 @@ public class StepTimer extends AbstractTimer {
     private final StepLong total;
     private final StepLongMax max;
 
+    /**
+     * Create a new {@code StepTimer}.
+     *
+     * @param id                            ID
+     * @param clock                         clock
+     * @param distributionStatisticConfig   distribution statistic configuration
+     * @param pauseDetector                 pause detector
+     * @param baseTimeUnit                  base time unit
+     * @param stepDurationMillis                    step in milliseconds
+     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
+     */
     public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
         final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
         final boolean supportsAggregablePercentiles

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument.step;
 import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.distribution.TimeWindowMax;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
 
@@ -30,82 +29,39 @@ import java.util.concurrent.TimeUnit;
 public class StepTimer extends AbstractTimer {
     private final StepLong count;
     private final StepLong total;
-    private final TimeWindowMax max;
+    private final StepLongMax max;
 
-    /**
-     * Create a new {@code StepTimer}.
-     *
-     * @param id                          ID
-     * @param clock                       clock
-     * @param distributionStatisticConfig distribution statistic configuration
-     * @param pauseDetector               pause detector
-     * @param baseTimeUnit                base time unit
-     * @deprecated Use {@link #StepTimer(io.micrometer.core.instrument.Meter.Id, Clock, DistributionStatisticConfig, PauseDetector, TimeUnit, long, boolean)}
-     */
-    @Deprecated
-    public StepTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-                     PauseDetector pauseDetector, TimeUnit baseTimeUnit) {
-        this(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, false);
-    }
-
-    /**
-     * Create a new {@code StepTimer}.
-     *
-     * @param id                            ID
-     * @param clock                         clock
-     * @param distributionStatisticConfig   distribution statistic configuration
-     * @param pauseDetector                 pause detector
-     * @param baseTimeUnit                  base time unit
-     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
-     * @deprecated Use {@link #StepTimer(io.micrometer.core.instrument.Meter.Id, Clock, DistributionStatisticConfig, PauseDetector, TimeUnit, long, boolean)}
-     */
-    @Deprecated
-    @SuppressWarnings("ConstantConditions")
-    public StepTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-                     PauseDetector pauseDetector, TimeUnit baseTimeUnit, boolean supportsAggregablePercentiles) {
-        this(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, distributionStatisticConfig.getExpiry().toMillis(), supportsAggregablePercentiles);
-    }
-
-    /**
-     * Create a new {@code StepTimer}.
-     *
-     * @param id                            ID
-     * @param clock                         clock
-     * @param distributionStatisticConfig   distribution statistic configuration
-     * @param pauseDetector                 pause detector
-     * @param baseTimeUnit                  base time unit
-     * @param stepMillis                    step in milliseconds
-     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
-     */
-    @SuppressWarnings("ConstantConditions")
-    public StepTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-                     PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepMillis, boolean supportsAggregablePercentiles) {
+    public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
+        final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
+        final boolean supportsAggregablePercentiles
+    ) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
-        this.count = new StepLong(clock, stepMillis);
-        this.total = new StepLong(clock, stepMillis);
-        this.max = new TimeWindowMax(clock, distributionStatisticConfig);
+
+        count = new StepLong(clock, stepDurationMillis);
+        total = new StepLong(clock, stepDurationMillis);
+        max = new StepLongMax(clock, stepDurationMillis);
     }
 
     @Override
-    protected void recordNonNegative(long amount, TimeUnit unit) {
-        long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
+    protected void recordNonNegative(final long amount, final TimeUnit unit) {
+        final long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
         count.getCurrent().add(1);
         total.getCurrent().add(nanoAmount);
-        max.record(amount, unit);
+        max.record(nanoAmount);
     }
 
     @Override
     public long count() {
-        return (long) count.poll();
+        return count.poll();
     }
 
     @Override
-    public double totalTime(TimeUnit unit) {
+    public double totalTime(final TimeUnit unit) {
         return TimeUtils.nanosToUnit(total.poll(), unit);
     }
 
     @Override
-    public double max(TimeUnit unit) {
-        return max.poll(unit);
+    public double max(final TimeUnit unit) {
+        return TimeUtils.nanosToUnit(max.poll(), unit);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Clock;
+
+/**
+ * Tracks 'values' for periods (steps) of time.  The previous step's value is
+ * obtained by calling {@link #poll}.
+ */
+public abstract class StepValue<V> {
+
+    private final Clock clock;
+    private final long stepMillis;
+    private AtomicLong lastInitPos;
+    private volatile V previous = noValue();
+
+    public StepValue(final Clock clock, final long stepMillis) {
+        this.clock = clock;
+        this.stepMillis = stepMillis;
+        lastInitPos = new AtomicLong(clock.wallTime() / stepMillis);
+    }
+
+    protected abstract Supplier<V> valueSupplier();
+
+    /**
+     * The value that should be returned by {@link #poll} if within the first
+     * step period or if the previous step didn't record a value.
+     */
+    protected abstract V noValue();
+
+    private void rollCount(long now) {
+        final long stepTime = now / stepMillis;
+        final long lastInit = lastInitPos.get();
+        if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
+            final V v = valueSupplier().get();
+            // Need to check if there was any activity during the previous step interval. If there was
+            // then the init position will move forward by 1, otherwise it will be older. No activity
+            // means the previous interval should be set to the `init` value.
+            previous = (lastInit == stepTime - 1) ? v : noValue();
+        }
+    }
+
+    /**
+     * @return The value for the last completed interval.
+     */
+    public V poll() {
+        rollCount(clock.wallTime());
+        return previous;
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepLongMaxTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepLongMaxTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+import io.micrometer.core.instrument.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StepLongMaxTest {
+
+    private final MockClock clock = new MockClock();
+
+    @Test
+    public void poll() {
+        final long stepTime = 60;
+        final StepLongMax stepMax = new StepLongMax(clock, stepTime);
+
+        assertThat(stepMax.poll()).isEqualTo(0L);
+
+        stepMax.record(24);
+        stepMax.record(42);
+        stepMax.record(4);
+
+        clock.add(Duration.ofMillis(1));
+        assertThat(stepMax.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(59));
+        assertThat(stepMax.poll()).isEqualTo(42L);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepMax.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepMax.poll()).isEqualTo(0L);
+
+        stepMax.record(4);
+        stepMax.record(24);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepMax.poll()).isEqualTo(24L);
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -84,4 +84,33 @@ class StepMeterRegistryTest {
         registry.close();
         assertThat(publishes.get()).isEqualTo(1);
     }
+
+    @Issue("#1796")
+    @Test
+    void maxValueFromLastStep() {
+
+        final Timer timer = Timer.builder("my.timer").register(registry);
+
+        timer.record(Duration.ofMillis(20));
+        timer.record(Duration.ofMillis(10));
+
+        clock.add(config.step().minusMillis(2));
+        assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(1));
+        assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(20L);
+
+        clock.add(Duration.ofMillis(1));
+        timer.record(Duration.ofMillis(10));
+        timer.record(Duration.ofMillis(5));
+
+        clock.add(config.step().minusMillis(2));
+        assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(20L);
+
+        clock.add(Duration.ofMillis(1));
+        assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(10L);
+
+        clock.add(config.step());
+        assertThat(timer.max(TimeUnit.MILLISECONDS)).isEqualTo(0L);
+    }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+import io.micrometer.core.instrument.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StepValueTest {
+
+    private final MockClock clock = new MockClock();
+
+    @Test
+    public void poll() {
+        final AtomicLong aLong = new AtomicLong(42);
+        final long stepTime = 60;
+
+        final StepValue<Long> stepValue = new StepValue<Long>(clock, stepTime) {
+            @Override
+            public Supplier<Long> valueSupplier() {
+                return () -> aLong.getAndSet(0);
+            }
+
+            @Override
+            public Long noValue() {
+                return 0L;
+            }
+        };
+
+        assertThat(stepValue.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(1));
+        assertThat(stepValue.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(59));
+        assertThat(stepValue.poll()).isEqualTo(42L);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepValue.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepValue.poll()).isEqualTo(0L);
+
+        aLong.set(24);
+        assertThat(stepValue.poll()).isEqualTo(0L);
+
+        clock.add(Duration.ofMillis(60));
+        assertThat(stepValue.poll()).isEqualTo(24L);
+    }
+}


### PR DESCRIPTION
This also includes a refactoring of the 'rolling' logic for step values.

Currently, this is copied between the classes.  I had to create a custom
Step value for a specific registry and some of the grief my team members
gave me was how much code I had to copy from the open source repo.  This
allows for customization with much less copying.  If you don't want
that, I will take it out.

Resolves #1796