### PR TITLE
Use micrometer-core project dependency in micrometer-samples-boot2

### DIFF
--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -14,12 +14,15 @@ dependencyManagement {
 }
 
 dependencies {
+    implementation project(":micrometer-core")
     ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'humio', 'appoptics', 'stackdriver'].each { sys ->
         implementation project(":micrometer-registry-$sys")
     }
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation('org.springframework.boot:spring-boot-starter-actuator') {
+        exclude group: 'io.micrometer', module: 'micrometer-core'
+    }
     implementation 'org.springframework.integration:spring-integration-ws'
     implementation 'org.springframework.integration:spring-integration-xml'
 


### PR DESCRIPTION
When I was looking at the build failure from https://github.com/micrometer-metrics/micrometer/pull/1921#issuecomment-601674179, I noticed that `micrometer-samples-boot2` uses Spring Boot managed version of `micrometer-core` dependency whereas it uses backend implementations from the project. This PR changes to use `micrometer-core` project dependency in `micrometer-samples-boot2`.

I don't know the root cause of the build failure, but this change seems to fix it.