### PR TITLE
Polish

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -285,7 +285,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         return writeCounter(counter, counter.count());
     }
 
-    private Optional<String> writeCounter(Meter meter, Double value) {
+    private Optional<String> writeCounter(Meter meter, double value) {
         if (Double.isFinite(value)) {
             return Optional.of(writeDocument(meter, builder -> {
                 builder.append(",\"count\":").append(value);
@@ -296,7 +296,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Optional<String> writeGauge(Gauge gauge) {
-        Double value = gauge.value();
+        double value = gauge.value();
         if (Double.isFinite(value)) {
             return Optional.of(writeDocument(gauge, builder -> {
                 builder.append(",\"value\":").append(value);
@@ -307,7 +307,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Optional<String> writeTimeGauge(TimeGauge gauge) {
-        Double value = gauge.value(getBaseTimeUnit());
+        double value = gauge.value(getBaseTimeUnit());
         if (Double.isFinite(value)) {
             return Optional.of(writeDocument(gauge, builder -> {
                 builder.append(",\"value\":").append(value);

--- a/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
+++ b/implementations/micrometer-registry-kairos/src/main/java/io/micrometer/kairos/KairosMeterRegistry.java
@@ -150,7 +150,7 @@ public class KairosMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Stream<String> writeGauge(Gauge gauge) {
-        Double value = gauge.value();
+        double value = gauge.value();
         if (Double.isFinite(value)) {
             return Stream.of(writeMetric(gauge.getId(), config().clock().wallTime(), value));
         }
@@ -159,7 +159,7 @@ public class KairosMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Stream<String> writeTimeGauge(TimeGauge timeGauge) {
-        Double value = timeGauge.value(getBaseTimeUnit());
+        double value = timeGauge.value(getBaseTimeUnit());
         if (Double.isFinite(value)) {
             return Stream.of(writeMetric(timeGauge.getId(), config().clock().wallTime(), value));
         }

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicMeterRegistry.java
@@ -159,7 +159,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Stream<String> writeGauge(Gauge gauge) {
-        Double value = gauge.value();
+        double value = gauge.value();
         if (Double.isFinite(value)) {
             return Stream.of(event(gauge.getId(), new Attribute("value", value)));
         }
@@ -168,7 +168,7 @@ public class NewRelicMeterRegistry extends StepMeterRegistry {
 
     // VisibleForTesting
     Stream<String> writeTimeGauge(TimeGauge gauge) {
-        Double value = gauge.value(getBaseTimeUnit());
+        double value = gauge.value(getBaseTimeUnit());
         if (Double.isFinite(value)) {
             return Stream.of(event(gauge.getId(), new Attribute("value", value)));
         }


### PR DESCRIPTION
This PR simply changes `Double` to `double` with the following reasons:

- To avoid unnecessary boxing in `ElasticMeterRegistry`.
- To avoid unnecessary boxing/unboxing in `KairosMeterRegistry`.
- Just for consistency in `NewRelicMeterRegistry`.