### PR TITLE
Retry failing assertion in TomcatMetricsTest

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 //    testCompile 'com.google.dagger:dagger-compiler:2.11'
 
     testCompile 'org.assertj:assertj-core:latest.release'
+    testCompile 'org.awaitility:awaitility:latest.release'
 
     testCompile 'org.ehcache:ehcache:latest.release'
 

--- a/micrometer-core/gradle/dependency-locks/testCompile.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testCompile.lockfile
@@ -67,6 +67,7 @@ org.apache.tomcat.embed:tomcat-embed-core:8.5.34
 org.apache.tomcat:tomcat-annotations-api:8.5.34
 org.aspectj:aspectjweaver:1.8.13
 org.assertj:assertj-core:3.11.1
+org.awaitility:awaitility:4.0.2
 org.eclipse.jetty:jetty-continuation:9.2.24.v20180105
 org.eclipse.jetty:jetty-http:9.2.24.v20180105
 org.eclipse.jetty:jetty-io:9.2.24.v20180105
@@ -79,6 +80,7 @@ org.eclipse.jetty:jetty-webapp:9.2.24.v20180105
 org.eclipse.jetty:jetty-xml:9.2.24.v20180105
 org.ehcache:ehcache:3.6.1
 org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest:2.1
 org.hdrhistogram:HdrHistogram:2.1.9
 org.hibernate.common:hibernate-commons-annotations:5.0.1.Final
 org.hibernate:hibernate-core:5.3.0.Beta1

--- a/micrometer-core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -68,6 +68,7 @@ org.apache.tomcat:tomcat-annotations-api:8.5.34
 org.apiguardian:apiguardian-api:1.1.0
 org.aspectj:aspectjweaver:1.8.13
 org.assertj:assertj-core:3.11.1
+org.awaitility:awaitility:4.0.2
 org.eclipse.jetty:jetty-continuation:9.2.28.v20190418
 org.eclipse.jetty:jetty-http:9.2.28.v20190418
 org.eclipse.jetty:jetty-io:9.2.28.v20190418
@@ -80,6 +81,7 @@ org.eclipse.jetty:jetty-webapp:9.2.28.v20190418
 org.eclipse.jetty:jetty-xml:9.2.28.v20190418
 org.ehcache:ehcache:3.6.1
 org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest:2.1
 org.hdrhistogram:HdrHistogram:2.1.9
 org.hibernate.common:hibernate-commons-annotations:5.0.1.Final
 org.hibernate:hibernate-core:5.3.0.Beta1

--- a/micrometer-core/gradle/dependency-locks/testRuntime.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testRuntime.lockfile
@@ -68,6 +68,7 @@ org.apache.tomcat:tomcat-annotations-api:8.5.34
 org.apiguardian:apiguardian-api:1.1.0
 org.aspectj:aspectjweaver:1.8.13
 org.assertj:assertj-core:3.11.1
+org.awaitility:awaitility:4.0.2
 org.eclipse.jetty:jetty-continuation:9.2.24.v20180105
 org.eclipse.jetty:jetty-http:9.2.24.v20180105
 org.eclipse.jetty:jetty-io:9.2.24.v20180105
@@ -80,6 +81,7 @@ org.eclipse.jetty:jetty-webapp:9.2.24.v20180105
 org.eclipse.jetty:jetty-xml:9.2.24.v20180105
 org.ehcache:ehcache:3.6.1
 org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest:2.1
 org.hdrhistogram:HdrHistogram:2.1.9
 org.hibernate.common:hibernate-commons-annotations:5.0.1.Final
 org.hibernate:hibernate-core:5.3.0.Beta1

--- a/micrometer-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/micrometer-core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -68,6 +68,7 @@ org.apache.tomcat:tomcat-annotations-api:8.5.34
 org.apiguardian:apiguardian-api:1.1.0
 org.aspectj:aspectjweaver:1.8.13
 org.assertj:assertj-core:3.11.1
+org.awaitility:awaitility:4.0.2
 org.eclipse.jetty:jetty-continuation:9.2.28.v20190418
 org.eclipse.jetty:jetty-http:9.2.28.v20190418
 org.eclipse.jetty:jetty-io:9.2.28.v20190418
@@ -80,6 +81,7 @@ org.eclipse.jetty:jetty-webapp:9.2.28.v20190418
 org.eclipse.jetty:jetty-xml:9.2.28.v20190418
 org.ehcache:ehcache:3.6.1
 org.hamcrest:hamcrest-core:1.3
+org.hamcrest:hamcrest:2.1
 org.hdrhistogram:HdrHistogram:2.1.9
 org.hibernate.common:hibernate-commons-annotations:5.0.1.Final
 org.hibernate:hibernate-core:5.3.0.Beta1

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -49,6 +49,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
 
 
 /**
@@ -245,7 +246,8 @@ class TomcatMetricsTest {
     }
 
     private void checkMbeansAfterRequests(long expectedSentBytes) {
-        assertThat(registry.get("tomcat.global.sent").functionCounter().count()).isEqualTo(expectedSentBytes);
+        await().atMost(5, TimeUnit.SECONDS)
+                .until(() -> registry.get("tomcat.global.sent").functionCounter().count() == expectedSentBytes);
         assertThat(registry.get("tomcat.global.received").functionCounter().count()).isEqualTo(10.0);
         assertThat(registry.get("tomcat.global.error").functionCounter().count()).isEqualTo(1.0);
         assertThat(registry.get("tomcat.global.request").functionTimer().count()).isEqualTo(2.0);


### PR DESCRIPTION
This PR changes to retry a failing assertion in `TomcatMetricsTest` as it fails intermittently. I didn't look into it, but It seems to be possible to be out of sync. It rarely happens, but retrying seems to work.

See https://app.circleci.com/pipelines/github/izeye/micrometer/502/workflows/3b1a35c7-8705-4b05-a14e-53654d39f2a2/jobs/850/steps