### PR TITLE
Disable Spring Integration graph endpoint

### DIFF
--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/integration/SpringIntegrationApplication.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/integration/SpringIntegrationApplication.java
@@ -15,30 +15,27 @@
  */
 package io.micrometer.boot2.samples.integration;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.annotation.Gateway;
-import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
 import org.springframework.integration.ws.WebServiceHeaders;
 import org.springframework.integration.xml.transformer.XPathTransformer;
 
-@Configuration
 @SpringBootApplication
-@IntegrationComponentScan
 public class SpringIntegrationApplication {
 
     public static void main(String[] args) throws InterruptedException {
-        ConfigurableApplicationContext ctx = SpringApplication.run(SpringIntegrationApplication.class, args);
+        ConfigurableApplicationContext ctx = new SpringApplicationBuilder(SpringIntegrationApplication.class)
+                .profiles("spring-integration").run(args);
         TempConverter converter = ctx.getBean(TempConverter.class);
 
         for (int i = 0; i < 1000; i++) {
-            System.out.println(converter.fahrenheitToCelcius(68.0f));
+            System.out.println(converter.fahrenheitToCelsius(68.0f));
             Thread.sleep(10);
         }
 
@@ -64,7 +61,7 @@ public class SpringIntegrationApplication {
     @MessagingGateway
     public interface TempConverter {
         @Gateway(requestChannel = "convert.input")
-        float fahrenheitToCelcius(float fahren);
+        float fahrenheitToCelsius(float fahren);
     }
 
 }

--- a/samples/micrometer-samples-boot2/src/main/resources/application-spring-integration.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application-spring-integration.yml
@@ -1,0 +1,20 @@
+#
+# Copyright 2020 Pivotal Software, Inc.
+# <p>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://www.apache.org/licenses/LICENSE-2.0
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+management:
+  endpoint:
+    integrationgraph:
+      enabled: true

--- a/samples/micrometer-samples-boot2/src/main/resources/application.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application.yml
@@ -41,10 +41,12 @@ management:
     stackdriver.enabled: false
     statsd.enabled: false
     wavefront.enabled: false
-
-  endpoint.shutdown.enabled: true
-
   endpoints:
     web:
       exposure:
         include: '*'
+  endpoint:
+    shutdown:
+      enabled: true
+    integrationgraph:
+      enabled: false


### PR DESCRIPTION
I see the following error when running a sample like `SimpleSample`:

```
Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
:59:09 main ERROR o.s.b.d.LoggingFailureAnalysisReporter - 

***************************
APPLICATION FAILED TO START
***************************

Description:

A component required a bean named 'convert.input' that could not be found.


Action:

Consider defining a bean named 'convert.input' in your configuration.


Process finished with exit code 1
```

Disabling Spring Integration graph endpoint seems to resolve the error, so this PR disables it.