### PR TITLE
Use latest.release for com.github.charithe:kafka-junit

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ def VERSIONS = [
         'com.amazonaws:aws-java-sdk-cloudwatch:latest.release',
         'com.fasterxml.jackson.core:jackson-databind:latest.release',
         'com.github.ben-manes.caffeine:caffeine:latest.release',
-        'com.github.charithe:kafka-junit:4.1.2',
+        'com.github.charithe:kafka-junit:latest.release',
         'com.github.tomakehurst:wiremock-jre8:latest.release',
         'com.google.cloud:google-cloud-monitoring:latest.release',
         'com.google.dagger:dagger:2.11',

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/KafkaMetricsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/KafkaMetricsSample.java
@@ -18,7 +18,7 @@ package io.micrometer.core.samples;
 import com.github.charithe.kafka.EphemeralKafkaBroker;
 import com.github.charithe.kafka.KafkaHelper;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.kafka.KafkaConsumerMetrics;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import io.micrometer.core.samples.utils.SampleConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -37,11 +37,12 @@ public class KafkaMetricsSample {
         broker.start();
         KafkaHelper kafkaHelper = KafkaHelper.createFor(broker);
 
-        MeterRegistry registry = SampleConfig.myMonitoringSystem();
-        new KafkaConsumerMetrics().bindTo(registry);
-
         KafkaConsumer<String, String> consumer = kafkaHelper.createStringConsumer();
         KafkaProducer<String, String> producer = kafkaHelper.createStringProducer();
+
+        MeterRegistry registry = SampleConfig.myMonitoringSystem();
+        new KafkaClientMetrics(consumer).bindTo(registry);
+        new KafkaClientMetrics(producer).bindTo(registry);
 
         consumer.subscribe(singletonList(TOPIC));
 


### PR DESCRIPTION
With `com.github.charithe:kafka-junit` 4.1.2, `KafkaMetricsSample` doesn't work with the following error:

```
20:49:59.817 [ForkJoinPool.commonPool-worker-9] ERROR kafka.server.KafkaServer - [KafkaServer id=1] Fatal error during KafkaServer startup. Prepare to shutdown
java.lang.NoSuchMethodError: org.apache.kafka.common.network.ChannelBuilders.serverChannelBuilder(Lorg/apache/kafka/common/network/ListenerName;ZLorg/apache/kafka/common/security/auth/SecurityProtocol;Lorg/apache/kafka/common/config/AbstractConfig;Lorg/apache/kafka/common/security/authenticator/CredentialCache;Lorg/apache/kafka/common/security/token/delegation/internals/DelegationTokenCache;)Lorg/apache/kafka/common/network/ChannelBuilder;
	at kafka.network.Processor.<init>(SocketServer.scala:548)
	at kafka.network.SocketServer.newProcessor(SocketServer.scala:247)
	at kafka.network.SocketServer.$anonfun$addProcessors$1(SocketServer.scala:163)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:156)
	at kafka.network.SocketServer.addProcessors(SocketServer.scala:162)
	at kafka.network.SocketServer.$anonfun$createAcceptorAndProcessors$1(SocketServer.scala:150)
	at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:59)
	at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:52)
	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
	at kafka.network.SocketServer.createAcceptorAndProcessors(SocketServer.scala:145)
	at kafka.network.SocketServer.startup(SocketServer.scala:94)
	at kafka.server.KafkaServer.startup(KafkaServer.scala:250)
	at kafka.server.KafkaServerStartable.startup(KafkaServerStartable.scala:38)
	at com.github.charithe.kafka.EphemeralKafkaBroker.lambda$startBroker$0(EphemeralKafkaBroker.java:152)
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1626)
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1618)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

Upgrading it to the latest version (4.1.7) seems to work.

This PR changes to use `latest.release` for `com.github.charithe:kafka-junit`.

This PR also updates `KafkaMetricsSample` to use `KafkaClientMetrics`.