### PR TITLE
Autocloseable timer builder

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
@@ -1,0 +1,231 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.lang.Nullable;
+
+import java.time.Duration;
+import java.util.Arrays;
+
+@SuppressWarnings("unchecked")
+public class AbstractTimerBuilder<B extends AbstractTimerBuilder<B>> {
+    protected final String name;
+    protected Tags tags = Tags.empty();
+    protected final DistributionStatisticConfig.Builder distributionConfigBuilder;
+
+    @Nullable
+    protected String description;
+
+    @Nullable
+    protected PauseDetector pauseDetector;
+
+    protected AbstractTimerBuilder(String name) {
+        this.name = name;
+        this.distributionConfigBuilder = new DistributionStatisticConfig.Builder();
+        minimumExpectedValue(Duration.ofMillis(1));
+        maximumExpectedValue(Duration.ofSeconds(30));
+    }
+
+    /**
+     * @param tags Must be an even number of arguments representing key/value pairs of tags.
+     * @return This builder.
+     */
+    public B tags(String... tags) {
+        return tags(Tags.of(tags));
+    }
+
+    /**
+     * @param tags Tags to add to the eventual timer.
+     * @return The timer builder with added tags.
+     */
+    public B tags(Iterable<Tag> tags) {
+        this.tags = this.tags.and(tags);
+        return (B) this;
+    }
+
+    /**
+     * @param key   The tag key.
+     * @param value The tag value.
+     * @return The timer builder with a single added tag.
+     */
+    public B tag(String key, String value) {
+        this.tags = tags.and(key, value);
+        return (B) this;
+    }
+
+    /**
+     * Produces an additional time series for each requested percentile. This percentile
+     * is computed locally, and so can't be aggregated with percentiles computed across other
+     * dimensions (e.g. in a different instance). Use {@link #publishPercentileHistogram()}
+     * to publish a histogram that can be used to generate aggregable percentile approximations.
+     *
+     * @param percentiles Percentiles to compute and publish. The 95th percentile should be expressed as {@code 0.95}.
+     * @return This builder.
+     */
+    public B publishPercentiles(@Nullable double... percentiles) {
+        this.distributionConfigBuilder.percentiles(percentiles);
+        return (B) this;
+    }
+
+    /**
+     * Determines the number of digits of precision to maintain on the dynamic range histogram used to compute
+     * percentile approximations. The higher the degrees of precision, the more accurate the approximation is at the
+     * cost of more memory.
+     *
+     * @param digitsOfPrecision The digits of precision to maintain for percentile approximations.
+     * @return This builder.
+     */
+    public B percentilePrecision(@Nullable Integer digitsOfPrecision) {
+        this.distributionConfigBuilder.percentilePrecision(digitsOfPrecision);
+        return (B) this;
+    }
+
+    /**
+     * Adds histogram buckets used to generate aggregable percentile approximations in monitoring
+     * systems that have query facilities to do so (e.g. Prometheus' {@code histogram_quantile},
+     * Atlas' {@code :percentiles}).
+     *
+     * @return This builder.
+     */
+    public B publishPercentileHistogram() {
+        return publishPercentileHistogram(true);
+    }
+
+    /**
+     * Adds histogram buckets used to generate aggregable percentile approximations in monitoring
+     * systems that have query facilities to do so (e.g. Prometheus' {@code histogram_quantile},
+     * Atlas' {@code :percentiles}).
+     *
+     * @param enabled Determines whether percentile histograms should be published.
+     * @return This builder.
+     */
+    public B publishPercentileHistogram(@Nullable Boolean enabled) {
+        this.distributionConfigBuilder.percentilesHistogram(enabled);
+        return (B) this;
+    }
+
+    /**
+     * Publish at a minimum a histogram containing your defined service level objective (SLO) boundaries.
+     * When used in conjunction with {@link AbstractTimerBuilder#publishPercentileHistogram()}, the boundaries defined
+     * here are included alongside other buckets used to generate aggregable percentile approximations.
+     *
+     * @param sla Publish SLO boundaries in the set of histogram buckets shipped to the monitoring system.
+     * @return This builder.
+     * @deprecated Use {{@link #serviceLevelObjectives(Duration...)}} instead. "Service Level Agreement" is
+     * more formally the agreement between an engineering organization and the business. Service Level Objectives
+     * are set more conservatively than the SLA to provide some wiggle room while still satisfying the business
+     * requirement. SLOs are the threshold we intend to measure against, then.
+     */
+    @Deprecated
+    public B sla(@Nullable Duration... sla) {
+        return serviceLevelObjectives(sla);
+    }
+
+    /**
+     * Publish at a minimum a histogram containing your defined service level objective (SLO) boundaries.
+     * When used in conjunction with {@link AbstractTimerBuilder#publishPercentileHistogram()}, the boundaries defined
+     * here are included alongside other buckets used to generate aggregable percentile approximations.
+     *
+     * @param slos Publish SLO boundaries in the set of histogram buckets shipped to the monitoring system.
+     * @return This builder.
+     * @since 1.5.0
+     */
+    public B serviceLevelObjectives(@Nullable Duration... slos) {
+        if (slos != null) {
+            this.distributionConfigBuilder.serviceLevelObjectives(Arrays.stream(slos).mapToDouble(Duration::toNanos).toArray());
+        }
+        return (B) this;
+    }
+
+    /**
+     * Sets the minimum value that this timer is expected to observe. Sets a lower bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @param min The minimum value that this timer is expected to observe.
+     * @return This builder.
+     */
+    public B minimumExpectedValue(@Nullable Duration min) {
+        if (min != null)
+            this.distributionConfigBuilder.minimumExpectedValue((double) min.toNanos());
+        return (B) this;
+    }
+
+    /**
+     * Sets the maximum value that this timer is expected to observe. Sets an upper bound
+     * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+     *
+     * @param max The maximum value that this timer is expected to observe.
+     * @return This builder.
+     */
+    public B maximumExpectedValue(@Nullable Duration max) {
+        if (max != null)
+            this.distributionConfigBuilder.maximumExpectedValue((double) max.toNanos());
+        return (B) this;
+    }
+
+    /**
+     * Statistics emanating from a timer like max, percentiles, and histogram counts decay over time to
+     * give greater weight to recent samples (exception: histogram counts are cumulative for those systems that expect cumulative
+     * histogram buckets). Samples are accumulated to such statistics in ring buffers which rotate after
+     * this expiry, with a buffer length of {@link #distributionStatisticBufferLength(Integer)}.
+     *
+     * @param expiry The amount of time samples are accumulated to a histogram before it is reset and rotated.
+     * @return This builder.
+     */
+    public B distributionStatisticExpiry(@Nullable Duration expiry) {
+        this.distributionConfigBuilder.expiry(expiry);
+        return (B) this;
+    }
+
+    /**
+     * Statistics emanating from a timer like max, percentiles, and histogram counts decay over time to
+     * give greater weight to recent samples (exception: histogram counts are cumulative for those systems that expect cumulative
+     * histogram buckets). Samples are accumulated to such statistics in ring buffers which rotate after
+     * {@link #distributionStatisticExpiry(Duration)}, with this buffer length.
+     *
+     * @param bufferLength The number of histograms to keep in the ring buffer.
+     * @return This builder.
+     */
+    public B distributionStatisticBufferLength(@Nullable Integer bufferLength) {
+        this.distributionConfigBuilder.bufferLength(bufferLength);
+        return (B) this;
+    }
+
+    /**
+     * Sets the pause detector implementation to use for this timer. Can also be configured on a registry-level with
+     * {@link MeterRegistry.Config#pauseDetector(PauseDetector)}.
+     *
+     * @param pauseDetector The pause detector implementation to use.
+     * @return This builder.
+     * @see io.micrometer.core.instrument.distribution.pause.NoPauseDetector
+     * @see io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector
+     */
+    public B pauseDetector(@Nullable PauseDetector pauseDetector) {
+        this.pauseDetector = pauseDetector;
+        return (B) this;
+    }
+
+    /**
+     * @param description Description text of the eventual timer.
+     * @return This builder.
+     */
+    public B description(@Nullable String description) {
+        this.description = description;
+        return (B) this;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -18,11 +18,8 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
-import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
-import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.lang.Nullable;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -52,7 +49,7 @@ public interface Timer extends Meter, HistogramSupport {
     /**
      * Start a timing sample.
      *
-     * @param registry a meter registry whose clock is to be used
+     * @param registry A meter registry whose clock is to be used
      * @return A timing sample with start time recorded.
      */
     static Sample start(MeterRegistry registry) {
@@ -71,6 +68,17 @@ public interface Timer extends Meter, HistogramSupport {
 
     static Builder builder(String name) {
         return new Builder(name);
+    }
+
+    /**
+     * @param registry A meter registry against which the timer will be registered.
+     * @param name     The name of the timer.
+     * @return A timing builder that automatically records a timing on close.
+     * @since 1.6.0
+     */
+    @Incubating(since = "1.6.0")
+    static ResourceSample resource(MeterRegistry registry, String name) {
+        return new ResourceSample(registry, name);
     }
 
     /**
@@ -253,13 +261,6 @@ public interface Timer extends Meter, HistogramSupport {
      * sample is stopped, allowing you to determine the timer's tags at the last minute.
      */
     class Sample {
-        /**
-         * Tags determined at the start of a request. Useful for event-driven APIs where
-         * some tags are derived from a start event, and others are determined by a terminal
-         * event in some finite state machine.
-         */
-        private Tags tags = Tags.empty();
-
         private final long startTime;
         private final Clock clock;
 
@@ -280,250 +281,34 @@ public interface Timer extends Meter, HistogramSupport {
             timer.record(durationNs, TimeUnit.NANOSECONDS);
             return durationNs;
         }
+    }
 
-        /**
-         * Records the duration of the operation. Using this method, any tags
-         * stored on the sample are recorded with the timing.
-         *
-         * @param registry     The registry to which the timer will be registered.
-         * @param timerBuilder The timer to record the sample to.
-         * @return The total duration of the sample in nanoseconds
-         * @since 1.4.0
-         */
-        @Incubating(since = "1.4.0")
-        public long stop(MeterRegistry registry, Timer.Builder timerBuilder) {
-            return stop(timerBuilder.tags(tags).register(registry));
+    class ResourceSample extends AbstractTimerBuilder<ResourceSample> implements AutoCloseable {
+        private final MeterRegistry registry;
+        private final long startTime;
+
+        ResourceSample(MeterRegistry registry, String name) {
+            super(name);
+            this.registry = registry;
+            this.startTime = registry.config().clock().monotonicTime();
         }
 
-        /**
-         * @param tags Must be an even number of arguments representing key/value pairs of tags.
-         * @return This builder.
-         * @since 1.4.0
-         */
-        @Incubating(since = "1.4.0")
-        public Sample tags(String... tags) {
-            return tags(Tags.of(tags));
-        }
-
-        /**
-         * @param tags Tags to add to the eventual timer.
-         * @return The sample with added tags.
-         * @since 1.4.0
-         */
-        @Incubating(since = "1.4.0")
-        public Sample tags(Iterable<Tag> tags) {
-            this.tags = this.tags.and(tags);
-            return this;
+        @Override
+        public void close() {
+            long durationNs = registry.config().clock().monotonicTime() - startTime;
+            registry
+                    .timer(new Meter.Id(name, tags, null, description, Type.TIMER), distributionConfigBuilder.build(),
+                            pauseDetector == null ? registry.config().pauseDetector() : pauseDetector)
+                    .record(durationNs, TimeUnit.NANOSECONDS);
         }
     }
 
     /**
      * Fluent builder for timers.
      */
-    class Builder {
-        private final String name;
-        private Tags tags = Tags.empty();
-        private final DistributionStatisticConfig.Builder distributionConfigBuilder;
-
-        @Nullable
-        private String description;
-
-        @Nullable
-        private PauseDetector pauseDetector;
-
-        private Builder(String name) {
-            this.name = name;
-            this.distributionConfigBuilder = new DistributionStatisticConfig.Builder();
-            minimumExpectedValue(Duration.ofMillis(1));
-            maximumExpectedValue(Duration.ofSeconds(30));
-        }
-
-        /**
-         * @param tags Must be an even number of arguments representing key/value pairs of tags.
-         * @return This builder.
-         */
-        public Builder tags(String... tags) {
-            return tags(Tags.of(tags));
-        }
-
-        /**
-         * @param tags Tags to add to the eventual timer.
-         * @return The timer builder with added tags.
-         */
-        public Builder tags(Iterable<Tag> tags) {
-            this.tags = this.tags.and(tags);
-            return this;
-        }
-
-        /**
-         * @param key   The tag key.
-         * @param value The tag value.
-         * @return The timer builder with a single added tag.
-         */
-        public Builder tag(String key, String value) {
-            this.tags = tags.and(key, value);
-            return this;
-        }
-
-        /**
-         * Produces an additional time series for each requested percentile. This percentile
-         * is computed locally, and so can't be aggregated with percentiles computed across other
-         * dimensions (e.g. in a different instance). Use {@link #publishPercentileHistogram()}
-         * to publish a histogram that can be used to generate aggregable percentile approximations.
-         *
-         * @param percentiles Percentiles to compute and publish. The 95th percentile should be expressed as {@code 0.95}.
-         * @return This builder.
-         */
-        public Builder publishPercentiles(@Nullable double... percentiles) {
-            this.distributionConfigBuilder.percentiles(percentiles);
-            return this;
-        }
-
-        /**
-         * Determines the number of digits of precision to maintain on the dynamic range histogram used to compute
-         * percentile approximations. The higher the degrees of precision, the more accurate the approximation is at the
-         * cost of more memory.
-         *
-         * @param digitsOfPrecision The digits of precision to maintain for percentile approximations.
-         * @return This builder.
-         */
-        public Builder percentilePrecision(@Nullable Integer digitsOfPrecision) {
-            this.distributionConfigBuilder.percentilePrecision(digitsOfPrecision);
-            return this;
-        }
-
-        /**
-         * Adds histogram buckets used to generate aggregable percentile approximations in monitoring
-         * systems that have query facilities to do so (e.g. Prometheus' {@code histogram_quantile},
-         * Atlas' {@code :percentiles}).
-         *
-         * @return This builder.
-         */
-        public Builder publishPercentileHistogram() {
-            return publishPercentileHistogram(true);
-        }
-
-        /**
-         * Adds histogram buckets used to generate aggregable percentile approximations in monitoring
-         * systems that have query facilities to do so (e.g. Prometheus' {@code histogram_quantile},
-         * Atlas' {@code :percentiles}).
-         *
-         * @param enabled Determines whether percentile histograms should be published.
-         * @return This builder.
-         */
-        public Builder publishPercentileHistogram(@Nullable Boolean enabled) {
-            this.distributionConfigBuilder.percentilesHistogram(enabled);
-            return this;
-        }
-
-        /**
-         * Publish at a minimum a histogram containing your defined service level objective (SLO) boundaries.
-         * When used in conjunction with {@link Builder#publishPercentileHistogram()}, the boundaries defined
-         * here are included alongside other buckets used to generate aggregable percentile approximations.
-         *
-         * @param sla Publish SLO boundaries in the set of histogram buckets shipped to the monitoring system.
-         * @return This builder.
-         * @deprecated Use {{@link #serviceLevelObjectives(Duration...)}} instead. "Service Level Agreement" is
-         * more formally the agreement between an engineering organization and the business. Service Level Objectives
-         * are set more conservatively than the SLA to provide some wiggle room while still satisfying the business
-         * requirement. SLOs are the threshold we intend to measure against, then.
-         */
-        @Deprecated
-        public Builder sla(@Nullable Duration... sla) {
-            return serviceLevelObjectives(sla);
-        }
-
-        /**
-         * Publish at a minimum a histogram containing your defined service level objective (SLO) boundaries.
-         * When used in conjunction with {@link Builder#publishPercentileHistogram()}, the boundaries defined
-         * here are included alongside other buckets used to generate aggregable percentile approximations.
-         *
-         * @param slos Publish SLO boundaries in the set of histogram buckets shipped to the monitoring system.
-         * @return This builder.
-         * @since 1.5.0
-         */
-        public Builder serviceLevelObjectives(@Nullable Duration... slos) {
-            if (slos != null) {
-                this.distributionConfigBuilder.serviceLevelObjectives(Arrays.stream(slos).mapToDouble(Duration::toNanos).toArray());
-            }
-            return this;
-        }
-
-        /**
-         * Sets the minimum value that this timer is expected to observe. Sets a lower bound
-         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
-         *
-         * @param min The minimum value that this timer is expected to observe.
-         * @return This builder.
-         */
-        public Builder minimumExpectedValue(@Nullable Duration min) {
-            if (min != null)
-                this.distributionConfigBuilder.minimumExpectedValue((double) min.toNanos());
-            return this;
-        }
-
-        /**
-         * Sets the maximum value that this timer is expected to observe. Sets an upper bound
-         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
-         *
-         * @param max The maximum value that this timer is expected to observe.
-         * @return This builder.
-         */
-        public Builder maximumExpectedValue(@Nullable Duration max) {
-            if (max != null)
-                this.distributionConfigBuilder.maximumExpectedValue((double) max.toNanos());
-            return this;
-        }
-
-        /**
-         * Statistics emanating from a timer like max, percentiles, and histogram counts decay over time to
-         * give greater weight to recent samples (exception: histogram counts are cumulative for those systems that expect cumulative
-         * histogram buckets). Samples are accumulated to such statistics in ring buffers which rotate after
-         * this expiry, with a buffer length of {@link #distributionStatisticBufferLength(Integer)}.
-         *
-         * @param expiry The amount of time samples are accumulated to a histogram before it is reset and rotated.
-         * @return This builder.
-         */
-        public Builder distributionStatisticExpiry(@Nullable Duration expiry) {
-            this.distributionConfigBuilder.expiry(expiry);
-            return this;
-        }
-
-        /**
-         * Statistics emanating from a timer like max, percentiles, and histogram counts decay over time to
-         * give greater weight to recent samples (exception: histogram counts are cumulative for those systems that expect cumulative
-         * histogram buckets). Samples are accumulated to such statistics in ring buffers which rotate after
-         * {@link #distributionStatisticExpiry(Duration)}, with this buffer length.
-         *
-         * @param bufferLength The number of histograms to keep in the ring buffer.
-         * @return This builder.
-         */
-        public Builder distributionStatisticBufferLength(@Nullable Integer bufferLength) {
-            this.distributionConfigBuilder.bufferLength(bufferLength);
-            return this;
-        }
-
-        /**
-         * Sets the pause detector implementation to use for this timer. Can also be configured on a registry-level with
-         * {@link MeterRegistry.Config#pauseDetector(PauseDetector)}.
-         *
-         * @param pauseDetector The pause detector implementation to use.
-         * @return This builder.
-         * @see io.micrometer.core.instrument.distribution.pause.NoPauseDetector
-         * @see io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector
-         */
-        public Builder pauseDetector(@Nullable PauseDetector pauseDetector) {
-            this.pauseDetector = pauseDetector;
-            return this;
-        }
-
-        /**
-         * @param description Description text of the eventual timer.
-         * @return This builder.
-         */
-        public Builder description(@Nullable String description) {
-            this.description = description;
-            return this;
+    class Builder extends AbstractTimerBuilder<Builder> {
+        Builder(String name) {
+            super(name);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -20,6 +20,7 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -309,6 +310,81 @@ public interface Timer extends Meter, HistogramSupport {
     class Builder extends AbstractTimerBuilder<Builder> {
         Builder(String name) {
             super(name);
+        }
+
+        @Override
+        public Builder tags(String... tags) {
+            return super.tags(tags);
+        }
+
+        @Override
+        public Builder tags(Iterable<Tag> tags) {
+            return super.tags(tags);
+        }
+
+        @Override
+        public Builder tag(String key, String value) {
+            return super.tag(key, value);
+        }
+
+        @Override
+        public Builder publishPercentiles(double... percentiles) {
+            return super.publishPercentiles(percentiles);
+        }
+
+        @Override
+        public Builder percentilePrecision(Integer digitsOfPrecision) {
+            return super.percentilePrecision(digitsOfPrecision);
+        }
+
+        @Override
+        public Builder publishPercentileHistogram() {
+            return super.publishPercentileHistogram();
+        }
+
+        @Override
+        public Builder publishPercentileHistogram(Boolean enabled) {
+            return super.publishPercentileHistogram(enabled);
+        }
+
+        @Override
+        public Builder sla(Duration... sla) {
+            return super.sla(sla);
+        }
+
+        @Override
+        public Builder serviceLevelObjectives(Duration... slos) {
+            return super.serviceLevelObjectives(slos);
+        }
+
+        @Override
+        public Builder minimumExpectedValue(Duration min) {
+            return super.minimumExpectedValue(min);
+        }
+
+        @Override
+        public Builder maximumExpectedValue(Duration max) {
+            return super.maximumExpectedValue(max);
+        }
+
+        @Override
+        public Builder distributionStatisticExpiry(Duration expiry) {
+            return super.distributionStatisticExpiry(expiry);
+        }
+
+        @Override
+        public Builder distributionStatisticBufferLength(Integer bufferLength) {
+            return super.distributionStatisticBufferLength(bufferLength);
+        }
+
+        @Override
+        public Builder pauseDetector(PauseDetector pauseDetector) {
+            return super.pauseDetector(pauseDetector);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
@@ -51,7 +51,7 @@ import java.util.function.Function;
 public class MicrometerHttpClientInterceptor {
     private static final String METER_NAME = "httpcomponents.httpclient.request";
 
-    private final Map<HttpContext, Timer.Sample> timerByHttpContext = new ConcurrentHashMap<>();
+    private final Map<HttpContext, Timer.ResourceSample> timerByHttpContext = new ConcurrentHashMap<>();
 
     private final HttpRequestInterceptor requestInterceptor;
     private final HttpResponseInterceptor responseInterceptor;
@@ -59,33 +59,32 @@ public class MicrometerHttpClientInterceptor {
     /**
      * Create a {@code MicrometerHttpClientInterceptor} instance.
      *
-     * @param meterRegistry meter registry to bind
-     * @param uriMapper URI mapper to create {@code uri} tag
-     * @param extraTags extra tags
+     * @param meterRegistry      meter registry to bind
+     * @param uriMapper          URI mapper to create {@code uri} tag
+     * @param extraTags          extra tags
      * @param exportTagsForRoute whether to export tags for route
      */
     public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry,
                                            Function<HttpRequest, String> uriMapper,
                                            Iterable<Tag> extraTags,
                                            boolean exportTagsForRoute) {
-        this.requestInterceptor = (request, context) -> timerByHttpContext.put(context, Timer.start(meterRegistry)
+        this.requestInterceptor = (request, context) -> timerByHttpContext.put(context, Timer.resource(meterRegistry, METER_NAME)
                 .tags("method", request.getRequestLine().getMethod(), "uri", uriMapper.apply(request)));
 
         this.responseInterceptor = (response, context) -> {
-            Timer.Sample sample = timerByHttpContext.remove(context);
-            sample.stop(meterRegistry, Timer.builder(METER_NAME)
+            timerByHttpContext.remove(context)
                     .tag("status", Integer.toString(response.getStatusLine().getStatusCode()))
                     .tags(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
-                    .tags(extraTags));
+                    .tags(extraTags)
+                    .close();
         };
     }
-
 
     /**
      * Create a {@code MicrometerHttpClientInterceptor} instance with {@link DefaultUriMapper}.
      *
-     * @param meterRegistry meter registry to bind
-     * @param extraTags extra tags
+     * @param meterRegistry      meter registry to bind
+     * @param extraTags          extra tags
      * @param exportTagsForRoute whether to export tags for route
      */
     public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry,


### PR DESCRIPTION
Proposed API for #1425. The key (really clever) idea from @RichMacDonald that makes this possible is the use of an inner try/catch because the resource (`Timer.ResourceSample`) is inaccessible from the outer catch block (thanks Java).

```java
try (Timer.ResourceSample sample = Timer.resource(registry, "requests")
        .description("This is an operation")
        .publishPercentileHistogram()) {
    try {
        // do something that could potentially throw an exception
        sample.tag("outcome", "success");
    } catch (Throwable t) {
        sample.tag("outcome", "error");
    }
}
```

Some notes on this:

- `Timer.ResourceSample` is an `Autocloseable` extension of `Timer.Builder`. We can't simply make `Timer.Builder` an `Autocloseable`, because then IDE's and static analysis tools like Sonar would flag it as requiring a close call.
- Is the name `Timer.ResourceSample` as bad as I feel it is?
- `Timer.Builder` and `Timer.ResourceSample` now both extend from `AbstractTimerBuilder<B extends AbstractTimerBuilder<B>>`, the lovely generic builder pattern. I _think_ this preserves API compatibility?
- `Timer.resource(..)` is how the end user explicitly asks for an auto-closeable builder.
- For now, I've left off @RichMacDonald's suggestion to specify the success tag up front and overwrite that tag value in only the catch block. It means one more line of code to indicate success inside of the inner try, but avoids the O(N+M) loops over all existing (cardinality N) + added (cardinality M) tags in the error condition looking for tag key matches. We could still add a `Tags.merge(..)` method in addition to `Tags.add(..)` that has stronger guarantees about overwriting existing tag keys, but I think we can consider this separately.
- Removed incubating `tags` methods on `Timer.Sample`, introduced experimentally for the sake of `MicrometerHttpClientInterceptor` in 1.4.0, which now uses the auto-closeable form. Sonar would probably still flag [this line](https://github.com/micrometer-metrics/micrometer/pull/2084/files#diff-162d947a0c0dcf8aa96f7d81ce72a14aR71) as requiring a close call, but I think it's an infrequent enough pattern that we could manually suppress such errors rather than having a whole set of overloaded types for this pattern?

We do want to discourage users (through our API choices) from timing try/catch blocks with a timer without differentiating by error tag. See comments on #1425 about this. In Java 8, you _must_ assign try-with-resources resources to a variable, which kind of suggests that the variable should be _used_ somewhere in the try and/or catch blocks. So great. In Java 9, enhancements to ARM allow effectively final variables to _not_ be assigned. So this would be possible in Java 9 (not sure how I feel about this):

```java
try (Timer.resource(registry, "requests")
        .description("This is an operation")
        .publishPercentileHistogram()) {
    // do something that could potentially throw an exception
}
```

cc / @RichMacDonald @shakuzen @izeye @garfieldnate.
