### PR TITLE
Add sum for FunctionTimer in CloudWatchMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -209,11 +209,17 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             return Stream.of(metricDatum);
         }
 
-        private Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
+        // VisibleForTesting
+        Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
             // we can't know anything about max and percentiles originating from a function timer
-            return Stream.of(
-                    metricDatum(timer.getId(), "count", timer.count()),
-                    metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            double sum = timer.totalTime(getBaseTimeUnit());
+            if (Double.isFinite(sum)) {
+                return Stream.of(
+                        metricDatum(timer.getId(), "sum", sum),
+                        metricDatum(timer.getId(), "count", timer.count()),
+                        metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            }
+            return Stream.empty();
         }
 
         // VisibleForTesting

--- a/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch/src/test/java/io/micrometer/cloudwatch/CloudWatchMeterRegistryTest.java
@@ -124,4 +124,20 @@ class CloudWatchMeterRegistryTest {
                         new Dimension().withName("accepted").withValue("foo")));
     }
 
+    @Test
+    void functionTimerData() {
+        FunctionTimer timer = FunctionTimer.builder("my.function.timer", 1d, Number::longValue, Number::doubleValue,
+                TimeUnit.MILLISECONDS).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionTimerData(timer)).hasSize(3);
+    }
+
+    @Test
+    void functionTimerDataWhenSumIsNaNShouldReturnEmptyStream() {
+        FunctionTimer timer = FunctionTimer.builder("my.function.timer", Double.NaN, Number::longValue,
+                Number::doubleValue, TimeUnit.MILLISECONDS).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionTimerData(timer)).isEmpty();
+    }
+
 }


### PR DESCRIPTION
This PR adds sum for `FunctionTimer` in `CloudWatchMeterRegistry` as it seems to be missing accidentally.