### PR TITLE
Revert "Drop zero-count infinity bucket in StackdriverMeterRegistry"

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -424,10 +424,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
             }
 
             // add the "+infinity" bucket, which does NOT have a corresponding bucket boundary
-            long infinityBucketCount = snapshot.count() - truncatedSum.get();
-            if (infinityBucketCount > 0) {
-                bucketCounts.add(infinityBucketCount);
-            }
+            bucketCounts.add(Math.max(0, snapshot.count() - truncatedSum.get()));
 
             List<Double> bucketBoundaries = Arrays.stream(histogram)
                     .map(countAtBucket -> timeDomain ? countAtBucket.bucket(getBaseTimeUnit()) : countAtBucket.bucket())

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryTest.java
@@ -60,4 +60,14 @@ class StackdriverMeterRegistryTest {
         List<Long> bucketCountsList = distribution.getBucketCountsList();
         assertThat(bucketCountsList.get(bucketCountsList.size() - 1)).isNotNegative();
     }
+
+    @Test
+    @Issue("#2045")
+    void batchDistributionWhenHistogramSnapshotIsEmpty() {
+        StackdriverMeterRegistry.Batch batch = meterRegistry.new Batch();
+        HistogramSnapshot histogramSnapshot = HistogramSnapshot.empty(0, 0.0, 0.0);
+        Distribution distribution = batch.distribution(histogramSnapshot, false);
+        assertThat(distribution.getBucketOptions().getExplicitBuckets().getBoundsCount()).isEqualTo(1);
+        assertThat(distribution.getBucketCountsList()).hasSize(1);
+    }
 }


### PR DESCRIPTION
This PR reverts 2718921956863c5fa6f83f186bd3a718fa910282.

This PR also adds a test for gh-2045.

Closes gh-2045