### PR TITLE
Do not remap id in remove method

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -573,10 +573,10 @@ public abstract class MeterRegistry {
 
                     m = builder.apply(mappedId, config);
 
-                    Id synAssoc = originalId.syntheticAssociation();
+                    Id synAssoc = mappedId.syntheticAssociation();
                     if (synAssoc != null) {
                         PSet<Id> existingSynthetics = syntheticAssociations.getOrDefault(synAssoc, HashTreePSet.empty());
-                        syntheticAssociations = syntheticAssociations.plus(synAssoc, existingSynthetics.plus(originalId));
+                        syntheticAssociations = syntheticAssociations.plus(synAssoc, existingSynthetics.plus(mappedId));
                     }
 
                     for (Consumer<Meter> onAdd : meterAddedListeners) {
@@ -614,14 +614,13 @@ public abstract class MeterRegistry {
     }
 
     /**
-     * @param id The id of the meter to remove
+     * @param mappedId The id of the meter to remove
      * @return The removed meter, or null if no meter matched the provided id.
      * @since 1.1.0
      */
     @Incubating(since = "1.1.0")
     @Nullable
-    public Meter remove(Meter.Id id) {
-        Id mappedId = getMappedId(id);
+    public Meter remove(Meter.Id mappedId) {
         Meter m = meterMap.get(mappedId);
 
         if (m != null) {
@@ -630,10 +629,10 @@ public abstract class MeterRegistry {
                 if (m != null) {
                     meterMap = meterMap.minus(mappedId);
 
-                    for (Id synthetic : syntheticAssociations.getOrDefault(id, HashTreePSet.empty())) {
+                    for (Id synthetic : syntheticAssociations.getOrDefault(mappedId, HashTreePSet.empty())) {
                         remove(synthetic);
                     }
-                    syntheticAssociations = syntheticAssociations.minus(id);
+                    syntheticAssociations = syntheticAssociations.minus(mappedId);
 
                     for (Consumer<Meter> onRemove : meterRemovedListeners) {
                         onRemove.accept(m);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -132,6 +132,21 @@ class MeterRegistryTest {
     }
 
     @Test
+    void removeMetersAffectedByNonIdempotentMeterFilter() {
+        registry.config().meterFilter(new MeterFilter() {
+            @Override
+            public Meter.Id map(Meter.Id id) {
+                return id.withName("prefix." + id.getName());
+            }
+        });
+
+        Counter counter = registry.counter("name");
+        assertThat(registry.find("prefix.name").counter()).isSameAs(counter);
+        assertThat(registry.remove(counter)).isSameAs(counter);
+        assertThat(registry.find("prefix.name").counter()).isNull();
+    }
+
+    @Test
     void removeMetersWithSynthetics() {
         Timer timer = Timer.builder("my.timer")
                 .publishPercentiles(0.95)


### PR DESCRIPTION
Registering a meter to a `MeterRegistry` returns a meter with a mapped id (`MeterFilter`s `map` method applied to it), so we should allow users to pass that to the remove method and it work. The previous behavior mapped the ID (again), which was problematic if any `MeterFilter` mapping was not idempotent.

Fixes #1850

/cc @jkschneider to check if I'm missing something here