### PR TITLE
Allow `ExecutorServiceMetrics` accepting metric name prefix

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -30,8 +30,6 @@ import java.util.concurrent.*;
 
 import static java.util.Arrays.asList;
 
-import com.google.common.annotations.VisibleForTesting;
-
 /**
  * Monitors the status of executor service pools. Does not record timings on operations executed in the {@link ExecutorService},
  * as this requires the instance to be wrapped. Timings are provided separately by wrapping the executor service
@@ -44,7 +42,6 @@ import com.google.common.annotations.VisibleForTesting;
 @NonNullApi
 @NonNullFields
 public class ExecutorServiceMetrics implements MeterBinder {
-    @VisibleForTesting
     static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "executor";
     @Nullable
     private final ExecutorService executorService;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutor.java
@@ -23,7 +23,9 @@ import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.Executor;
 
 /**
- * An {@link Executor} that is timed
+ * An {@link Executor} that is timed. This class is for internal use.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
  */
 public class TimedExecutor implements Executor {
     private final MeterRegistry registry;
@@ -35,8 +37,8 @@ public class TimedExecutor implements Executor {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorName);
-        this.executionTimer = registry.timer(metricPrefix + ".execution", finalTags);
-        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
+        this.executionTimer = registry.timer(metricPrefix + "executor.execution", finalTags);
+        this.idleTimer = registry.timer(metricPrefix + "executor.idle", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutor.java
@@ -31,12 +31,12 @@ public class TimedExecutor implements Executor {
     private final Timer executionTimer;
     private final Timer idleTimer;
 
-    public TimedExecutor(MeterRegistry registry, Executor delegate, String executorName, Iterable<Tag> tags) {
+    public TimedExecutor(MeterRegistry registry, Executor delegate, String executorName, String metricPrefix, Iterable<Tag> tags) {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorName);
-        this.executionTimer = registry.timer("executor.execution", finalTags);
-        this.idleTimer = registry.timer("executor.idle", finalTags);
+        this.executionTimer = registry.timer(metricPrefix + ".execution", finalTags);
+        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
@@ -37,12 +37,13 @@ public class TimedExecutorService implements ExecutorService {
     private final Timer executionTimer;
     private final Timer idleTimer;
 
-    public TimedExecutorService(MeterRegistry registry, ExecutorService delegate, String executorServiceName, Iterable<Tag> tags) {
+    public TimedExecutorService(MeterRegistry registry, ExecutorService delegate, String executorServiceName,
+                                String metricPrefix, Iterable<Tag> tags) {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorServiceName);
-        this.executionTimer = registry.timer("executor", finalTags);
-        this.idleTimer = registry.timer("executor.idle", finalTags);
+        this.executionTimer = registry.timer(metricPrefix , finalTags);
+        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
@@ -27,9 +27,10 @@ import java.util.concurrent.*;
 import static java.util.stream.Collectors.toList;
 
 /**
- * An {@link java.util.concurrent.ExecutorService} that is timed
+ * An {@link java.util.concurrent.ExecutorService} that is timed. This class is for internal use.
  *
  * @author Jon Schneider
+ * @see io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
  */
 public class TimedExecutorService implements ExecutorService {
     private final MeterRegistry registry;
@@ -42,8 +43,8 @@ public class TimedExecutorService implements ExecutorService {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorServiceName);
-        this.executionTimer = registry.timer(metricPrefix , finalTags);
-        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
+        this.executionTimer = registry.timer(metricPrefix + "executor", finalTags);
+        this.idleTimer = registry.timer(metricPrefix + "executor.idle", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
@@ -37,14 +37,16 @@ public class TimedScheduledExecutorService implements ScheduledExecutorService {
     private final Counter scheduledOnce;
     private final Counter scheduledRepetitively;
 
-    public TimedScheduledExecutorService(MeterRegistry registry, ScheduledExecutorService delegate, String executorServiceName, Iterable<Tag> tags) {
+    public TimedScheduledExecutorService(MeterRegistry registry, ScheduledExecutorService delegate,
+                                         String executorServiceName, String metricPrefix,
+                                         Iterable<Tag> tags) {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorServiceName);
-        this.executionTimer = registry.timer("executor", finalTags);
-        this.idleTimer = registry.timer("executor.idle", finalTags);
-        this.scheduledOnce = registry.counter("executor.scheduled.once", finalTags);
-        this.scheduledRepetitively = registry.counter("executor.scheduled.repetitively", finalTags);
+        this.executionTimer = registry.timer(metricPrefix, finalTags);
+        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
+        this.scheduledOnce = registry.counter(metricPrefix + ".scheduled.once", finalTags);
+        this.scheduledRepetitively = registry.counter(metricPrefix + ".scheduled.repetitively", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
@@ -24,10 +24,11 @@ import java.util.concurrent.*;
 import static java.util.stream.Collectors.toList;
 
 /**
- * A {@link ScheduledExecutorService} that is timed.
+ * A {@link ScheduledExecutorService} that is timed. This class is for internal use.
  *
  * @author Sebastian Lövdahl
  * @since 1.3.0
+ * @see io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics
  */
 public class TimedScheduledExecutorService implements ScheduledExecutorService {
     private final MeterRegistry registry;
@@ -43,10 +44,10 @@ public class TimedScheduledExecutorService implements ScheduledExecutorService {
         this.registry = registry;
         this.delegate = delegate;
         Tags finalTags = Tags.concat(tags, "name", executorServiceName);
-        this.executionTimer = registry.timer(metricPrefix, finalTags);
-        this.idleTimer = registry.timer(metricPrefix + ".idle", finalTags);
-        this.scheduledOnce = registry.counter(metricPrefix + ".scheduled.once", finalTags);
-        this.scheduledRepetitively = registry.counter(metricPrefix + ".scheduled.repetitively", finalTags);
+        this.executionTimer = registry.timer(metricPrefix + "executor", finalTags);
+        this.idleTimer = registry.timer(metricPrefix + "executor.idle", finalTags);
+        this.scheduledOnce = registry.counter(metricPrefix + "executor.scheduled.once", finalTags);
+        this.scheduledRepetitively = registry.counter(metricPrefix + "executor.scheduled.repetitively", finalTags);
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.lang.Nullable;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -21,11 +21,15 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.lang.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.concurrent.*;
 
+import static io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics.DEFAULT_EXECUTOR_METRIC_PREFIX;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /**
@@ -41,65 +45,76 @@ class ExecutorServiceMetricsTest {
     private Iterable<Tag> userTags = Tags.of("userTagKey", "userTagValue");
 
     @DisplayName("Normal executor can be instrumented after being initialized")
-    @Test
-    void executor() throws InterruptedException {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void executor(String metricPrefix) throws InterruptedException {
         CountDownLatch lock = new CountDownLatch(1);
         Executor exec = r -> {
             r.run();
             lock.countDown();
         };
-        Executor executor = ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
+        Executor executor = monitorExecutorService("exec", metricPrefix, exec);
         executor.execute(() -> System.out.println("hello"));
         lock.await();
+        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
 
-        assertThat(registry.get("executor.execution").tags(userTags).tag("name", "exec").timer().count()).isEqualTo(1L);
-        assertThat(registry.get("executor.idle").tags(userTags).tag("name", "exec").timer().count()).isEqualTo(1L);
+        assertThat(registry.get(expectedMetricPrefix + ".execution").tags(userTags).tag("name", "exec").timer()
+                           .count()).isEqualTo(1L);
+        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).tag("name", "exec").timer()
+                           .count()).isEqualTo(1L);
     }
 
     @DisplayName("ExecutorService is casted from Executor when necessary")
-    @Test
-    void executorCasting() {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void executorCasting(String metricPrefix) {
         Executor exec = Executors.newFixedThreadPool(2);
-        ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
-        assertThreadPoolExecutorMetrics("exec");
+        monitorExecutorService("exec", metricPrefix, exec);
+        assertThreadPoolExecutorMetrics("exec", metricPrefix);
     }
 
     @DisplayName("thread pool executor can be instrumented after being initialized")
-    @Test
-    void threadPoolExecutor() {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void threadPoolExecutor(String metricPrefix) {
         ExecutorService exec = Executors.newFixedThreadPool(2);
-        ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
-        assertThreadPoolExecutorMetrics("exec");
+        monitorExecutorService("exec", metricPrefix, exec);
+        assertThreadPoolExecutorMetrics("exec", metricPrefix);
     }
 
     @DisplayName("Scheduled thread pool executor can be instrumented after being initialized")
-    @Test
-    void scheduledThreadPoolExecutor() {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void scheduledThreadPoolExecutor(String metricPrefix) {
         ScheduledExecutorService exec = Executors.newScheduledThreadPool(2);
-        ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
-        assertThreadPoolExecutorMetrics("exec");
+        monitorExecutorService("exec", metricPrefix, exec);
+        assertThreadPoolExecutorMetrics("exec", metricPrefix);
     }
 
     @DisplayName("ScheduledExecutorService is casted from Executor when necessary")
-    @Test
-    void scheduledThreadPoolExecutorAsExecutor() {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void scheduledThreadPoolExecutorAsExecutor(String metricPrefix) {
         Executor exec = Executors.newScheduledThreadPool(2);
-        ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
-        assertThreadPoolExecutorMetrics("exec");
+        monitorExecutorService("exec", metricPrefix, exec);
+        assertThreadPoolExecutorMetrics("exec", metricPrefix);
     }
 
     @DisplayName("ScheduledExecutorService is casted from ExecutorService when necessary")
-    @Test
-    void scheduledThreadPoolExecutorAsExecutorService() {
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void scheduledThreadPoolExecutorAsExecutorService(String metricPrefix) {
         ExecutorService exec = Executors.newScheduledThreadPool(2);
-        ExecutorServiceMetrics.monitor(registry, exec, "exec", userTags);
-        assertThreadPoolExecutorMetrics("exec");
+        monitorExecutorService("exec", metricPrefix, exec);
+        assertThreadPoolExecutorMetrics("exec", metricPrefix);
     }
 
     @DisplayName("ExecutorService can be monitored with a default set of metrics")
-    @Test
-    void monitorExecutorService() throws InterruptedException {
-        ExecutorService pool = ExecutorServiceMetrics.monitor(registry, Executors.newSingleThreadExecutor(), "beep.pool", userTags);
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void monitorExecutorService(String metricPrefix) throws InterruptedException {
+        ExecutorService pool = monitorExecutorService("beep.pool", metricPrefix,
+                                                      Executors.newSingleThreadExecutor());
         CountDownLatch taskStart = new CountDownLatch(1);
         CountDownLatch taskComplete = new CountDownLatch(1);
 
@@ -112,23 +127,29 @@ class ExecutorServiceMetricsTest {
         pool.submit(() -> System.out.println("boop"));
 
         assertThat(taskStart.await(1, TimeUnit.SECONDS)).isTrue();
-        assertThat(registry.get("executor.queued").tags(userTags).tag("name", "beep.pool")
-                .gauge().value()).isEqualTo(1.0);
+
+        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
+        assertThat(registry.get(expectedMetricPrefix + ".queued").tags(userTags).tag("name", "beep.pool")
+                           .gauge().value()).isEqualTo(1.0);
 
         taskComplete.countDown();
 
         pool.shutdown();
         assertThat(pool.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(registry.get("executor").tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get("executor.idle").tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get("executor.queued").tags(userTags).gauge().value()).isEqualTo(0.0);
+        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + ".queued").tags(userTags).gauge().value()).isEqualTo(0.0);
     }
 
     @DisplayName("ScheduledExecutorService can be monitored with a default set of metrics")
-    @Test
-    void monitorScheduledExecutorService() throws TimeoutException, ExecutionException, InterruptedException {
-        ScheduledExecutorService pool = ExecutorServiceMetrics.monitor(registry, Executors.newScheduledThreadPool(2), "scheduled.pool", userTags);
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void monitorScheduledExecutorService(String metricPrefix)
+            throws TimeoutException, ExecutionException, InterruptedException {
+        ScheduledExecutorService pool = monitorExecutorService("scheduled.pool", metricPrefix,
+                                                               Executors.newScheduledThreadPool(2));
+
         CountDownLatch callableTaskStart = new CountDownLatch(1);
         CountDownLatch runnableTaskStart = new CountDownLatch(1);
         CountDownLatch callableTaskComplete = new CountDownLatch(1);
@@ -139,7 +160,8 @@ class ExecutorServiceMetricsTest {
             assertThat(callableTaskComplete.await(1, TimeUnit.SECONDS)).isTrue();
             return 1;
         };
-        ScheduledFuture<Integer> callableResult = pool.schedule(scheduledBeepCallable, 10, TimeUnit.MILLISECONDS);
+        ScheduledFuture<Integer> callableResult = pool.schedule(scheduledBeepCallable, 10,
+                                                                TimeUnit.MILLISECONDS);
 
         Runnable scheduledBeepRunnable = () -> {
             runnableTaskStart.countDown();
@@ -151,7 +173,11 @@ class ExecutorServiceMetricsTest {
         };
         ScheduledFuture<?> runnableResult = pool.schedule(scheduledBeepRunnable, 15, TimeUnit.MILLISECONDS);
 
-        assertThat(registry.get("executor.scheduled.once").tags(userTags).tag("name", "scheduled.pool").counter().count()).isEqualTo(2);
+        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
+
+        assertThat(registry.get(expectedMetricPrefix + ".scheduled.once").tags(userTags).tag("name",
+                                                                                             "scheduled.pool")
+                           .counter().count()).isEqualTo(2);
 
         assertThat(callableTaskStart.await(1, TimeUnit.SECONDS)).isTrue();
         assertThat(runnableTaskStart.await(1, TimeUnit.SECONDS)).isTrue();
@@ -165,19 +191,24 @@ class ExecutorServiceMetricsTest {
         assertThat(callableResult.get(1, TimeUnit.MINUTES)).isEqualTo(1);
         assertThat(runnableResult.get(1, TimeUnit.MINUTES)).isNull();
 
-        assertThat(registry.get("executor").tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get("executor.idle").tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(0L);
     }
 
     @DisplayName("ScheduledExecutorService repetitive tasks can be monitored with a default set of metrics")
-    @Test
-    void monitorScheduledExecutorServiceWithRepetitiveTasks() throws InterruptedException {
-        ScheduledExecutorService pool = ExecutorServiceMetrics.monitor(registry, Executors.newScheduledThreadPool(1), "scheduled.pool", userTags);
+    @ParameterizedTest
+    @CsvSource({ "custom.executor", "," })
+    void monitorScheduledExecutorServiceWithRepetitiveTasks(String metricPrefix) throws InterruptedException {
+        ScheduledExecutorService pool = monitorExecutorService("scheduled.pool", metricPrefix,
+                                                               Executors.newScheduledThreadPool(1));
         CountDownLatch fixedRateInvocations = new CountDownLatch(3);
         CountDownLatch fixedDelayInvocations = new CountDownLatch(3);
+        
+        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
 
-        assertThat(registry.get("executor.scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(0);
-        assertThat(registry.get("executor").tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix + ".scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
+                0);
+        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(0L);
 
         Runnable repeatedAtFixedRate = () -> {
             fixedRateInvocations.countDown();
@@ -195,7 +226,8 @@ class ExecutorServiceMetricsTest {
         };
         pool.scheduleWithFixedDelay(repeatedWithFixedDelay, 5, 15, TimeUnit.MILLISECONDS);
 
-        assertThat(registry.get("executor.scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(2);
+        assertThat(registry.get(expectedMetricPrefix + ".scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
+                2);
 
         assertThat(fixedRateInvocations.await(5, TimeUnit.SECONDS)).isTrue();
         assertThat(fixedDelayInvocations.await(5, TimeUnit.SECONDS)).isTrue();
@@ -203,17 +235,27 @@ class ExecutorServiceMetricsTest {
         pool.shutdown();
         assertThat(pool.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(registry.get("executor").tags(userTags).timer().count()).isEqualTo(6L);
-        assertThat(registry.get("executor.idle").tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(6L);
+        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(0L);
     }
 
-    private void assertThreadPoolExecutorMetrics(String executorName) {
-        registry.get("executor.completed").tags(userTags).tag("name", executorName).meter();
-        registry.get("executor.queued").tags(userTags).tag("name", executorName).gauge();
-        registry.get("executor.queue.remaining").tags(userTags).tag("name", executorName).gauge();
-        registry.get("executor.active").tags(userTags).tag("name", executorName).gauge();
-        registry.get("executor.pool.size").tags(userTags).tag("name", executorName).gauge();
-        registry.get("executor.idle").tags(userTags).tag("name", executorName).timer();
-        registry.get("executor").tags(userTags).tag("name", executorName).timer();
+    @SuppressWarnings("unchecked")
+    private <T extends Executor> T monitorExecutorService(String executorName, String metricPrefix, T exec) {
+        if (metricPrefix == null) {
+            return (T) ExecutorServiceMetrics.monitor(registry, exec, executorName, userTags);
+        } else {
+            return (T) ExecutorServiceMetrics.monitor(registry, exec, executorName, metricPrefix, userTags);
+        }
+    }
+
+    private void assertThreadPoolExecutorMetrics(String executorName, @Nullable String metricPrefix) {
+        metricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
+        registry.get(metricPrefix + ".completed").tags(userTags).tag("name", executorName).meter();
+        registry.get(metricPrefix + ".queued").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + ".queue.remaining").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + ".active").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + ".pool.size").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + ".idle").tags(userTags).tag("name", executorName).timer();
+        registry.get(metricPrefix).tags(userTags).tag("name", executorName).timer();
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -45,8 +45,8 @@ class ExecutorServiceMetricsTest {
 
     @DisplayName("Normal executor can be instrumented after being initialized")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void executor(String metricPrefix) throws InterruptedException {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void executor(String metricPrefix, String expectedMetricPrefix) throws InterruptedException {
         CountDownLatch lock = new CountDownLatch(1);
         Executor exec = r -> {
             r.run();
@@ -55,63 +55,62 @@ class ExecutorServiceMetricsTest {
         Executor executor = monitorExecutorService("exec", metricPrefix, exec);
         executor.execute(() -> System.out.println("hello"));
         lock.await();
-        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
 
-        assertThat(registry.get(expectedMetricPrefix + ".execution").tags(userTags).tag("name", "exec").timer()
+        assertThat(registry.get(expectedMetricPrefix + "executor.execution").tags(userTags).tag("name", "exec").timer()
                            .count()).isEqualTo(1L);
-        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).tag("name", "exec").timer()
+        assertThat(registry.get(expectedMetricPrefix + "executor.idle").tags(userTags).tag("name", "exec").timer()
                            .count()).isEqualTo(1L);
     }
 
     @DisplayName("ExecutorService is casted from Executor when necessary")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void executorCasting(String metricPrefix) {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void executorCasting(String metricPrefix, String expectedMetricPrefix) {
         Executor exec = Executors.newFixedThreadPool(2);
         monitorExecutorService("exec", metricPrefix, exec);
-        assertThreadPoolExecutorMetrics("exec", metricPrefix);
+        assertThreadPoolExecutorMetrics("exec", expectedMetricPrefix);
     }
 
     @DisplayName("thread pool executor can be instrumented after being initialized")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void threadPoolExecutor(String metricPrefix) {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void threadPoolExecutor(String metricPrefix, String expectedMetricPrefix) {
         ExecutorService exec = Executors.newFixedThreadPool(2);
         monitorExecutorService("exec", metricPrefix, exec);
-        assertThreadPoolExecutorMetrics("exec", metricPrefix);
+        assertThreadPoolExecutorMetrics("exec", expectedMetricPrefix);
     }
 
     @DisplayName("Scheduled thread pool executor can be instrumented after being initialized")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void scheduledThreadPoolExecutor(String metricPrefix) {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void scheduledThreadPoolExecutor(String metricPrefix, String expectedMetricPrefix) {
         ScheduledExecutorService exec = Executors.newScheduledThreadPool(2);
         monitorExecutorService("exec", metricPrefix, exec);
-        assertThreadPoolExecutorMetrics("exec", metricPrefix);
+        assertThreadPoolExecutorMetrics("exec", expectedMetricPrefix);
     }
 
     @DisplayName("ScheduledExecutorService is casted from Executor when necessary")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void scheduledThreadPoolExecutorAsExecutor(String metricPrefix) {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void scheduledThreadPoolExecutorAsExecutor(String metricPrefix, String expectedMetricPrefix) {
         Executor exec = Executors.newScheduledThreadPool(2);
         monitorExecutorService("exec", metricPrefix, exec);
-        assertThreadPoolExecutorMetrics("exec", metricPrefix);
+        assertThreadPoolExecutorMetrics("exec", expectedMetricPrefix);
     }
 
     @DisplayName("ScheduledExecutorService is casted from ExecutorService when necessary")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void scheduledThreadPoolExecutorAsExecutorService(String metricPrefix) {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void scheduledThreadPoolExecutorAsExecutorService(String metricPrefix, String expectedMetricPrefix) {
         ExecutorService exec = Executors.newScheduledThreadPool(2);
         monitorExecutorService("exec", metricPrefix, exec);
-        assertThreadPoolExecutorMetrics("exec", metricPrefix);
+        assertThreadPoolExecutorMetrics("exec", expectedMetricPrefix);
     }
 
     @DisplayName("ExecutorService can be monitored with a default set of metrics")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void monitorExecutorService(String metricPrefix) throws InterruptedException {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void monitorExecutorService(String metricPrefix, String expectedMetricPrefix) throws InterruptedException {
         ExecutorService pool = monitorExecutorService("beep.pool", metricPrefix,
                                                       Executors.newSingleThreadExecutor());
         CountDownLatch taskStart = new CountDownLatch(1);
@@ -127,8 +126,7 @@ class ExecutorServiceMetricsTest {
 
         assertThat(taskStart.await(1, TimeUnit.SECONDS)).isTrue();
 
-        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
-        assertThat(registry.get(expectedMetricPrefix + ".queued").tags(userTags).tag("name", "beep.pool")
+        assertThat(registry.get(expectedMetricPrefix + "executor.queued").tags(userTags).tag("name", "beep.pool")
                            .gauge().value()).isEqualTo(1.0);
 
         taskComplete.countDown();
@@ -136,15 +134,15 @@ class ExecutorServiceMetricsTest {
         pool.shutdown();
         assertThat(pool.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get(expectedMetricPrefix + ".queued").tags(userTags).gauge().value()).isEqualTo(0.0);
+        assertThat(registry.get(expectedMetricPrefix + "executor").tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + "executor.idle").tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + "executor.queued").tags(userTags).gauge().value()).isEqualTo(0.0);
     }
 
     @DisplayName("ScheduledExecutorService can be monitored with a default set of metrics")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void monitorScheduledExecutorService(String metricPrefix)
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void monitorScheduledExecutorService(String metricPrefix, String expectedMetricPrefix)
             throws TimeoutException, ExecutionException, InterruptedException {
         ScheduledExecutorService pool = monitorExecutorService("scheduled.pool", metricPrefix,
                                                                Executors.newScheduledThreadPool(2));
@@ -172,9 +170,7 @@ class ExecutorServiceMetricsTest {
         };
         ScheduledFuture<?> runnableResult = pool.schedule(scheduledBeepRunnable, 15, TimeUnit.MILLISECONDS);
 
-        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
-
-        assertThat(registry.get(expectedMetricPrefix + ".scheduled.once").tags(userTags).tag("name",
+        assertThat(registry.get(expectedMetricPrefix + "executor.scheduled.once").tags(userTags).tag("name",
                                                                                              "scheduled.pool")
                            .counter().count()).isEqualTo(2);
 
@@ -190,24 +186,22 @@ class ExecutorServiceMetricsTest {
         assertThat(callableResult.get(1, TimeUnit.MINUTES)).isEqualTo(1);
         assertThat(runnableResult.get(1, TimeUnit.MINUTES)).isNull();
 
-        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(2L);
-        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix + "executor").tags(userTags).timer().count()).isEqualTo(2L);
+        assertThat(registry.get(expectedMetricPrefix + "executor.idle").tags(userTags).timer().count()).isEqualTo(0L);
     }
 
     @DisplayName("ScheduledExecutorService repetitive tasks can be monitored with a default set of metrics")
     @ParameterizedTest
-    @CsvSource({ "custom.executor", "," })
-    void monitorScheduledExecutorServiceWithRepetitiveTasks(String metricPrefix) throws InterruptedException {
+    @CsvSource({ "custom,custom.", "custom.,custom." , ",''", "' ',''" })
+    void monitorScheduledExecutorServiceWithRepetitiveTasks(String metricPrefix, String expectedMetricPrefix) throws InterruptedException {
         ScheduledExecutorService pool = monitorExecutorService("scheduled.pool", metricPrefix,
                                                                Executors.newScheduledThreadPool(1));
         CountDownLatch fixedRateInvocations = new CountDownLatch(3);
         CountDownLatch fixedDelayInvocations = new CountDownLatch(3);
-        
-        String expectedMetricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
 
-        assertThat(registry.get(expectedMetricPrefix + ".scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
+        assertThat(registry.get(expectedMetricPrefix + "executor.scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
                 0);
-        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix + "executor").tags(userTags).timer().count()).isEqualTo(0L);
 
         Runnable repeatedAtFixedRate = () -> {
             fixedRateInvocations.countDown();
@@ -225,7 +219,7 @@ class ExecutorServiceMetricsTest {
         };
         pool.scheduleWithFixedDelay(repeatedWithFixedDelay, 5, 15, TimeUnit.MILLISECONDS);
 
-        assertThat(registry.get(expectedMetricPrefix + ".scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
+        assertThat(registry.get(expectedMetricPrefix + "executor.scheduled.repetitively").tags(userTags).counter().count()).isEqualTo(
                 2);
 
         assertThat(fixedRateInvocations.await(5, TimeUnit.SECONDS)).isTrue();
@@ -234,8 +228,8 @@ class ExecutorServiceMetricsTest {
         pool.shutdown();
         assertThat(pool.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(registry.get(expectedMetricPrefix).tags(userTags).timer().count()).isEqualTo(6L);
-        assertThat(registry.get(expectedMetricPrefix + ".idle").tags(userTags).timer().count()).isEqualTo(0L);
+        assertThat(registry.get(expectedMetricPrefix + "executor").tags(userTags).timer().count()).isEqualTo(6L);
+        assertThat(registry.get(expectedMetricPrefix + "executor.idle").tags(userTags).timer().count()).isEqualTo(0L);
     }
 
     @SuppressWarnings("unchecked")
@@ -249,12 +243,12 @@ class ExecutorServiceMetricsTest {
 
     private void assertThreadPoolExecutorMetrics(String executorName, @Nullable String metricPrefix) {
         metricPrefix = metricPrefix != null ? metricPrefix : DEFAULT_EXECUTOR_METRIC_PREFIX;
-        registry.get(metricPrefix + ".completed").tags(userTags).tag("name", executorName).meter();
-        registry.get(metricPrefix + ".queued").tags(userTags).tag("name", executorName).gauge();
-        registry.get(metricPrefix + ".queue.remaining").tags(userTags).tag("name", executorName).gauge();
-        registry.get(metricPrefix + ".active").tags(userTags).tag("name", executorName).gauge();
-        registry.get(metricPrefix + ".pool.size").tags(userTags).tag("name", executorName).gauge();
-        registry.get(metricPrefix + ".idle").tags(userTags).tag("name", executorName).timer();
-        registry.get(metricPrefix).tags(userTags).tag("name", executorName).timer();
+        registry.get(metricPrefix + "executor.completed").tags(userTags).tag("name", executorName).meter();
+        registry.get(metricPrefix + "executor.queued").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.queue.remaining").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.active").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.pool.size").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.idle").tags(userTags).tag("name", executorName).timer();
+        registry.get(metricPrefix + "executor").tags(userTags).tag("name", executorName).timer();
     }
 }


### PR DESCRIPTION
Motivation:

`ExecutorService` metrics are hardcoded with 'executor.' prefix.
Some users want to monitor an `ExecutorService` with their own namespace to avoid conflict
with other executors such as Reactor Scheduler.

Modifications:

- Add `metricPrefix` paremeter to `ExecutorServiceMetrics` factory methods
- Add `metricPrefix` parameter to `Timed*` class constructor

Result:
Fixes #1919