### PR TITLE
Rename tags provider classes to indicate Servlet dependency

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpServletRequestTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpServletRequestTagsProvider.java
@@ -17,24 +17,15 @@ package io.micrometer.core.instrument.binder.http;
 
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/**
- *  Provides {@link Tag Tags} for HTTP request handling.
- *
- *  @author Jon Schneider
- *  @since 1.4.0
- */
 @Incubating(since = "1.4.0")
-public interface HttpRequestTagsProvider {
-    /**
-     * Provides tags to be associated with metrics for the given {@code request} and
-     * {@code response} exchange.
-     * @param request the request
-     * @param response the response
-     * @return tags to associate with metrics for the request and response exchange
-     */
-    Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response);
+public class DefaultHttpServletRequestTagsProvider implements HttpServletRequestTagsProvider {
+    @Override
+    public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response) {
+        return Tags.of(HttpRequestTags.method(request), HttpRequestTags.status(response), HttpRequestTags.outcome(response));
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpServletRequestTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpServletRequestTagsProvider.java
@@ -17,15 +17,24 @@ package io.micrometer.core.instrument.binder.http;
 
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ *  Provides {@link Tag Tags} for HTTP Servlet request handling.
+ *
+ *  @author Jon Schneider
+ *  @since 1.4.0
+ */
 @Incubating(since = "1.4.0")
-public class DefaultHttpRequestTagsProvider implements HttpRequestTagsProvider {
-    @Override
-    public Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response) {
-        return Tags.of(HttpRequestTags.method(request), HttpRequestTags.status(response), HttpRequestTags.outcome(response));
-    }
+public interface HttpServletRequestTagsProvider {
+    /**
+     * Provides tags to be associated with metrics for the given {@code request} and
+     * {@code response} exchange.
+     * @param request the request
+     * @param response the response
+     * @return tags to associate with metrics for the request and response exchange
+     */
+    Iterable<Tag> getTags(HttpServletRequest request, HttpServletResponse response);
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/TimedHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/TimedHandler.java
@@ -17,8 +17,8 @@ package io.micrometer.core.instrument.binder.jetty;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
-import io.micrometer.core.instrument.binder.http.DefaultHttpRequestTagsProvider;
-import io.micrometer.core.instrument.binder.http.HttpRequestTagsProvider;
+import io.micrometer.core.instrument.binder.http.DefaultHttpServletRequestTagsProvider;
+import io.micrometer.core.instrument.binder.http.HttpServletRequestTagsProvider;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
 import org.eclipse.jetty.http.HttpStatus;
@@ -53,7 +53,7 @@ public class TimedHandler extends HandlerWrapper implements Graceful {
 
     private final MeterRegistry registry;
     private final Iterable<Tag> tags;
-    private final HttpRequestTagsProvider tagsProvider;
+    private final HttpServletRequestTagsProvider tagsProvider;
 
     private final Shutdown shutdown = new Shutdown() {
         @Override
@@ -68,10 +68,10 @@ public class TimedHandler extends HandlerWrapper implements Graceful {
     private final AtomicInteger asyncWaits = new AtomicInteger();
 
     public TimedHandler(MeterRegistry registry, Iterable<Tag> tags) {
-        this(registry, tags, new DefaultHttpRequestTagsProvider());
+        this(registry, tags, new DefaultHttpServletRequestTagsProvider());
     }
 
-    public TimedHandler(MeterRegistry registry, Iterable<Tag> tags, HttpRequestTagsProvider tagsProvider) {
+    public TimedHandler(MeterRegistry registry, Iterable<Tag> tags, HttpServletRequestTagsProvider tagsProvider) {
         this.registry = registry;
         this.tags = tags;
         this.tagsProvider = tagsProvider;


### PR DESCRIPTION
This was added as part of the Jetty connector metrics, but I noticed that they are not generic to any HTTP implementation, so I thought best to include Servlet in the name before releasing 1.4. Let me know if this sounds good for now or if we want to make something more generic to encompass more than Servlet @jkschneider 