### PR TITLE
Fix NewRelicMeterRegistry - No enum constant java.util.concurrent.TimeUnit.seconds

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -167,7 +167,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeTimer(Timer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);		
@@ -181,7 +181,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeFunctionTimer(FunctionTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -95,7 +95,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeLongTaskTimer(LongTaskTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(ACTIVE_TASKS, timer.activeTasks(), attributes);          	
         addAttribute(DURATION, timer.duration(timeUnit), attributes);
         addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(), attributes);
@@ -167,7 +167,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeTimer(Timer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);		
@@ -181,7 +181,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeFunctionTimer(FunctionTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -118,7 +118,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     
     @Override
     public Stream<String> writeLongTaskTimer(LongTaskTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(ACTIVE_TASKS, timer.activeTasks()),
@@ -179,7 +179,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeTimer(Timer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),
@@ -193,7 +193,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -179,7 +179,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeTimer(Timer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),
@@ -193,7 +193,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -38,9 +38,11 @@ import com.newrelic.api.agent.TraceMetadata;
 import com.newrelic.api.agent.TracedMethod;
 import com.newrelic.api.agent.Transaction;
 
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
@@ -465,6 +467,76 @@ class NewRelicMeterRegistryTest {
         
         FunctionTimer functionTimer = registry.find("myFunTimer2").functionTimer();
         assertThat(clientProvider.writeFunctionTimer(functionTimer)).isEqualTo(expectedEntries);
+    }
+    
+    @Test
+    void writeLongTaskTimer() {
+        //test API clientProvider
+        writeLongTaskTimer(getInsightsApiClientProvider(meterNameEventTypeEnabledConfig),
+                "{\"eventType\":\"myLongTaskTimer\",\"activeTasks\":0,\"duration\":0,\"timeUnit\":\"seconds\"}");
+        writeLongTaskTimer(getInsightsApiClientProvider(insightsApiConfig),
+                "{\"eventType\":\"MicrometerSample\",\"activeTasks\":0,\"duration\":0,\"timeUnit\":\"seconds\",\"metricName\":\"myLongTaskTimer\",\"metricType\":\"LONG_TASK_TIMER\"}");
+
+        //test Agent clientProvider
+        Map<String, Object> expectedEntries = new HashMap<>();
+        expectedEntries.put("activeTasks", 0);
+        expectedEntries.put("duration", 0);
+        expectedEntries.put("timeUnit", "seconds");
+        writeLongTaskTimer(getInsightsAgentClientProvider(meterNameEventTypeEnabledConfig), expectedEntries);
+        expectedEntries.put("activeTasks", 0);
+        expectedEntries.put("duration", 0);
+        expectedEntries.put("timeUnit", "seconds");
+        expectedEntries.put("metricName", "myLongTaskTimer2");
+        expectedEntries.put("metricType", "LONG_TASK_TIMER");
+        writeLongTaskTimer(getInsightsAgentClientProvider(agentConfig), expectedEntries);
+    }
+    
+    private void writeLongTaskTimer(NewRelicInsightsApiClientProvider clientProvider, String expectedJson) {
+        registry.more().longTaskTimer("myLongTaskTimer", emptyList());
+        LongTaskTimer longTaskTimer = registry.find("myLongTaskTimer").longTaskTimer();
+        assertThat(clientProvider.writeLongTaskTimer(longTaskTimer)).containsExactly(expectedJson);       
+    }
+    
+    private void writeLongTaskTimer(NewRelicInsightsAgentClientProvider clientProvider, Map<String, Object> expectedEntries) {
+        registry.more().longTaskTimer("myLongTaskTimer2", emptyList());
+        LongTaskTimer longTaskTimer = registry.find("myLongTaskTimer2").longTaskTimer();
+        assertThat(clientProvider.writeLongTaskTimer(longTaskTimer)).isEqualTo(expectedEntries);
+    }
+    
+    @Test
+    void writeSummary() {
+        //test API clientProvider
+        writeSummary(getInsightsApiClientProvider(meterNameEventTypeEnabledConfig),
+                "{\"eventType\":\"myDistSummary\",\"count\":0,\"avg\":0,\"total\":0,\"max\":0}");
+        writeSummary(getInsightsApiClientProvider(insightsApiConfig),
+                "{\"eventType\":\"MicrometerSample\",\"count\":0,\"avg\":0,\"total\":0,\"max\":0,\"metricName\":\"myDistSummary\",\"metricType\":\"DISTRIBUTION_SUMMARY\"}");
+
+        //test Agent clientProvider
+        Map<String, Object> expectedEntries = new HashMap<>();
+        expectedEntries.put("avg", 0);
+        expectedEntries.put("count", 0);
+        expectedEntries.put("max", 0);
+        expectedEntries.put("total", 0);
+        writeSummary(getInsightsAgentClientProvider(meterNameEventTypeEnabledConfig), expectedEntries);
+        expectedEntries.put("avg", 0);
+        expectedEntries.put("count", 0);
+        expectedEntries.put("max", 0);
+        expectedEntries.put("total", 0);
+        expectedEntries.put("metricName", "myDistSummary2");
+        expectedEntries.put("metricType", "DISTRIBUTION_SUMMARY");
+        writeSummary(getInsightsAgentClientProvider(agentConfig), expectedEntries);
+    }
+    
+    private void writeSummary(NewRelicInsightsApiClientProvider clientProvider, String expectedJson) {
+        registry.summary("myDistSummary", emptyList());
+        DistributionSummary summary = registry.find("myDistSummary").summary();
+        assertThat(clientProvider.writeSummary(summary)).containsExactly(expectedJson);       
+    }
+    
+    private void writeSummary(NewRelicInsightsAgentClientProvider clientProvider, Map<String, Object> expectedEntries) {
+        registry.summary("myDistSummary2", emptyList());
+        DistributionSummary summary = registry.find("myDistSummary2").summary();
+        assertThat(clientProvider.writeSummary(summary)).isEqualTo(expectedEntries);
     }
     
     @Test


### PR DESCRIPTION
@shakuzen  I found a critical issue that exists in both of the Client Provider implementations when processing Timers.  The previous version of Micrometer used the NewRelicMeterRegistry’s BaseTimeUnit to compute mean, totalTime, etc.
v1.3.x Ex:
timer.mean(getBaseTimeUnit())

Whereas the Client Providers are coded to use the meter.Id BaseUnit (lack of registry and allows TImeUnit to be specified at meter creation vs. tied to registry). The issue is that the Meter.Id BaseUnit is lowercase and fails to convert to TimeUnit.
v1.4 Ex:
TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
timer.mean(timeUnit)

The underlying cause is in the base MeterRegistry (line 254) when a Timer is being created, it uses getBaseTimeUnitStr() which applies toLowercase() to the original TimeUnit provided.

This PR fixes with (timer.getId().getBaseUnit().toUpperCase(), to continue allowing  Timer Meter's to be created with varying TimeUnits.  It can be changed to use the registry's baseTimeUnit if preferred.  Or should the underlying MeterRegistry.getBaseTimeUnitStr() be changed? It would be more consistent/elegant if the Meter.Id's baseUnit could easily convert back to TimeUnit.

Resolves #1931