### PR TITLE
fix (kafka): only consider same client meters when filtering out

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -160,7 +160,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
             if (tag.getKey().equals(KAFKA_VERSION_TAG_NAME))
                 if (!kafkaVersion.equals(tag.getValue())) anotherVersion = true;
         }
-        return anotherClient && anotherVersion;
+        return anotherClient || anotherVersion;
     }
 
     private void bindMeter(MeterRegistry registry, Metric metric, String name, Iterable<Tag> tags) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -154,14 +154,11 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
     }
 
     private boolean differentClient(List<Tag> tags) {
-        boolean anotherClient = false, anotherVersion = false;
-        for (Tag tag : tags) {
+        boolean anotherClient = false;
+        for (Tag tag : tags)
             if (tag.getKey().equals(CLIENT_ID_TAG_NAME))
                 if (!clientId.equals(tag.getValue())) anotherClient = true;
-            if (tag.getKey().equals(KAFKA_VERSION_TAG_NAME))
-                if (!kafkaVersion.equals(tag.getValue())) anotherVersion = true;
-        }
-        return anotherClient || anotherVersion;
+        return anotherClient;
     }
 
     private void bindMeter(MeterRegistry registry, Metric metric, String name, Iterable<Tag> tags) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -91,6 +91,12 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
     }
 
     @Override public void bindTo(MeterRegistry registry) {
+        prepareToBindMetrics(registry);
+        scheduler.scheduleAtFixedRate(() -> checkAndBindMetrics(registry), 0, getRefreshIntervalInMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /** Define common tags and meters before binding metrics */
+    void prepareToBindMetrics(MeterRegistry registry) {
         Map<MetricName, ? extends Metric> metrics = metricsSupplier.get();
         // Collect static metrics and tags
         Metric startTime = null;
@@ -104,8 +110,6 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                     startTime = entry.getValue();
         }
         if (startTime != null) bindMeter(registry, startTime, meterName(startTime), meterTags(startTime));
-        // Collect dynamic metrics
-        scheduler.scheduleAtFixedRate(() -> checkAndBindMetrics(registry), 0, getRefreshIntervalInMillis(), TimeUnit.MILLISECONDS);
     }
 
     private long getRefreshIntervalInMillis() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -108,7 +108,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         Metric startTime = null;
         for (Map.Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
             MetricName name = entry.getKey();
-            if (clientId.equals(DEFAULT_VALUE)) clientId = name.tags().get(CLIENT_ID_TAG_NAME);
+            if (clientId.equals(DEFAULT_VALUE) && name.tags().get(CLIENT_ID_TAG_NAME) != null) clientId = name.tags().get(CLIENT_ID_TAG_NAME);
             if (METRIC_GROUP_APP_INFO.equals(name.group()))
                 if (VERSION_METRIC_NAME.equals(name.name()))
                     kafkaVersion = (String) entry.getValue().metricValue();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -61,6 +61,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
     static final Duration DEFAULT_REFRESH_INTERVAL = Duration.ofSeconds(60);
     static final String KAFKA_VERSION_TAG_NAME = "kafka-version";
     static final String CLIENT_ID_TAG_NAME = "client-id";
+    static final String DEFAULT_VALUE = "unknown";
 
     private final Supplier<Map<MetricName, ? extends Metric>> metricsSupplier;
     private final Iterable<Tag> extraTags;
@@ -72,8 +73,8 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
      */
     private volatile Set<MetricName> currentMeters = new HashSet<>();
 
-    private String kafkaVersion = "unknown";
-    private String clientId = "unknown";
+    private String kafkaVersion = DEFAULT_VALUE;
+    private String clientId = DEFAULT_VALUE;
 
     KafkaMetrics(Supplier<Map<MetricName, ? extends Metric>> metricsSupplier) {
         this(metricsSupplier, emptyList());
@@ -95,7 +96,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         Metric startTime = null;
         for (Map.Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
             MetricName name = entry.getKey();
-            if (clientId.equals("unknown")) clientId = name.tags().get(CLIENT_ID_TAG_NAME);
+            if (clientId.equals(DEFAULT_VALUE)) clientId = name.tags().get(CLIENT_ID_TAG_NAME);
             if (METRIC_GROUP_APP_INFO.equals(name.group()))
                 if (VERSION_METRIC_NAME.equals(name.name()))
                     kafkaVersion = (String) entry.getValue().metricValue();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
@@ -136,8 +136,7 @@ class KafkaClientMetricsIntegrationTest {
                 producer1Configs, new StringSerializer(), new StringSerializer());
 
         KafkaClientMetrics producer1KafkaMetrics = new KafkaClientMetrics(producer1);
-        producer1KafkaMetrics.prepareToBindMetrics(registry);
-        producer1KafkaMetrics.checkAndBindMetrics(registry);
+        producer1KafkaMetrics.bindTo(registry);
 
         int producer1Metrics = registry.getMeters().size();
         assertThat(registry.getMeters()).hasSizeGreaterThan(0);
@@ -158,8 +157,7 @@ class KafkaClientMetricsIntegrationTest {
                 producer2Configs, new StringSerializer(), new StringSerializer());
 
         KafkaClientMetrics producer2KafkaMetrics = new KafkaClientMetrics(producer2);
-        producer2KafkaMetrics.prepareToBindMetrics(registry);
-        producer2KafkaMetrics.checkAndBindMetrics(registry);
+        producer2KafkaMetrics.bindTo(registry);
 
         producer2.send(new ProducerRecord<>("topic1", "foo"));
         producer2.flush();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -203,24 +203,17 @@ class KafkaMetricsTest {
             firstTags.put("client-id", "client0");
             MetricName firstName = new MetricName("a", "b", "c", firstTags);
             KafkaMetric firstMetric = new KafkaMetric(this, firstName, new Value(), new MetricConfig(), Time.SYSTEM);
-            MetricName versionName = new MetricName("version", "app-info", "kafka version", Collections.emptyMap());
-            Gauge<String> version = (config, now) -> "2.0";
-            KafkaMetric versionMetric = new KafkaMetric(this, versionName, version, new MetricConfig(), Time.SYSTEM);
 
             Map<MetricName, KafkaMetric> metrics = new LinkedHashMap<>();
             metrics.put(firstName, firstMetric);
-            metrics.put(versionName, versionMetric);
             return metrics;
         };
         KafkaMetrics kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
-        registry.counter("kafka.b.a", "client-id", "client0", "key0", "value0", "kafka-version", "1.0");
-        registry.counter("kafka.b.a", "client-id", "client1", "key0", "value0", "kafka-version", "1.0");
+        registry.counter("kafka.b.a", "client-id", "client1", "key0", "value0");
         //When
-        kafkaMetrics.bindTo(registry);
+        kafkaMetrics.checkAndBindMetrics(registry);
         //Then
-        assertThat(registry.getMeters()).hasSize(3);
-        Meter meter = registry.getMeters().get(0);
-        assertThat(meter.getId().getTags()).hasSize(3); // version + clientId + key0
+        assertThat(registry.getMeters()).hasSize(2);
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.stats.Value;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -57,7 +57,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(1);
         //When
@@ -78,7 +78,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(1);
         //Given
@@ -112,7 +112,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(1);
         //When
@@ -132,7 +132,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.getMeters().get(0).getId().getTags()).hasSize(1); //only version
@@ -162,7 +162,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(1);
         Meter meter = registry.getMeters().get(0);
@@ -189,7 +189,7 @@ class KafkaMetricsTest {
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
         //When
-        kafkaMetrics.checkAndBindMetrics(registry);
+        kafkaMetrics.bindTo(registry);
         //Then
         assertThat(registry.getMeters()).hasSize(2);
         Meter meter = registry.getMeters().get(0);


### PR DESCRIPTION
* Handle multiple clients
* Handle common tags

Fix #1968 