### PR TITLE
Update naming convention consistently in StatsdLineBuilders

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -50,17 +50,20 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private void updateIfNamingConventionChanged() {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
-            this.namingConvention = next;
-            this.name = next.name(sanitizeName(id.getName()), id.getType(), id.getBaseUnit()) + ":";
             synchronized (tagsLock) {
+                if (this.namingConvention == next) {
+                    return;
+                }
                 this.tags = HashTreePMap.empty();
                 this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
-                        id.getConventionTags(this.namingConvention).stream()
+                        id.getConventionTags(next).stream()
                                 .map(t -> sanitizeName(t.getKey()) + ":" + sanitizeTagValue(t.getValue()))
                                 .collect(Collectors.joining(","))
                         : null;
             }
+            this.name = next.name(sanitizeName(id.getName()), id.getType(), id.getBaseUnit()) + ":";
             this.tagsNoStat = tags(null, conventionTags, ":", "|#");
+            this.namingConvention = next;
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/EtsyStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/EtsyStatsdLineBuilder.java
@@ -47,9 +47,9 @@ public class EtsyStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private void updateIfNamingConventionChanged() {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
-            this.namingConvention = next;
             this.names = HashTreePMap.empty();
             this.nameNoStat = null;
+            this.namingConvention = next;
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/SysdigStatsdLineBuilder.java
@@ -53,15 +53,15 @@ public class SysdigStatsdLineBuilder extends FlavorStatsdLineBuilder {
     private void updateIfNamingConventionChanged() {
         NamingConvention next = config.namingConvention();
         if (this.namingConvention != next) {
-            this.namingConvention = next;
             this.name = sanitize(next.name(id.getName(), id.getType(), id.getBaseUnit()));
             this.tags = HashTreePMap.empty();
             this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
-                    id.getConventionTags(this.namingConvention).stream()
+                    id.getConventionTags(next).stream()
                             .map(t -> sanitize(t.getKey()) + "=" + sanitize(t.getValue()))
                             .collect(Collectors.joining(","))
                     : null;
             this.tagsNoStat = tags(null, conventionTags, "=", "#");
+            this.namingConvention = next;
         }
     }
 


### PR DESCRIPTION
This PR changes to update naming convention consistently in `StatsdLineBuilder` implementations. For example, with the current implementations, `name` could be `null` if `line()` is accessed concurrently.