### PR TITLE
NewRelicClientProvider Use NamingConvention From Registry

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicClientProvider.java
@@ -83,4 +83,6 @@ public interface NewRelicClientProvider {
     Object writeFunctionCounter(FunctionCounter counter);
 
     Object writeMeter(Meter meter);
+
+    void setNamingConvention(NamingConvention namingConvention);
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -54,17 +54,18 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
     private final NewRelicConfig config;
     private final Agent newRelicAgent;
     // VisibleForTesting
-    final NamingConvention namingConvention;
+    NamingConvention namingConvention;
     
     public NewRelicInsightsAgentClientProvider(NewRelicConfig config) {
-        this(config, new NewRelicNamingConvention());
-    }
-    
-    public NewRelicInsightsAgentClientProvider(NewRelicConfig config, NamingConvention namingConvention) {
-        this(config, NewRelic.getAgent(), namingConvention);
+        this(config, NewRelic.getAgent(), new NewRelicNamingConvention());
     }
 
-    public NewRelicInsightsAgentClientProvider(NewRelicConfig config, Agent newRelicAgent, NamingConvention namingConvention) {
+    public NewRelicInsightsAgentClientProvider(NewRelicConfig config, Agent newRelicAgent) {
+        this(config, newRelicAgent, new NewRelicNamingConvention());
+    }
+
+    // VisibleForTesting
+    NewRelicInsightsAgentClientProvider(NewRelicConfig config, Agent newRelicAgent, NamingConvention namingConvention) {
 
         if (!config.meterNameEventTypeEnabled() && StringUtils.isEmpty(config.eventType())) {
             throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
@@ -256,5 +257,9 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
                 logger.warn("failed to send metrics to new relic", e);
             }
         }
+    }
+    
+    public void setNamingConvention(NamingConvention namingConvention) {
+        this.namingConvention = namingConvention;
     }
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -53,10 +53,15 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
 
     private final NewRelicConfig config;
     private final Agent newRelicAgent;
-    private final NamingConvention namingConvention;
+    // VisibleForTesting
+    final NamingConvention namingConvention;
     
     public NewRelicInsightsAgentClientProvider(NewRelicConfig config) {
-        this(config, NewRelic.getAgent(), new NewRelicNamingConvention());
+        this(config, new NewRelicNamingConvention());
+    }
+    
+    public NewRelicInsightsAgentClientProvider(NewRelicConfig config, NamingConvention namingConvention) {
+        this(config, NewRelic.getAgent(), namingConvention);
     }
 
     public NewRelicInsightsAgentClientProvider(NewRelicConfig config, Agent newRelicAgent, NamingConvention namingConvention) {

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -63,12 +63,17 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
 
     private final NewRelicConfig config;
     private final HttpSender httpClient;
-    private final NamingConvention namingConvention;
     private final String insightsEndpoint;
+    // VisibleForTesting
+    final NamingConvention namingConvention;
 
-    @SuppressWarnings("deprecation")
     public NewRelicInsightsApiClientProvider(NewRelicConfig config) {
-        this(config, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), new NewRelicNamingConvention());
+        this(config, new NewRelicNamingConvention());
+    }
+    
+    @SuppressWarnings("deprecation")
+    public NewRelicInsightsApiClientProvider(NewRelicConfig config, NamingConvention namingConvention) {
+        this(config, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), namingConvention);
     }
     
     @SuppressWarnings("deprecation")

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -65,25 +65,26 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     // VisibleForTesting
     final HttpSender httpClient;
     // VisibleForTesting
-    final NamingConvention namingConvention;
+    NamingConvention namingConvention;
     private final String insightsEndpoint;
 
-    public NewRelicInsightsApiClientProvider(NewRelicConfig config) {
-        this(config, new NewRelicNamingConvention());
-    }
-    
     @SuppressWarnings("deprecation")
-    public NewRelicInsightsApiClientProvider(NewRelicConfig config, NamingConvention namingConvention) {
-        this(config, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), namingConvention);
+    public NewRelicInsightsApiClientProvider(NewRelicConfig config) {
+        this(config, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), new NewRelicNamingConvention());
     }
-    
+
     @SuppressWarnings("deprecation")
     public NewRelicInsightsApiClientProvider(NewRelicConfig config, String proxyHost, int proxyPort) {
         this(config, new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout(), 
                             new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort))), new NewRelicNamingConvention());
     }
 
-    public NewRelicInsightsApiClientProvider(NewRelicConfig config, HttpSender httpClient, NamingConvention namingConvention) {
+    public NewRelicInsightsApiClientProvider(NewRelicConfig config, HttpSender httpClient) {
+        this(config, httpClient, new NewRelicNamingConvention());
+    }
+
+    // VisibleForTesting
+    NewRelicInsightsApiClientProvider(NewRelicConfig config, HttpSender httpClient, NamingConvention namingConvention) {
 
         if (!config.meterNameEventTypeEnabled() && StringUtils.isEmpty(config.eventType())) {
             throw new MissingRequiredConfigurationException("eventType must be set to report metrics to New Relic");
@@ -298,5 +299,9 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         public Object getValue() {
             return value;
         }
+    }
+    
+    public void setNamingConvention(NamingConvention namingConvention) {
+        this.namingConvention = namingConvention;
     }
 }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -66,10 +66,11 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         if (clientProvider == null) {
             //default to Insight API client provider if not specified in config or provided
             clientProvider = (config.clientProviderType() == ClientProviderType.INSIGHTS_AGENT)
-                    ? new NewRelicInsightsAgentClientProvider(config, namingConvention)
-                    : new NewRelicInsightsApiClientProvider(config, namingConvention);
+                    ? new NewRelicInsightsAgentClientProvider(config)
+                    : new NewRelicInsightsApiClientProvider(config);
         }
 
+        clientProvider.setNamingConvention(namingConvention);
         this.clientProvider = clientProvider;
 
         config().namingConvention(namingConvention);
@@ -117,7 +118,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         }
 
         /**
-         * Use the naming convention.
+         * Use the naming convention. Defaults to {@link NewRelicNamingConvention}
          * @param convention naming convention to use
          * @return builder
          * @since 1.4.0

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -65,8 +65,8 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
         if (clientProvider == null) {
             //default to Insight API client provider if not specified in config or provided
             clientProvider = (config.clientProviderType() == ClientProviderType.INSIGHTS_AGENT)
-                    ? new NewRelicInsightsAgentClientProvider(config)
-                    : new NewRelicInsightsApiClientProvider(config);
+                    ? new NewRelicInsightsAgentClientProvider(config, namingConvention)
+                    : new NewRelicInsightsApiClientProvider(config, namingConvention);
         }
 
         this.config = config;

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -35,7 +35,6 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("new-relic-metrics-publisher");
 
-    private final NewRelicConfig config;
     // VisibleForTesting
     final NewRelicClientProvider clientProvider;
 
@@ -69,7 +68,6 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
                     : new NewRelicInsightsApiClientProvider(config, namingConvention);
         }
 
-        this.config = config;
         this.clientProvider = clientProvider;
 
         config().namingConvention(namingConvention);

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -757,7 +757,9 @@ class NewRelicMeterRegistryTest {
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsApiConfig, null, clock);
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        
         assertThat(((NewRelicInsightsApiClientProvider)registry.clientProvider).namingConvention).isInstanceOf(NewRelicNamingConvention.class);
+        assertThat(registry.config().namingConvention()).isInstanceOf(NewRelicNamingConvention.class);
     }
     
     @Test
@@ -767,7 +769,9 @@ class NewRelicMeterRegistryTest {
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsApiConfig, null, customNamingConvention, clock, new NamedThreadFactory("new-relic-test"));
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        
         assertThat(((NewRelicInsightsApiClientProvider)registry.clientProvider).namingConvention).isSameAs(customNamingConvention);
+        assertThat(registry.config().namingConvention()).isSameAs(customNamingConvention);
     }
     
     @Test
@@ -775,7 +779,9 @@ class NewRelicMeterRegistryTest {
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsAgentConfig, null, clock);
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsAgentClientProvider.class);
+        
         assertThat(((NewRelicInsightsAgentClientProvider)registry.clientProvider).namingConvention).isInstanceOf(NewRelicNamingConvention.class);
+        assertThat(registry.config().namingConvention()).isInstanceOf(NewRelicNamingConvention.class);
     }
     
     @Test
@@ -785,7 +791,9 @@ class NewRelicMeterRegistryTest {
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsAgentConfig, null, customNamingConvention, clock, new NamedThreadFactory("new-relic-test"));
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsAgentClientProvider.class);
+        
         assertThat(((NewRelicInsightsAgentClientProvider)registry.clientProvider).namingConvention).isSameAs(customNamingConvention);
+        assertThat(registry.config().namingConvention()).isSameAs(customNamingConvention);
     }
     
     @Test

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -51,6 +51,8 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MissingRequiredConfigurationException;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.newrelic.NewRelicMeterRegistryTest.MockNewRelicAgent.MockNewRelicInsights;
 
@@ -751,17 +753,39 @@ class NewRelicMeterRegistryTest {
     }
     
     @Test
-    void succeedsConfigInsightsApiClientProvider() {        
+    void succeedsConfigInsightsApiClientProviderAndDefaultNamingConvention() {        
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsApiConfig, null, clock);
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        assertThat(((NewRelicInsightsApiClientProvider)registry.clientProvider).namingConvention).isInstanceOf(NewRelicNamingConvention.class);
     }
     
     @Test
-    void succeedsConfigInsightsAgentClientProvider() {        
+    void succeedsConfigInsightsApiClientProviderAndCustomNamingConvention() {
+        NamingConvention customNamingConvention = mock(NewRelicNamingConvention.class);
+        
+        NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsApiConfig, null, customNamingConvention, clock, new NamedThreadFactory("new-relic-test"));
+        
+        assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsApiClientProvider.class);
+        assertThat(((NewRelicInsightsApiClientProvider)registry.clientProvider).namingConvention).isSameAs(customNamingConvention);
+    }
+    
+    @Test
+    void succeedsConfigInsightsAgentClientProviderAndDefaultNamingConvention() {        
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsAgentConfig, null, clock);
         
         assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsAgentClientProvider.class);
+        assertThat(((NewRelicInsightsAgentClientProvider)registry.clientProvider).namingConvention).isInstanceOf(NewRelicNamingConvention.class);
+    }
+    
+    @Test
+    void succeedsConfigInsightsAgentClientProviderAndCustomNamingConvention() {
+        NamingConvention customNamingConvention = mock(NewRelicNamingConvention.class);
+        
+        NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsAgentConfig, null, customNamingConvention, clock, new NamedThreadFactory("new-relic-test"));
+        
+        assertThat(registry.clientProvider).isInstanceOf(NewRelicInsightsAgentClientProvider.class);
+        assertThat(((NewRelicInsightsAgentClientProvider)registry.clientProvider).namingConvention).isSameAs(customNamingConvention);
     }
     
     @Test


### PR DESCRIPTION
This is to resolve https://github.com/micrometer-metrics/micrometer/issues/1958
Allow construction of client provider implementations with a naming convention, so that it can be supplied by the NewRelicMeterRegistry. This covers normal construction/builder use cases, except if a client provider is supplied to registry.  If the client provider is custom, then it's reasonable to expect the creator to explicitly use the NewRelicNamingConvention or not.

Alternatively, setNamingConvetion() could be added to the client provider implementations and used in registry construction.  Having NewRelicClientProvider.setNamingConvention() would make the expectation more clear/formal for other implementations.

@shakuzen