### PR TITLE
Polish HibernateQueryMetrics changes

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Pivotal Software, Inc.
+ * Copyright 2020 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package io.micrometer.core.instrument.binder.jpa;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.search.Search;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
 import org.hibernate.SessionFactory;
@@ -113,49 +112,46 @@ public class HibernateQueryMetrics implements MeterBinder {
         void registerQueryMetric(Statistics statistics) {
             for (String query : statistics.getQueries()) {
                 QueryStatistics queryStatistics = statistics.getQueryStatistics(query);
-                if (queryStatistics == null) continue;
-                String queryName = meterRegistry.config().namingConvention().tagValue(query);
-                if (Search.in(meterRegistry).tags("query", queryName).functionCounter() != null) continue;
 
                 FunctionCounter.builder("hibernate.query.cache.requests", queryStatistics, QueryStatistics::getCacheHitCount)
                         .tags(tags)
-                        .tags("result", "hit", "query", queryName)
-                        .description("Number of query cache hits/misses")
+                        .tags("result", "hit", "query", query)
+                        .description("Number of query cache hits")
                         .register(meterRegistry);
 
                 FunctionCounter.builder("hibernate.query.cache.requests", queryStatistics, QueryStatistics::getCacheMissCount)
                         .tags(tags)
-                        .tags("result", "miss", "query", queryName)
-                        .description("Number of query cache hits/misses")
+                        .tags("result", "miss", "query", query)
+                        .description("Number of query cache misses")
                         .register(meterRegistry);
 
                 FunctionCounter.builder("hibernate.query.cache.puts", queryStatistics, QueryStatistics::getCachePutCount)
                         .tags(tags)
-                        .tags("query", queryName)
+                        .tags("query", query)
                         .description("Number of cache puts for a query")
                         .register(meterRegistry);
 
                 FunctionTimer.builder("hibernate.query.execution.total", queryStatistics, QueryStatistics::getExecutionCount, QueryStatistics::getExecutionTotalTime, TimeUnit.MILLISECONDS)
                         .tags(tags)
-                        .tags("query", queryName)
-                        .description("Number of query executions")
+                        .tags("query", query)
+                        .description("Query executions")
                         .register(meterRegistry);
 
                 TimeGauge.builder("hibernate.query.execution.max", queryStatistics, TimeUnit.MILLISECONDS, QueryStatistics::getExecutionMaxTime)
                         .tags(tags)
-                        .tags("query", queryName)
+                        .tags("query", query)
                         .description("Query maximum execution time")
                         .register(meterRegistry);
 
                 TimeGauge.builder("hibernate.query.execution.min", queryStatistics, TimeUnit.MILLISECONDS, QueryStatistics::getExecutionMinTime)
                         .tags(tags)
-                        .tags("query", queryName)
+                        .tags("query", query)
                         .description("Query minimum execution time")
                         .register(meterRegistry);
 
                 FunctionCounter.builder("hibernate.query.execution.rows", queryStatistics, QueryStatistics::getExecutionRowCount)
                         .tags(tags)
-                        .tags("query", queryName)
+                        .tags("query", query)
                         .description("Number of rows processed for a query")
                         .register(meterRegistry);
             }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Pivotal Software, Inc.
+ * Copyright 2020 Pivotal Software, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.jpa;
 
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -49,10 +50,11 @@ class HibernateQueryMetricsTest {
         eventHandler.registerQueryMetric(statistics);
 
         assertThat(registry.get("hibernate.query.cache.requests").tags("result", "hit", "query", query).functionCounter().count()).isEqualTo(43.0d);
-        assertThat(registry.get("hibernate.query.cache.requests").tags("result", "hit", "query", query).functionCounter().count()).isEqualTo(43.0d);
+        assertThat(registry.get("hibernate.query.cache.requests").tags("result", "miss", "query", query).functionCounter().count()).isEqualTo(43.0d);
         assertThat(registry.get("hibernate.query.cache.puts").tags("query", query).functionCounter().count()).isEqualTo(43.0d);
-        assertThat(registry.get("hibernate.query.execution.total").tags("query", query).functionTimer().count()).isEqualTo(43.0d);
-        assertThat(registry.get("hibernate.query.execution.total").tags("query", query).functionTimer().totalTime(TimeUnit.MILLISECONDS)).isEqualTo(43.0d);
+        FunctionTimer timer = registry.get("hibernate.query.execution.total").tags("query", query).functionTimer();
+        assertThat(timer.count()).isEqualTo(43.0d);
+        assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(43.0d);
         assertThat(registry.get("hibernate.query.execution.max").tags("query", query).timeGauge().value(TimeUnit.MILLISECONDS)).isEqualTo(43.0d);
         assertThat(registry.get("hibernate.query.execution.min").tags("query", query).timeGauge().value(TimeUnit.MILLISECONDS)).isEqualTo(43.0d);
         assertThat(registry.get("hibernate.query.execution.rows").tags("query", query).functionCounter().count()).isEqualTo(43.0);


### PR DESCRIPTION
This PR polishes `HibernateQueryMetrics` changes as follows:

- Removing `queryStatistics` `null` check as it doesn't seem to be necessary based on its implementation:

```java
	public QueryStatisticsImpl getQueryStatistics(String queryString) {
		return queryStatsMap.getOrCompute(
				queryString,
				s -> new QueryStatisticsImpl( s )
		);
	}
```

- Removing duplicate query check as it doesn't seem to be necessary based on its implementation:

```java
	public String[] getQueries() {
		return queryStatsMap.keysAsArray();
	}
```