### PR TITLE
Add Javadoc since to classes in io.micrometer.core.instrument.binder.http

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpServletRequestTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpServletRequestTagsProvider.java
@@ -22,6 +22,12 @@ import io.micrometer.core.instrument.Tags;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * Default {@link HttpServletRequestTagsProvider}.
+ *
+ * @author Jon Schneider
+ * @since 1.4.0
+ */
 @Incubating(since = "1.4.0")
 public class DefaultHttpServletRequestTagsProvider implements HttpServletRequestTagsProvider {
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpRequestTags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpRequestTags.java
@@ -22,6 +22,12 @@ import io.micrometer.core.instrument.util.StringUtils;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * Tags for HTTP requests.
+ *
+ * @author Jon Schneider
+ * @since 1.4.0
+ */
 @Incubating(since = "1.4.0")
 public class HttpRequestTags {
     private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpServletRequestTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpServletRequestTagsProvider.java
@@ -22,10 +22,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
- *  Provides {@link Tag Tags} for HTTP Servlet request handling.
+ * Provides {@link Tag Tags} for HTTP Servlet request handling.
  *
- *  @author Jon Schneider
- *  @since 1.4.0
+ * @author Jon Schneider
+ * @since 1.4.0
  */
 @Incubating(since = "1.4.0")
 public interface HttpServletRequestTagsProvider {


### PR DESCRIPTION
This PR adds Javadoc `@since` to classes in `io.micrometer.core.instrument.binder.http` package.