### PR TITLE
Fix version in DistributionStatisticConfig.getSlaBoundaries() Javadoc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -236,7 +236,7 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
      *
      * @return The SLA boundaries to include the set of histogram buckets shipped to the monitoring system.
      * @deprecated Use {@link #getServiceLevelObjectiveBoundaries()}. If you use this method, your
-     * code will not be compatible with code that uses Micrometer 1.5.x and later.
+     * code will not be compatible with code that uses Micrometer 1.4.x and later.
      */
     @Deprecated
     @Nullable


### PR DESCRIPTION
This PR fixes incompatible version in `DistributionStatisticConfig.getSlaBoundaries()` Javadoc.