### PR TITLE
Fix deadlock in DatadogStatsdLineBuilder

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -75,12 +75,15 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     }
 
     private String tagsByStatistic(@Nullable Statistic stat) {
-        return stat == null ? tagsNoStat : tags.computeIfAbsent(stat, this::ddTag);
-    }
-
-    private String ddTag(@Nullable Statistic stat) {
+        if (stat == null) {
+            return tagsNoStat;
+        }
+        String tags = this.tags.get(stat);
+        if (tags != null) {
+            return tags;
+        }
         synchronized (conventionTagsLock) {
-            return tags(stat, conventionTags, ":", "|#");
+            return this.tags.computeIfAbsent(stat, (key) -> tags(key, conventionTags, ":", "|#"));
         }
     }
 }


### PR DESCRIPTION
This PR fixes deadlock in `DatadogStatsdLineBuilder`.

Closes gh-2100