### PR TITLE
Handle NaN for FunctionTimer in ElasticMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -318,11 +318,15 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Optional<String> writeFunctionTimer(FunctionTimer timer) {
-        return Optional.of(writeDocument(timer, builder -> {
-            builder.append(",\"count\":").append(timer.count());
-            builder.append(",\"sum\" :").append(timer.totalTime(getBaseTimeUnit()));
-            builder.append(",\"mean\":").append(timer.mean(getBaseTimeUnit()));
-        }));
+        double sum = timer.totalTime(getBaseTimeUnit());
+        if (Double.isFinite(sum)) {
+            return Optional.of(writeDocument(timer, builder -> {
+                builder.append(",\"count\":").append(timer.count());
+                builder.append(",\"sum\":").append(sum);
+                builder.append(",\"mean\":").append(timer.mean(getBaseTimeUnit()));
+            }));
+        }
+        return Optional.empty();
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -86,6 +86,13 @@ class ElasticMeterRegistryTest {
     }
 
     @Test
+    void nanFunctionTimerShouldNotBeWritten() {
+        FunctionTimer timer = FunctionTimer.builder("myFunctionTimer", Double.NaN, Number::longValue, Number::doubleValue, TimeUnit.MILLISECONDS).register(registry);
+        clock.add(config.step());
+        assertThat(registry.writeFunctionTimer(timer)).isEmpty();
+    }
+
+    @Test
     void writeGauge() {
         Gauge gauge = Gauge.builder("myGauge", 123.0, Number::doubleValue).register(registry);
         assertThat(registry.writeGauge(gauge))


### PR DESCRIPTION
This PR changes to handle NaN for `FunctionTimer` in `ElasticMeterRegistry`.

See https://github.com/micrometer-metrics/micrometer/issues/1123#issuecomment-602488229