### PR TITLE
Relax assertion for jetty.threads.busy in test

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetricsTest.java
@@ -62,6 +62,6 @@ class JettyServerThreadPoolMetricsTest {
         assertThat(registry.get("jetty.threads.config.min").gauge().value()).isEqualTo(32.0);
         assertThat(registry.get("jetty.threads.config.max").gauge().value()).isEqualTo(100.0);
         assertThat(registry.get("jetty.threads.current").gauge().value()).isNotEqualTo(0.0);
-        assertThat(registry.get("jetty.threads.busy").gauge().value()).isNotEqualTo(0.0);
+        assertThat(registry.get("jetty.threads.busy").gauge().value()).isGreaterThanOrEqualTo(0.0);
     }
 }


### PR DESCRIPTION
[This build](https://circleci.com/gh/micrometer-metrics/micrometer/6151?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) shows that `jetty.threads.busy` could be 0.0, so this PR relaxes its assertion to avoid test flakiness.