### PR TITLE
Completable future support for @Timed

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -28,10 +28,12 @@ import io.micrometer.core.lang.NonNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.assertj.core.api.Assertions.*;
 
 class TimedAspectTest {
     @Test
@@ -110,6 +112,167 @@ class TimedAspectTest {
         });
     }
 
+    @Test
+    void timeMethodWhenCompleted() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(registry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.call(guardedResult);
+
+        assertThat(registry.find("call")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "call")
+                .tag("extra", "tag")
+                .tag("exception", "none")
+                .timer()).isNull();
+
+        guardedResult.complete();
+        completableFuture.join();
+
+        assertThat(registry.get("call")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "call")
+                .tag("extra", "tag")
+                .tag("exception", "none")
+                .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    void timeMethodWhenCompletedExceptionally() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(registry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.call(guardedResult);
+
+        assertThat(registry.find("call")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "call")
+                .tag("extra", "tag")
+                .tag("exception", "NullPointerException")
+                .timer()).isNull();
+
+        guardedResult.complete(new NullPointerException());
+        catchThrowableOfType(completableFuture::join, CompletionException.class);
+
+        assertThat(registry.get("call")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "call")
+                .tag("extra", "tag")
+                .tag("exception", "NullPointerException")
+                .timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    void timeMethodWithLongTaskTimerWhenCompleted() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(registry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.longCall(guardedResult);
+
+        assertThat(registry.find("longCall")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "longCall")
+                .tag("extra", "tag")
+                .longTaskTimers().iterator().next().activeTasks()).isEqualTo(1);
+
+        guardedResult.complete();
+        completableFuture.join();
+
+        assertThat(registry.get("longCall")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "longCall")
+                .tag("extra", "tag")
+                .longTaskTimers().iterator().next().activeTasks()).isEqualTo(0);
+    }
+
+    @Test
+    void timeMethodWithLongTaskTimerWhenCompletedExceptionally() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(registry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.longCall(guardedResult);
+
+        assertThat(registry.find("longCall")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "longCall")
+                .tag("extra", "tag")
+                .longTaskTimers().iterator().next().activeTasks()).isEqualTo(1);
+
+        guardedResult.complete(new NullPointerException());
+        catchThrowableOfType(completableFuture::join, CompletionException.class);
+
+        assertThat(registry.get("longCall")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "longCall")
+                .tag("extra", "tag")
+                .longTaskTimers().iterator().next().activeTasks()).isEqualTo(0);
+    }
+
+    @Test
+    void timeMethodFailureWhenCompletedExceptionally() {
+        MeterRegistry failingRegistry = new FailingMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(failingRegistry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.call(guardedResult);
+        guardedResult.complete();
+        completableFuture.join();
+
+        assertThatExceptionOfType(MeterNotFoundException.class).isThrownBy(() -> failingRegistry.get("call")
+                .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                .tag("method", "call")
+                .tag("extra", "tag")
+                .tag("exception", "none")
+                .timer());
+    }
+
+    @Test
+    void timeMethodFailureWithLongTaskTimerWhenCompleted() {
+        MeterRegistry failingRegistry = new FailingMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new AsyncTimedService());
+        pf.addAspect(new TimedAspect(failingRegistry));
+
+        AsyncTimedService service = pf.getProxy();
+
+        GuardedResult guardedResult = new GuardedResult();
+        CompletableFuture<?> completableFuture = service.longCall(guardedResult);
+        guardedResult.complete();
+        completableFuture.join();
+
+        assertThatExceptionOfType(MeterNotFoundException.class).isThrownBy(() -> {
+            failingRegistry.get("longCall")
+                    .tag("class", "io.micrometer.core.aop.TimedAspectTest$AsyncTimedService")
+                    .tag("method", "longCall")
+                    .tag("extra", "tag")
+                    .longTaskTimer();
+        });
+    }
+
     private final class FailingMeterRegistry extends SimpleMeterRegistry {
         private FailingMeterRegistry() {
             super();
@@ -138,5 +301,50 @@ class TimedAspectTest {
         @Timed(value = "longCall", extraTags = {"extra", "tag"}, longTask = true)
         void longCall() {
         }
+    }
+
+    static class AsyncTimedService {
+        @Timed(value = "call", extraTags = {"extra", "tag"})
+        CompletableFuture<?> call(GuardedResult guardedResult) {
+            return supplyAsync(guardedResult::get);
+        }
+
+        @Timed(value = "longCall", extraTags = {"extra", "tag"}, longTask = true)
+        CompletableFuture<?> longCall(GuardedResult guardedResult) {
+            return supplyAsync(guardedResult::get);
+        }
+    }
+
+    static class GuardedResult {
+
+        private boolean complete;
+        private RuntimeException withException;
+
+        synchronized Object get() {
+            while (!complete) {
+                try {
+                    wait();
+                } catch (InterruptedException e) {
+                    // Intentionally empty
+                }
+            }
+
+            if (withException == null) {
+                return new Object();
+            }
+
+            throw withException;
+        }
+
+        synchronized void complete() {
+            complete(null);
+        }
+
+        synchronized void complete(RuntimeException withException) {
+            this.complete = true;
+            this.withException = withException;
+            notifyAll();
+        }
+
     }
 }


### PR DESCRIPTION
When utilizing reactive programming libraries that rely on Futures, `@Timed` will report the execution time for the `CompletionStage` creation, but not then it's completed. 

This PR is solves this issue, by intercepting `CompletionStage`s return types and stopping the timer once completed normally or exceptionally.