### PR TITLE
Upgrade to Gradle Wrapper 6.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = '6.2.1'
+    gradleVersion = '6.2.2'
 }
 
 defaultTasks 'build'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to Gradle Wrapper 6.2.2.