### PR TITLE
Allow colons in datadogstatsd tag values

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -51,12 +51,12 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
             this.namingConvention = next;
-            this.name = next.name(sanitize(id.getName()), id.getType(), id.getBaseUnit()) + ":";
+            this.name = next.name(sanitizeColons(id.getName()), id.getType(), id.getBaseUnit()) + ":";
             synchronized (tagsLock) {
                 this.tags = HashTreePMap.empty();
                 this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
                         id.getConventionTags(this.namingConvention).stream()
-                                .map(t -> sanitize(t.getKey()) + ":" + sanitize(t.getValue()))
+                                .map(t -> sanitizeColons(t.getKey()) + ":" + sanitizeTagValue(t.getValue()))
                                 .collect(Collectors.joining(","))
                         : null;
             }
@@ -64,8 +64,15 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
         }
     }
 
-    private String sanitize(String value) {
+    private String sanitizeColons(String value) {
         return value.replace(':', '_');
+    }
+
+    private String sanitizeTagValue(String value) {
+        if (!Character.isLetter(value.charAt(0))) {
+            value = "m." + value;
+        }
+        return (value.charAt(value.length() - 1) == ':') ? value.substring(0, value.length() - 1) + '_' : value;
     }
 
     private String tagsByStatistic(@Nullable Statistic stat) {

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
@@ -42,11 +42,22 @@ class DatadogStatsdLineBuilderTest {
 
     @Issue("#739")
     @Test
-    void sanitizeColons() {
-        Counter c = registry.counter("my:counter", "my:tag", "my:value");
+    void sanitizeColonsInTagKeys() {
+        Counter c = registry.counter("my:counter", "my:tag", "my_value");
         DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(c.getId(), registry.config());
 
         registry.config().namingConvention(NamingConvention.dot);
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag:my_value");
+    }
+
+    @Issue("#1998")
+    @Test
+    void allowColonsInTagValues() {
+        Counter c = registry.counter("my:counter", "my:tag", "my:value", "other_tag", "some:value:", "yet.another.tag", "123:value");
+        DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(c.getId(), registry.config());
+
+        registry.config().namingConvention(NamingConvention.dot);
+        assertThat(lb.line("1", Statistic.COUNT, "c"))
+                .isEqualTo("my_counter:1|c|#statistic:count,my_tag:my:value,other_tag:some:value_,yet.another.tag:m.123:value");
     }
 }


### PR DESCRIPTION
Colons are allowed in the tag values except for at the end of the tag value.

Fixes #1998