### PR TITLE
Fix tag mismatch due to request tags in OkHttp metrics

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
@@ -211,6 +211,20 @@ class OkHttpMetricsEventListenerTest {
                 .tags("uri", "UNKNOWN").timer().count()).isEqualTo(1L);
     }
 
+    @Test
+    void timeWhenRequestIsNullAndRequestTagKeysAreGiven() {
+        OkHttpMetricsEventListener listener = OkHttpMetricsEventListener.builder(registry, "okhttp.requests")
+                .requestTagKeys("tag1", "tag2").build();
+        OkHttpMetricsEventListener.CallState state = new OkHttpMetricsEventListener.CallState(registry.config().clock().monotonicTime(), null);
+        listener.time(state);
+
+        assertThat(registry.get("okhttp.requests")
+                .tags("uri", "UNKNOWN",
+                        "tag1", "UNKNOWN",
+                        "tag2", "UNKNOWN")
+                .timer().count()).isEqualTo(1L);
+    }
+
     private void testRequestTags(@WiremockResolver.Wiremock WireMockServer server, Request request) throws IOException {
         server.stubFor(any(anyUrl()));
         OkHttpClient client = new OkHttpClient.Builder()


### PR DESCRIPTION
This PR is an attempt to fix the tag mismatch due to request tags mentioned in https://github.com/micrometer-metrics/micrometer/pull/2062.

I'm not sure if there's a better way with the current implementation. I'm also not sure if this is a bug or limitation with Prometheus as it's an optional feature. I just went with 1.5.x branch, but if this solution is acceptable and we want to fix it in 1.3.x branch, I can retarget its branch.