### PR TITLE
Add Jetty handshake metrics binding

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
@@ -44,7 +44,7 @@ public class JettySslHandshakeMetrics implements SslHandshakeListener {
     private final MeterRegistry registry;
     private final Iterable<Tag> tags;
 
-    Counter handshakesFailed;
+    private final Counter handshakesFailed;
 
     public JettySslHandshakeMetrics(MeterRegistry registry) {
         this(registry, Tags.empty());

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
@@ -1,4 +1,6 @@
 /**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetrics.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import org.eclipse.jetty.io.ssl.SslHandshakeListener;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+
+import javax.net.ssl.SSLSession;
+
+/**
+ * Jetty SSL/TLS handshake metrics.<br><br>
+ * <p>
+ * Usage example:
+ *
+ * <pre>{@code
+ * MeterRegistry registry = ...;
+ * Server server = new Server(0);
+ * Connector connector = new ServerConnector(server);
+ * connector.addBean(new JettySslHandshakeMetrics(registry));
+ * server.setConnectors(new Connector[] { connector });
+ * }</pre>
+ *
+ * Alternatively, configure on all connectors with {@link JettySslHandshakeMetrics#addToAllConnectors(Server, MeterRegistry, Iterable)}.
+ *
+ */
+public class JettySslHandshakeMetrics implements SslHandshakeListener {
+    private final MeterRegistry registry;
+    private final Iterable<Tag> tags;
+
+    Counter handshakesFailed;
+
+    public JettySslHandshakeMetrics(MeterRegistry registry) {
+        this(registry, Tags.empty());
+    }
+
+    public JettySslHandshakeMetrics(MeterRegistry registry, Iterable<Tag> tags) {
+        this.registry = registry;
+        this.tags = tags;
+
+        this.handshakesFailed = Counter.builder("jetty.ssl.handshakes")
+                .baseUnit(BaseUnits.EVENTS)
+                .description("SSL/TLS handshakes")
+                .tags(Tags.concat(tags, "result", "failed"))
+                .register(registry);
+    }
+
+    @Override
+    public void handshakeSucceeded(Event event) {
+        SSLSession session = event.getSSLEngine().getSession();
+        Counter.builder("jetty.ssl.handshakes")
+                .baseUnit(BaseUnits.EVENTS)
+                .description("SSL/TLS handshakes")
+                .tag("result", "succeeded")
+                .tag("protocol", session.getProtocol())
+                .tag("ciphersuite", session.getCipherSuite())
+                .tags(tags)
+                .register(registry)
+                .increment();
+    }
+
+    @Override
+    public void handshakeFailed(Event event, Throwable failure) {
+        handshakesFailed.increment();
+    }
+
+    public static void addToAllConnectors(Server server, MeterRegistry registry, Iterable<Tag> tags) {
+        for (Connector connector : server.getConnectors()) {
+            if (connector != null) {
+                connector.addBean(new JettySslHandshakeMetrics(registry, tags));
+            }
+        }
+    }
+
+    public static void addToAllConnectors(Server server, MeterRegistry registry) {
+        addToAllConnectors(server, registry, Tags.empty());
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.eclipse.jetty.io.ssl.SslHandshakeListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+
+class JettySslHandshakeMetricsTest {
+    private SimpleMeterRegistry registry;
+    private JettySslHandshakeMetrics sslHandshakeMetrics;
+
+    @Mock SSLSession session;
+    @Mock SSLEngine engine;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.when(engine.getSession()).thenReturn(session);
+
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+        Iterable<Tag> tags = Tags.of("id", "0");
+        sslHandshakeMetrics = new JettySslHandshakeMetrics(registry, tags);
+    }
+
+    @Test
+    void handshakeFailed() {
+        SslHandshakeListener.Event event = new SslHandshakeListener.Event(engine);
+        sslHandshakeMetrics.handshakeFailed(event, new javax.net.ssl.SSLHandshakeException(""));
+        assertThat(registry.get("jetty.ssl.handshakes")
+                           .tags("id", "0", "result", "failed")
+                           .counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void handshakeSucceeded() {
+        SslHandshakeListener.Event event = new SslHandshakeListener.Event(engine);
+        Mockito.when(session.getProtocol()).thenReturn("TLSv1.3");
+        Mockito.when(session.getCipherSuite()).thenReturn("RSA_XYZZY");
+        sslHandshakeMetrics.handshakeSucceeded(event);
+        assertThat(registry.get("jetty.ssl.handshakes")
+                           .tags("id", "0", "protocol", "TLSv1.3", "ciphersuite", "RSA_XYZZY", "result", "succeeded")
+                           .counter().count()).isEqualTo(1.0);
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
@@ -1,4 +1,6 @@
 /**
+ * Copyright 2020 Pivotal Software, Inc.
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
Add a Jetty binding to record the TLS version and ciphersuite used for new TLS connections, along with handshake failures.