### PR TITLE
Prevent Graphite reporter from modifying user tags 

### DIFF
--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteMeterRegistry.java
@@ -59,6 +59,7 @@ public class GraphiteMeterRegistry extends DropwizardMeterRegistry {
                 .withClock(new DropwizardClock(clock))
                 .convertRatesTo(config.rateUnits())
                 .convertDurationsTo(config.durationUnits())
+                .addMetricAttributesAsTags(config.graphiteTagsEnabled())
                 .build(getGraphiteSender(config));
     }
 


### PR DESCRIPTION
# Context
As noted in #2069, the recently added Graphite tag support doesn't work for most metric types due to the way that the Dropwizard reporter appends metric attributes (min, max, p95, etc).

A metric that is reported this way using the traditional format:
`my.timer.host.foo.max` 
Is currently reported like this using the tag format:
`my.timer;host=foo.max`

https://github.com/dropwizard/metrics/pull/1576 was recently merged on the reporter side, adding a new flag to the reporter which would cause it to report the example used above as `my.timer;host=foo;metricattribute=max`.

# What this PR does now
This PR adds a failing test to the end to end `GraphiteMeterRegistryTest` showing what the modified graphite output will eventually be. 

It may also serve as a discussion starter around if the upstream changes to the Dropwizard metrics library are appropriate, or if more changes are required/desirable (is a `metricattribute` tag? Does it need to be more configurable?).

# What this PR should do before merging
Pull in a Dropwizard metrics release containing https://github.com/dropwizard/metrics/pull/1576  and ensure that the Graphite reporter is configured to use the tag format when appropriate.