### PR TITLE
Add since to GraphiteHierarchicalNameMapper

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteHierarchicalNameMapper.java
@@ -28,6 +28,7 @@ import java.util.List;
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @since 1.4.0
  */
 public class GraphiteHierarchicalNameMapper implements HierarchicalNameMapper {
     private final List<String> tagsAsPrefix;


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to `GraphiteHierarchicalNameMapper`.