### PR TITLE
Use latest.release for spring-context

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -65,7 +65,7 @@ def VERSIONS = [
         'org.mockito:mockito-core:latest.release',
         'org.mongodb:mongo-java-driver:latest.release',
         'org.slf4j:slf4j-api:1.7.+',
-        'org.springframework:spring-context:4.+',
+        'org.springframework:spring-context:latest.release',
         'org.testcontainers:junit-jupiter:latest.release',
         'org.testcontainers:kafka:latest.release',
         'org.testcontainers:testcontainers:latest.release',


### PR DESCRIPTION
This PR changes to use `latest.release` for `spring-context`.