### PR TITLE
Fix 'time' field key restriction for InfluxDB

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -271,11 +271,15 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         }
     }
 
-    class Field {
+    static class Field {
         final String key;
         final double value;
 
         Field(String key, double value) {
+            // `time` cannot be a field key or tag key
+            if (key.equals("time")) {
+                throw new IllegalArgumentException("'time' is an invalid field key in InfluxDB");
+            }
             this.key = key;
             this.value = value;
         }

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
@@ -54,16 +54,14 @@ public class InfluxNamingConvention implements NamingConvention {
     @Override
     public String tagKey(String key) {
         // `time` cannot be a field key or tag key
-        if (key.equals("time"))
+        if (key.equals("time")) {
             throw new IllegalArgumentException("'time' is an invalid tag key in InfluxDB");
+        }
         return escape(delegate.tagKey(key));
     }
 
     @Override
     public String tagValue(String value) {
-        // `time` cannot be a field key or tag key
-        if (value.equals("time"))
-            throw new IllegalArgumentException("'time' is an invalid tag value in InfluxDB");
         return escape(this.delegate.tagValue(value));
     }
 

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryFieldTest.java
@@ -15,17 +15,24 @@
  */
 package io.micrometer.influx;
 
-import io.micrometer.core.instrument.MockClock;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
-class InfluxMeterRegistryFieldToStringTest {
+/**
+ * Tests for {@link io.micrometer.influx.InfluxMeterRegistry.Field}.
+ *
+ * @author Niclas Thall
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
+class InfluxMeterRegistryFieldTest {
 
-    private Locale originalLocale = Locale.getDefault();
+    private final Locale originalLocale = Locale.getDefault();
 
     @AfterEach
     void cleanUp() {
@@ -33,32 +40,34 @@ class InfluxMeterRegistryFieldToStringTest {
     }
 
     @Test
-    void testWithEnglishLocale() {
+    void toStringWithEnglishLocale() {
         Locale.setDefault(Locale.ENGLISH);
-        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
 
-        InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+        InfluxMeterRegistry.Field field = new InfluxMeterRegistry.Field("value", 0.01);
 
         assertThat(field.toString()).isEqualTo("value=0.01");
     }
 
     @Test
-    void testWithEnglishLocaleWithLargerResolution() {
+    void toStringWithEnglishLocaleWithLargerResolution() {
         Locale.setDefault(Locale.ENGLISH);
-        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
 
-        InfluxMeterRegistry.Field field = instance.new Field("value", 0.0000009);
+        InfluxMeterRegistry.Field field = new InfluxMeterRegistry.Field("value", 0.0000009);
 
         assertThat(field.toString()).isEqualTo("value=0.000001");
     }
 
     @Test
-    void testWithSwedishLocale() {
+    void toStringWithSwedishLocale() {
         Locale.setDefault(new Locale("sv", "SE"));
 
-        InfluxMeterRegistry instance = new InfluxMeterRegistry(k -> null, new MockClock());
-        InfluxMeterRegistry.Field field = instance.new Field("value", 0.01);
+        InfluxMeterRegistry.Field field = new InfluxMeterRegistry.Field("value", 0.01);
 
         assertThat(field.toString()).isEqualTo("value=0.01");
+    }
+
+    @Test
+    void timeCannotBeAFieldKey() {
+        assertThat(catchThrowable(() -> new InfluxMeterRegistry.Field("time", 1.0))).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxNamingConventionTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxNamingConventionTest.java
@@ -49,9 +49,13 @@ class InfluxNamingConventionTest {
     }
 
     @Test
-    void timeCannotBeATagKeyOrValue() {
+    void timeCannotBeATagKey() {
         assertThat(catchThrowable(() -> convention.tagKey("time"))).isInstanceOf(IllegalArgumentException.class);
-        assertThat(catchThrowable(() -> convention.tagValue("time"))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void timeCanBeATagValue() {
+        assertThat(convention.tagValue("time")).isEqualTo("time");
     }
 
     @Issue("#645")


### PR DESCRIPTION
This PR fixes 'time' field key restriction for InfluxDB.

Closes gh-1902