### PR TITLE
Only set Azure instrumentation key if not already set

### DIFF
--- a/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorConfig.java
+++ b/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorConfig.java
@@ -40,14 +40,14 @@ public interface AzureMonitorConfig extends StepRegistryConfig {
      * @return Instrumentation Key
      */
     default String instrumentationKey() {
-        return getSecret(this, "instrumentationKey").required().get();
+        return getSecret(this, "instrumentationKey").get();
     }
 
     @Override
     default Validated<?> validate() {
         return checkAll(this,
                 c -> StepRegistryConfig.validate(c),
-                checkRequired("instrumentationKey", AzureMonitorConfig::instrumentationKey)
+                check("instrumentationKey", AzureMonitorConfig::instrumentationKey)
         );
     }
 }

--- a/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
+++ b/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
@@ -23,6 +23,7 @@ import com.microsoft.applicationinsights.telemetry.TraceTelemetry;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkRequired;
 import static java.util.stream.StreamSupport.stream;
 
 /**
@@ -60,7 +62,10 @@ public class AzureMonitorMeterRegistry extends StepMeterRegistry {
         this.config = config;
 
         config().namingConvention(new AzureMonitorNamingConvention());
-        telemetryConfiguration.setInstrumentationKey(config.instrumentationKey());
+        if (StringUtils.isEmpty(telemetryConfiguration.getInstrumentationKey())) {
+            checkRequired("instrumentationKey", AzureMonitorConfig::instrumentationKey).apply(config).orThrow();
+            telemetryConfiguration.setInstrumentationKey(config.instrumentationKey());
+        }
 
         client = new TelemetryClient(telemetryConfiguration);
         client.getContext().getInternal().setSdkVersion(SDK_VERSION);

--- a/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorConfigTest.java
+++ b/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorConfigTest.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.azuremonitor;
 
-import io.micrometer.core.instrument.config.validate.Validated;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -26,12 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AzureMonitorConfigTest {
     private final Map<String, String> props = new HashMap<>();
     private final AzureMonitorConfig config = props::get;
-
-    @Test
-    void invalid() {
-        assertThat(config.validate().failures().stream().map(Validated.Invalid::getMessage))
-                .containsExactly("is required");
-    }
 
     @Test
     void valid() {

--- a/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistryTest.java
+++ b/implementations/micrometer-registry-azure-monitor/src/test/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistryTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.azuremonitor;
+
+import com.microsoft.applicationinsights.TelemetryConfiguration;
+import io.micrometer.core.instrument.config.validate.ValidationException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests for {@link AzureMonitorMeterRegistry}.
+ */
+class AzureMonitorMeterRegistryTest {
+
+    @Test
+    void useTelemetryConfigInstrumentationKeyWhenSet() {
+        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
+        telemetryConfiguration.setInstrumentationKey("fake");
+        AzureMonitorMeterRegistry.builder(new AzureMonitorConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String instrumentationKey() {
+                return "other";
+            }
+        }).telemetryConfiguration(telemetryConfiguration).build();
+        assertThat(telemetryConfiguration.getInstrumentationKey()).isEqualTo("fake");
+    }
+
+    @Test
+    void failWhenTelemetryConfigInstrumentationKeyIsUnsetAndConfigInstrumentationKeyIsNull() {
+        TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.createDefault();
+        assertThatExceptionOfType(ValidationException.class)
+                .isThrownBy(() -> AzureMonitorMeterRegistry.builder(key -> null)
+                        .telemetryConfiguration(telemetryConfiguration).build());
+    }
+}


### PR DESCRIPTION
Restores previous behavior of not overriding an already set instrumentation key on the `TelemetryConfiguration`. Accordingly, the instrumentationKey config is only required if not set in the `TelemetryConfiguration`.

See https://github.com/micrometer-metrics/micrometer/commit/30f6f8ea787d33d181562f50a11fefe41f921a06#r38747077