### PR TITLE
Additional ThreadPoolExecutor metrics for pool configuration

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -317,6 +317,18 @@ public class ExecutorServiceMetrics implements MeterBinder {
                 .description("The current number of threads in the pool")
                 .baseUnit(BaseUnits.THREADS)
                 .register(registry);
+
+        Gauge.builder(metricPrefix + "executor.pool.core", tp, ThreadPoolExecutor::getCorePoolSize)
+                .tags(tags)
+                .description("The core number of threads for the pool")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
+
+        Gauge.builder(metricPrefix + "executor.pool.max", tp, ThreadPoolExecutor::getMaximumPoolSize)
+                .tags(tags)
+                .description("The maximum allowed number of threads in the pool")
+                .baseUnit(BaseUnits.THREADS)
+                .register(registry);
     }
 
     private void monitor(MeterRegistry registry, ForkJoinPool fj) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -248,6 +248,8 @@ class ExecutorServiceMetricsTest {
         registry.get(metricPrefix + "executor.queue.remaining").tags(userTags).tag("name", executorName).gauge();
         registry.get(metricPrefix + "executor.active").tags(userTags).tag("name", executorName).gauge();
         registry.get(metricPrefix + "executor.pool.size").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.pool.core").tags(userTags).tag("name", executorName).gauge();
+        registry.get(metricPrefix + "executor.pool.max").tags(userTags).tag("name", executorName).gauge();
         registry.get(metricPrefix + "executor.idle").tags(userTags).tag("name", executorName).timer();
         registry.get(metricPrefix + "executor").tags(userTags).tag("name", executorName).timer();
     }


### PR DESCRIPTION
Adds gauges for the configured thread pool max size and core size.

See https://github.com/micrometer-metrics/micrometer/issues/1665#issuecomment-555288655