### PR TITLE
Remove implementation dependency on logback in stackdriver module.

### DIFF
--- a/implementations/micrometer-registry-stackdriver/build.gradle
+++ b/implementations/micrometer-registry-stackdriver/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 
     api 'com.google.cloud:google-cloud-monitoring'
     implementation 'org.slf4j:slf4j-api'
-    implementation 'ch.qos.logback:logback-classic'
+    compileOnly 'ch.qos.logback:logback-classic'
 
     testImplementation project(':micrometer-test')
 }


### PR DESCRIPTION
For libraries best practise is to include only slf4j-api as dependency.