### PR TITLE
Use FunctionTimer for cache.load.duration (fixes #1880)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -151,9 +151,11 @@ public class CaffeineCacheMetrics extends CacheMeterBinder {
 
         if (cache instanceof LoadingCache) {
             // dividing these gives you a measure of load latency
-            TimeGauge.builder("cache.load.duration", cache, TimeUnit.NANOSECONDS, c -> c.stats().totalLoadTime())
+            FunctionTimer.builder("cache.load.duration", cache,
+                                  c -> c.stats().loadCount(),
+                                  c -> c.stats().totalLoadTime(), TimeUnit.NANOSECONDS)
                     .tags(getTagsWithCacheName())
-                    .description("The time the cache has spent loading new values")
+                    .description("Cache loads, including both successes and failures")
                     .register(registry);
 
             FunctionCounter.builder("cache.load", cache, c -> c.stats().loadSuccessCount())

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -21,14 +21,16 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link CaffeineCacheMetrics}.
@@ -52,8 +54,9 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         assertThat(evictionWeight.count()).isEqualTo(stats.evictionWeight());
 
         // specific to LoadingCache instance
-        TimeGauge loadDuration = fetch(registry, "cache.load.duration").timeGauge();
-        assertThat(loadDuration.value()).isEqualTo(stats.totalLoadTime());
+        FunctionTimer loadDuration = fetch(registry, "cache.load.duration").functionTimer();
+        assertThat(loadDuration.totalTime(TimeUnit.NANOSECONDS)).isEqualTo(stats.totalLoadTime());
+        assertThat(loadDuration.count()).isEqualTo(stats.loadCount());
 
         FunctionCounter successfulLoad = fetch(registry, "cache.load", Tags.of("result", "success")).functionCounter();
         assertThat(successfulLoad.count()).isEqualTo(stats.loadSuccessCount());


### PR DESCRIPTION
Completes conversion of cumulative meters for Caffeine - see https://github.com/micrometer-metrics/micrometer/issues/1880#issuecomment-601889864