### PR TITLE
Deprecate PushRegistryConfig.numThreads()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -44,9 +44,15 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     }
 
     /**
+     * Return the number of threads to use with the scheduler.
+     *
+     * Note that this configuration is NOT supported.
+     *
      * @return The number of threads to use with the scheduler. The default is
      * 2 threads.
+     * @deprecated since 1.1.13
      */
+    @Deprecated
     default int numThreads() {
         String v = get(prefix() + ".numThreads");
         return v == null ? 2 : Integer.parseInt(v);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -50,7 +50,7 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
      *
      * @return The number of threads to use with the scheduler. The default is
      * 2 threads.
-     * @deprecated since 1.1.13
+     * @deprecated since 1.1.13 because this configuration is not used
      */
     @Deprecated
     default int numThreads() {


### PR DESCRIPTION
This PR adds no support note to `PushRegistryConfig.numThreads()`'s Javadoc.

See gh-1900