### PR TITLE
Mark shadow jar for publication.

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -37,6 +37,8 @@ jar.dependsOn shadowJar
 publishing {
     publications {
         withType(MavenPublication) {
+            artifact(shadowJar)
+
             pom.withXml {
                 asNode()
                         .dependencies


### PR DESCRIPTION
I'm not entirely sure but guess that recent versions of Gradle added validation that only tasks registered with `artifact` are pubished (even if a non-registered task generates a file with the same name coincidentally).

Registering the task explicitly seems to fix it.

Fixes #1872