### PR TITLE
Allowing CountAtBucket to store doubles

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/CountAtBucket.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/CountAtBucket.java
@@ -26,15 +26,22 @@ import java.util.concurrent.TimeUnit;
  */
 public final class CountAtBucket {
 
-    private final long bucket;
+    private final double bucket;
     private final double count;
 
-    public CountAtBucket(long bucket, double count) {
-        this.bucket = bucket;
-        this.count = count;
+    private final boolean isLong;
+
+    public CountAtBucket(double bucket, double count) {
+        this(bucket, count, true);
     }
 
-    public long bucket() {
+    public CountAtBucket(double bucket, double count, boolean isLong) {
+        this.bucket = bucket;
+        this.count = count;
+        this.isLong = isLong;
+    }
+
+    public double bucket() {
         return bucket;
     }
 
@@ -44,6 +51,13 @@ public final class CountAtBucket {
 
     public double count() {
         return count;
+    }
+
+    public boolean isPositiveInf() {
+        if (isLong)
+            return bucket == (double)Long.MAX_VALUE;
+        else
+            return bucket == Double.POSITIVE_INFINITY;
     }
 
     @Override
@@ -58,16 +72,17 @@ public final class CountAtBucket {
 
         CountAtBucket that = (CountAtBucket) o;
 
-        return bucket == that.bucket && Double.compare(that.count, count) == 0;
+        return Double.compare(that.bucket, bucket) == 0 && Double.compare(that.count, count) == 0;
     }
 
     @Override
     public int hashCode() {
         int result;
-        long temp;
-        result = (int) (bucket ^ (bucket >>> 32));
-        temp = Double.doubleToLongBits(count);
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        long tempCount, tempBucket;
+        tempBucket = Double.doubleToLongBits(bucket);
+        result = (int) (tempBucket ^ (tempBucket >>> 32));
+        tempCount = Double.doubleToLongBits(count);
+        result = 31 * result + (int) (tempCount ^ (tempCount >>> 32));
         return result;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -49,8 +49,8 @@ public class HistogramGauges {
                 percentile -> percentile.value(timer.baseTimeUnit()),
                 bucket -> id.getName() + ".histogram",
                 // We look for Long.MAX_VALUE to ensure a sensible tag on our +Inf bucket
-                bucket -> Tags.concat(id.getTagsAsIterable(), "le", bucket.bucket() != Long.MAX_VALUE
-                        ? DoubleFormat.wholeOrDecimal(bucket.bucket(timer.baseTimeUnit())) : "+Inf"));
+                bucket -> Tags.concat(id.getTagsAsIterable(), "le", bucket.isPositiveInf()
+                        ?  "+Inf" : DoubleFormat.wholeOrDecimal(bucket.bucket(timer.baseTimeUnit()))));
     }
 
     public static HistogramGauges registerWithCommonFormat(DistributionSummary summary, MeterRegistry registry) {
@@ -61,8 +61,8 @@ public class HistogramGauges {
                 ValueAtPercentile::value,
                 bucket -> id.getName() + ".histogram",
                 // We look for Long.MAX_VALUE to ensure a sensible tag on our +Inf bucket
-                bucket -> Tags.concat(id.getTagsAsIterable(), "le", bucket.bucket() != Long.MAX_VALUE
-                        ? DoubleFormat.wholeOrDecimal(bucket.bucket()) : "+Inf"));
+                bucket -> Tags.concat(id.getTagsAsIterable(), "le", bucket.isPositiveInf()
+                        ? "+Inf" : DoubleFormat.wholeOrDecimal(bucket.bucket())));
     }
 
     public static HistogramGauges register(HistogramSupport meter, MeterRegistry registry,


### PR DESCRIPTION
Near all usages of `CountAtBucket.bucket()` are made from `double` context. This allows to make `HistogramSnapshot` objects for histograms with `double` bucket boundaries