### PR TITLE
Fix Javadoc errors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.conf.Settings;
 import org.jooq.exception.*;
 import org.jooq.impl.DSL;
@@ -43,8 +44,6 @@ import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static org.jooq.SQLDialect.*;
 
 /**
  * Time SQL queries passing through jOOQ.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringEscapeUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringEscapeUtils.java
@@ -20,7 +20,7 @@ import io.micrometer.core.lang.Nullable;
 /**
  * Utilities for JSON escaping {@code String}.
  *
- * <h3>Implementation Approach</h3>
+ * <h2>Implementation Approach</h2>
  * This uses a replacement char array to perform escaping, an idea from Square/Moshi. In their case,
  * it was an internal detail of {@code com.squareup.moshi.JsonUtf8Writer}, licensed Apache 2.0
  * Copyright 2010 Google Inc. The comments and initialization of {@code REPLACEMENT_CHARS} came


### PR DESCRIPTION
Since 1.4.1, Javadoc doesn't seem to have been published to the Maven Central properly due to Javadoc errors with Java 14 as follows:

```
> Task :micrometer-core:javadoc2s]
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:133: error: reference to Record is ambiguous
    public <R extends Record> Table<R> map(Table<R> table) {
                      ^
  both interface org.jooq.Record in org.jooq and class java.lang.Record in java.lang match
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java:379: error: reference to Record is ambiguous
    public <R extends Record> LoaderOptionsStep<R> loadInto(Table<R> table) {
...
  both interface org.jooq.Record in org.jooq and class java.lang.Record in java.lang match
100 errors
```

This PR fixes the errors in addition to the following error:

```
> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringEscapeUtils.java:23: error: heading used out of sequence: <H3>, compared to implicit preceding heading: <H1>
 * <h3>Implementation Approach</h3>
   ^
```