### PR TITLE
Update JavaDocs for deprecated get*ExpectedValue methods

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -158,7 +158,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
      *
      * @return The minimum value that this distribution summary is expected to observe.
      * @deprecated Use {@link #getMinimumExpectedValueAsDouble}. If you use this method, your code
-     * will not be compatible with code that uses Micrometer 1.4.x and later.
+     * will not be compatible with code that uses Micrometer 1.3.x.
      */
     @Deprecated
     @Nullable
@@ -183,7 +183,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
      *
      * @return The maximum value that the meter is expected to observe.
      * @deprecated Use {@link #getMaximumExpectedValueAsDouble}. If you use this method, your code
-     * will not be compatible with code that uses Micrometer 1.4.x and later.
+     * will not be compatible with code that uses Micrometer 1.3.x.
      */
     @Deprecated
     @Nullable


### PR DESCRIPTION
….3.x to allow libraries to be compatible with it.

For #2002 - took the liberty of creating a PR to provide an example of how we could solve the compatibility issue. It's not pretty, but if we wanted to avoid `asDouble`, need to come up with a new semantic name since the method name `get*ExpectedValue` is already taken by 1.3.x and returns `Long`.

To finish addressing #2002 a similar change will need to be merged to 1.3.x branch which adds these methods along with `public double[] getServiceLevelObjectiveBoundaries()`.