### PR TITLE
Use managed versions in micrometer-sample-core

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,8 +1,10 @@
 def VERSIONS = [
         'ch.qos.logback:logback-classic:1.2.+',
+        'colt:colt:1.2.0',
         'com.amazonaws:aws-java-sdk-cloudwatch:latest.release',
         'com.fasterxml.jackson.core:jackson-databind:latest.release',
         'com.github.ben-manes.caffeine:caffeine:latest.release',
+        'com.github.charithe:kafka-junit:4.1.2',
         'com.github.tomakehurst:wiremock-jre8:latest.release',
         'com.google.cloud:google-cloud-monitoring:latest.release',
         'com.google.dagger:dagger:2.11',
@@ -29,6 +31,7 @@ def VERSIONS = [
         'io.projectreactor:reactor-test:latest.release',
         'io.projectreactor.netty:reactor-netty:latest.release',
         'io.prometheus:simpleclient_common:latest.release',
+        'io.prometheus:simpleclient_pushgateway:latest.release',
         'javax.cache:cache-api:latest.release',
         'javax.inject:javax.inject:1',
         'javax.xml.bind:jaxb-api:2.3.+',

--- a/samples/micrometer-samples-core/build.gradle
+++ b/samples/micrometer-samples-core/build.gradle
@@ -1,20 +1,15 @@
 dependencies {
     implementation project(':micrometer-core')
-    implementation 'colt:colt:1.2.0'
-    implementation('ch.qos.logback:logback-classic:1.2.+') {
-        force = true
-    }
-    implementation('org.slf4j:slf4j-api:1.7.25') {
-        // logback doesn't yet work with slf4j 1.8
-        force = true
-    }
+    implementation 'colt:colt'
+    implementation('ch.qos.logback:logback-classic')
+    implementation('org.slf4j:slf4j-api')
 
     ['atlas', 'prometheus', 'datadog', 'ganglia', 'elastic', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver'].each { sys ->
         implementation project(":micrometer-registry-$sys")
     }
 
-    implementation 'io.prometheus:simpleclient_pushgateway:latest.release'
-    implementation 'io.projectreactor.netty:reactor-netty:latest.release'
-    implementation 'org.apache.kafka:kafka-clients:latest.release'
-    implementation 'com.github.charithe:kafka-junit:4.1.2'
+    implementation 'io.prometheus:simpleclient_pushgateway'
+    implementation 'io.projectreactor.netty:reactor-netty'
+    implementation 'org.apache.kafka:kafka-clients'
+    implementation 'com.github.charithe:kafka-junit'
 }


### PR DESCRIPTION
There is a deprecation warning as follows:

```
> Configure project :micrometer-samples-core
Using force on a dependency has been deprecated. This is scheduled to be removed in Gradle 7.0. Consider using strict version constraints instead (version { strictly ... } }). Consult the upgrading guide for further information: https://docs.gradle.org/6.2.2/userguide/upgrading_version_5.html#forced_dependencies
        at build_c0b3jgz888lzxibox4ubdhoqc$_run_closure1$_closure2.doCall(/Users/user/IdeaProjects/micrometer/samples/micrometer-samples-core/build.gradle:5)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
I'm configuring micrometer-samples-core with version 1.4.0-SNAPSHOT
```

Just using managed versions seems to be sufficient, so this PR changes to use managed versions in `micrometer-sample-core`.

This PR also moves versions in `micrometer-sample-core` to `dependencies.gradle` for consistency.