### PR TITLE
Performance enhancement for logback's isDebugEnabled (et al) calls.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -130,7 +130,9 @@ class MetricsTurboFilter extends TurboFilter {
 
     @Override
     public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
-        // If format is null we can short circuit
+        // When filter is asked for decision for an isDebugEnabled call or similar test, there is no message (ie format) 
+        // and no intention to log anything with this call. We will not increment counters and can return immediately and
+        // avoid the relatively expensive ThreadLocal access below. See also logbacks Logger.callTurboFilters().
         if (format == null) {
             return FilterReply.NEUTRAL;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -131,7 +131,7 @@ class MetricsTurboFilter extends TurboFilter {
     @Override
     public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
         // If format is null we can short circuit
-        if(format == null) {
+        if (format == null) {
             return FilterReply.NEUTRAL;
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -130,13 +130,18 @@ class MetricsTurboFilter extends TurboFilter {
 
     @Override
     public FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
+        // If format is null we can short circuit
+        if(format == null) {
+            return FilterReply.NEUTRAL;
+        }
+
         Boolean ignored = LogbackMetrics.ignoreMetrics.get();
         if (ignored != null && ignored) {
             return FilterReply.NEUTRAL;
         }
 
         // cannot use logger.isEnabledFor(level), as it would cause a StackOverflowError by calling this filter again!
-        if (level.isGreaterOrEqual(logger.getEffectiveLevel()) && format != null) {
+        if (level.isGreaterOrEqual(logger.getEffectiveLevel())) {
             switch (level.toInt()) {
                 case Level.ERROR_INT:
                     errorCounter.increment();


### PR DESCRIPTION
During profiling of an application running on Spring Boot with Hibernate, we noted that 4% of cpu was used in ThreadLocal.get(), where most of the calls came through micrometer on calls to isTraceEnabled() and isDebugEnabled(). Since the calls were only to test if logging would happen, (with format parameter set to null), counters would never be incremented for these calls. By moving the test on format parameter first, the much more expensive thread local call can be avoided, without putting a penalty on other usages. Fix was verified in our setup.