### PR TITLE
Apache HttpClient per route connection metrics 

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/AbstractPoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/AbstractPoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.lang.NonNull;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.pool.ConnPoolControl;
+import org.apache.http.pool.PoolStats;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Base class which collects total metrics including {@link HttpRoute} state from {@link ConnPoolControl}, for example {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager}
+ * for synchronous HTTP clients or {@link org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager} for asynchronous HTTP clients.
+ * <p>
+ * It monitors the overall and per route connection pool state.
+ *
+ * @author Mikhail Yakimchenko (mikhailyakimchenko@gmail.com)
+ * @since 1.5.0
+ */
+abstract class AbstractPoolingHttpClientConnectionManagerMetricsBinder<T extends ConnPoolControl<HttpRoute>> extends
+        ConnPoolControlMetricsBinder<HttpRoute> {
+
+    @SuppressWarnings("unchecked")
+    private final T connectionManager = (T) connPoolControl;
+    private final ConcurrentMap<String, PoolStats> poolStatsByHost = new ConcurrentHashMap<>();
+
+    public AbstractPoolingHttpClientConnectionManagerMetricsBinder(T connectionManager, String name, String... tags) {
+        this(connectionManager, name, Tags.of(tags));
+    }
+
+    public AbstractPoolingHttpClientConnectionManagerMetricsBinder(T connectionManager, String name, Iterable<Tag> tags) {
+        super(connectionManager, name, tags);
+    }
+
+    protected abstract Collection<HttpRoute> getRoutes(T connectionManager);
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        super.bindTo(registry);
+        updateRoutesMetrics(registry);
+    }
+
+    /**
+     * Adds metrics for newly created {@link HttpRoute} to the given meter registry.
+     */
+    public void updateRoutesMetrics(MeterRegistry registry) {
+        for (HttpRoute route : getRoutes(connectionManager)) {
+            String hostName = route.getTargetHost().getHostName();
+            if (!poolStatsByHost.containsKey(hostName)) {
+                PoolStats stats = connectionManager.getStats(route);
+                poolStatsByHost.put(hostName, stats);
+                registerRouteMetrics(hostName, stats, registry);
+            }
+        }
+    }
+
+    private void registerRouteMetrics(String host, PoolStats poolStats, MeterRegistry registry) {
+        Gauge.builder("httpcomponents.httpclient.pool.route.max",
+                poolStats,
+                PoolStats::getMax)
+                .description("The configured maximum number of allowed persistent connections for route.")
+                .tags(tags).tag("host", host)
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.route.connections",
+                poolStats,
+                PoolStats::getAvailable)
+                .description("The number of persistent and available connections for route.")
+                .tags(tags).tag("host", host).tag("state", "available")
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.route.connections",
+                poolStats,
+                PoolStats::getLeased)
+                .description("The number of persistent and leased connections for route.")
+                .tags(tags).tag("host", host).tag("state", "leased")
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.route.pending",
+                poolStats,
+                PoolStats::getPending)
+                .description("The number of connection requests being blocked awaiting a free connection for route.")
+                .tags(tags).tag("host", host)
+                .register(registry);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinder.java
@@ -21,11 +21,10 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.lang.NonNull;
-import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.pool.ConnPoolControl;
 
 /**
- * Collects metrics from a {@link ConnPoolControl}, for example {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager}
+ * Collects total metrics without routes state from a {@link ConnPoolControl}, for example {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager}
  * for synchronous HTTP clients or {@link org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager} for asynchronous HTTP clients.
  * <p>
  * It monitors the overall connection pool state.
@@ -33,22 +32,22 @@ import org.apache.http.pool.ConnPoolControl;
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
  * @since 1.3.0
  */
-public class ConnPoolControlMetricsBinder implements MeterBinder {
+public class ConnPoolControlMetricsBinder<T> implements MeterBinder {
 
-    private final ConnPoolControl<HttpRoute> connPoolControl;
-    private final Iterable<Tag> tags;
+    protected final ConnPoolControl<T> connPoolControl;
+    protected final Iterable<Tag> tags;
 
     /**
      * Creates a metrics binder for the given pooling connection pool control.
      *
      * @param connPoolControl The connection pool control to monitor.
-     * @param name              Name of the connection pool control. Will be added as tag with the
-     *                          key "httpclient".
-     * @param tags              Tags to apply to all recorded metrics. Must be an even number
-     *                          of arguments representing key/value pairs of tags.
+     * @param name            Name of the connection pool control. Will be added as tag with the
+     *                        key "httpclient".
+     * @param tags            Tags to apply to all recorded metrics. Must be an even number
+     *                        of arguments representing key/value pairs of tags.
      */
     @SuppressWarnings("WeakerAccess")
-    public ConnPoolControlMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, String... tags) {
+    public ConnPoolControlMetricsBinder(ConnPoolControl<T> connPoolControl, String name, String... tags) {
         this(connPoolControl, name, Tags.of(tags));
     }
 
@@ -60,7 +59,7 @@ public class ConnPoolControlMetricsBinder implements MeterBinder {
      * @param tags            Tags to apply to all recorded metrics.
      */
     @SuppressWarnings("WeakerAccess")
-    public ConnPoolControlMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, Iterable<Tag> tags) {
+    public ConnPoolControlMetricsBinder(ConnPoolControl<T> connPoolControl, String name, Iterable<Tag> tags) {
         this.connPoolControl = connPoolControl;
         this.tags = Tags.concat(tags, "httpclient", name);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinder.java
@@ -33,7 +33,7 @@ import org.apache.http.pool.ConnPoolControl;
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
  * @since 1.3.0
  */
-public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
+public class ConnPoolControlMetricsBinder implements MeterBinder {
 
     private final ConnPoolControl<HttpRoute> connPoolControl;
     private final Iterable<Tag> tags;
@@ -48,7 +48,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
      *                          of arguments representing key/value pairs of tags.
      */
     @SuppressWarnings("WeakerAccess")
-    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, String... tags) {
+    public ConnPoolControlMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, String... tags) {
         this(connPoolControl, name, Tags.of(tags));
     }
 
@@ -60,7 +60,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
      * @param tags            Tags to apply to all recorded metrics.
      */
     @SuppressWarnings("WeakerAccess")
-    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, Iterable<Tag> tags) {
+    public ConnPoolControlMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, Iterable<Tag> tags) {
         this.connPoolControl = connPoolControl;
         this.tags = Tags.concat(tags, "httpclient", name);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.Tag;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import java.util.Collection;
+
+/**
+ * Collects total metrics including {@link HttpRoute} state for synchronous HTTP clients {@link PoolingHttpClientConnectionManager}
+ * <p>
+ * It monitors the overall and per route connection pool state.
+ *
+ * @author Mikhail Yakimchenko (mikhailyakimchenko@gmail.com)
+ * @since 1.5.0
+ */
+public class PoolingHttpClientConnectionManagerMetricsBinder extends AbstractPoolingHttpClientConnectionManagerMetricsBinder<PoolingHttpClientConnectionManager> {
+
+    /**
+     * Creates a metrics binder for the given http client connection manager.
+     *
+     * @param connectionManager Connection manager whose maintained connection pool will be monitored.
+     * @param name              Name of the connection pool control. Will be added as tag with the key "httpclient".
+     * @param tags              Tags to apply to all recorded metrics. Must be an even number
+     *                          of arguments representing key/value pairs of tags.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(PoolingHttpClientConnectionManager connectionManager, String name, String... tags) {
+        super(connectionManager, name, tags);
+    }
+
+    /**
+     * Creates a metrics binder for the given http client connection manager.
+     *
+     * @param connectionManager Connection manager whose maintained connection pool will be monitored.
+     * @param name              Name of the connection pool control. Will be added as tag with the key "httpclient".
+     * @param tags              Tags to apply to all recorded metrics.
+     */
+    public PoolingHttpClientConnectionManagerMetricsBinder(PoolingHttpClientConnectionManager connectionManager, String name, Iterable<Tag> tags) {
+        super(connectionManager, name, tags);
+    }
+
+    @Override
+    protected Collection<HttpRoute> getRoutes(PoolingHttpClientConnectionManager connectionManager) {
+        return connectionManager.getRoutes();
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingNHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingNHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.Tag;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+
+import java.util.Collection;
+
+/**
+ * Collects total metrics including {@link HttpRoute} state for asynchronous HTTP clients {@link PoolingNHttpClientConnectionManager}
+ * <p>
+ * It monitors the overall and per route connection pool state.
+ *
+ * @author Mikhail Yakimchenko (mikhailyakimchenko@gmail.com)
+ * @since 1.5.0
+ */
+public class PoolingNHttpClientConnectionManagerMetricsBinder extends AbstractPoolingHttpClientConnectionManagerMetricsBinder<PoolingNHttpClientConnectionManager> {
+
+    /**
+     * Creates a metrics binder for the given http client connection manager.
+     *
+     * @param connectionManager Connection manager whose maintained connection pool will be monitored.
+     * @param name              Name of the connection pool control. Will be added as tag with the key "httpclient".
+     * @param tags              Tags to apply to all recorded metrics. Must be an even number
+     *                          of arguments representing key/value pairs of tags.
+     */
+    public PoolingNHttpClientConnectionManagerMetricsBinder(PoolingNHttpClientConnectionManager connectionManager, String name, String... tags) {
+        super(connectionManager, name, tags);
+    }
+
+    /**
+     * Creates a metrics binder for the given http client connection manager.
+     *
+     * @param connectionManager Connection manager whose maintained connection pool will be monitored.
+     * @param name              Name of the connection pool control. Will be added as tag with the key "httpclient".
+     * @param tags              Tags to apply to all recorded metrics.
+     */
+    public PoolingNHttpClientConnectionManagerMetricsBinder(PoolingNHttpClientConnectionManager connectionManager, String name, Iterable<Tag> tags) {
+        super(connectionManager, name, tags);
+    }
+
+    @Override
+    protected Collection<HttpRoute> getRoutes(PoolingNHttpClientConnectionManager connectionManager) {
+        return connectionManager.getRoutes();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/ConnPoolControlMetricsBinderTest.java
@@ -30,21 +30,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link PoolingHttpClientConnectionManagerMetricsBinder}.
+ * Unit tests for {@link ConnPoolControlMetricsBinder}.
  *
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
  */
-class PoolingHttpClientConnectionManagerMetricsBinderTest {
+class ConnPoolControlMetricsBinderTest {
 
     private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
     private ConnPoolControl<HttpRoute> connPoolControl;
-    private PoolingHttpClientConnectionManagerMetricsBinder binder;
+    private ConnPoolControlMetricsBinder binder;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setup() {
         connPoolControl = (ConnPoolControl<HttpRoute>) mock(ConnPoolControl.class);
-        binder = new PoolingHttpClientConnectionManagerMetricsBinder(connPoolControl, "test");
+        binder = new ConnPoolControlMetricsBinder(connPoolControl, "test");
         binder.bindTo(registry);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.pool.PoolStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PoolingHttpClientConnectionManagerMetricsBinder}.
+ *
+ * @author Mikhail Yakimchenko (mikhailyakimchenko@gmail.com)
+ */
+class PoolingHttpClientConnectionManagerMetricsBinderTest {
+
+    private PoolingHttpClientConnectionManager connectionManager;
+    private PoolingHttpClientConnectionManagerMetricsBinder binder;
+
+    private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private HttpRoute route = new HttpRoute(new HttpHost("localhost"));
+    private PoolStats poolStats = mock(PoolStats.class);
+
+    @BeforeEach
+    void setup() {
+        connectionManager = mock(PoolingHttpClientConnectionManager.class);
+        when(connectionManager.getRoutes()).thenReturn(Collections.singleton(route));
+        when(connectionManager.getStats(route)).thenReturn(poolStats);
+
+        binder = new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
+        binder.bindTo(registry);
+    }
+
+    @Test
+    void totalMax() {
+        when(poolStats.getMax()).thenReturn(13);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
+                .tags("httpclient", "test", "host", "localhost")
+                .gauge().value()).isEqualTo(13.0);
+    }
+
+    @Test
+    void totalAvailable() {
+        when(poolStats.getAvailable()).thenReturn(17);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+                .tags("httpclient", "test", "host", "localhost", "state", "available")
+                .gauge().value()).isEqualTo(17.0);
+    }
+
+    @Test
+    void totalLeased() {
+        when(poolStats.getLeased()).thenReturn(23);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+                .tags("httpclient", "test", "host", "localhost", "state", "leased")
+                .gauge().value()).isEqualTo(23.0);
+    }
+
+    @Test
+    void totalPending() {
+        when(poolStats.getPending()).thenReturn(37);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+                .tags("httpclient", "test", "host", "localhost")
+                .gauge().value()).isEqualTo(37.0);
+    }
+
+    @Test
+    void updateRoutesMetrics() {
+        HttpRoute newRoute = new HttpRoute(new HttpHost("micrometer.io"));
+        PoolStats newPoolStats = mock(PoolStats.class);
+        when(newPoolStats.getPending()).thenReturn(45);
+        when(connectionManager.getStats(newRoute)).thenReturn(newPoolStats);
+
+        Set<HttpRoute> routes = new HashSet<>();
+        routes.add(route);
+        routes.add(newRoute);
+        when(connectionManager.getRoutes()).thenReturn(routes);
+
+        binder.updateRoutesMetrics(registry);
+
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+                .tags("httpclient", "test", "host", "micrometer.io")
+                .gauge().value()).isEqualTo(45.0);
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingNHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingNHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.pool.PoolStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PoolingNHttpClientConnectionManagerMetricsBinder}.
+ *
+ * @author Mikhail Yakimchenko (mikhailyakimchenko@gmail.com)
+ */
+class PoolingNHttpClientConnectionManagerMetricsBinderTest {
+
+    private PoolingNHttpClientConnectionManager connectionManager;
+    private PoolingNHttpClientConnectionManagerMetricsBinder binder;
+
+    private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private HttpRoute route = new HttpRoute(new HttpHost("localhost"));
+    private PoolStats poolStats = mock(PoolStats.class);
+
+    @BeforeEach
+    void setup() {
+        connectionManager = mock(PoolingNHttpClientConnectionManager.class);
+        when(connectionManager.getRoutes()).thenReturn(Collections.singleton(route));
+        when(connectionManager.getStats(route)).thenReturn(poolStats);
+
+        binder = new PoolingNHttpClientConnectionManagerMetricsBinder(connectionManager, "test");
+        binder.bindTo(registry);
+    }
+
+    @Test
+    void totalMax() {
+        when(poolStats.getMax()).thenReturn(13);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max")
+                .tags("httpclient", "test", "host", "localhost")
+                .gauge().value()).isEqualTo(13.0);
+    }
+
+    @Test
+    void totalAvailable() {
+        when(poolStats.getAvailable()).thenReturn(17);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+                .tags("httpclient", "test", "host", "localhost", "state", "available")
+                .gauge().value()).isEqualTo(17.0);
+    }
+
+    @Test
+    void totalLeased() {
+        when(poolStats.getLeased()).thenReturn(23);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.connections")
+                .tags("httpclient", "test", "host", "localhost", "state", "leased")
+                .gauge().value()).isEqualTo(23.0);
+    }
+
+    @Test
+    void totalPending() {
+        when(poolStats.getPending()).thenReturn(37);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+                .tags("httpclient", "test", "host", "localhost")
+                .gauge().value()).isEqualTo(37.0);
+    }
+
+    @Test
+    void updateRoutesMetrics() {
+        HttpRoute newRoute = new HttpRoute(new HttpHost("micrometer.io"));
+        PoolStats newPoolStats = mock(PoolStats.class);
+        when(newPoolStats.getPending()).thenReturn(45);
+        when(connectionManager.getStats(newRoute)).thenReturn(newPoolStats);
+
+        Set<HttpRoute> routes = new HashSet<>();
+        routes.add(route);
+        routes.add(newRoute);
+        when(connectionManager.getRoutes()).thenReturn(routes);
+
+        binder.updateRoutesMetrics(registry);
+
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.pending")
+                .tags("httpclient", "test", "host", "micrometer.io")
+                .gauge().value()).isEqualTo(45.0);
+    }
+}


### PR DESCRIPTION
This PR adds per route connection metrics according to #1616

I'm not sure if it's good decision to introduce abstraction over `ConnPoolControl` as I found only one usage across _Apache HttpComponents_ of `HttpRoute` as generic type. It will break compatibility as well 🤔 