### PR TITLE
Update default value logic for graphite tags

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
@@ -49,13 +49,13 @@ public interface GraphiteConfig extends DropwizardConfig {
 
     /**
      * @return Whether Graphite tags should be used, as opposed to a hierarchical naming convention.
-     * Defaults to true if a value is present for {@link GraphiteConfig#tagsAsPrefix}.
+     * Defaults to true if no values are present for {@link GraphiteConfig#tagsAsPrefix}.
      * @see <a href="https://graphite.readthedocs.io/en/latest/tags.html">Graphite Tag Support</a>
      * @since 1.4.0
      */
     default boolean graphiteTagsEnabled() {
         String v = get(prefix() + ".graphiteTagsEnabled");
-        return v == null ? tagsAsPrefix().length > 0 : Boolean.parseBoolean(v);
+        return v == null ? tagsAsPrefix().length == 0 : Boolean.parseBoolean(v);
     }
 
     /**

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
@@ -49,12 +49,13 @@ public interface GraphiteConfig extends DropwizardConfig {
 
     /**
      * @return Whether Graphite tags should be used, as opposed to a hierarchical naming convention.
-     * Defaults to {@code true}.
+     * Defaults to true if a value is present for {@link GraphiteConfig#tagsAsPrefix}.
      * @see <a href="https://graphite.readthedocs.io/en/latest/tags.html">Graphite Tag Support</a>
      * @since 1.4.0
      */
     default boolean graphiteTagsEnabled() {
-        return true;
+        String v = get(prefix() + ".graphiteTagsEnabled");
+        return v == null ? tagsAsPrefix().length > 0 : Boolean.parseBoolean(v);
     }
 
     /**


### PR DESCRIPTION
When Graphite tag support was initially added to micrometer in #1806, tag support was configured to be on by default.

In an ensuing discussion (https://github.com/micrometer-metrics/micrometer-docs/issues/123), @snicoll suggested updating the logic to default to `true` *unless* the user has specified prefix tags.

This PR implements those changes, as well as adding a configuration property for `graphiteTagsEnabled`.

Also related: https://github.com/spring-projects/spring-boot/issues/20884