### PR TITLE
Fix a Javadoc warning

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java
@@ -29,7 +29,6 @@ import io.micrometer.core.lang.Nullable;
  *
  *
  * @see <a href="https://cloud.google.com/monitoring/api/v3/metrics-details">"Naming rules" section on Stackdriver's reference documentation</a>
- * and
  * @see <a href="https://cloud.google.com/monitoring/quotas#custom_metrics_quotas">"Custom Metrics" on the Stackdriver's Quotas and limits reference documentation</a>
  * 
  * @author Jon Schneider


### PR DESCRIPTION
There is a Javadoc warning as follows:

```
$ ./gradlew clean javadoc
> Task :micrometer-registry-stackdriver:javadoc
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverNamingConvention.java:38: warning - Tag @see: missing final '>': "<a href="https://cloud.google.com/monitoring/api/v3/metrics-details">"Naming rules" section on Stackdriver's reference documentation</a>
 and"
1 warning
$
```

This PR fixes it.