### PR TITLE
Add `status` tag in `MicrometerHttpClientInterceptor`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
@@ -74,6 +74,7 @@ public class MicrometerHttpClientInterceptor {
         this.responseInterceptor = (response, context) -> {
             Timer.Sample sample = timerByHttpContext.remove(context);
             sample.stop(meterRegistry, Timer.builder(METER_NAME)
+                    .tag("status", Integer.toString(response.getStatusLine().getStatusCode()))
                     .tags(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
                     .tags(extraTags));
         };

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptorTest.java
@@ -80,7 +80,7 @@ class MicrometerHttpClientInterceptorTest {
         HttpResponse response = future.get();
 
         assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
-        assertThat(registry.get("httpcomponents.httpclient.request").tag("uri", "/some/pattern").timer().count())
+        assertThat(registry.get("httpcomponents.httpclient.request").tag("uri", "/some/pattern").tag("status", "200").timer().count())
                 .isEqualTo(1);
 
         client.close();


### PR DESCRIPTION
This mimics the behavior of `MicrometerHttpRequestExecutor` and is important for users who use both these classes i.c.w. with e.g. `PrometheusMeterRegistry`, as that class requires that meters with matching names have matching sets of tag keys.