### PR TITLE
Use latest.release for jOOQ

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,8 +56,7 @@ def VERSIONS = [
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:latest.release',
         'org.hsqldb:hsqldb:latest.release',
-        // Pin version temporarily to restore builds. See gh-1852
-        'org.jooq:jooq:3.13.+',
+        'org.jooq:jooq:latest.release',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
         'org.junit.jupiter:junit-jupiter:latest.release',
         'org.junit.platform:junit-platform-launcher:latest.release',


### PR DESCRIPTION
This PR changes to use `latest.release` for jOOQ.