### PR TITLE
Improve perf by reducing the number of requests to Datadog

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -242,10 +242,9 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                 .findAny()
                 .map(t -> ",\"host\":\"" + escapeJson(t.getValue()) + "\"")
                 .orElse("");
-
         // Create type attribute
         String type = ",\"type\":\"" + DatadogMetricMetadata.sanitizeType(statistic) + "\"";
-        // Create type attribute
+        // Create unit attribute
         String unit = "";
         if (id.getBaseUnit() != null || overrideBaseUnit != null) {
             unit = ",\"unit\":\"" + DatadogMetricMetadata.sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit) + "\"";

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -247,7 +247,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         String type = ",\"type\":\"" + DatadogMetricMetadata.sanitizeType(statistic) + "\"";
         // Create type attribute
         String unit = "";
-        if(id.getBaseUnit() != null || overrideBaseUnit != null) {
+        if (id.getBaseUnit() != null || overrideBaseUnit != null) {
             unit = ",\"unit\":\"" + DatadogMetricMetadata.sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit) + "\"";
         }
         // Create tags attribute

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -44,6 +44,7 @@ import static java.util.stream.StreamSupport.stream;
 
 /**
  * @author Jon Schneider
+ * @author Gregory Zussa
  */
 public class DatadogMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("datadog-metrics-publisher");
@@ -117,20 +118,22 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                         [{\"metric\":\"test.metric\",
                           \"points\":[[$currenttime, 20]],
                           \"host\":\"test.example.com\",
+                          \"type\":\"count\",
+                          \"unit\":\"millisecond\",
                           \"tags\":[\"environment:test\"]}
                         ]
                 }"
                 */
                 String body = batch.stream().flatMap(meter -> meter.match(
-                        m -> writeMeter(m, metadataToSend),
-                        m -> writeMeter(m, metadataToSend),
-                        timer -> writeTimer(timer, metadataToSend),
-                        summary -> writeSummary(summary, metadataToSend),
-                        m -> writeMeter(m, metadataToSend),
-                        m -> writeMeter(m, metadataToSend),
-                        m -> writeMeter(m, metadataToSend),
-                        timer -> writeTimer(timer, metadataToSend),
-                        m -> writeMeter(m, metadataToSend))
+                        m -> writeMeter(m, metadataToSend), // visitGauge
+                        m -> writeMeter(m, metadataToSend), // visitCounter
+                        timer -> writeTimer(timer, metadataToSend), // visitTimer
+                        summary -> writeSummary(summary, metadataToSend), // visitSummary
+                        m -> writeMeter(m, metadataToSend), // visitLongTaskTimer
+                        m -> writeMeter(m, metadataToSend), // visitTimeGauge
+                        m -> writeMeter(m, metadataToSend), // visitFunctionCounter
+                        timer -> writeTimer(timer, metadataToSend), // visitFunctionTimer
+                        m -> writeMeter(m, metadataToSend)) // visitMeter
                 ).collect(joining(",", "{\"series\":[", "]}"));
 
                 logger.trace("sending metrics batch to datadog:{}{}", System.lineSeparator(), body);
@@ -146,7 +149,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
             logger.warn("failed to send metrics to datadog", e);
         }
 
-        metadataToSend.forEach(this::postMetricMetadata);
+        metadataToSend.forEach(this::postMetricDescriptionMetadata);
     }
 
     private Stream<String> writeTimer(FunctionTimer timer, Map<String, DatadogMetricMetadata> metadata) {
@@ -154,15 +157,15 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
         Meter.Id id = timer.getId();
 
-        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
-        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
-        addToMetadataList(metadata, id, "sum", Statistic.TOTAL_TIME, null);
+        addToMetadataList(metadata, id, "count");
+        addToMetadataList(metadata, id, "avg");
+        addToMetadataList(metadata, id, "sum");
 
         // we can't know anything about max and percentiles originating from a function timer
         return Stream.of(
-                writeMetric(id, "count", wallTime, timer.count()),
-                writeMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit())),
-                writeMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit())));
+                writeMetric(id, "count", wallTime, timer.count(), Statistic.COUNT, "occurrence"),
+                writeMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit()), Statistic.VALUE, null),
+                writeMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()), Statistic.TOTAL_TIME, null));
     }
 
     private Stream<String> writeTimer(Timer timer, Map<String, DatadogMetricMetadata> metadata) {
@@ -170,15 +173,15 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         final Stream.Builder<String> metrics = Stream.builder();
 
         Meter.Id id = timer.getId();
-        metrics.add(writeMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit())));
-        metrics.add(writeMetric(id, "count", wallTime, timer.count()));
-        metrics.add(writeMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit())));
-        metrics.add(writeMetric(id, "max", wallTime, timer.max(getBaseTimeUnit())));
+        metrics.add(writeMetric(id, "sum", wallTime, timer.totalTime(getBaseTimeUnit()), Statistic.TOTAL_TIME, null));
+        metrics.add(writeMetric(id, "count", wallTime, timer.count(), Statistic.COUNT, "occurrence"));
+        metrics.add(writeMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit()), Statistic.VALUE, null));
+        metrics.add(writeMetric(id, "max", wallTime, timer.max(getBaseTimeUnit()), Statistic.MAX, null));
 
-        addToMetadataList(metadata, id, "sum", Statistic.TOTAL_TIME, null);
-        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
-        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
-        addToMetadataList(metadata, id, "max", Statistic.MAX, null);
+        addToMetadataList(metadata, id, "sum");
+        addToMetadataList(metadata, id, "count");
+        addToMetadataList(metadata, id, "avg");
+        addToMetadataList(metadata, id, "max");
 
         return metrics.build();
     }
@@ -188,15 +191,15 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         final Stream.Builder<String> metrics = Stream.builder();
 
         Meter.Id id = summary.getId();
-        metrics.add(writeMetric(id, "sum", wallTime, summary.totalAmount()));
-        metrics.add(writeMetric(id, "count", wallTime, summary.count()));
-        metrics.add(writeMetric(id, "avg", wallTime, summary.mean()));
-        metrics.add(writeMetric(id, "max", wallTime, summary.max()));
+        metrics.add(writeMetric(id, "sum", wallTime, summary.totalAmount(), Statistic.TOTAL, null));
+        metrics.add(writeMetric(id, "count", wallTime, summary.count(), Statistic.COUNT, "occurrence"));
+        metrics.add(writeMetric(id, "avg", wallTime, summary.mean(), Statistic.VALUE, null));
+        metrics.add(writeMetric(id, "max", wallTime, summary.max(), Statistic.MAX, null));
 
-        addToMetadataList(metadata, id, "sum", Statistic.TOTAL, null);
-        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
-        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
-        addToMetadataList(metadata, id, "max", Statistic.MAX, null);
+        addToMetadataList(metadata, id, "sum");
+        addToMetadataList(metadata, id, "count");
+        addToMetadataList(metadata, id, "avg");
+        addToMetadataList(metadata, id, "max");
 
         return metrics.build();
     }
@@ -206,13 +209,12 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         return stream(m.measure().spliterator(), false)
                 .map(ms -> {
                     Meter.Id id = m.getId().withTag(ms.getStatistic());
-                    addToMetadataList(metadata, id, null, ms.getStatistic(), null);
-                    return writeMetric(id, null, wallTime, ms.getValue());
+                    addToMetadataList(metadata, id, null);
+                    return writeMetric(id, null, wallTime, ms.getValue(), ms.getStatistic(), null);
                 });
     }
 
-    private void addToMetadataList(Map<String, DatadogMetricMetadata> metadata, Meter.Id id, @Nullable String suffix,
-                                   Statistic stat, @Nullable String overrideBaseUnit) {
+    private void addToMetadataList(Map<String, DatadogMetricMetadata> metadata, Meter.Id id, @Nullable String suffix) {
         if (config.applicationKey() == null)
             return; // we can't set metadata correctly without the application key
 
@@ -222,24 +224,33 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
         String metricName = getConventionName(fullId);
         if (!verifiedMetadata.contains(metricName)) {
-            metadata.put(metricName, new DatadogMetricMetadata(fullId, stat, config.descriptions(), overrideBaseUnit));
+            metadata.put(metricName, new DatadogMetricMetadata(fullId, config.descriptions()));
         }
     }
 
     //VisibleForTesting
-    String writeMetric(Meter.Id id, @Nullable String suffix, long wallTime, double value) {
+    String writeMetric(Meter.Id id, @Nullable String suffix, long wallTime, double value, Statistic statistic, String overrideBaseUnit) {
         Meter.Id fullId = id;
         if (suffix != null)
             fullId = idWithSuffix(id, suffix);
 
         Iterable<Tag> tags = getConventionTags(fullId);
 
+        // Create host attribute
         String host = config.hostTag() == null ? "" : stream(tags.spliterator(), false)
                 .filter(t -> requireNonNull(config.hostTag()).equals(t.getKey()))
                 .findAny()
                 .map(t -> ",\"host\":\"" + escapeJson(t.getValue()) + "\"")
                 .orElse("");
 
+        // Create type attribute
+        String type = ",\"type\":\"" + DatadogMetricMetadata.sanitizeType(statistic) + "\"";
+        // Create type attribute
+        String unit = "";
+        if(id.getBaseUnit() != null || overrideBaseUnit != null) {
+            unit = ",\"unit\":\"" + DatadogMetricMetadata.sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit) + "\"";
+        }
+        // Create tags attribute
         String tagsArray = tags.iterator().hasNext()
                 ? stream(tags.spliterator(), false)
                 .map(t -> "\"" + escapeJson(t.getKey()) + ":" + escapeJson(t.getValue()) + "\"")
@@ -247,22 +258,22 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
                 : "";
 
         return "{\"metric\":\"" + escapeJson(getConventionName(fullId)) + "\"," +
-                "\"points\":[[" + (wallTime / 1000) + ", " + value + "]]" + host + tagsArray + "}";
+                "\"points\":[[" + (wallTime / 1000) + ", " + value + "]]" + host + type + unit + tagsArray + "}";
     }
 
     /**
      * Set up metric metadata once per time series
      */
-    private void postMetricMetadata(String metricName, DatadogMetricMetadata metadata) {
+    private void postMetricDescriptionMetadata(String metricName, DatadogMetricMetadata metadata) {
         // already posted the metadata for this metric
-        if (verifiedMetadata.contains(metricName))
+        if (verifiedMetadata.contains(metricName) || !metadata.isDescriptionsEnabled())
             return;
 
         try {
             httpClient
                     .put(config.uri() + "/api/v1/metrics/" + URLEncoder.encode(metricName, "UTF-8")
                             + "?api_key=" + config.apiKey() + "&application_key=" + config.applicationKey())
-                    .withJsonContent(metadata.editMetadataBody())
+                    .withJsonContent(metadata.editDescriptionMetadataBody())
                     .send()
                     .onSuccess(response -> verifiedMetadata.add(metricName))
                     .onError(response -> {

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -24,6 +24,7 @@ import java.util.*;
 
 /**
  * @author Jon Schneider
+ * @author Gregory Zussa
  */
 class DatadogMetricMetadata {
 
@@ -55,48 +56,50 @@ class DatadogMetricMetadata {
     }
 
     private final Meter.Id id;
-    private final String type;
     private final boolean descriptionsEnabled;
 
-    @Nullable
-    private final String overrideBaseUnit;
-
-    DatadogMetricMetadata(Meter.Id id, Statistic statistic, boolean descriptionsEnabled,
-                          @Nullable String overrideBaseUnit) {
+    DatadogMetricMetadata(Meter.Id id, boolean descriptionsEnabled) {
         this.id = id;
         this.descriptionsEnabled = descriptionsEnabled;
-        this.overrideBaseUnit = overrideBaseUnit;
+    }
 
+    public boolean isDescriptionsEnabled() {
+        return descriptionsEnabled;
+    }
+
+    String editDescriptionMetadataBody() {
+        String body = null;
+
+        if (descriptionsEnabled && id.getDescription() != null) {
+            body = "{\"description\":\"" + StringEscapeUtils.escapeJson(id.getDescription()) + "\"}";
+        }
+
+        return body;
+    }
+
+    static String sanitizeBaseUnit(String baseUnit, String overrideBaseUnit){
+        String sanitizeBaseUnit = overrideBaseUnit != null ? overrideBaseUnit : baseUnit;
+        if (sanitizeBaseUnit != null) {
+            String whitelistedBaseUnit = UNIT_WHITELIST.contains(sanitizeBaseUnit) ? sanitizeBaseUnit :
+                    PLURALIZED_UNIT_MAPPING.get(sanitizeBaseUnit);
+
+            if (whitelistedBaseUnit != null) {
+                sanitizeBaseUnit = whitelistedBaseUnit;
+            }else{
+                sanitizeBaseUnit = null;
+            }
+        }
+        return sanitizeBaseUnit;
+    }
+
+    static String sanitizeType(Statistic statistic){
         switch (statistic) {
             case COUNT:
             case TOTAL:
             case TOTAL_TIME:
-                this.type = "count";
-                break;
+                return "count";
             default:
-                this.type = "gauge";
+                return "gauge";
         }
-    }
-
-    String editMetadataBody() {
-        String body = "{\"type\":\"" + type + "\"";
-
-        String baseUnit = overrideBaseUnit != null ? overrideBaseUnit : id.getBaseUnit();
-        if (baseUnit != null) {
-            String whitelistedBaseUnit = UNIT_WHITELIST.contains(baseUnit) ? baseUnit :
-                    PLURALIZED_UNIT_MAPPING.get(baseUnit);
-
-            if (whitelistedBaseUnit != null) {
-                body += ",\"unit\":\"" + whitelistedBaseUnit + "\"";
-            }
-        }
-
-        if (descriptionsEnabled && id.getDescription() != null) {
-            body += ",\"description\":\"" + StringEscapeUtils.escapeJson(id.getDescription()) + "\"";
-        }
-
-        body += "}";
-
-        return body;
     }
 }

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -18,7 +18,6 @@ package io.micrometer.datadog;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
-import io.micrometer.core.lang.Nullable;
 
 import java.util.*;
 
@@ -77,7 +76,7 @@ class DatadogMetricMetadata {
         return body;
     }
 
-    static String sanitizeBaseUnit(String baseUnit, String overrideBaseUnit){
+    static String sanitizeBaseUnit(String baseUnit, String overrideBaseUnit) {
         String sanitizeBaseUnit = overrideBaseUnit != null ? overrideBaseUnit : baseUnit;
         if (sanitizeBaseUnit != null) {
             String whitelistedBaseUnit = UNIT_WHITELIST.contains(sanitizeBaseUnit) ? sanitizeBaseUnit :
@@ -85,14 +84,14 @@ class DatadogMetricMetadata {
 
             if (whitelistedBaseUnit != null) {
                 sanitizeBaseUnit = whitelistedBaseUnit;
-            }else{
+            } else {
                 sanitizeBaseUnit = null;
             }
         }
         return sanitizeBaseUnit;
     }
 
-    static String sanitizeType(Statistic statistic){
+    static String sanitizeType(Statistic statistic) {
         switch (statistic) {
             case COUNT:
             case TOTAL:

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -33,7 +33,7 @@ class DatadogMeterRegistryTest {
     @Issue("#463")
     @Test
     void encodeMetricName(@WiremockResolver.Wiremock WireMockServer server) {
-        Clock clock = new MockClock()
+        Clock clock = new MockClock();
         DatadogMeterRegistry registry = new DatadogMeterRegistry(new DatadogConfig() {
             @Override
             public String uri() {
@@ -85,7 +85,7 @@ class DatadogMeterRegistryTest {
 
     @Test
     void testWithDescriptionEnabled(@WiremockResolver.Wiremock WireMockServer server) {
-        Clock clock = new MockClock()
+        Clock clock = new MockClock();
         DatadogMeterRegistry registry = new DatadogMeterRegistry(new DatadogConfig() {
             @Override
             public String uri() {

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -64,8 +64,8 @@ class DatadogMeterRegistryTest {
 
         Counter.builder("my.counter#abc")
             .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
-            .register(registry)
             .description("metric description")
+            .register(registry)
             .increment(Math.PI);
         registry.publish();
 
@@ -110,8 +110,8 @@ class DatadogMeterRegistryTest {
 
         Counter.builder("my.counter#abc")
                 .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
-                .register(registry)
                 .description("metric description")
+                .register(registry)
                 .increment(Math.PI);
         registry.publish();
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -78,7 +78,7 @@ class DatadogMeterRegistryTest {
 
         server.verify(putRequestedFor(
                 urlEqualTo("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         registry.close();
@@ -130,7 +130,7 @@ class DatadogMeterRegistryTest {
 
         server.verify(putRequestedFor(
                 urlEqualTo("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         server.verify(putRequestedFor(

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -67,7 +67,7 @@ class DatadogMeterRegistryTest {
 
         server.stubFor(any(anyUrl()));
 
-        Counter.builder("my.counter#abc")
+        Counter.builder("my.dd.counter1#abc")
             .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
             .description("metric description")
             .register(registry)
@@ -76,7 +76,7 @@ class DatadogMeterRegistryTest {
 
         server.verify(putRequestedFor(
                 urlMatching("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1582636851,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[1582636851,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         registry.close();
@@ -118,7 +118,7 @@ class DatadogMeterRegistryTest {
 
         server.stubFor(any(anyUrl()));
 
-        Counter.builder("my.counter#abc")
+        Counter.builder("my.dd.counter2#abc")
                 .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
                 .description("metric description")
                 .register(registry)
@@ -126,7 +126,7 @@ class DatadogMeterRegistryTest {
         registry.publish();
 
         server.verify(putRequestedFor(
-                urlMatching("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))
+                urlMatching("/api/v1/metrics/my.dd.counter2%23abc?api_key=fake&application_key=fake"))
                 .withRequestBody(equalToJson("{\"description\":\"metric description\"}")
                 ));
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -71,12 +71,12 @@ class DatadogMeterRegistryTest {
             .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
             .description("metric description")
             .register(registry)
-            .increment(1);
+            .increment(Math.PI);
         registry.publish();
 
         server.verify(putRequestedFor(
                 urlMatching("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1582636851,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         registry.close();
@@ -124,11 +124,6 @@ class DatadogMeterRegistryTest {
                 .register(registry)
                 .increment(Math.PI);
         registry.publish();
-
-//        server.verify(putRequestedFor(
-//                urlMatching("/api/v1/series?api_key=fake"))
-//                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
-//                ));
 
         server.verify(putRequestedFor(
                 urlMatching("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -78,7 +78,7 @@ class DatadogMeterRegistryTest {
 
         server.verify(putRequestedFor(
                 urlEqualTo("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[1582636851,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         registry.close();

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -55,6 +55,11 @@ class DatadogMeterRegistryTest {
             }
 
             @Override
+            public boolean descriptions() {
+                return false;
+            }
+
+            @Override
             public boolean enabled() {
                 return false;
             }
@@ -101,8 +106,13 @@ class DatadogMeterRegistryTest {
             }
 
             @Override
-            public boolean enabled() {
+            public boolean descriptions() {
                 return true;
+            }
+
+            @Override
+            public boolean enabled() {
+                return false;
             }
         }, Clock.SYSTEM);
 
@@ -121,7 +131,7 @@ class DatadogMeterRegistryTest {
                 ));
 
         server.verify(putRequestedFor(
-                urlMatching("/api/v1/metrics/my.counter%23abc?.+"))
+                urlMatching("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))
                 .withRequestBody(equalToJson("{\"description\":\"metric description\"}")
                 ));
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -33,6 +33,7 @@ class DatadogMeterRegistryTest {
     @Issue("#463")
     @Test
     void encodeMetricName(@WiremockResolver.Wiremock WireMockServer server) {
+        Clock clock = new MockClock()
         DatadogMeterRegistry registry = new DatadogMeterRegistry(new DatadogConfig() {
             @Override
             public String uri() {
@@ -63,11 +64,11 @@ class DatadogMeterRegistryTest {
             public boolean enabled() {
                 return false;
             }
-        }, Clock.SYSTEM);
+        }, clock);
 
         server.stubFor(any(anyUrl()));
 
-        Counter.builder("my.dd.counter1#abc")
+        Counter.builder("my.counter#abc")
             .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
             .description("metric description")
             .register(registry)
@@ -75,7 +76,7 @@ class DatadogMeterRegistryTest {
         registry.publish();
 
         server.verify(putRequestedFor(
-                urlMatching("/api/v1/series?api_key=fake"))
+                urlEqualTo("/api/v1/series?api_key=fake"))
                 .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[1582636851,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
@@ -84,6 +85,7 @@ class DatadogMeterRegistryTest {
 
     @Test
     void testWithDescriptionEnabled(@WiremockResolver.Wiremock WireMockServer server) {
+        Clock clock = new MockClock()
         DatadogMeterRegistry registry = new DatadogMeterRegistry(new DatadogConfig() {
             @Override
             public String uri() {
@@ -114,11 +116,11 @@ class DatadogMeterRegistryTest {
             public boolean enabled() {
                 return false;
             }
-        }, Clock.SYSTEM);
+        }, clock);
 
         server.stubFor(any(anyUrl()));
 
-        Counter.builder("my.dd.counter2#abc")
+        Counter.builder("my.counter#abc")
                 .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
                 .description("metric description")
                 .register(registry)
@@ -126,7 +128,7 @@ class DatadogMeterRegistryTest {
         registry.publish();
 
         server.verify(putRequestedFor(
-                urlMatching("/api/v1/metrics/my.dd.counter2%23abc?api_key=fake&application_key=fake"))
+                urlEqualTo("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))
                 .withRequestBody(equalToJson("{\"description\":\"metric description\"}")
                 ));
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MockClock;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.lanwen.wiremock.ext.WiremockResolver;

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -129,6 +129,11 @@ class DatadogMeterRegistryTest {
         registry.publish();
 
         server.verify(putRequestedFor(
+                urlEqualTo("/api/v1/series?api_key=fake"))
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.dd.counter1#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                ));
+
+        server.verify(putRequestedFor(
                 urlEqualTo("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))
                 .withRequestBody(equalToJson("{\"description\":\"metric description\"}")
                 ));

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -71,12 +71,12 @@ class DatadogMeterRegistryTest {
             .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
             .description("metric description")
             .register(registry)
-            .increment(Math.PI);
+            .increment(1);
         registry.publish();
 
         server.verify(putRequestedFor(
                 urlMatching("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1582634980,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
 
         registry.close();
@@ -125,10 +125,10 @@ class DatadogMeterRegistryTest {
                 .increment(Math.PI);
         registry.publish();
 
-        server.verify(putRequestedFor(
-                urlMatching("/api/v1/series?api_key=fake"))
-                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1582634980,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
-                ));
+//        server.verify(putRequestedFor(
+//                urlMatching("/api/v1/series?api_key=fake"))
+//                .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[1,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
+//                ));
 
         server.verify(putRequestedFor(
                 urlMatching("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -76,7 +76,7 @@ class DatadogMeterRegistryTest {
             .increment(Math.PI);
         registry.publish();
 
-        server.verify(putRequestedFor(
+        server.verify(postRequestedFor(
                 urlEqualTo("/api/v1/series?api_key=fake"))
                 .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));
@@ -128,7 +128,7 @@ class DatadogMeterRegistryTest {
                 .increment(Math.PI);
         registry.publish();
 
-        server.verify(putRequestedFor(
+        server.verify(postRequestedFor(
                 urlEqualTo("/api/v1/series?api_key=fake"))
                 .withRequestBody(equalToJson("{\"series\":[{\"metric\":\"my.counter#abc\",\"points\":[[0,0.0]],\"type\":\"count\",\"unit\":\"microsecond\",\"tags\":[\"statistic:count\"]}]}")
                 ));

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -33,7 +33,7 @@ class DatadogMetricMetadataTest {
                         .tag("key", "value")
                         .description("The /\"recent cpu usage\" for the Java Virtual Machine process")
                         .register(new SimpleMeterRegistry()).getId(),
-                Statistic.COUNT
+                true
         );
 
         assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo("{\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
@@ -56,7 +56,7 @@ class DatadogMetricMetadataTest {
                         return null;
                     }
                 }, Clock.SYSTEM)).getId(),
-            Statistic.TOTAL_TIME);
+            false);
 
         assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo(null);
     }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -17,7 +17,6 @@ package io.micrometer.datadog;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -33,9 +33,7 @@ class DatadogMetricMetadataTest {
                         .tag("key", "value")
                         .description("The /\"recent cpu usage\" for the Java Virtual Machine process")
                         .register(new SimpleMeterRegistry()).getId(),
-                Statistic.COUNT,
-                true,
-                null
+                Statistic.COUNT
         );
 
         assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo("{\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
@@ -58,9 +56,7 @@ class DatadogMetricMetadataTest {
                         return null;
                     }
                 }, Clock.SYSTEM)).getId(),
-            Statistic.TOTAL_TIME,
-            false,
-            null);
+            Statistic.TOTAL_TIME);
 
         assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo(null);
     }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -38,7 +38,7 @@ class DatadogMetricMetadataTest {
                 null
         );
 
-        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
+        assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo("{\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
     }
 
     @Test
@@ -62,7 +62,7 @@ class DatadogMetricMetadataTest {
             false,
             null);
 
-        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"unit\":\"millisecond\"}");
+        assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo(null);
     }
 
 }


### PR DESCRIPTION
This PR improves performance for the `micrometer-registry-datadog` implementation.
Instead of sending metrics `unit` and `type` attributes as part of the unbatched edit metric endpoint `/api/v1/metrics/<METRIC_NAME>`, we now  submit them as part of the batched metric intake endpoint `/api/v1/series`.

Note that metric description cannot be submitted as part of the metric intake endpoint at the moment.
However, this attribute is optional  and can be disabled. If disabled the edit metric endpoint won't be call at all. 

Related issue #1867.