### PR TITLE
Add logback logger context listener that re-adds MetricTurboFilters after logger context reset

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.binder.logging;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
 import ch.qos.logback.classic.turbo.TurboFilter;
 import ch.qos.logback.core.spi.FilterReply;
 import io.micrometer.core.instrument.Counter;
@@ -30,8 +31,8 @@ import io.micrometer.core.lang.NonNullFields;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptyList;
 
@@ -45,7 +46,7 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
 
     private final Iterable<Tag> tags;
     private final LoggerContext loggerContext;
-    private final Map<MeterRegistry, MetricsTurboFilter> metricsTurboFilters = new ConcurrentHashMap<>();
+    private final Map<MeterRegistry, MetricsTurboFilter> metricsTurboFilters = new HashMap<>();
 
     public LogbackMetrics() {
         this(emptyList());
@@ -58,13 +59,47 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
     public LogbackMetrics(Iterable<Tag> tags, LoggerContext context) {
         this.tags = tags;
         this.loggerContext = context;
+
+        loggerContext.addListener(new LoggerContextListener() {
+            @Override
+            public boolean isResetResistant() {
+                return true;
+            }
+
+            @Override
+            public void onReset(LoggerContext context) {
+                // re-add turbo filter because reset clears the turbo filter list
+                synchronized (metricsTurboFilters) {
+                    for (MetricsTurboFilter metricsTurboFilter : metricsTurboFilters.values()) {
+                        loggerContext.addTurboFilter(metricsTurboFilter);
+                    }
+                }
+            }
+
+            @Override
+            public void onStart(LoggerContext context) {
+                // no-op
+            }
+
+            @Override
+            public void onStop(LoggerContext context) {
+                // no-op
+            }
+
+            @Override
+            public void onLevelChange(Logger logger, Level level) {
+                // no-op
+            }
+        });
     }
 
     @Override
     public void bindTo(MeterRegistry registry) {
         MetricsTurboFilter filter = new MetricsTurboFilter(registry, tags);
-        metricsTurboFilters.put(registry, filter);
-        loggerContext.addTurboFilter(filter);
+        synchronized (metricsTurboFilters) {
+            metricsTurboFilters.put(registry, filter);
+            loggerContext.addTurboFilter(filter);
+        }
     }
 
     /**
@@ -81,8 +116,10 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
 
     @Override
     public void close() {
-        for (MetricsTurboFilter metricsTurboFilter : metricsTurboFilters.values()) {
-            loggerContext.getTurboFilterList().remove(metricsTurboFilter);
+        synchronized (metricsTurboFilters) {
+            for (MetricsTurboFilter metricsTurboFilter : metricsTurboFilters.values()) {
+                loggerContext.getTurboFilterList().remove(metricsTurboFilter);
+            }
         }
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
@@ -86,6 +86,20 @@ class LogbackMetricsTest {
         assertThat(loggerContext.getTurboFilterList()).isEmpty();
     }
 
+    @Issue("#2028")
+    @Test
+    void reAddFilterToLoggerContextAfterReset() {
+        LoggerContext loggerContext = new LoggerContext();
+        assertThat(loggerContext.getTurboFilterList()).isEmpty();
+
+        LogbackMetrics logbackMetrics = new LogbackMetrics(emptyList(), loggerContext);
+        logbackMetrics.bindTo(registry);
+
+        assertThat(loggerContext.getTurboFilterList()).hasSize(1);
+        loggerContext.reset();
+        assertThat(loggerContext.getTurboFilterList()).hasSize(1);
+    }
+
     @NonNullApi
     private static class LoggingCounterMeterRegistry extends SimpleMeterRegistry {
         @Override


### PR DESCRIPTION
The `LogbackMetrics` stops to record logback events after logback LoggerContext reset. The reset can happen for instance when a configuration is reloaded via the "scan" feature. The reset listener solves this issue by re-adding all metrics turbo filters after every reset.

Note that the metricsTurboFilters map was changed from a `ConcurrentHashMap` to a `HashMap` with `synchronized` blocks. This is to prevent a race-condition between a call to `bindTo` method and logback reset event.

Fixes #2028 