### PR TITLE
Fix NPE from uri tag creation in OkHttpMetricsEventListener.time()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
@@ -201,6 +201,16 @@ class OkHttpMetricsEventListenerTest {
         testRequestTags(server, request);
     }
 
+    @Test
+    void timeWhenRequestIsNull() {
+        OkHttpMetricsEventListener listener = OkHttpMetricsEventListener.builder(registry, "okhttp.requests").build();
+        OkHttpMetricsEventListener.CallState state = new OkHttpMetricsEventListener.CallState(registry.config().clock().monotonicTime(), null);
+        listener.time(state);
+
+        assertThat(registry.get("okhttp.requests")
+                .tags("uri", "UNKNOWN").timer().count()).isEqualTo(1L);
+    }
+
     private void testRequestTags(@WiremockResolver.Wiremock WireMockServer server, Request request) throws IOException {
         server.stubFor(any(anyUrl()));
         OkHttpClient client = new OkHttpClient.Builder()


### PR DESCRIPTION
Since d4bfe2a7f8274286a4cf87942598c8c9e6e60dd1, `OkHttpMetricsEventListener.time()` seems to be possible to cause NPE with `null` request when creating `uri` tag. This PR fixes it by restoring the previous behavior. This PR also adds a test for it.