### PR TITLE
Long task timer add base time unit

### DIFF
--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -174,7 +174,7 @@ public class AtlasMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        return new SpectatorLongTaskTimer(id, com.netflix.spectator.api.patterns.LongTaskTimer.get(registry, spectatorId(id)));
+        return new SpectatorLongTaskTimer(id, com.netflix.spectator.api.patterns.LongTaskTimer.get(registry, spectatorId(id)), getBaseTimeUnit());
     }
 
     @Override

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorLongTaskTimer.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorLongTaskTimer.java
@@ -15,19 +15,19 @@
  */
 package io.micrometer.atlas;
 
-import io.micrometer.core.instrument.AbstractMeter;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.AbstractLongTaskTimer;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.instrument.util.TimeUtils;
 
-import java.util.concurrent.TimeUnit;
-
-public class SpectatorLongTaskTimer extends AbstractMeter implements LongTaskTimer {
+public class SpectatorLongTaskTimer extends AbstractLongTaskTimer implements LongTaskTimer {
     private final com.netflix.spectator.api.LongTaskTimer timer;
 
-    SpectatorLongTaskTimer(Meter.Id id, com.netflix.spectator.api.LongTaskTimer timer) {
-        super(id);
+    SpectatorLongTaskTimer(Meter.Id id, com.netflix.spectator.api.LongTaskTimer timer, TimeUnit baseTimeUnit) {
+        super(id, baseTimeUnit);
         this.timer = timer;
     }
 

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -167,7 +167,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeTimer(Timer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);		
@@ -181,7 +181,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeFunctionTimer(FunctionTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -95,7 +95,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeLongTaskTimer(LongTaskTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         addAttribute(ACTIVE_TASKS, timer.activeTasks(), attributes);          	
         addAttribute(DURATION, timer.duration(timeUnit), attributes);
         addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(), attributes);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -95,7 +95,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeLongTaskTimer(LongTaskTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(ACTIVE_TASKS, timer.activeTasks(), attributes);          	
         addAttribute(DURATION, timer.duration(timeUnit), attributes);
         addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(), attributes);
@@ -167,7 +167,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeTimer(Timer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);		
@@ -181,7 +181,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     @Override
     public Map<String, Object> writeFunctionTimer(FunctionTimer timer) {
         Map<String, Object> attributes = new HashMap<>();
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -118,7 +118,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     
     @Override
     public Stream<String> writeLongTaskTimer(LongTaskTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(ACTIVE_TASKS, timer.activeTasks()),

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -118,7 +118,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     
     @Override
     public Stream<String> writeLongTaskTimer(LongTaskTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(ACTIVE_TASKS, timer.activeTasks()),
@@ -179,7 +179,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeTimer(Timer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),
@@ -193,7 +193,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit());
+        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -179,7 +179,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeTimer(Timer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),
@@ -193,7 +193,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     @Override
     public Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        TimeUnit timeUnit = TimeUnit.valueOf(timer.getId().getBaseUnit().toUpperCase());
+        TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(
                 event(timer.getId(),
                         new Attribute(COUNT, timer.count()),

--- a/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBMeterRegistry.java
+++ b/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBMeterRegistry.java
@@ -129,7 +129,7 @@ public class OpenTSDBMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        return new DefaultLongTaskTimer(id, clock);
+        return new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -282,7 +282,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
         MicrometerCollector collector = collectorByName(id);
-        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock);
+        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit()); //TODO: Use getBaseTimeUnit() for duration, etc throughout?
         List<String> tagValues = tagValues(id);
 
         collector.add(tagValues, (conventionName, tagKeys) -> Stream.of(new MicrometerCollector.Family(Collector.Type.UNTYPED, conventionName,

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -208,7 +208,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     List<String> quantileValues = new LinkedList<>(tagValues);
                     quantileValues.add(Collector.doubleToGoString(v.percentile()));
                     samples.add(new Collector.MetricFamilySamples.Sample(
-                            conventionName, quantileKeys, quantileValues, v.value(TimeUnit.SECONDS)));
+                            conventionName, quantileKeys, quantileValues, v.value(getBaseTimeUnit())));
                 }
             }
 
@@ -226,7 +226,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                         // satisfies https://prometheus.io/docs/concepts/metric_types/#histogram
                         for (CountAtBucket c : histogramCounts) {
                             final List<String> histogramValues = new LinkedList<>(tagValues);
-                            histogramValues.add(Collector.doubleToGoString(c.bucket(TimeUnit.SECONDS)));
+                            histogramValues.add(Collector.doubleToGoString(c.bucket(getBaseTimeUnit())));
                             samples.add(new Collector.MetricFamilySamples.Sample(
                                     conventionName + "_bucket", histogramKeys, histogramValues, c.count()));
                         }
@@ -256,7 +256,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     conventionName + "_count", tagKeys, tagValues, count));
 
             samples.add(new Collector.MetricFamilySamples.Sample(
-                    conventionName + "_sum", tagKeys, tagValues, timer.totalTime(TimeUnit.SECONDS)));
+                    conventionName + "_sum", tagKeys, tagValues, timer.totalTime(getBaseTimeUnit())));
 
             return Stream.of(new MicrometerCollector.Family(type, conventionName, samples.build()),
                     new MicrometerCollector.Family(Collector.Type.GAUGE, conventionName + "_max", Stream.of(
@@ -282,12 +282,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
         MicrometerCollector collector = collectorByName(id);
-        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit()); //TODO: Use getBaseTimeUnit() for duration, etc throughout?
+        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
         List<String> tagValues = tagValues(id);
 
         collector.add(tagValues, (conventionName, tagKeys) -> Stream.of(new MicrometerCollector.Family(Collector.Type.UNTYPED, conventionName,
                 new Collector.MetricFamilySamples.Sample(conventionName + "_active_count", tagKeys, tagValues, ltt.activeTasks()),
-                new Collector.MetricFamilySamples.Sample(conventionName + "_duration_sum", tagKeys, tagValues, ltt.duration(TimeUnit.SECONDS))
+                new Collector.MetricFamilySamples.Sample(conventionName + "_duration_sum", tagKeys, tagValues, ltt.duration(getBaseTimeUnit()))
         )));
 
         return ltt;
@@ -301,7 +301,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
         collector.add(tagValues, (conventionName, tagKeys) -> Stream.of(new MicrometerCollector.Family(Collector.Type.SUMMARY, conventionName,
                 new Collector.MetricFamilySamples.Sample(conventionName + "_count", tagKeys, tagValues, ft.count()),
-                new Collector.MetricFamilySamples.Sample(conventionName + "_sum", tagKeys, tagValues, ft.totalTime(TimeUnit.SECONDS))
+                new Collector.MetricFamilySamples.Sample(conventionName + "_sum", tagKeys, tagValues, ft.totalTime(getBaseTimeUnit()))
         )));
 
         return ft;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
@@ -32,8 +32,8 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
 
     private final boolean alwaysPublish;
 
-    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock, boolean alwaysPublish) {
-        super(id, clock);
+    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock, boolean alwaysPublish, TimeUnit baseTimeUnit) {
+        super(id, clock, baseTimeUnit);
         this.lineBuilder = lineBuilder;
         this.sink = sink;
         this.alwaysPublish = alwaysPublish;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -329,7 +329,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        StatsdLongTaskTimer ltt = new StatsdLongTaskTimer(id, lineBuilder(id), fluxSink, clock, statsdConfig.publishUnchangedMeters());
+        StatsdLongTaskTimer ltt = new StatsdLongTaskTimer(id, lineBuilder(id), fluxSink, clock, statsdConfig.publishUnchangedMeters(), getBaseTimeUnit());
         pollableMeters.put(id, ltt);
         return ltt;
     }

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -137,7 +137,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        return new DefaultLongTaskTimer(id, clock);
+        return new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractLongTaskTimer.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.util.MeterEquivalence;
+
+public abstract class AbstractLongTaskTimer extends AbstractMeter implements LongTaskTimer {
+
+    private final TimeUnit baseTimeUnit;
+    
+    /**
+     * Creates a new long task timer.
+     *
+     * @param id                            The timer's name and tags.
+     * @param clock                         The clock used to measure latency.
+     * @param baseTimeUnit                  The time scale of this timer.
+     */
+    public AbstractLongTaskTimer(Id id, TimeUnit baseTimeUnit) {
+        super(id);
+        this.baseTimeUnit = baseTimeUnit;
+    }
+    
+    @Override
+    public TimeUnit baseTimeUnit() {
+        return baseTimeUnit;
+    }
+    
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(Object o) {
+        return MeterEquivalence.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return MeterEquivalence.hashCode(this);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -160,6 +160,11 @@ public interface LongTaskTimer extends Meter {
         );
     }
 
+    /**
+     * @return The base time unit of the timer to which all published metrics will be scaled
+     */
+    TimeUnit baseTimeUnit();
+    
     class Sample {
         private final LongTaskTimer timer;
         private final long task;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
@@ -78,6 +78,11 @@ class CompositeLongTaskTimer extends AbstractCompositeMeter<LongTaskTimer> imple
     }
 
     @Override
+    public TimeUnit baseTimeUnit() {
+        return firstChild().baseTimeUnit();
+    }
+    
+    @Override
     LongTaskTimer newNoopMeter() {
         return new NoopLongTaskTimer(getId());
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -111,7 +111,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock);
+        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());  //TODO: Use getBaseTimeUnit() for duration?
         registry.register(hierarchicalName(id.withTag(Statistic.ACTIVE_TASKS)), (Gauge<Integer>) ltt::activeTasks);
         registry.register(hierarchicalName(id.withTag(Statistic.DURATION)), (Gauge<Double>) () -> ltt.duration(TimeUnit.NANOSECONDS));
         return ltt;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -111,7 +111,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());  //TODO: Use getBaseTimeUnit() for duration?
+        LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
         registry.register(hierarchicalName(id.withTag(Statistic.ACTIVE_TASKS)), (Gauge<Integer>) ltt::activeTasks);
         registry.register(hierarchicalName(id.withTag(Statistic.DURATION)), (Gauge<Double>) () -> ltt.duration(TimeUnit.NANOSECONDS));
         return ltt;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -15,25 +15,25 @@
  */
 package io.micrometer.core.instrument.internal;
 
-import io.micrometer.core.instrument.AbstractMeter;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.AbstractLongTaskTimer;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.instrument.util.TimeUtils;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer {
+public class DefaultLongTaskTimer extends AbstractLongTaskTimer implements LongTaskTimer {
     private final ConcurrentMap<Long, Long> tasks = new ConcurrentHashMap<>();
     private final AtomicLong nextTask = new AtomicLong(0L);
     private final Clock clock;
 
-    public DefaultLongTaskTimer(Meter.Id id, Clock clock) {
-        super(id);
+    public DefaultLongTaskTimer(Meter.Id id, Clock clock, TimeUnit baseTimeUnit) {
+        super(id, baseTimeUnit);
         this.clock = clock;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/noop/NoopLongTaskTimer.java
@@ -48,4 +48,9 @@ public class NoopLongTaskTimer extends NoopMeter implements LongTaskTimer {
     public int activeTasks() {
         return 0;
     }
+    
+    @Override
+    public TimeUnit baseTimeUnit() {
+        return TimeUnit.SECONDS;
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
@@ -115,7 +115,7 @@ public class SimpleMeterRegistry extends MeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        return new DefaultLongTaskTimer(id, clock);
+        return new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -54,7 +54,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id) {
-        return new DefaultLongTaskTimer(id, clock);
+        return new DefaultLongTaskTimer(id, clock, getBaseTimeUnit());
     }
 
     @Override


### PR DESCRIPTION
Add baseTimeUnit to LongTaskTimer for consistency with other timers.  This adds AbstractLongTaskTimer which DefaultLongTaskTimer and SpectatorLongTaskTimer extends. Updates to the other implementations.  Other changes are to use a registry's getBaseTimeUnit() in newLongTaskTimer() to construct the timer.

See related comments: https://github.com/micrometer-metrics/micrometer/pull/1930