### PR TITLE
Run StatsdMeterRegistryPublishTest.receiveMetricsSuccessfully() only on Linux

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -52,6 +52,8 @@ class StatsdMeterRegistryPublishTest {
     CountDownLatch serverLatch;
 
     @ParameterizedTest
+    // test behavior is not stable on at least macOS, so only run on Linux for now
+    @EnabledOnOs(OS.LINUX)
     @EnumSource(StatsdProtocol.class)
     void receiveMetricsSuccessfully(StatsdProtocol protocol) throws InterruptedException {
         serverLatch = new CountDownLatch(3);


### PR DESCRIPTION
This PR changes to run `StatsdMeterRegistryPublishTest.receiveMetricsSuccessfully()` only on Linux as it's flaky in macOS. I'm not sure if it has the same cause as the other two tests in `StatsdMeterRegistryPublishTest`.