### PR TITLE
Prevent sending null description in DatadogMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -261,10 +261,13 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
     /**
      * Set up metric metadata once per time series
      */
-    private void postMetricDescriptionMetadata(String metricName, DatadogMetricMetadata metadata) {
+    // VisibleForTesting
+    void postMetricDescriptionMetadata(String metricName, DatadogMetricMetadata metadata) {
         // already posted the metadata for this metric
-        if (verifiedMetadata.contains(metricName) || !metadata.isDescriptionsEnabled())
+        if (!metadata.isDescriptionsEnabled() || metadata.editDescriptionMetadataBody() == null
+                || verifiedMetadata.contains(metricName)) {
             return;
+        }
 
         try {
             httpClient


### PR DESCRIPTION
This PR changes to prevent sending `null` description in `DatadogMeterRegistry`.

Closes gh-1933