### PR TITLE
Fix ClassCastException in OpenTSDBMeterRegistry.writeLongTaskTimer()

### DIFF
--- a/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBLongTaskTimer.java
+++ b/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBLongTaskTimer.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.opentsdb;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+import io.micrometer.core.lang.Nullable;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Extends the default long task timer, making histogram counts cumulative over time.
+ *
+ * @author Jon Schneider
+ * @since 1.5.2
+ */
+public class OpenTSDBLongTaskTimer extends DefaultLongTaskTimer {
+    @Nullable
+    private CountAtBucket[] lastSnapshot;
+
+    public OpenTSDBLongTaskTimer(Id id, Clock clock, TimeUnit baseTimeUnit, DistributionStatisticConfig distributionStatisticConfig) {
+        super(id, clock, baseTimeUnit, distributionStatisticConfig, true);
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        HistogramSnapshot snapshot = super.takeSnapshot();
+
+        AtomicInteger i = new AtomicInteger(0);
+
+        snapshot = new HistogramSnapshot(
+                snapshot.count(),
+                snapshot.total(),
+                snapshot.max(),
+                snapshot.percentileValues(),
+                Arrays.stream(snapshot.histogramCounts())
+                    .map(countAtBucket -> lastSnapshot == null ?
+                            countAtBucket :
+                            new CountAtBucket(
+                                    countAtBucket.bucket(),
+                                    countAtBucket.count() + lastSnapshot[i.getAndIncrement()].count()
+                            )
+                    ).toArray(CountAtBucket[]::new),
+                snapshot::outputSummary
+        );
+
+        lastSnapshot = snapshot.histogramCounts();
+        return snapshot;
+    }
+}

--- a/implementations/micrometer-registry-opentsdb/src/test/java/io/micrometer/opentsdb/OpenTSDBMeterRegistryTest.java
+++ b/implementations/micrometer-registry-opentsdb/src/test/java/io/micrometer/opentsdb/OpenTSDBMeterRegistryTest.java
@@ -118,4 +118,15 @@ class OpenTSDBMeterRegistryTest {
                 .contains("{\"metric\":\"my_timer_duration_seconds_bucket\",\"timestamp\":60001,\"value\":1,\"tags\":{\"le\":\"1.0\"}}")
                 .contains("{\"metric\":\"my_timer_duration_seconds_bucket\",\"timestamp\":60001,\"value\":0,\"tags\":{\"le\":\"0.9\"}}");
     }
+
+    @Test
+    void longTaskTimer() {
+        LongTaskTimer timer = LongTaskTimer.builder("my.timer").tag("tag", "value").register(meterRegistry);
+        meterRegistry.writeLongTaskTimer(timer).forEach(System.out::println);
+
+        assertThat(meterRegistry.writeLongTaskTimer(timer))
+                .contains("{\"metric\":\"my_timer_duration_seconds_active_count\",\"timestamp\":1,\"value\":0,\"tags\":{\"tag\":\"value\"}}")
+                .contains("{\"metric\":\"my_timer_duration_seconds_duration_sum\",\"timestamp\":1,\"value\":0,\"tags\":{\"tag\":\"value\"}}")
+                .contains("{\"metric\":\"my_timer_duration_seconds_max\",\"timestamp\":1,\"value\":0,\"tags\":{\"tag\":\"value\"}}");
+    }
 }


### PR DESCRIPTION
This PR fixes `ClassCastException` in `OpenTSDBMeterRegistry.writeLongTaskTimer()`.

This PR also changes as follows:

- Use snapshot for histogram counts in `writeTimer()`
- Use Prometheus variant for `LongTaskTimer` implementation