### PR TITLE
Fix rejected cloudwatch metric with empty tag

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.config.MissingRequiredConfigurationExceptio
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
@@ -270,6 +271,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         private List<Dimension> toDimensions(List<Tag> tags) {
             return tags.stream()
+                    .filter(t -> StringUtils.isNotBlank(t.getValue()))
                     .map(tag -> new Dimension().withName(tag.getKey()).withValue(tag.getValue()))
                     .collect(toList());
         }

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -21,7 +21,6 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsync;
 import com.amazonaws.services.cloudwatch.model.*;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
-import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.instrument.util.StringUtils;
@@ -69,7 +68,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         this.amazonCloudWatchAsync = amazonCloudWatchAsync;
         this.config = config;
-        config().namingConvention(NamingConvention.identity);
+        config().namingConvention(new CloudWatchNamingConvention());
         start(threadFactory);
     }
 

--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchNamingConvention.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchNamingConvention.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.StringUtils;
+import io.micrometer.core.lang.Nullable;
+
+/**
+ * {@link NamingConvention} for CloudWatch.
+ *
+ * @author Klaus Hartl
+ */
+public class CloudWatchNamingConvention implements NamingConvention {
+
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html
+    private static final int MAX_TAG_KEY_LENGTH = 255;
+    private static final int MAX_TAG_VALUE_LENGTH = 255;
+
+    private final NamingConvention delegate;
+
+    public CloudWatchNamingConvention() {
+        this(NamingConvention.identity);
+    }
+
+    public CloudWatchNamingConvention(NamingConvention delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String name(String name, Meter.Type type, @Nullable String baseUnit) {
+        return delegate.name(name, type, baseUnit);
+    }
+
+    @Override
+    public String tagKey(String key) {
+        return StringUtils.truncate(delegate.tagKey(key), MAX_TAG_KEY_LENGTH);
+    }
+
+    @Override
+    public String tagValue(String value) {
+        return StringUtils.truncate(delegate.tagValue(value), MAX_TAG_VALUE_LENGTH);
+    }
+}

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.cloudwatch;
 
+import com.amazonaws.services.cloudwatch.model.Dimension;
 import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
@@ -112,6 +113,15 @@ class CloudWatchMeterRegistryTest {
         List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
         assertThat(registry.new Batch().metricData(meter)).hasSize(2);
+    }
+
+    @Test
+    void writeShouldDropTagWithBlankValue() {
+        registry.gauge("my.gauge", Tags.of("accepted", "foo").and("empty", ""), 1d);
+        assertThat(registry.metricData())
+                .hasSize(1)
+                .allSatisfy(datum -> assertThat(datum.getDimensions()).hasSize(1).contains(
+                        new Dimension().withName("accepted").withValue("foo")));
     }
 
 }

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchNamingConventionTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchNamingConventionTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.config.NamingConvention;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+class CloudWatchNamingConventionTest {
+    private final NamingConvention namingConvention = new CloudWatchNamingConvention();
+
+    @Test
+    void truncateTagKey() {
+        assertThat(namingConvention
+                .tagKey(StringUtils.repeat("x", 256)).length()).isEqualTo(255);
+    }
+
+    @Test
+    void truncateTagValue() {
+        assertThat(namingConvention
+                .tagValue(StringUtils.repeat("x", 256)).length()).isEqualTo(255);
+    }
+
+}


### PR DESCRIPTION
CloudWatch rejects any metric with a dimension that has an empty value, which might cause unexpected loss of metrics. Reactor for instance produces metrics where the "exception" dimension may have an empty value, and thus those metrics do not show up in CloudWatch without a workaround.

Similar to how the InfluxMeterRegistry behaves (see #1166) we're dropping such a faulty dimension before sending off the data.

~Additionally dropping dimensions with values exceeding the maximum (255).~
EDIT: Additionally implementing a CloudWatch naming convention that ensures the maximum length for both key and value are adhered to (by truncating).

Reference:
https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html

Closes #1813