### PR TITLE
Support Datadog distributions via DogStatsD

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -299,7 +299,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
             lineBuilderFunction = id2 -> {
                 switch (statsdConfig.flavor()) {
                     case DATADOG:
-                        return new DatadogStatsdLineBuilder(id2, config());
+                        return new DatadogStatsdLineBuilder(id2, statsdConfig, config());
                     case TELEGRAF:
                         return new TelegrafStatsdLineBuilder(id2, config());
                     case SYSDIG:

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/datadog/DataDogStatsdConfig.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/datadog/DataDogStatsdConfig.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.statsd.datadog;
+
+import io.micrometer.statsd.StatsdConfig;
+
+/**
+ * StatsD configuration with specific DataDog options
+ */
+public interface DataDogStatsdConfig extends StatsdConfig {
+    DataDogStatsdConfig DEFAULT = k -> null;
+
+    /**
+     * @return Whether or not the statsd client should publish histograms as distributions, which are aggregated on the
+     * DataDog side
+     */
+    default boolean publishDistributions() {
+        return false;
+    }
+}


### PR DESCRIPTION
First attempt at adding support for recording histogram values as DataDog distributions in StatsD.

Pretty straightforward, this will add an additional interface for configuring DataDog-specific StatsD options with the option to override the `publishDistributions()` option.  It will default to `false` if not overridden, using the default behavior.

More information about DataDog distributions:
https://docs.datadoghq.com/metrics/distributions/

Source code for DataDog StatsD client where the distribution type is used:
https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L1121

Related to #1056