### PR TITLE
Use consistent value for active tasks in LongTaskTimer.mean()

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontLongTaskTimer.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontLongTaskTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 VMware, Inc.
+ * Copyright 2020 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -144,7 +144,8 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * @since 1.5.1
      */
     default double mean(TimeUnit unit) {
-        return activeTasks() == 0 ? 0 : duration(unit) / activeTasks();
+        int activeTasks = activeTasks();
+        return activeTasks == 0 ? 0 : duration(unit) / activeTasks;
     }
 
     /**


### PR DESCRIPTION
This PR changes to use consistent value for active tasks in `LongTaskTimer.mean()`.