### PR TITLE
Configure PushRegistry#batchSize for Wavefront

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -317,7 +317,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
                     "apiToken must be set whenever publishing directly to the Wavefront API");
         }
         return new WavefrontDirectIngestionClient.Builder(getWavefrontReportingUri(config),
-                config.apiToken());
+                config.apiToken()).batchSize(config.batchSize());
     }
 
     public static Builder builder(WavefrontConfig config) {


### PR DESCRIPTION
This commit uses the batchSize property of WavefrontConfig to customize
the default WavefrontSender.