### PR TITLE
Fix MeterRegistry.gauge @return javadoc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -425,7 +425,7 @@ public abstract class MeterRegistry {
      * @param obj           State object used to compute a value.
      * @param valueFunction Function that produces an instantaneous gauge value from the state object.
      * @param <T>           The type of the state object from which the gauge value is extracted.
-     * @return The number that was passed in so the registration can be done as part of an assignment
+     * @return The state object that was passed in so the registration can be done as part of an assignment
      * statement.
      */
     @Nullable


### PR DESCRIPTION
The Javadoc for the function `MeterRegistry.gauge(String, Iterable<Tag>, @Nullable T, ToDoubleFunction<T>)` is not quite correct.

It states that it returns "The number that was passed in..." while it actually takes and returns an arbitrary state object.

I suggest to change it with this PR changes this to "The state object that was passed in"