### PR TITLE
Align StepDistributionSummary with StepTimer for max

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -20,45 +20,19 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.distribution.TimeWindowMax;
 
 import java.util.Arrays;
 
+/**
+ * Step-normalized {@link io.micrometer.core.instrument.DistributionSummary}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public class StepDistributionSummary extends AbstractDistributionSummary {
     private final StepLong count;
     private final StepDouble total;
-    private final TimeWindowMax max;
-
-    /**
-     * Create a new {@code StepDistributionSummary}.
-     *
-     * @param id                          ID
-     * @param clock                       clock
-     * @param distributionStatisticConfig distribution static configuration
-     * @param scale                       scale
-     * @deprecated Use {@link #StepDistributionSummary(io.micrometer.core.instrument.Meter.Id, Clock, DistributionStatisticConfig, double, long, boolean)}
-     */
-    @Deprecated
-    public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale) {
-        this(id, clock, distributionStatisticConfig, scale, false);
-    }
-
-    /**
-     * Create a new {@code StepDistributionSummary}.
-     *
-     * @param id                            ID
-     * @param clock                         clock
-     * @param distributionStatisticConfig   distribution static configuration
-     * @param scale                         scale
-     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
-     * @deprecated Use {@link #StepDistributionSummary(io.micrometer.core.instrument.Meter.Id, Clock, DistributionStatisticConfig, double, long, boolean)}
-     */
-    @Deprecated
-    @SuppressWarnings("ConstantConditions")
-    public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale,
-                                   boolean supportsAggregablePercentiles) {
-        this(id, clock, distributionStatisticConfig, scale, distributionStatisticConfig.getExpiry().toMillis(), supportsAggregablePercentiles);
-    }
+    private final StepDoubleMax max;
 
     /**
      * Create a new {@code StepDistributionSummary}.
@@ -76,7 +50,7 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
         super(id, clock, distributionStatisticConfig, scale, supportsAggregablePercentiles);
         this.count = new StepLong(clock, stepMillis);
         this.total = new StepDouble(clock, stepMillis);
-        this.max = new TimeWindowMax(clock, distributionStatisticConfig);
+        this.max = new StepDoubleMax(clock, stepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDoubleMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDoubleMax.java
@@ -15,44 +15,40 @@
  */
 package io.micrometer.core.instrument.step;
 
+import io.micrometer.core.instrument.Clock;
+
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
-import io.micrometer.core.instrument.Clock;
-
 /**
- * A class similar to {@link StepLong}, but records the maximum <b>positive</b>
+ * A class similar to {@link StepDouble}, but records the maximum
  * value recorded in steps as opposed accumulated values.
  *
  * @author Samuel Cox
+ * @author Johnny Lim
  */
-class StepLongMax extends StepValue<Long> {
-    private final AtomicLong current = new AtomicLong(0);
+class StepDoubleMax extends StepValue<Double> {
+    private final AtomicLong current = new AtomicLong();
 
-    public StepLongMax(Clock clock, long stepMillis) {
+    public StepDoubleMax(Clock clock, long stepMillis) {
         super(clock, stepMillis);
     }
 
     @Override
-    protected Supplier<Long> valueSupplier() {
-        return () -> current.getAndSet(0L);
+    protected Supplier<Double> valueSupplier() {
+        return () -> Double.longBitsToDouble(current.getAndSet(0));
     }
 
     @Override
-    protected Long noValue() {
-        return 0L;
+    protected Double noValue() {
+        return 0.0;
     }
 
     /**
-     * Record a positive amount.
-     *
-     * @throws {@link IllegalArgumentException} if the amount is negative.
+     * Record a amount.
      */
-    void record(final long amount) {
-        if (amount < 0) {
-            throw new IllegalArgumentException("Only positive values can be recorded.");
-        }
-        current.updateAndGet(curr -> Math.max(curr, amount));
+    void record(double amount) {
+        current.updateAndGet(current -> Math.max(current, Double.doubleToLongBits(amount)));
     }
 
 }


### PR DESCRIPTION
This PR changes to align `StepDistributionSummary` with `StepTimer` for max.

See gh-1796