### PR TITLE
Add get*ValueAsDouble and getServiceLevelObjectiveBoundaries methods …

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -299,6 +299,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
         return lineBuilderFunction.apply(id);
     }
 
+    @SuppressWarnings("deprecation")
     private DistributionStatisticConfig addInfBucket(DistributionStatisticConfig config) {
         long[] slas = config.getSlaBoundaries() == null ? new long[]{Long.MAX_VALUE} :
                 LongStream.concat(Arrays.stream(config.getSlaBoundaries()), LongStream.of(Long.MAX_VALUE)).toArray();
@@ -326,7 +327,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
             pauseDetector) {
 
         // Adds an infinity bucket for SLA violation calculation
-        if (distributionStatisticConfig.getSlaBoundaries() != null) {
+        if (distributionStatisticConfig.getServiceLevelObjectiveBoundaries() != null) {
             distributionStatisticConfig = addInfBucket(distributionStatisticConfig);
         }
 
@@ -342,7 +343,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
             distributionStatisticConfig, double scale) {
 
         // Adds an infinity bucket for SLA violation calculation
-        if (distributionStatisticConfig.getSlaBoundaries() != null) {
+        if (distributionStatisticConfig.getServiceLevelObjectiveBoundaries() != null) {
             distributionStatisticConfig = addInfBucket(distributionStatisticConfig);
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
@@ -63,7 +63,7 @@ class CompositeDistributionSummary extends AbstractCompositeMeter<DistributionSu
         return new NoopDistributionSummary(getId());
     }
 
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings({"ConstantConditions", "deprecation"})
     @Override
     DistributionSummary registerNewMeter(MeterRegistry registry) {
         return DistributionSummary.builder(getId().getName())

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -113,7 +113,7 @@ class CompositeTimer extends AbstractCompositeMeter<Timer> implements Timer {
         return new NoopTimer(getId());
     }
 
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings({"ConstantConditions", "deprecation"})
     @Override
     Timer registerNewMeter(MeterRegistry registry) {
         Timer.Builder builder = Timer.builder(getId().getName())

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
@@ -97,8 +97,8 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
             }
         }
 
-        final Long minimumExpectedValue = distributionStatisticConfig.getMinimumExpectedValue();
-        final Long maximumExpectedValue = distributionStatisticConfig.getMaximumExpectedValue();
+        final Double minimumExpectedValue = distributionStatisticConfig.getMinimumExpectedValueAsDouble();
+        final Double maximumExpectedValue = distributionStatisticConfig.getMaximumExpectedValueAsDouble();
         if (minimumExpectedValue == null || minimumExpectedValue <= 0) {
             rejectHistogramConfig("minimumExpectedValue (" + minimumExpectedValue + ") must be greater than 0.");
         }
@@ -108,8 +108,8 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
                     minimumExpectedValue + ").");
         }
 
-        if (distributionStatisticConfig.getSlaBoundaries() != null) {
-            for (long sla : distributionStatisticConfig.getSlaBoundaries()) {
+        if (distributionStatisticConfig.getServiceLevelObjectiveBoundaries() != null) {
+            for (double sla : distributionStatisticConfig.getServiceLevelObjectiveBoundaries()) {
                 if (sla <= 0) {
                     rejectHistogramConfig("slaBoundaries must contain only the values greater than 0. " +
                             "Found " + sla);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -154,7 +154,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
 
     /**
      * @deprecated Use {@link #getMinimumExpectedValueAsDouble}. If you use this method, your code
-     * will not be compatible with code that uses Micrometer 1.4.x.
+     * will not be compatible with code that uses Micrometer 1.4.x and later.
      */
     @Deprecated
     @Nullable
@@ -175,7 +175,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
 
     /**
      * @deprecated Use {@link #getMaximumExpectedValueAsDouble}. If you use this method, your code
-     * will not be compatible with code that uses Micrometer 1.3.x.
+     * will not be compatible with code that uses Micrometer 1.4.x and later.
      */
     @Deprecated
     @Nullable
@@ -222,7 +222,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
 
     /**
      * @deprecated Use {@link #getServiceLevelObjectiveBoundaries()}. If you use this method, your
-     * code will not be compatible with code that uses Micrometer 1.4.x.
+     * code will not be compatible with code that uses Micrometer 1.4.x and later.
      */
     @Deprecated
     @Nullable

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -153,11 +153,10 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
-     * The minimum value that the meter is expected to observe. Sets a lower bound
-     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
-     *
-     * @return The minimum value that this distribution summary is expected to observe.
+     * @deprecated Use {@link #getMinimumExpectedValueAsDouble}. If you use this method, your code
+     * will not be compatible with code that uses Micrometer 1.4.x.
      */
+    @Deprecated
     @Nullable
     public Long getMinimumExpectedValue() {
         return minimumExpectedValue;
@@ -175,11 +174,10 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
-     * The maximum value that the meter is expected to observe. Sets an upper bound
-     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
-     *
-     * @return The maximum value that the meter is expected to observe.
+     * @deprecated Use {@link #getMaximumExpectedValueAsDouble}. If you use this method, your code
+     * will not be compatible with code that uses Micrometer 1.3.x.
      */
+    @Deprecated
     @Nullable
     public Long getMaximumExpectedValue() {
         return maximumExpectedValue;
@@ -223,13 +221,10 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
-     * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
-     * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
-     * generate aggregable percentile approximations. If the {@link DistributionStatisticConfig} is meant for
-     * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds.
-     *
-     * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
+     * @deprecated Use {@link #getServiceLevelObjectiveBoundaries()}. If you use this method, your
+     * code will not be compatible with code that uses Micrometer 1.4.x.
      */
+    @Deprecated
     @Nullable
     public long[] getSlaBoundaries() {
         return sla;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.internal.Mergeable;
 import io.micrometer.core.lang.Nullable;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.NavigableSet;
 import java.util.TreeSet;
 
@@ -55,6 +56,9 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
 
     @Nullable
     private long[] sla;
+
+    @Nullable
+    private double[] slaAsDouble;
 
     @Nullable
     private Long minimumExpectedValue;
@@ -160,6 +164,17 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
+     * The minimum value that the meter is expected to observe. Sets a lower bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @return The minimum value that this distribution summary is expected to observe.
+     */
+    @Nullable
+    public Double getMinimumExpectedValueAsDouble() {
+        return minimumExpectedValue != null ? (double) minimumExpectedValue : null;
+    }
+
+    /**
      * The maximum value that the meter is expected to observe. Sets an upper bound
      * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
      *
@@ -168,6 +183,17 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     @Nullable
     public Long getMaximumExpectedValue() {
         return maximumExpectedValue;
+    }
+
+    /**
+     * The maximum value that the meter is expected to observe. Sets an upper bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @return The maximum value that the meter is expected to observe.
+     */
+    @Nullable
+    public Double getMaximumExpectedValueAsDouble() {
+        return maximumExpectedValue != null ? (double) maximumExpectedValue : null;
     }
 
     /**
@@ -207,6 +233,19 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     @Nullable
     public long[] getSlaBoundaries() {
         return sla;
+    }
+
+    /**
+     * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
+     * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
+     * generate aggregable percentile approximations. If the {@link DistributionStatisticConfig} is meant for
+     * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds.
+     *
+     * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
+     */
+    @Nullable
+    public double[] getServiceLevelObjectiveBoundaries() {
+        return slaAsDouble;
     }
 
     public static class Builder {
@@ -255,6 +294,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
          */
         public Builder sla(@Nullable long... sla) {
             config.sla = sla;
+            config.slaAsDouble = sla != null ? Arrays.stream(sla).asDoubleStream().toArray() : null;
             return this;
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -153,6 +153,10 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
+     * The minimum value that the meter is expected to observe. Sets a lower bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @return The minimum value that this distribution summary is expected to observe.
      * @deprecated Use {@link #getMinimumExpectedValueAsDouble}. If you use this method, your code
      * will not be compatible with code that uses Micrometer 1.4.x and later.
      */
@@ -174,6 +178,10 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
+     * The maximum value that the meter is expected to observe. Sets an upper bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @return The maximum value that the meter is expected to observe.
      * @deprecated Use {@link #getMaximumExpectedValueAsDouble}. If you use this method, your code
      * will not be compatible with code that uses Micrometer 1.4.x and later.
      */
@@ -221,8 +229,14 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
+     * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
+     * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
+     * generate aggregable percentile approximations. If the {@link DistributionStatisticConfig} is meant for
+     * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds.
+     *
+     * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
      * @deprecated Use {@link #getServiceLevelObjectiveBoundaries()}. If you use this method, your
-     * code will not be compatible with code that uses Micrometer 1.4.x and later.
+     * code will not be compatible with code that uses Micrometer 1.5.x and later.
      */
     @Deprecated
     @Nullable
@@ -231,12 +245,12 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
     }
 
     /**
-     * Publish at a minimum a histogram containing your defined SLA boundaries. When used in conjunction with
+     * Publish at a minimum a histogram containing your defined SLO boundaries. When used in conjunction with
      * {@link #percentileHistogram}, the boundaries defined here are included alongside other buckets used to
      * generate aggregable percentile approximations. If the {@link DistributionStatisticConfig} is meant for
-     * use with a {@link io.micrometer.core.instrument.Timer}, the SLA unit is in nanoseconds.
+     * use with a {@link io.micrometer.core.instrument.Timer}, the SLO unit is in nanoseconds.
      *
-     * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
+     * @return The SLO boundaries to include the set of histogram buckets shipped to the monitoring system.
      */
     @Nullable
     public double[] getServiceLevelObjectiveBoundaries() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/PercentileHistogramBuckets.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/PercentileHistogramBuckets.java
@@ -75,6 +75,7 @@ public class PercentileHistogramBuckets {
      *                                    and maximum expected values..
      * @return The set of histogram buckets for use in computing aggregable percentiles.
      */
+    @SuppressWarnings("deprecation")
     public static NavigableSet<Long> buckets(DistributionStatisticConfig distributionStatisticConfig) {
         return PERCENTILE_BUCKETS.subSet(distributionStatisticConfig.getMinimumExpectedValue(), true,
                 distributionStatisticConfig.getMaximumExpectedValue(), true);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.*;
  * @author Jon Schneider
  * @author Johnny Lim
  */
+@SuppressWarnings("deprecation")
 class MeterFilterTest {
     private static Condition<Meter.Id> tag(String tagKey) {
         return tag(tagKey, null);

--- a/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
+++ b/micrometer-spring-legacy/src/test/java/io/micrometer/spring/autoconfigure/PropertiesMeterFilterTest.java
@@ -211,14 +211,14 @@ public class PropertiesMeterFilterTest {
     public void configureWhenHasSlaShouldSetSlaToValue() {
         slas("spring.boot", "1", "2", "3");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
-                .getSlaBoundaries()).containsExactly(1000000, 2000000, 3000000);
+                .getServiceLevelObjectiveBoundaries()).containsExactly(1000000, 2000000, 3000000);
     }
 
     @Test
     public void configureWhenHasHigherSlaShouldSetPercentilesToValue() {
         slas("spring", "1", "2", "3");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
-                .getSlaBoundaries()).containsExactly(1000000, 2000000, 3000000);
+                .getServiceLevelObjectiveBoundaries()).containsExactly(1000000, 2000000, 3000000);
     }
 
     @Test
@@ -226,14 +226,14 @@ public class PropertiesMeterFilterTest {
         slas("spring", "1", "2", "3");
         slas("spring.boot", "4", "5", "6");
         assertThat(filter.configure(createSpringBootMeter(), DistributionStatisticConfig.DEFAULT)
-                .getSlaBoundaries()).containsExactly(4000000, 5000000, 6000000);
+                .getServiceLevelObjectiveBoundaries()).containsExactly(4000000, 5000000, 6000000);
     }
 
     @Test
     public void configureWhenHasMinimumExpectedValueShouldSetMinimumExpectedToValue() {
         setMinimumExpectedValue("spring.boot", 10);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(10).toNanos());
     }
 
@@ -241,7 +241,7 @@ public class PropertiesMeterFilterTest {
     public void configureWhenHasHigherMinimumExpectedValueShouldSetMinimumExpectedValueToValue() {
         setMinimumExpectedValue("spring", 10);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(10).toNanos());
     }
 
@@ -250,7 +250,7 @@ public class PropertiesMeterFilterTest {
         setMinimumExpectedValue("spring", 10);
         setMinimumExpectedValue("spring.boot", 50);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMinimumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(50).toNanos());
     }
 
@@ -258,7 +258,7 @@ public class PropertiesMeterFilterTest {
     public void configureWhenHasMaximumExpectedValueShouldSetMaximumExpectedToValue() {
         setMaximumExpectedValue("spring.boot", 5000);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(5000).toNanos());
     }
 
@@ -266,7 +266,7 @@ public class PropertiesMeterFilterTest {
     public void configureWhenHasHigherMaximumExpectedValueShouldSetMaximumExpectedValueToValue() {
         setMaximumExpectedValue("spring", 5000);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(5000).toNanos());
     }
 
@@ -275,7 +275,7 @@ public class PropertiesMeterFilterTest {
         setMaximumExpectedValue("spring", 5000);
         setMaximumExpectedValue("spring.boot", 10000);
         assertThat(filter.configure(createSpringBootMeter(),
-                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValue())
+                DistributionStatisticConfig.DEFAULT).getMaximumExpectedValueAsDouble())
                         .isEqualTo(Duration.ofMillis(10000).toNanos());
     }
 


### PR DESCRIPTION
…to allow libraries to use these methods regardless of whether 1.3.x or 1.4.x is on the classpath.

This is for #2002 but for the 1.3.x branch. Because 1.4.x has methods with the same name but different return types, a library compiled against 1.4.x won't be usable with 1.3.x due to ABI change.

See #2003 