### PR TITLE
Fix Javadoc error and warnings

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -428,7 +428,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     /**
      * @deprecated queue capacity is no longer available since 1.4.0
-     * @return queue capacity
+     * @return constant {@literal -1}
      */
     @Deprecated
     public int queueCapacity() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -419,7 +419,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     /**
      * @deprecated queue size is no longer available since 1.4.0
-     * @return queue size
+     * @return constant {@literal -1}
      */
     @Deprecated
     public int queueSize() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -419,6 +419,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     /**
      * @deprecated queue size is no longer available since 1.4.0
+     * @return queue size
      */
     @Deprecated
     public int queueSize() {
@@ -427,6 +428,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     /**
      * @deprecated queue capacity is no longer available since 1.4.0
+     * @return queue capacity
      */
     @Deprecated
     public int queueCapacity() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -51,10 +51,12 @@ import java.util.stream.Stream;
  * <p>
  * This can be used as the regular JOOQ {@link DSLContext} but queries will be timed
  * and tags can be set for the query timed. For example:
- * <code><pre>
+ * <pre>
+ * <code>
  *     MetricsDSLContext jooq = MetricsDSLContext.withMetrics(DSL.using(configuration), meterRegistry, Tags.empty());
  *     jooq.tag("name", "selectAllAuthors").select(asterisk()).from("author").fetch();
- * </pre></code>
+ * </code>
+ * </pre>
  *
  * @author Jon Schneider
  * @since 1.4.0


### PR DESCRIPTION
There are Javadoc error and warnings as follows:

```
$ ./gradlew clean javadoc
...
> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:54: error: block element not allowed within inline element <code>: pre
 * <code><pre>
         ^
1 error

> Task :micrometer-registry-statsd:javadoc
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java:424: warning: no @return
    public int queueSize() {
               ^
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java:432: warning: no @return
    public int queueCapacity() {
               ^
2 warnings
...
$
```

This PR fixes them.