### PR TITLE
Potential fix for UdpClient disconnect

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -267,7 +267,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
             }
             return Mono.empty();
         })
-                .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1)).maxBackoff(Duration.ofMinutes(1)))
+                .retryBackoff(Long.MAX_VALUE, Duration.ofSeconds(1), Duration.ofMinutes(1))
                 .subscribe(client -> {
                     this.client.replace(client);
 


### PR DESCRIPTION
When using UDP, I'm seeing the reactor netty client log the following:
```
[id: 0xcc44ff33, L:/172.17.0.8:34809 ! R:dockerhost/172.17.0.1:8127] onStateChange([disconnecting], SimpleConnection{channel=[id: 0xcc44ff33, L:/172.17.0.8:34809 ! R:dockerhost/172.17.0.1:8127]})
```
After which I no longer get any stats. I am unclear as to why the retry by the `PortUnreachableException` isn't triggered like it is on my local setup, but I expect there's something more complicated going on in my k8s setup. So, I threw together this change, in hopes of fixing it; it's a copy paste of the TcpClient fix.


Problem I'm currently having is that this project is failing to build because of jersey2. I was hoping something could help me verify this fix and get it merged