### PR TITLE
Use strong reference for NewRelicMeterRegistryTest.publishWithApiClientProvider()

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -679,11 +679,11 @@ class NewRelicMeterRegistryTest {
 
         NewRelicMeterRegistry registry = new NewRelicMeterRegistry(insightsApiConfig, apiProvider, clock);
 
-        registry.gauge("my.gauge", Tags.of("theTag", "theValue"), 1d);
+        Gauge.builder("my.gauge", () -> 1d).tag("theTag", "theValue").register(registry);
         Gauge gauge = registry.get("my.gauge").gauge();
         assertThat(gauge).isNotNull();
 
-        registry.gauge("other.gauge", 2d);
+        Gauge.builder("other.gauge", () -> 2d).register(registry);
         Gauge other = registry.get("other.gauge").gauge();
         assertThat(other).isNotNull();
 


### PR DESCRIPTION
This PR changes to use strong references for gauges in `NewRelicMeterRegistryTest.publishWithApiClientProvider()` as it's flaky due to garbage collection as follows:

```
NewRelicMeterRegistryTest > publishWithApiClientProvider() FAILED
    java.lang.AssertionError: 
    Expecting:
     <"[]">
    to contain:
     <"[{"eventType":"MicrometerSample","value":2,"metricName":"otherGauge","metricType":"GAUGE"},{"eventType":"MicrometerSample","value":1,"metricName":"myGauge","metricType":"GAUGE","theTag":"theValue"}]"> 
        at io.micrometer.newrelic.NewRelicMeterRegistryTest.publishWithApiClientProvider(NewRelicMeterRegistryTest.java:694)
```

See https://circleci.com/gh/izeye/micrometer/826