### PR TITLE
Introducing TimeWindowStats

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowStats.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowStats.java
@@ -1,0 +1,358 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.distribution;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+
+import io.micrometer.core.instrument.Clock;
+
+/**
+ * An implementation of a moving-window stats based on a configurable ring buffer.
+ * Currently exposed statistics are :
+ * <ul>
+ * <li>Samples sum</li>
+ * <li>Samples count</li>
+ * <li>Samples mean</li>
+ * <li>Samples min</li>
+ * <li>Samples frequency (events / milliseconds)</li>
+ * <li>Time window's oldest event's age</li>
+ * </ul>
+ *
+ * @author N.Billard
+ */
+public class TimeWindowStats {
+    private static final long MAX_DOUBLE_TO_LONG = 0x7ff0000000000000L - 1;
+    
+    private static final AtomicIntegerFieldUpdater<TimeWindowStats> rotatingUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(TimeWindowStats.class, "rotating");
+
+    private final Clock clock;
+    private final long durationBetweenRotatesMillis;
+    private final AtomicHolder[] ringBuffer;
+    private int currentBucket;
+    private volatile long lastRotateTimestampMillis;
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private volatile int rotating = 0; // 0 - not rotating, 1 - rotating
+    
+    private final TimeWindowStatsSnapshot snapshot = new TimeWindowStatsSnapshot() {
+        @Override
+        public double sum() {
+            return TimeWindowStats.this.sum();
+        }
+        @Override
+        public double min() {
+            return TimeWindowStats.this.min();
+        }
+        @Override
+        public double max() {
+            return TimeWindowStats.this.max();
+        }
+        @Override
+        public double mean() {
+            return TimeWindowStats.this.mean();
+        }
+        @Override
+        public long count() {
+            return TimeWindowStats.this.count();
+        }
+        @Override
+        public double freq() {
+            return TimeWindowStats.this.freq();
+        }
+        @Override
+        public long age() {
+            return TimeWindowStats.this.age();
+        }
+    };
+
+    public TimeWindowStats(final Clock clock, final DistributionStatisticConfig config) {
+        this(clock, config.getExpiry().toMillis(), config.getBufferLength());
+    }
+
+    public TimeWindowStats(final Clock clock, final long rotateFrequencyMillis, final int bufferLength) {
+        this.clock = clock;
+        durationBetweenRotatesMillis = rotateFrequencyMillis;
+        lastRotateTimestampMillis = clock.wallTime();
+        currentBucket = 0;
+
+        ringBuffer = new AtomicHolder[bufferLength];
+        for (int i = 0; i < bufferLength; i++) {
+            ringBuffer[i] = new AtomicHolder();
+        }
+        ringBuffer[currentBucket].age = lastRotateTimestampMillis;
+    }
+
+    private static class AtomicHolder {
+        long age = 0L;
+        LongAdder cnt = new LongAdder();
+        DoubleAdder sum = new DoubleAdder();
+        AtomicLong min = new AtomicLong(MAX_DOUBLE_TO_LONG);
+        AtomicLong max = new AtomicLong();
+
+        @Override
+        public String toString() {
+            return "AtomicHolder [age=" + age + ", cnt=" + cnt + ", sum=" + sum + ", min=" + min + ", max=" + max + "]";
+        }
+    }
+
+    /**
+     * Increments counter.
+     * @param sample Sample to record
+     */
+    public void record(final double sample) {
+        if (sample >= 0) {
+            rotate();
+            //No need to synchronize here
+            //Don't use updateAndGet exposed by updateAndGet : performances are awful.
+            long doubleToLongBits = Double.doubleToLongBits(sample);
+            final AtomicHolder current = ringBuffer[currentBucket];
+            current.cnt.add(1);
+            current.sum.add(sample);
+			updateMin(current.min, doubleToLongBits);
+            updateMax(current.max, doubleToLongBits);
+        }
+    }
+
+    private void updateMin(AtomicLong min, long sample) {
+        for (; ; ) {
+            long curMin = min.get();
+            if (curMin <= sample || min.compareAndSet(curMin, sample))
+                break;
+        }
+    }
+
+    private void updateMax(AtomicLong max, long sample) {
+        for (; ; ) {
+            long curMax = max.get();
+            if (curMax >= sample || max.compareAndSet(curMax, sample))
+                break;
+        }
+    }
+
+    /**
+     * @return event count on time window.
+     */
+    public long count() {
+        rotate();
+        long cnt = 0L;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                if (element.age > 0) {
+                    cnt += element.cnt.sum();
+                }
+            }
+        }
+        return cnt;
+    }
+
+    /**
+     * @return sum on time window.
+     */
+    public double sum() {
+        rotate();
+        double sum = 0L;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                if (element.age > 0) {
+                    sum += element.sum.sum();
+                }
+            }
+        }
+        return sum;
+    }
+
+    /**
+     * @return min on time window.
+     */
+    public double min() {
+        rotate();
+        long min = MAX_DOUBLE_TO_LONG;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                if (element.age > 0) {
+                    min = Math.min(min, element.min.get());
+                }
+            }
+        }
+        return Double.longBitsToDouble(min);
+    }
+
+    /**
+     * @return max on time window.
+     */
+    public double max() {
+        rotate();
+        long max = 0;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                if (element.age > 0) {
+                    max = Math.max(max, element.max.get());
+                }
+            }
+        }
+        return Double.longBitsToDouble(max);
+    }
+
+    /**
+     * @return mean on time window.
+     */
+    public double mean() {
+        rotate();
+        double sum = 0L;
+        long cnt = 0L;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                if (element.age > 0) {
+                    sum += element.sum.sum();
+                    cnt += element.cnt.sum();
+                }
+            }
+        }
+        return sum / cnt;
+    }
+
+    /**
+     * @return frequency (events / milliseconds) on time window.
+     */
+    public double freq() {
+        rotate();
+        long minAge = Long.MAX_VALUE;
+        long cnt = 0L;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                final long age = element.age;
+                if (age > 0) {
+                    minAge = Long.min(minAge, age);
+                    cnt += element.cnt.sum();
+                }
+            }
+        }
+        return (double) cnt / (clock.wallTime() - minAge);
+    }
+
+    /**
+     * @return age of the oldest time window's sample in milliseconds.
+     */
+    public long age() {
+        rotate();
+        long minAge = Long.MAX_VALUE;
+        synchronized (this) {
+            for (final AtomicHolder element : ringBuffer) {
+                final long age = element.age;
+                if (age > 0) {
+                    minAge = Long.min(minAge, age);
+                }
+            }
+        }
+        return clock.wallTime() - minAge;
+    }
+
+    /**
+     * @return Unmodifiable Snapshot.
+     */
+    public TimeWindowStatsSnapshot getSnapshot() {
+        return snapshot;
+    }
+
+    private void rotate() {
+        final long wallTime = clock.wallTime();
+        long timeSinceLastRotateMillis = wallTime - lastRotateTimestampMillis;
+        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
+            // Need to wait more for next rotation.
+            return;
+        }
+
+        if (!TimeWindowStats.rotatingUpdater.compareAndSet(this, 0, 1)) {
+            // Being rotated by other thread already.
+            return;
+        }
+
+        try {
+            int iterations = 0;
+            synchronized (this) {
+                do {
+                	int tmpCurrentBucket = currentBucket + 1;
+                    if (tmpCurrentBucket >= ringBuffer.length) {
+                        currentBucket = 0;
+                    } else {
+                    	currentBucket = tmpCurrentBucket;
+                    }
+
+                    //Init old buffers
+                    if (ringBuffer[currentBucket].age > 0L) {
+	                    ringBuffer[currentBucket].age = 0L;
+	                    ringBuffer[currentBucket].min.set(MAX_DOUBLE_TO_LONG);
+	                    ringBuffer[currentBucket].max.set(0L);
+	                    ringBuffer[currentBucket].sum.reset();
+	                    ringBuffer[currentBucket].cnt.reset();
+                    }
+
+                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
+                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
+                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
+
+                //New buffer starts now
+                ringBuffer[currentBucket].age = wallTime;
+            }
+        } finally {
+            rotating = 0;
+        }
+    }
+
+    /**
+     * Provides a way to expose a readonly snapshot of stats.
+     */
+    public interface TimeWindowStatsSnapshot {
+        /**
+         * @return event count on time window.
+         */
+        public long count();
+
+        /**
+         * @return sum on time window.
+         */
+        public double sum();
+
+        /**
+         * @return min on time window.
+         */
+        public double min();
+
+        /**
+         * @return max on time window.
+         */
+        public double max();
+
+        /**
+         * @return mean on time window.
+         */
+        public double mean();
+
+        /**
+         * @return frequency (events / milliseconds) on time window.
+         */
+        public double freq();
+
+        /**
+         * @return age of the oldest time window's sample in milliseconds.
+         */
+        public long age();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowStatsBenchTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowStatsBenchTest.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2020.
+ */
+
+package io.micrometer.core.instrument.distribution;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Clock;
+
+public class TimeWindowStatsBenchTest {
+
+	TimeWindowMax max = new TimeWindowMax(Clock.SYSTEM, 100, 10);
+	TimeWindowSum sum = new TimeWindowSum(10, Duration.ofMillis(100));
+	TimeWindowStats stats = new TimeWindowStats(Clock.SYSTEM, 100, 10);
+	TimeWindowStatsMax statsMax = new TimeWindowStatsMax(Clock.SYSTEM, 100, 10);
+	TimeWindowBencher current = null;
+	
+	boolean started = true;
+	
+	static {
+		try  {
+		TimeWindowStatsBenchTest t = new TimeWindowStatsBenchTest();
+		t.testMax();
+		t.testStats();
+		t.testStatsMax();
+		t.testSum();
+		} catch (Exception e) {}
+		System.out.println();
+	}
+
+    @Test
+    void testMax() throws Exception {
+    	current = new TimeWindowBencher() {
+			@Override
+			public void record(double sample) {
+				max.record(sample);
+			}
+			@Override
+			public double poll() {
+				return max.poll();
+			}
+		};
+		System.out.println("Starting testMax.");
+    	pTest();
+		System.out.println("Ending testMax.");
+    }
+
+    @Test
+    void testStats() throws Exception {
+    	current = new TimeWindowBencher() {
+			@Override
+			public void record(double sample) {
+				stats.record(sample);
+			}
+			@Override
+			public double poll() {
+				return stats.max();
+			}
+		};
+		System.out.println("Starting testStats.");
+    	pTest();
+		System.out.println("Ending testStats.");
+    }
+
+    @Test
+    void testStatsMax() throws Exception {
+    	current = new TimeWindowBencher() {
+			@Override
+			public void record(double sample) {
+				statsMax.record(sample);
+			}
+			@Override
+			public double poll() {
+				return statsMax.max();
+			}
+		};
+		System.out.println("Starting testStatsMax.");
+    	pTest();
+		System.out.println("Ending testStatsMax.");
+    }
+
+    @Test
+    void testSum() throws Exception {
+//    	current = new TimeWindowBencher() {
+//			@Override
+//			public void record(double sample) {
+//				sum.record((long) sample);
+//			}
+//			@Override
+//			public double poll() {
+//				return sum.poll();
+//			}
+//		};
+//		System.out.println("Starting testSum.");
+//    	pTest();
+//		System.out.println("Ending testSum.");
+    }
+
+    private void pTest() throws Exception {
+		System.out.println("Preparing threads.");
+		
+    	Thread poller = new Thread(new PollerThread());
+		final ArrayList<Thread> allThreads = new ArrayList<Thread>(8);
+		for (int i = 0 ; i < 8 ; i++) {
+			allThreads.add(new Thread(new Recorder()));
+		}
+
+		long l = System.nanoTime();
+		System.out.println("Starting threads.");
+    	poller.start();
+		for (final Thread t: allThreads) {
+			t.setPriority(Thread.MIN_PRIORITY);
+			t.start();
+		}
+
+		System.out.println("Waiting threads.");
+		for (final Thread t: allThreads) {
+			t.join();
+		}
+
+		System.out.println("OK : " + (System.nanoTime() - l) / 1_000_000 + " ms");
+    }
+    
+    private interface TimeWindowBencher {
+		public double poll();
+		public void record(double sample);
+    }
+    
+    private class Recorder implements Runnable {
+		@Override
+		public void run() {
+			int cnt = 0;
+			while (cnt < 10_000_000) {
+				current.record((cnt % 9) + (cnt / 100_000));
+				++cnt;
+			}
+		}
+    }
+    
+    private class PollerThread implements Runnable {
+		@Override
+		public void run() {
+			while (started) {
+				current.poll();
+				synchronized (this) {
+					try {
+						this.wait(250);
+					} catch (InterruptedException e) {
+						throw new RuntimeException(e);
+					}
+				}
+			}
+		}
+    }
+    
+    
+	// Just for the test ...
+	public static class TimeWindowStatsMax {
+	    private static final long MAX_DOUBLE_TO_LONG = 0x7ff0000000000000L - 1;
+	    
+	    private final AtomicInteger rotatingUpdater = new AtomicInteger();
+	
+	    private final Clock clock;
+	    private final long durationBetweenRotatesMillis;
+	    private final AtomicHolder[] ringBuffer;
+	    private int currentBucket;
+	    private volatile long lastRotateTimestampMillis;
+	
+	    private final TimeWindowStatsMaxSnapshot snapshot = new TimeWindowStatsMaxSnapshot() {
+	        @Override
+	        public double max() {
+	            return TimeWindowStatsMax.this.max();
+	        }
+	    };
+	
+	    public TimeWindowStatsMax(final Clock clock, final DistributionStatisticConfig config) {
+	        this(clock, config.getExpiry().toMillis(), config.getBufferLength());
+	    }
+	
+	    public TimeWindowStatsMax(final Clock clock, final long rotateFrequencyMillis, final int bufferLength) {
+	        this.clock = clock;
+	        durationBetweenRotatesMillis = rotateFrequencyMillis;
+	        lastRotateTimestampMillis = clock.wallTime();
+	        currentBucket = 0;
+	
+	        ringBuffer = new AtomicHolder[bufferLength];
+	        for (int i = 0; i < bufferLength; i++) {
+	            ringBuffer[i] = new AtomicHolder();
+	        }
+	        ringBuffer[currentBucket].age = lastRotateTimestampMillis;
+	    }
+	
+	    private static class AtomicHolder {
+	        long age = 0L;
+	        AtomicLong max = new AtomicLong();
+	
+	        @Override
+	        public String toString() {
+	            return "AtomicHolder [age=" + age + ", max=" + max + "]";
+	        }
+	    }
+	
+	    /**
+	     * Increments counter.
+	     * @param sample Sample to record
+	     */
+	    public void record(final double sample) {
+	        if (sample >= 0) {
+	            rotate();
+	            //No need to synchronize here
+	            long s = Double.doubleToLongBits(sample);
+	            //ringBuffer[currentBucket].max.updateAndGet((curMax) -> Math.max(curMax, s));
+	            updateMax(ringBuffer[currentBucket].max, s);
+	        }
+	    }
+	
+	    private void updateMax(AtomicLong max, long sample) {
+	        for (; ; ) {
+	            long curMax = max.get();
+	            if (curMax >= sample || max.compareAndSet(curMax, sample))
+	                break;
+	        }
+	    }
+	
+	    /**
+	     * @return max on time window.
+	     */
+	    public double max() {
+	        rotate();
+	        long max = 0;
+	        synchronized (this) {
+	            for (final AtomicHolder element : ringBuffer) {
+	                if (element.age > 0) {
+	                    max = Math.max(max, element.max.get());
+	                }
+	            }
+	        }
+	        return Double.longBitsToDouble(max);
+	    }
+	
+	    /**
+	     * @return age of the oldest time window's sample in milliseconds.
+	     */
+	    public long age() {
+	        rotate();
+	        long minAge = Long.MAX_VALUE;
+	        synchronized (this) {
+	            for (final AtomicHolder element : ringBuffer) {
+	                if (element.age > 0) {
+	                    minAge = Long.min(minAge, element.age);
+	                }
+	            }
+	        }
+	        return clock.wallTime() - minAge;
+	    }
+	
+	    /**
+	     * @return Unmodifiable Snapshot.
+	     */
+	    public TimeWindowStatsMaxSnapshot getSnapshot() {
+	        return snapshot;
+	    }
+	
+	    private void rotate() {
+	        final long wallTime = clock.wallTime();
+	        long timeSinceLastRotateMillis = wallTime - lastRotateTimestampMillis;
+	        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
+	            // Need to wait more for next rotation.
+	            return;
+	        }
+	
+	        if (!rotatingUpdater.compareAndSet(0, 1)) {
+	            // Being rotated by other thread already.
+	            return;
+	        }
+	
+	        try {
+	            int iterations = 0;
+	            synchronized (this) {
+	                do {
+	                	int tmpCurrentBucket = currentBucket + 1;
+	                    if (tmpCurrentBucket >= ringBuffer.length) {
+	                        currentBucket = 0;
+	                    } else {
+	                    	currentBucket = tmpCurrentBucket;
+	                    }
+	
+	                    //Init old buffers
+	                    if (ringBuffer[currentBucket].age > 0L) {
+		                    ringBuffer[currentBucket].age = 0L;
+		                    ringBuffer[currentBucket].max.set(0L);
+	                    }
+	
+	                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
+	                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
+	                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
+	
+	                //New buffer starts now
+	                ringBuffer[currentBucket].age = wallTime;
+	            }
+	        } finally {
+	            rotatingUpdater.set(0);
+	        }
+	    }
+	
+	    /**
+	     * Provides a way to expose a readonly snapshot of stats.
+	     */
+	    public interface TimeWindowStatsMaxSnapshot {
+	        /**
+	         * @return max on time window.
+	         */
+	        public double max();
+	    }
+	}
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowStatsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowStatsTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2020.
+ */
+
+package io.micrometer.core.instrument.distribution;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import io.micrometer.core.instrument.Clock;
+
+/**
+ * Tests TimeWindowStats
+ */
+public class TimeWindowStatsTest {
+
+    Clock clock = Mockito.mock(Clock.class, (Answer<Long>) e -> 1L);
+    final TimeWindowStats tws = new TimeWindowStats(clock, 5, 2);
+
+    /** Tests that TimeWindowStats inits correctly */
+    @Test
+    void testInit() {
+        Assert.assertEquals(Double.MAX_VALUE, tws.min(), 0D);
+        Assert.assertEquals(0D, tws.max(), 0D);
+        Assert.assertTrue(Double.isNaN(tws.mean()));
+        Assert.assertEquals(0, tws.sum(), 0D);
+        Assert.assertEquals(0, tws.count(), 0D);
+        Assert.assertTrue(Double.isNaN(tws.freq()));
+        Assert.assertEquals(0, tws.age(), 0D);
+
+        Mockito.when(clock.wallTime()).thenReturn(2L);
+        Assert.assertEquals(1, tws.age(), 0D);
+        Assert.assertEquals(0, tws.freq(), 0D);
+    }
+
+    /** Tests that TimeWindowStats behaves correctly */
+    @Test
+    void testBehavior() {
+        Mockito.when(clock.wallTime()).thenReturn(2L);
+        tws.record(50D);
+        Assert.assertEquals(50D, tws.min(), 0.00000001D);
+        Assert.assertEquals(50D, tws.max(), 0.00000001D);
+        Assert.assertEquals(50D, tws.sum(), 0.00000001D);
+        Assert.assertEquals(50D, tws.mean(), 0.00000001D);
+        Assert.assertEquals(1D, tws.count(), 0.00000001D);
+
+        tws.record(60D);
+        Assert.assertEquals(50D, tws.min(), 0.00000001D);
+        Assert.assertEquals(60D, tws.max(), 0.00000001D);
+        Assert.assertEquals(110D, tws.sum(), 0.00000001D);
+        Assert.assertEquals(55D, tws.mean(), 0.00000001D);
+        Assert.assertEquals(2D, tws.count(), 0.00000001D);
+
+        tws.record(40D);
+        Assert.assertEquals(40D, tws.min(), 0.00000001D);
+        Assert.assertEquals(60D, tws.max(), 0.00000001D);
+        Assert.assertEquals(150D, tws.sum(), 0.00000001D);
+        Assert.assertEquals(50D, tws.mean(), 0.00000001D);
+        Assert.assertEquals(3D, tws.count(), 0.00000001D);
+
+        tws.record(1D);
+        Assert.assertEquals(1D, tws.min(), 0.00000001D);
+        Assert.assertEquals(60D, tws.max(), 0.00000001D);
+        Assert.assertEquals(151D, tws.sum(), 0.00000001D);
+        Assert.assertEquals(4D, tws.count(), 0.00000001D);
+
+        tws.record(1000D);
+        Assert.assertEquals(1D, tws.min(), 0.00000001D);
+        Assert.assertEquals(1000D, tws.max(), 0.00000001D);
+        Assert.assertEquals(1151D, tws.sum(), 0.00000001D);
+        Assert.assertEquals(5D, tws.count(), 0.00000001D);
+
+        tws.record(0.0000001D);
+        Assert.assertEquals(0.0000001D, tws.min(), 0.0000000001D);
+        Assert.assertEquals(1000D, tws.max(), 0.00000001D);
+        Assert.assertEquals(1151.0000001D, tws.sum(), 0.0000000001D);
+        Assert.assertEquals(6D, tws.count(), 0.00000001D);
+
+        tws.record(0D);
+        Assert.assertEquals(0D, tws.min(), 0.000000000000001D);
+        Assert.assertEquals(1151.0000001D, tws.sum(), 0.0000000001D);
+        Assert.assertEquals(7D, tws.count(), 0.00000001D);
+
+        //Ignored samples
+        tws.record(-1D);
+        Assert.assertEquals(7D, tws.count(), 0.00000001D);
+
+        //Frequency
+        Assert.assertEquals(7D, tws.freq(), 0.00000001D);
+        Mockito.when(clock.wallTime()).thenReturn(3L);
+        Assert.assertEquals(3.5D, tws.freq(), 0.00000001D);
+
+        //Age
+        Mockito.when(clock.wallTime()).thenReturn(4L);
+        Mockito.when(clock.wallTime()).thenReturn(4L);
+
+        //First rotation
+        Mockito.when(clock.wallTime()).thenReturn(7L);
+        tws.record(80D);
+        Assert.assertEquals(8D, tws.count(), 0.00000001D);
+
+        Mockito.when(clock.wallTime()).thenReturn(12L);
+        Assert.assertEquals(1D, tws.count(), 0.00000001D);
+        
+        Assert.assertEquals(tws.sum(), tws.getSnapshot().sum(), 0D);
+        Assert.assertEquals(tws.min(), tws.getSnapshot().min(), 0D);
+        Assert.assertEquals(tws.max(), tws.getSnapshot().max(), 0D);
+        Assert.assertEquals(tws.count(), tws.getSnapshot().count(), 0D);
+        Assert.assertEquals(tws.mean(), tws.getSnapshot().mean(), 0D);
+        Assert.assertEquals(tws.freq(), tws.getSnapshot().freq(), 0D);
+        Assert.assertEquals(tws.age(), tws.getSnapshot().age(), 0D);
+    }
+}


### PR DESCRIPTION
Hi,

This PR is not ready to be merged, but I wanted to open a discussion on metrics available in DistributionSummaries. May be it could be applicable to other metrics, for the moment I'm not experienced enough in micrometer code to be exhaustive, so this is why this discussion is needed.

First, when I started to use DistributionSummaries, I noticed that it provides Max value, but not Min value.
Also, I wanted to retrieve some more information, like mean and frequency.

So I started to create my own components. But doing so, I noticed that some of the metrics provided by DistributionSummary are not limited to time window (sum, count, mean) while others are (max).

I did not mange to find out why, but I wanted to have these metrics and the new one inside time window.
Typically, it's interesting to have average frequency (events / sec) on the last 2 hours for instance, but it has no meaning on the full uptime.

So I started to develop TimeWindowStats.
1 - It provides metrics, all in time window : [min, max, sum, mean, count, frequency, age].
2 - It can replace TimeWindowMax and TimeWindowSum.
3 - The "record" method does not use a system like the "updateMax" method in TimeWindowMax, but it relies on "updateAndGet" exposed by AtomicLong, which makes code safer and more maintainable.
4 - It will be easier to make it evolve with the "Snapshot" interface.
5 - It's tested :-)

I used PrometheusDistributionSummary as an example to how it can be used.

But I did not change default metrics exposed by Summaries. May-be it could be opportunate ?

Thanks in advance for your feedback. I think this could help improve metrics exposed by micrometer but I need some advices to make it clean and coherent with the whole code base :-)

