### PR TITLE
Add back httpClient method to NewRelicMeterRegistry Builder

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -62,7 +62,8 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     private final Logger logger = LoggerFactory.getLogger(NewRelicInsightsApiClientProvider.class);
 
     private final NewRelicConfig config;
-    private final HttpSender httpClient;
+    // VisibleForTesting
+    final HttpSender httpClient;
     private final NamingConvention namingConvention;
     private final String insightsEndpoint;
 

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -925,6 +925,24 @@ class NewRelicMeterRegistryTest {
 
         assertThat(getInsightsAgentClientProvider(config)).isNotNull();
     }
+
+    @Test
+    void canCustomizeHttpSenderViaBuilder_deprecated() {
+        HttpSender httpSender = mock(HttpSender.class);
+        NewRelicClientProvider clientProvider = NewRelicMeterRegistry.builder(insightsApiConfig).httpClient(httpSender).build().clientProvider;
+        assertThat(clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        assertThat(((NewRelicInsightsApiClientProvider) clientProvider).httpClient).isEqualTo(httpSender);
+    }
+
+    @Test
+    void canCustomizeHttpSenderViaBuilder() {
+        HttpSender httpSender = mock(HttpSender.class);
+        NewRelicClientProvider clientProvider = NewRelicMeterRegistry.builder(insightsApiConfig)
+                .clientProvider(new NewRelicInsightsApiClientProvider(insightsApiConfig, httpSender, new NewRelicNamingConvention()))
+                .build().clientProvider;
+        assertThat(clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        assertThat(((NewRelicInsightsApiClientProvider) clientProvider).httpClient).isEqualTo(httpSender);
+    }
     
     static class MockHttpSender implements HttpSender {
         


### PR DESCRIPTION
This preserves backwards compatibility with previous versions while deprecating the method. An alternate way to customize the `HttpSender` is available now via the `clientProvider` method.

Fixes #1956