### PR TITLE
Suppress warnings for PushRegistryConfig.numThreads()

### DIFF
--- a/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapter.java
+++ b/micrometer-spring-legacy/src/main/java/io/micrometer/spring/autoconfigure/export/properties/StepRegistryPropertiesConfigAdapter.java
@@ -65,6 +65,7 @@ public abstract class StepRegistryPropertiesConfigAdapter<T extends StepRegistry
         return get(T::getReadTimeout, StepRegistryConfig.super::readTimeout);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public int numThreads() {
         return get(T::getNumThreads, StepRegistryConfig.super::numThreads);


### PR DESCRIPTION
This PR suppresses warnings for `PushRegistryConfig.numThreads()`.