### PR TITLE
Remove configuration for checkstyle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,11 +106,6 @@ subprojects {
             }
         }
 
-        checkstyle {
-            toolVersion = '8.23'
-            configFile = rootProject.file('config/checkstyle/checkstyle.xml')
-        }
-
         license {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true


### PR DESCRIPTION
This PR removes configuration for `checkstyle` task.

This changes to use [Gradle Checkstyle default version (8.27)](https://github.com/gradle/gradle/blob/v6.3.0/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java#L37). The value for `configFile` was the same as [its default value](https://github.com/gradle/gradle/blob/v6.3.0/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java#L38), so it seems to be redundant.