### PR TITLE
Remove @Support and @PlainSQL in MetricsDSLContext

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -243,8 +243,7 @@ public class MetricsDSLContext implements DSLContext {
         return context.informationSchema(table);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public Explain explain(Query query) {
         return context.explain(query);
     }
@@ -374,770 +373,592 @@ public class MetricsDSLContext implements DSLContext {
         context.attach(attachables);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> LoaderOptionsStep<R> loadInto(Table<R> table) {
         return context.loadInto(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public Queries queries(Query... queries) {
         return context.queries(queries);
     }
 
-    @Override
-    @Support
+    @Override    
     public Queries queries(Collection<? extends Query> queries) {
         return context.queries(queries);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public Block begin(Statement... statements) {
         return context.begin(statements);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public Block begin(Collection<? extends Statement> statements) {
         return context.begin(statements);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public RowCountQuery query(SQL sql) {
         return context.query(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public RowCountQuery query(String sql) {
         return context.query(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public RowCountQuery query(String sql, Object... bindings) {
         return context.query(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public RowCountQuery query(String sql, QueryPart... parts) {
         return context.query(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Result<Record> fetch(SQL sql) throws DataAccessException {
         return context.fetch(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Result<Record> fetch(String sql) throws DataAccessException {
         return context.fetch(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Result<Record> fetch(String sql, Object... bindings) throws DataAccessException {
         return context.fetch(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Result<Record> fetch(String sql, QueryPart... parts) throws DataAccessException {
         return context.fetch(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(SQL sql) throws DataAccessException {
         return context.fetchLazy(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(String sql) throws DataAccessException {
         return context.fetchLazy(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(String sql, Object... bindings) throws DataAccessException {
         return context.fetchLazy(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(String sql, QueryPart... parts) throws DataAccessException {
         return context.fetchLazy(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(SQL sql) {
         return context.fetchAsync(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(String sql) {
         return context.fetchAsync(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(String sql, Object... bindings) {
         return context.fetchAsync(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(String sql, QueryPart... parts) {
         return context.fetchAsync(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, SQL sql) {
         return context.fetchAsync(executor, sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, String sql) {
         return context.fetchAsync(executor, sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, String sql, Object... bindings) {
         return context.fetchAsync(executor, sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, String sql, QueryPart... parts) {
         return context.fetchAsync(executor, sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Stream<Record> fetchStream(SQL sql) throws DataAccessException {
         return context.fetchStream(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Stream<Record> fetchStream(String sql) throws DataAccessException {
         return context.fetchStream(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Stream<Record> fetchStream(String sql, Object... bindings) throws DataAccessException {
         return context.fetchStream(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Stream<Record> fetchStream(String sql, QueryPart... parts) throws DataAccessException {
         return context.fetchStream(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Results fetchMany(SQL sql) throws DataAccessException {
         return context.fetchMany(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Results fetchMany(String sql) throws DataAccessException {
         return context.fetchMany(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Results fetchMany(String sql, Object... bindings) throws DataAccessException {
         return context.fetchMany(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Results fetchMany(String sql, QueryPart... parts) throws DataAccessException {
         return context.fetchMany(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchOne(SQL sql) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchOne(String sql) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchOne(String sql, Object... bindings) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchOne(String sql, QueryPart... parts) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchSingle(SQL sql) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchSingle(String sql) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchSingle(String sql, Object... bindings) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Record fetchSingle(String sql, QueryPart... parts) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(SQL sql) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(String sql) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(String sql, Object... bindings) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(String sql, QueryPart... parts) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Object fetchValue(SQL sql) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Object fetchValue(String sql) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Object fetchValue(String sql, Object... bindings) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Object fetchValue(String sql, QueryPart... parts) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<?> fetchOptionalValue(SQL sql) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<?> fetchOptionalValue(String sql) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<?> fetchOptionalValue(String sql, Object... bindings) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public Optional<?> fetchOptionalValue(String sql, QueryPart... parts) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public List<?> fetchValues(SQL sql) throws DataAccessException, InvalidResultException {
         return context.fetchValues(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public List<?> fetchValues(String sql) throws DataAccessException, InvalidResultException {
         return context.fetchValues(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public List<?> fetchValues(String sql, Object... bindings) throws DataAccessException, InvalidResultException {
         return context.fetchValues(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public List<?> fetchValues(String sql, QueryPart... parts) throws DataAccessException, InvalidResultException {
         return context.fetchValues(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public int execute(SQL sql) throws DataAccessException {
         return context.execute(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public int execute(String sql) throws DataAccessException {
         return context.execute(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public int execute(String sql, Object... bindings) throws DataAccessException {
         return context.execute(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public int execute(String sql, QueryPart... parts) throws DataAccessException {
         return context.execute(sql, parts);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public ResultQuery<Record> resultQuery(SQL sql) {
         return context.resultQuery(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public ResultQuery<Record> resultQuery(String sql) {
         return context.resultQuery(sql);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public ResultQuery<Record> resultQuery(String sql, Object... bindings) {
         return context.resultQuery(sql, bindings);
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public ResultQuery<Record> resultQuery(String sql, QueryPart... parts) {
         return context.resultQuery(sql, parts);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetch(ResultSet rs) throws DataAccessException {
         return context.fetch(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetch(ResultSet rs, Field<?>... fields) throws DataAccessException {
         return context.fetch(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetch(ResultSet rs, DataType<?>... types) throws DataAccessException {
         return context.fetch(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetch(ResultSet rs, Class<?>... types) throws DataAccessException {
         return context.fetch(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchOne(ResultSet rs) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchOne(ResultSet rs, Field<?>... fields) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchOne(ResultSet rs, DataType<?>... types) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchOne(ResultSet rs, Class<?>... types) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(ResultSet rs) throws DataAccessException, TooManyRowsException {
         return context.fetchSingle(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(ResultSet rs, Field<?>... fields) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(ResultSet rs, DataType<?>... types) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(ResultSet rs, Class<?>... types) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(ResultSet rs) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchOptional(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(ResultSet rs, Field<?>... fields) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(ResultSet rs, DataType<?>... types) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Optional<Record> fetchOptional(ResultSet rs, Class<?>... types) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Object fetchValue(ResultSet rs) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> T fetchValue(ResultSet rs, Field<T> field) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(rs, field);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> T fetchValue(ResultSet rs, DataType<T> type) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> T fetchValue(ResultSet rs, Class<T> type) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchValue(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public Optional<?> fetchOptionalValue(ResultSet rs) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> Optional<T> fetchOptionalValue(ResultSet rs, Field<T> field) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(rs, field);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> Optional<T> fetchOptionalValue(ResultSet rs, DataType<T> type) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> Optional<T> fetchOptionalValue(ResultSet rs, Class<T> type) throws DataAccessException, TooManyRowsException, InvalidResultException {
         return context.fetchOptionalValue(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public List<?> fetchValues(ResultSet rs) throws DataAccessException, InvalidResultException {
         return context.fetchValues(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> List<T> fetchValues(ResultSet rs, Field<T> field) throws DataAccessException, InvalidResultException {
         return context.fetchValues(rs, field);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> List<T> fetchValues(ResultSet rs, DataType<T> type) throws DataAccessException, InvalidResultException {
         return context.fetchValues(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T> List<T> fetchValues(ResultSet rs, Class<T> type) throws DataAccessException, InvalidResultException {
         return context.fetchValues(rs, type);
     }
 
-    @Override
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(ResultSet rs) throws DataAccessException {
         return context.fetchLazy(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(ResultSet rs, Field<?>... fields) throws DataAccessException {
         return context.fetchLazy(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(ResultSet rs, DataType<?>... types) throws DataAccessException {
         return context.fetchLazy(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Cursor<Record> fetchLazy(ResultSet rs, Class<?>... types) throws DataAccessException {
         return context.fetchLazy(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(ResultSet rs) {
         return context.fetchAsync(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(ResultSet rs, Field<?>... fields) {
         return context.fetchAsync(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(ResultSet rs, DataType<?>... types) {
         return context.fetchAsync(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(ResultSet rs, Class<?>... types) {
         return context.fetchAsync(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, ResultSet rs) {
         return context.fetchAsync(executor, rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, ResultSet rs, Field<?>... fields) {
         return context.fetchAsync(executor, rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, ResultSet rs, DataType<?>... types) {
         return context.fetchAsync(executor, rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public CompletionStage<Result<Record>> fetchAsync(Executor executor, ResultSet rs, Class<?>... types) {
         return context.fetchAsync(executor, rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Stream<Record> fetchStream(ResultSet rs) throws DataAccessException {
         return context.fetchStream(rs);
     }
 
-    @Override
-    @Support
+    @Override    
     public Stream<Record> fetchStream(ResultSet rs, Field<?>... fields) throws DataAccessException {
         return context.fetchStream(rs, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Stream<Record> fetchStream(ResultSet rs, DataType<?>... types) throws DataAccessException {
         return context.fetchStream(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Stream<Record> fetchStream(ResultSet rs, Class<?>... types) throws DataAccessException {
         return context.fetchStream(rs, types);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromTXT(String string) throws DataAccessException {
         return context.fetchFromTXT(string);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromTXT(String string, String nullLiteral) throws DataAccessException {
         return context.fetchFromTXT(string, nullLiteral);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromHTML(String string) throws DataAccessException {
         return context.fetchFromHTML(string);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromCSV(String string) throws DataAccessException {
         return context.fetchFromCSV(string);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromCSV(String string, char delimiter) throws DataAccessException {
         return context.fetchFromCSV(string, delimiter);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromCSV(String string, boolean header) throws DataAccessException {
         return context.fetchFromCSV(string, header);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromCSV(String string, boolean header, char delimiter) throws DataAccessException {
         return context.fetchFromCSV(string, header, delimiter);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromJSON(String string) {
         return context.fetchFromJSON(string);
     }
 
-    @Override
-    @Support
+    @Override    
     public Result<Record> fetchFromXML(String string) {
         return context.fetchFromXML(string);
     }
@@ -1157,1404 +978,1167 @@ public class MetricsDSLContext implements DSLContext {
         return context.fetchFromStringData(data, header);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(String alias) {
         return context.with(alias);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(String alias, String... fieldAliases) {
         return context.with(alias, fieldAliases);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(Name alias) {
         return context.with(alias);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(Name alias, Name... fieldAliases) {
         return context.with(alias, fieldAliases);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(String alias, Function<? super Field<?>, ? extends String> fieldNameFunction) {
         return context.with(alias, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep with(String alias, BiFunction<? super Field<?>, ? super Integer, ? extends String> fieldNameFunction) {
         return context.with(alias, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep1 with(String alias, String fieldAlias1) {
         return context.with(alias, fieldAlias1);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep2 with(String alias, String fieldAlias1, String fieldAlias2) {
         return context.with(alias, fieldAlias1, fieldAlias2);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep3 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep4 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep5 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep6 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep7 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep8 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep9 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep10 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep11 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep12 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep13 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep14 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep15 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep16 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep17 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep18 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep19 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep20 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep21 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20, String fieldAlias21) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep22 with(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20, String fieldAlias21, String fieldAlias22) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21, fieldAlias22);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep1 with(Name alias, Name fieldAlias1) {
         return context.with(alias, fieldAlias1);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep2 with(Name alias, Name fieldAlias1, Name fieldAlias2) {
         return context.with(alias, fieldAlias1, fieldAlias2);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep3 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep4 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep5 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep6 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep7 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep8 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep9 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep10 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep11 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep12 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep13 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep14 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep15 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep16 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep17 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep18 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep19 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep20 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep21 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20, Name fieldAlias21) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep22 with(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20, Name fieldAlias21, Name fieldAlias22) {
         return context.with(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21, fieldAlias22);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithStep with(CommonTableExpression<?>... tables) {
         return context.with(tables);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(String alias) {
         return context.withRecursive(alias);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(String alias, String... fieldAliases) {
         return context.withRecursive(alias, fieldAliases);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(Name alias) {
         return context.withRecursive(alias);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(Name alias, Name... fieldAliases) {
         return context.withRecursive(alias, fieldAliases);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(String alias, Function<? super Field<?>, ? extends String> fieldNameFunction) {
         return context.withRecursive(alias, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep withRecursive(String alias, BiFunction<? super Field<?>, ? super Integer, ? extends String> fieldNameFunction) {
         return context.withRecursive(alias, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep1 withRecursive(String alias, String fieldAlias1) {
         return context.withRecursive(alias, fieldAlias1);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep2 withRecursive(String alias, String fieldAlias1, String fieldAlias2) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep3 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep4 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep5 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep6 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep7 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep8 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep9 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep10 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep11 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep12 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep13 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep14 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep15 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep16 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep17 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep18 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep19 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep20 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep21 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20, String fieldAlias21) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep22 withRecursive(String alias, String fieldAlias1, String fieldAlias2, String fieldAlias3, String fieldAlias4, String fieldAlias5, String fieldAlias6, String fieldAlias7, String fieldAlias8, String fieldAlias9, String fieldAlias10, String fieldAlias11, String fieldAlias12, String fieldAlias13, String fieldAlias14, String fieldAlias15, String fieldAlias16, String fieldAlias17, String fieldAlias18, String fieldAlias19, String fieldAlias20, String fieldAlias21, String fieldAlias22) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21, fieldAlias22);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep1 withRecursive(Name alias, Name fieldAlias1) {
         return context.withRecursive(alias, fieldAlias1);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep2 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep3 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep4 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep5 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep6 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep7 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep8 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep9 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep10 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep11 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep12 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep13 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep14 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep15 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep16 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep17 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep18 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep19 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep20 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep21 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20, Name fieldAlias21) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithAsStep22 withRecursive(Name alias, Name fieldAlias1, Name fieldAlias2, Name fieldAlias3, Name fieldAlias4, Name fieldAlias5, Name fieldAlias6, Name fieldAlias7, Name fieldAlias8, Name fieldAlias9, Name fieldAlias10, Name fieldAlias11, Name fieldAlias12, Name fieldAlias13, Name fieldAlias14, Name fieldAlias15, Name fieldAlias16, Name fieldAlias17, Name fieldAlias18, Name fieldAlias19, Name fieldAlias20, Name fieldAlias21, Name fieldAlias22) {
         return context.withRecursive(alias, fieldAlias1, fieldAlias2, fieldAlias3, fieldAlias4, fieldAlias5, fieldAlias6, fieldAlias7, fieldAlias8, fieldAlias9, fieldAlias10, fieldAlias11, fieldAlias12, fieldAlias13, fieldAlias14, fieldAlias15, fieldAlias16, fieldAlias17, fieldAlias18, fieldAlias19, fieldAlias20, fieldAlias21, fieldAlias22);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public WithStep withRecursive(CommonTableExpression<?>... tables) {
         return context.withRecursive(tables);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> SelectWhereStep<R> selectFrom(Table<R> table) {
         return time(context.selectFrom(table));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectWhereStep<Record> selectFrom(Name table) {
         return time(context.selectFrom(table));
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public SelectWhereStep<Record> selectFrom(SQL sql) {
         return time(context.selectFrom(sql));
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public SelectWhereStep<Record> selectFrom(String sql) {
         return time(context.selectFrom(sql));
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public SelectWhereStep<Record> selectFrom(String sql, Object... bindings) {
         return time(context.selectFrom(sql, bindings));
     }
 
-    @Override
-    @PlainSQL
-    @Support
+    @Override    
     public SelectWhereStep<Record> selectFrom(String sql, QueryPart... parts) {
         return time(context.selectFrom(sql, parts));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record> select(Collection<? extends SelectFieldOrAsterisk> fields) {
         return time(context.select(fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record> select(SelectFieldOrAsterisk... fields) {
         return time(context.select(fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1> SelectSelectStep<Record1<T1>> select(SelectField<T1> field1) {
         return time(context.select(field1));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2> SelectSelectStep<Record2<T1, T2>> select(SelectField<T1> field1, SelectField<T2> field2) {
         return time(context.select(field1, field2));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3> SelectSelectStep<Record3<T1, T2, T3>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3) {
         return time(context.select(field1, field2, field3));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4> SelectSelectStep<Record4<T1, T2, T3, T4>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4) {
         return time(context.select(field1, field2, field3, field4));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5> SelectSelectStep<Record5<T1, T2, T3, T4, T5>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5) {
         return time(context.select(field1, field2, field3, field4, field5));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6> SelectSelectStep<Record6<T1, T2, T3, T4, T5, T6>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6) {
         return time(context.select(field1, field2, field3, field4, field5, field6));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7> SelectSelectStep<Record7<T1, T2, T3, T4, T5, T6, T7>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8> SelectSelectStep<Record8<T1, T2, T3, T4, T5, T6, T7, T8>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9> SelectSelectStep<Record9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SelectSelectStep<Record10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SelectSelectStep<Record11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SelectSelectStep<Record12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SelectSelectStep<Record13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SelectSelectStep<Record14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SelectSelectStep<Record15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> SelectSelectStep<Record16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> SelectSelectStep<Record17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> SelectSelectStep<Record18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> SelectSelectStep<Record19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> SelectSelectStep<Record20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> SelectSelectStep<Record21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> SelectSelectStep<Record22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>> select(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21, SelectField<T22> field22) {
         return time(context.select(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21, field22));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record> selectDistinct(Collection<? extends SelectFieldOrAsterisk> fields) {
         return time(context.selectDistinct(fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record> selectDistinct(SelectFieldOrAsterisk... fields) {
         return time(context.selectDistinct(fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1> SelectSelectStep<Record1<T1>> selectDistinct(SelectField<T1> field1) {
         return time(context.selectDistinct(field1));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2> SelectSelectStep<Record2<T1, T2>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2) {
         return time(context.selectDistinct(field1, field2));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3> SelectSelectStep<Record3<T1, T2, T3>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3) {
         return time(context.selectDistinct(field1, field2, field3));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4> SelectSelectStep<Record4<T1, T2, T3, T4>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4) {
         return time(context.selectDistinct(field1, field2, field3, field4));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5> SelectSelectStep<Record5<T1, T2, T3, T4, T5>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6> SelectSelectStep<Record6<T1, T2, T3, T4, T5, T6>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7> SelectSelectStep<Record7<T1, T2, T3, T4, T5, T6, T7>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8> SelectSelectStep<Record8<T1, T2, T3, T4, T5, T6, T7, T8>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9> SelectSelectStep<Record9<T1, T2, T3, T4, T5, T6, T7, T8, T9>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> SelectSelectStep<Record10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> SelectSelectStep<Record11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> SelectSelectStep<Record12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> SelectSelectStep<Record13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> SelectSelectStep<Record14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> SelectSelectStep<Record15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> SelectSelectStep<Record16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> SelectSelectStep<Record17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> SelectSelectStep<Record18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> SelectSelectStep<Record19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> SelectSelectStep<Record20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> SelectSelectStep<Record21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21));
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> SelectSelectStep<Record22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22>> selectDistinct(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21, SelectField<T22> field22) {
         return time(context.selectDistinct(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21, field22));
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record1<Integer>> selectZero() {
         return time(context.selectZero());
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record1<Integer>> selectOne() {
         return time(context.selectOne());
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectSelectStep<Record1<Integer>> selectCount() {
         return time(context.selectCount());
     }
 
-    @Override
-    @Support
+    @Override    
     public SelectQuery<Record> selectQuery() {
         return time(context.selectQuery());
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> SelectQuery<R> selectQuery(TableLike<R> table) {
         return time(context.selectQuery(table));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> InsertQuery<R> insertQuery(Table<R> into) {
         return time(context.insertQuery(into));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> InsertSetStep<R> insertInto(Table<R> into) {
         return timeCoercable(context.insertInto(into));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1> InsertValuesStep1<R, T1> insertInto(Table<R> into, Field<T1> field1) {
         return time(context.insertInto(into, field1));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2> InsertValuesStep2<R, T1, T2> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2) {
         return time(context.insertInto(into, field1, field2));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3> InsertValuesStep3<R, T1, T2, T3> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3) {
         return time(context.insertInto(into, field1, field2, field3));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4> InsertValuesStep4<R, T1, T2, T3, T4> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4) {
         return time(context.insertInto(into, field1, field2, field3, field4));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5> InsertValuesStep5<R, T1, T2, T3, T4, T5> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6> InsertValuesStep6<R, T1, T2, T3, T4, T5, T6> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7> InsertValuesStep7<R, T1, T2, T3, T4, T5, T6, T7> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8> InsertValuesStep8<R, T1, T2, T3, T4, T5, T6, T7, T8> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9> InsertValuesStep9<R, T1, T2, T3, T4, T5, T6, T7, T8, T9> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> InsertValuesStep10<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> InsertValuesStep11<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> InsertValuesStep12<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> InsertValuesStep13<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> InsertValuesStep14<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> InsertValuesStep15<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> InsertValuesStep16<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> InsertValuesStep17<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> InsertValuesStep18<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> InsertValuesStep19<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> InsertValuesStep20<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> InsertValuesStep21<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20, Field<T21> field21) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> InsertValuesStep22<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> insertInto(Table<R> into, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20, Field<T21> field21, Field<T22> field22) {
         return time(context.insertInto(into, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21, field22));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> InsertValuesStepN<R> insertInto(Table<R> into, Field<?>... fields) {
         return time(context.insertInto(into, fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> InsertValuesStepN<R> insertInto(Table<R> into, Collection<? extends Field<?>> fields) {
         return time(context.insertInto(into, fields));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> UpdateQuery<R> updateQuery(Table<R> table) {
         return time(context.updateQuery(table));
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> UpdateSetFirstStep<R> update(Table<R> table) {
         return timeCoercable(context.update(table));
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record> MergeUsingStep<R> mergeInto(Table<R> table) {
         return context.mergeInto(table);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1> MergeKeyStep1<R, T1> mergeInto(Table<R> table, Field<T1> field1) {
         return context.mergeInto(table, field1);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2> MergeKeyStep2<R, T1, T2> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2) {
         return context.mergeInto(table, field1, field2);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3> MergeKeyStep3<R, T1, T2, T3> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3) {
         return context.mergeInto(table, field1, field2, field3);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4> MergeKeyStep4<R, T1, T2, T3, T4> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4) {
         return context.mergeInto(table, field1, field2, field3, field4);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5> MergeKeyStep5<R, T1, T2, T3, T4, T5> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5) {
         return context.mergeInto(table, field1, field2, field3, field4, field5);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6> MergeKeyStep6<R, T1, T2, T3, T4, T5, T6> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7> MergeKeyStep7<R, T1, T2, T3, T4, T5, T6, T7> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8> MergeKeyStep8<R, T1, T2, T3, T4, T5, T6, T7, T8> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9> MergeKeyStep9<R, T1, T2, T3, T4, T5, T6, T7, T8, T9> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> MergeKeyStep10<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> MergeKeyStep11<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> MergeKeyStep12<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> MergeKeyStep13<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> MergeKeyStep14<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> MergeKeyStep15<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> MergeKeyStep16<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> MergeKeyStep17<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> MergeKeyStep18<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> MergeKeyStep19<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> MergeKeyStep20<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> MergeKeyStep21<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20, Field<T21> field21) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> MergeKeyStep22<R, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> mergeInto(Table<R> table, Field<T1> field1, Field<T2> field2, Field<T3> field3, Field<T4> field4, Field<T5> field5, Field<T6> field6, Field<T7> field7, Field<T8> field8, Field<T9> field9, Field<T10> field10, Field<T11> field11, Field<T12> field12, Field<T13> field13, Field<T14> field14, Field<T15> field15, Field<T16> field16, Field<T17> field17, Field<T18> field18, Field<T19> field19, Field<T20> field20, Field<T21> field21, Field<T22> field22) {
         return context.mergeInto(table, field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21, field22);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record> MergeKeyStepN<R> mergeInto(Table<R> table, Field<?>... fields) {
         return context.mergeInto(table, fields);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public <R extends Record> MergeKeyStepN<R> mergeInto(Table<R> table, Collection<? extends Field<?>> fields) {
         return context.mergeInto(table, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> DeleteQuery<R> deleteQuery(Table<R> table) {
         return context.deleteQuery(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> DeleteUsingStep<R> deleteFrom(Table<R> table) {
         return context.deleteFrom(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> DeleteUsingStep<R> delete(Table<R> table) {
         return context.delete(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(Query... queries) {
         return context.batch(queries);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(Queries queries) {
         return context.batch(queries);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(String... queries) {
         return context.batch(queries);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(Collection<? extends Query> queries) {
         return context.batch(queries);
     }
 
-    @Override
-    @Support
+    @Override    
     public BatchBindStep batch(Query query) {
         return context.batch(query);
     }
 
-    @Override
-    @Support
+    @Override    
     public BatchBindStep batch(String sql) {
         return context.batch(sql);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(Query query, Object[]... bindings) {
         return context.batch(query, bindings);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batch(String sql, Object[]... bindings) {
         return context.batch(sql, bindings);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchStore(UpdatableRecord<?>... records) {
         return context.batchStore(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchStore(Collection<? extends UpdatableRecord<?>> records) {
         return context.batchStore(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchInsert(TableRecord<?>... records) {
         return context.batchInsert(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchInsert(Collection<? extends TableRecord<?>> records) {
         return context.batchInsert(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchUpdate(UpdatableRecord<?>... records) {
         return context.batchUpdate(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchUpdate(Collection<? extends UpdatableRecord<?>> records) {
         return context.batchUpdate(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchDelete(UpdatableRecord<?>... records) {
         return context.batchDelete(records);
     }
 
-    @Override
-    @Support
+    @Override    
     public Batch batchDelete(Collection<? extends UpdatableRecord<?>> records) {
         return context.batchDelete(records);
     }
@@ -2634,1112 +2218,927 @@ public class MetricsDSLContext implements DSLContext {
         return context.ddl(tables, configuration);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL})
+    @Override    
     public RowCountQuery setCatalog(String catalog) {
         return context.setCatalog(catalog);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL})
+    @Override    
     public RowCountQuery setCatalog(Name catalog) {
         return context.setCatalog(catalog);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL})
+    @Override    
     public RowCountQuery setCatalog(Catalog catalog) {
         return context.setCatalog(catalog);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RowCountQuery setSchema(String schema) {
         return context.setSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RowCountQuery setSchema(Name schema) {
         return context.setSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RowCountQuery setSchema(Schema schema) {
         return context.setSchema(schema);
     }
 
-    @Override
-    @Support({ MYSQL })
+    @Override    
     public RowCountQuery set(Name name, Param<?> param) {
         return context.set(name, param);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnTable(String tableName) {
         return context.commentOnTable(tableName);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnTable(Name tableName) {
         return context.commentOnTable(tableName);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnTable(Table<?> table) {
         return context.commentOnTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnView(String viewName) {
         return context.commentOnView(viewName);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnView(Name viewName) {
         return context.commentOnView(viewName);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnView(Table<?> view) {
         return context.commentOnView(view);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnColumn(Name columnName) {
         return context.commentOnColumn(columnName);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CommentOnIsStep commentOnColumn(Field<?> field) {
         return context.commentOnColumn(field);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchema(String schema) {
         return context.createSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchema(Name schema) {
         return context.createSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchema(Schema schema) {
         return context.createSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchemaIfNotExists(String schema) {
         return context.createSchemaIfNotExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchemaIfNotExists(Name schema) {
         return context.createSchemaIfNotExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateSchemaFinalStep createSchemaIfNotExists(Schema schema) {
         return context.createSchemaIfNotExists(schema);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateTableColumnStep createTable(String table) {
         return context.createTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateTableColumnStep createTable(Name table) {
         return context.createTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateTableColumnStep createTable(Table<?> table) {
         return context.createTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateTableColumnStep createTableIfNotExists(String table) {
         return context.createTableIfNotExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateTableColumnStep createTableIfNotExists(Name table) {
         return context.createTableIfNotExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateTableColumnStep createTableIfNotExists(Table<?> table) {
         return context.createTableIfNotExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createTemporaryTable(String table) {
         return context.createTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createTemporaryTable(Name table) {
         return context.createTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createTemporaryTable(Table<?> table) {
         return context.createTemporaryTable(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public CreateTableColumnStep createTemporaryTableIfNotExists(String table) {
         return context.createTemporaryTableIfNotExists(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public CreateTableColumnStep createTemporaryTableIfNotExists(Name table) {
         return context.createTemporaryTableIfNotExists(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public CreateTableColumnStep createTemporaryTableIfNotExists(Table<?> table) {
         return context.createTemporaryTableIfNotExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createGlobalTemporaryTable(String table) {
         return context.createGlobalTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createGlobalTemporaryTable(Name table) {
         return context.createGlobalTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateTableColumnStep createGlobalTemporaryTable(Table<?> table) {
         return context.createGlobalTemporaryTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(String view, String... fields) {
         return context.createView(view, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Name view, Name... fields) {
         return context.createView(view, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Table<?> view, Field<?>... fields) {
         return context.createView(view, fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(String view, Function<? super Field<?>, ? extends String> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(String view, BiFunction<? super Field<?>, ? super Integer, ? extends String> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Name view, Function<? super Field<?>, ? extends Name> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Name view, BiFunction<? super Field<?>, ? super Integer, ? extends Name> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Table<?> view, Function<? super Field<?>, ? extends Field<?>> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateViewAsStep<Record> createView(Table<?> view, BiFunction<? super Field<?>, ? super Integer, ? extends Field<?>> fieldNameFunction) {
         return context.createView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(String view, String... fields) {
         return context.createOrReplaceView(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Name view, Name... fields) {
         return context.createOrReplaceView(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Table<?> view, Field<?>... fields) {
         return context.createOrReplaceView(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(String view, Function<? super Field<?>, ? extends String> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(String view, BiFunction<? super Field<?>, ? super Integer, ? extends String> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Name view, Function<? super Field<?>, ? extends Name> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Name view, BiFunction<? super Field<?>, ? super Integer, ? extends Name> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Table<?> view, Function<? super Field<?>, ? extends Field<?>> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public CreateViewAsStep<Record> createOrReplaceView(Table<?> view, BiFunction<? super Field<?>, ? super Integer, ? extends Field<?>> fieldNameFunction) {
         return context.createOrReplaceView(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(String view, String... fields) {
         return context.createViewIfNotExists(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Name view, Name... fields) {
         return context.createViewIfNotExists(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Table<?> view, Field<?>... fields) {
         return context.createViewIfNotExists(view, fields);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(String view, Function<? super Field<?>, ? extends String> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(String view, BiFunction<? super Field<?>, ? super Integer, ? extends String> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Name view, Function<? super Field<?>, ? extends Name> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Name view, BiFunction<? super Field<?>, ? super Integer, ? extends Name> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Table<?> view, Function<? super Field<?>, ? extends Field<?>> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateViewAsStep<Record> createViewIfNotExists(Table<?> view, BiFunction<? super Field<?>, ? super Integer, ? extends Field<?>> fieldNameFunction) {
         return context.createViewIfNotExists(view, fieldNameFunction);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public CreateTypeStep createType(String type) {
         return context.createType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public CreateTypeStep createType(Name type) {
         return context.createType(type);
     }
 
-    @Override
-    @Support({ POSTGRES })
+    @Override    
     public AlterTypeStep alterType(String type) {
         return context.alterType(type);
     }
 
-    @Override
-    @Support({ POSTGRES })
+    @Override    
     public AlterTypeStep alterType(Name type) {
         return context.alterType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropType(String type) {
         return context.dropType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropType(Name type) {
         return context.dropType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropType(String... type) {
         return context.dropType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropType(Name... type) {
         return context.dropType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropType(Collection<?> type) {
         return context.dropType(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropTypeIfExists(String type) {
         return context.dropTypeIfExists(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropTypeIfExists(Name type) {
         return context.dropTypeIfExists(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropTypeIfExists(String... type) {
         return context.dropTypeIfExists(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropTypeIfExists(Name... type) {
         return context.dropTypeIfExists(type);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public DropTypeStep dropTypeIfExists(Collection<?> type) {
         return context.dropTypeIfExists(type);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createIndex() {
         return context.createIndex();
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createIndex(String index) {
         return context.createIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createIndex(Name index) {
         return context.createIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createIndex(Index index) {
         return context.createIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createIndexIfNotExists(String index) {
         return context.createIndexIfNotExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createIndexIfNotExists(Name index) {
         return context.createIndexIfNotExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createIndexIfNotExists(Index index) {
         return context.createIndexIfNotExists(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createUniqueIndex() {
         return context.createUniqueIndex();
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createUniqueIndex(String index) {
         return context.createUniqueIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createUniqueIndex(Name index) {
         return context.createUniqueIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public CreateIndexStep createUniqueIndex(Index index) {
         return context.createUniqueIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createUniqueIndexIfNotExists(String index) {
         return context.createUniqueIndexIfNotExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createUniqueIndexIfNotExists(Name index) {
         return context.createUniqueIndexIfNotExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public CreateIndexStep createUniqueIndexIfNotExists(Index index) {
         return context.createUniqueIndexIfNotExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequence(String sequence) {
         return context.createSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequence(Name sequence) {
         return context.createSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequence(Sequence<?> sequence) {
         return context.createSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequenceIfNotExists(String sequence) {
         return context.createSequenceIfNotExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequenceIfNotExists(Name sequence) {
         return context.createSequenceIfNotExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public CreateSequenceFlagsStep createSequenceIfNotExists(Sequence<?> sequence) {
         return context.createSequenceIfNotExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterSequenceStep<BigInteger> alterSequence(String sequence) {
         return context.alterSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterSequenceStep<BigInteger> alterSequence(Name sequence) {
         return context.alterSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public <T extends Number> AlterSequenceStep<T> alterSequence(Sequence<T> sequence) {
         return context.alterSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public AlterSequenceStep<BigInteger> alterSequenceIfExists(String sequence) {
         return context.alterSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public AlterSequenceStep<BigInteger> alterSequenceIfExists(Name sequence) {
         return context.alterSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public <T extends Number> AlterSequenceStep<T> alterSequenceIfExists(Sequence<T> sequence) {
         return context.alterSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support
+    @Override    
     public AlterTableStep alterTable(String table) {
         return context.alterTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public AlterTableStep alterTable(Name table) {
         return context.alterTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public AlterTableStep alterTable(Table<?> table) {
         return context.alterTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.POSTGRES})
+    @Override    
     public AlterTableStep alterTableIfExists(String table) {
         return context.alterTableIfExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.POSTGRES})
+    @Override    
     public AlterTableStep alterTableIfExists(Name table) {
         return context.alterTableIfExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.MARIADB, SQLDialect.POSTGRES})
+    @Override    
     public AlterTableStep alterTableIfExists(Table<?> table) {
         return context.alterTableIfExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterSchemaStep alterSchema(String schema) {
         return context.alterSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterSchemaStep alterSchema(Name schema) {
         return context.alterSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterSchemaStep alterSchema(Schema schema) {
         return context.alterSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2})
+    @Override    
     public AlterSchemaStep alterSchemaIfExists(String schema) {
         return context.alterSchemaIfExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2})
+    @Override    
     public AlterSchemaStep alterSchemaIfExists(Name schema) {
         return context.alterSchemaIfExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2})
+    @Override    
     public AlterSchemaStep alterSchemaIfExists(Schema schema) {
         return context.alterSchemaIfExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterView(String view) {
         return context.alterView(view);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterView(Name view) {
         return context.alterView(view);
     }
 
-    @Override
-    @Support({SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterView(Table<?> view) {
         return context.alterView(view);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterViewIfExists(String view) {
         return context.alterViewIfExists(view);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterViewIfExists(Name view) {
         return context.alterViewIfExists(view);
     }
 
-    @Override
-    @Support({SQLDialect.POSTGRES})
+    @Override    
     public AlterViewStep alterViewIfExists(Table<?> view) {
         return context.alterViewIfExists(view);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexOnStep alterIndex(String index) {
         return context.alterIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexOnStep alterIndex(Name index) {
         return context.alterIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexOnStep alterIndex(Index index) {
         return context.alterIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexStep alterIndexIfExists(String index) {
         return context.alterIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexStep alterIndexIfExists(Name index) {
         return context.alterIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.POSTGRES})
+    @Override    
     public AlterIndexStep alterIndexIfExists(Index index) {
         return context.alterIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchema(String schema) {
         return context.dropSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchema(Name schema) {
         return context.dropSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchema(Schema schema) {
         return context.dropSchema(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchemaIfExists(String schema) {
         return context.dropSchemaIfExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchemaIfExists(Name schema) {
         return context.dropSchemaIfExists(schema);
     }
 
-    @Override
-    @Support({SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropSchemaStep dropSchemaIfExists(Schema schema) {
         return context.dropSchemaIfExists(schema);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropView(String view) {
         return context.dropView(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropView(Name view) {
         return context.dropView(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropView(Table<?> view) {
         return context.dropView(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropViewIfExists(String view) {
         return context.dropViewIfExists(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropViewIfExists(Name view) {
         return context.dropViewIfExists(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropViewFinalStep dropViewIfExists(Table<?> view) {
         return context.dropViewIfExists(view);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTable(String table) {
         return context.dropTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTable(Name table) {
         return context.dropTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTable(Table<?> table) {
         return context.dropTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTableIfExists(String table) {
         return context.dropTableIfExists(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTableIfExists(Name table) {
         return context.dropTableIfExists(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropTableStep dropTableIfExists(Table<?> table) {
         return context.dropTableIfExists(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropTableStep dropTemporaryTable(String table) {
         return context.dropTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropTableStep dropTemporaryTable(Name table) {
         return context.dropTemporaryTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public DropTableStep dropTemporaryTable(Table<?> table) {
         return context.dropTemporaryTable(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public DropTableStep dropTemporaryTableIfExists(String table) {
         return context.dropTemporaryTableIfExists(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public DropTableStep dropTemporaryTableIfExists(Name table) {
         return context.dropTemporaryTableIfExists(table);
     }
 
-    @Override
-    @Support({ FIREBIRD, MARIADB, MYSQL, POSTGRES })
+    @Override    
     public DropTableStep dropTemporaryTableIfExists(Table<?> table) {
         return context.dropTemporaryTableIfExists(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropIndexOnStep dropIndex(String index) {
         return context.dropIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropIndexOnStep dropIndex(Name index) {
         return context.dropIndex(index);
     }
 
-    @Override
-    @Support
+    @Override    
     public DropIndexOnStep dropIndex(Index index) {
         return context.dropIndex(index);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public DropIndexOnStep dropIndexIfExists(String index) {
         return context.dropIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public DropIndexOnStep dropIndexIfExists(Name index) {
         return context.dropIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public DropIndexOnStep dropIndexIfExists(Index index) {
         return context.dropIndexIfExists(index);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequence(String sequence) {
         return context.dropSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequence(Name sequence) {
         return context.dropSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequence(Sequence<?> sequence) {
         return context.dropSequence(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequenceIfExists(String sequence) {
         return context.dropSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequenceIfExists(Name sequence) {
         return context.dropSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public DropSequenceFinalStep dropSequenceIfExists(Sequence<?> sequence) {
         return context.dropSequenceIfExists(sequence);
     }
 
-    @Override
-    @Support
+    @Override    
     public TruncateIdentityStep<Record> truncate(String table) {
         return context.truncate(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public TruncateIdentityStep<Record> truncate(Name table) {
         return context.truncate(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> TruncateIdentityStep<R> truncate(Table<R> table) {
         return context.truncate(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public TruncateIdentityStep<Record> truncateTable(String table) {
         return context.truncateTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public TruncateIdentityStep<Record> truncateTable(Name table) {
         return context.truncateTable(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> TruncateIdentityStep<R> truncateTable(Table<R> table) {
         return context.truncateTable(table);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public GrantOnStep grant(Privilege privilege) {
         return context.grant(privilege);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public GrantOnStep grant(Privilege... privileges) {
         return context.grant(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public GrantOnStep grant(Collection<? extends Privilege> privileges) {
         return context.grant(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revoke(Privilege privilege) {
         return context.revoke(privilege);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revoke(Privilege... privileges) {
         return context.revoke(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revoke(Collection<? extends Privilege> privileges) {
         return context.revoke(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revokeGrantOptionFor(Privilege privilege) {
         return context.revokeGrantOptionFor(privilege);
     }
 
-    @Override
-    @Support({SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revokeGrantOptionFor(Privilege... privileges) {
         return context.revokeGrantOptionFor(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public RevokeOnStep revokeGrantOptionFor(Collection<? extends Privilege> privileges) {
         return context.revokeGrantOptionFor(privileges);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES, SQLDialect.SQLITE})
+    @Override    
     public BigInteger lastID() throws DataAccessException {
         return context.lastID();
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public BigInteger nextval(String sequence) throws DataAccessException {
         return context.nextval(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public BigInteger nextval(Name sequence) throws DataAccessException {
         return context.nextval(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public <T extends Number> T nextval(Sequence<T> sequence) throws DataAccessException {
         return context.nextval(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public BigInteger currval(String sequence) throws DataAccessException {
         return context.currval(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public BigInteger currval(Name sequence) throws DataAccessException {
         return context.currval(sequence);
     }
 
-    @Override
-    @Support({SQLDialect.CUBRID, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.POSTGRES})
+    @Override    
     public <T extends Number> T currval(Sequence<T> sequence) throws DataAccessException {
         return context.currval(sequence);
     }
@@ -4154,392 +3553,327 @@ public class MetricsDSLContext implements DSLContext {
         return context.execute(query);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Result<R> fetch(Table<R> table) throws DataAccessException {
         return context.fetch(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Result<R> fetch(Table<R> table, Condition condition) throws DataAccessException {
         return context.fetch(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Result<R> fetch(Table<R> table, Condition... conditions) throws DataAccessException {
         return context.fetch(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Result<R> fetch(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException {
         return context.fetch(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchOne(Table<R> table) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchOne(Table<R> table, Condition condition) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchOne(Table<R> table, Condition... conditions) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchOne(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException, TooManyRowsException {
         return context.fetchOne(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchSingle(Table<R> table) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchSingle(Table<R> table, Condition condition) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchSingle(Table<R> table, Condition... conditions) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchSingle(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException, NoDataFoundException, TooManyRowsException {
         return context.fetchSingle(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(SelectField<?>... fields) throws DataAccessException {
         return context.fetchSingle(fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public Record fetchSingle(Collection<? extends SelectField<?>> fields) throws DataAccessException {
         return context.fetchSingle(fields);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1> Record1<T1> fetchSingle(SelectField<T1> field1) throws DataAccessException {
         return context.fetchSingle(field1);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2> Record2<T1, T2> fetchSingle(SelectField<T1> field1, SelectField<T2> field2) throws DataAccessException {
         return context.fetchSingle(field1, field2);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3> Record3<T1, T2, T3> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4> Record4<T1, T2, T3, T4> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5> Record5<T1, T2, T3, T4, T5> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6> Record6<T1, T2, T3, T4, T5, T6> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7> Record7<T1, T2, T3, T4, T5, T6, T7> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8> Record8<T1, T2, T3, T4, T5, T6, T7, T8> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9> Record9<T1, T2, T3, T4, T5, T6, T7, T8, T9> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Record10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Record11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> Record12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> Record13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> Record14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> Record15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> Record16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> Record17<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> Record18<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> Record19<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> Record20<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> Record21<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21);
     }
 
-    @Override
-    @Support
+    @Override    
     public <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> Record22<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22> fetchSingle(SelectField<T1> field1, SelectField<T2> field2, SelectField<T3> field3, SelectField<T4> field4, SelectField<T5> field5, SelectField<T6> field6, SelectField<T7> field7, SelectField<T8> field8, SelectField<T9> field9, SelectField<T10> field10, SelectField<T11> field11, SelectField<T12> field12, SelectField<T13> field13, SelectField<T14> field14, SelectField<T15> field15, SelectField<T16> field16, SelectField<T17> field17, SelectField<T18> field18, SelectField<T19> field19, SelectField<T20> field20, SelectField<T21> field21, SelectField<T22> field22) throws DataAccessException {
         return context.fetchSingle(field1, field2, field3, field4, field5, field6, field7, field8, field9, field10, field11, field12, field13, field14, field15, field16, field17, field18, field19, field20, field21, field22);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Optional<R> fetchOptional(Table<R> table) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Optional<R> fetchOptional(Table<R> table, Condition condition) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Optional<R> fetchOptional(Table<R> table, Condition... conditions) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Optional<R> fetchOptional(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException, TooManyRowsException {
         return context.fetchOptional(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchAny(Table<R> table) throws DataAccessException {
         return context.fetchAny(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchAny(Table<R> table, Condition condition) throws DataAccessException {
         return context.fetchAny(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchAny(Table<R> table, Condition... conditions) throws DataAccessException {
         return context.fetchAny(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> R fetchAny(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException {
         return context.fetchAny(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Cursor<R> fetchLazy(Table<R> table) throws DataAccessException {
         return context.fetchLazy(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Cursor<R> fetchLazy(Table<R> table, Condition condition) throws DataAccessException {
         return context.fetchLazy(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Cursor<R> fetchLazy(Table<R> table, Condition... conditions) throws DataAccessException {
         return context.fetchLazy(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Cursor<R> fetchLazy(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException {
         return context.fetchLazy(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Table<R> table) {
         return context.fetchAsync(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Table<R> table, Condition condition) {
         return context.fetchAsync(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Table<R> table, Condition... condition) {
         return context.fetchAsync(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Table<R> table, Collection<? extends Condition> condition) {
         return context.fetchAsync(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Executor executor, Table<R> table) {
         return context.fetchAsync(executor, table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Executor executor, Table<R> table, Condition condition) {
         return context.fetchAsync(executor, table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Executor executor, Table<R> table, Condition... conditions) {
         return context.fetchAsync(executor, table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> CompletionStage<Result<R>> fetchAsync(Executor executor, Table<R> table, Collection<? extends Condition> conditions) {
         return context.fetchAsync(executor, table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Stream<R> fetchStream(Table<R> table) throws DataAccessException {
         return context.fetchStream(table);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Stream<R> fetchStream(Table<R> table, Condition condition) throws DataAccessException {
         return context.fetchStream(table, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Stream<R> fetchStream(Table<R> table, Condition... conditions) throws DataAccessException {
         return context.fetchStream(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public <R extends Record> Stream<R> fetchStream(Table<R> table, Collection<? extends Condition> conditions) throws DataAccessException {
         return context.fetchStream(table, conditions);
     }
 
-    @Override
-    @Support
+    @Override    
     public int executeInsert(TableRecord<?> record) throws DataAccessException {
         return context.executeInsert(record);
     }
 
-    @Override
-    @Support
+    @Override    
     public int executeUpdate(UpdatableRecord<?> record) throws DataAccessException {
         return context.executeUpdate(record);
     }
 
-    @Override
-    @Support
+    @Override    
     public int executeUpdate(TableRecord<?> record, Condition condition) throws DataAccessException {
         return context.executeUpdate(record, condition);
     }
 
-    @Override
-    @Support
+    @Override    
     public int executeDelete(UpdatableRecord<?> record) throws DataAccessException {
         return context.executeDelete(record);
     }
 
-    @Override
-    @Support
+    @Override    
     public int executeDelete(TableRecord<?> record, Condition condition) throws DataAccessException {
         return context.executeDelete(record, condition);
     }


### PR DESCRIPTION
Building the current master branch gives the following deprecation warnings:

```
> Task :micrometer-core:compileJava
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:2299: warning: [deprecation] CUBRID in SQLDialect has been deprecated
    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
                        ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:2305: warning: [deprecation] CUBRID in SQLDialect has been deprecated
    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
                        ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:2311: warning: [deprecation] CUBRID in SQLDialect has been deprecated
    @Support({SQLDialect.CUBRID, SQLDialect.DERBY, SQLDialect.FIREBIRD, SQLDialect.H2, SQLDialect.HSQLDB, SQLDialect.MARIADB, SQLDialect.MYSQL, SQLDialect.POSTGRES})
```

Looking at [`@Support`](https://www.jooq.org/javadoc/latest/org.jooq/org/jooq/Support.html)'s Javadoc and [`DefaultDSLContext`](https://github.com/jOOQ/jOOQ/blob/master/jOOQ/src/main/java/org/jooq/impl/DefaultDSLContext.java), it doesn't seem to be necessary. Removing them looks more appropriate. The same reasoning seems to be able to apply to [`@PlainSQL`](https://www.jooq.org/javadoc/latest/org.jooq/org/jooq/PlainSQL.html).

This PR simply removes `@Support` and `@PlainSQL` in `MetricsDSLContext`.