### PR TITLE
Add level2 cache region name as a tag in HibernateMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
@@ -16,7 +16,6 @@
 package io.micrometer.core.instrument.binder.jpa;
 
 import io.micrometer.core.instrument.FunctionCounter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -148,18 +147,6 @@ public class HibernateMetrics implements MeterBinder {
             .register(registry);
     }
 
-    private void gauge(MeterRegistry registry, String name, String description, ToDoubleFunction<Statistics> f, String... extraTags) {
-        if (this.statistics == null) {
-            return;
-        }
-
-        Gauge.builder(name, statistics, f)
-                .tags(tags)
-                .tags(extraTags)
-                .description(description)
-                .register(registry);
-    }
-
     @Override
     public void bindTo(MeterRegistry registry) {
         if (this.statistics == null) {
@@ -199,12 +186,6 @@ public class HibernateMetrics implements MeterBinder {
                             stats -> stats.getSecondLevelCacheStatistics(regionName).getMissCount(), "region", regionName, "result", "miss");
                     counter(registry, "hibernate.second.level.cache.puts", "The number of cacheable entities/collections put in the cache",
                             stats -> stats.getSecondLevelCacheStatistics(regionName).getPutCount(), "region", regionName);
-                    gauge(registry, "hibernate.second.level.cache.elements", "The number of cacheable entities/collections stored in memory",
-                            stats -> stats.getSecondLevelCacheStatistics(regionName).getElementCountInMemory(), "region", regionName, "store", "memory");
-                    gauge(registry, "hibernate.second.level.cache.elements", "The number of cacheable entities/collections stored on disk",
-                            stats -> stats.getSecondLevelCacheStatistics(regionName).getElementCountOnDisk(), "region", regionName, "store", "disk");
-                    gauge(registry, "hibernate.second.level.cache.size", "The size in bytes of cacheable entities/collections stored in memory",
-                            stats -> stats.getSecondLevelCacheStatistics(regionName).getSizeInMemory(), "region", regionName, "store", "memory");
                 });
 
         // Entity information

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -99,12 +99,6 @@ class HibernateMetricsTest {
         assertThat(registry.get("hibernate.second.level.cache.requests").tags("result", "miss", "region", "region2").functionCounter().count()).isEqualTo(42.0d);
         assertThat(registry.get("hibernate.second.level.cache.puts").tags("region", "region1").functionCounter().count()).isEqualTo(42.0d);
         assertThat(registry.get("hibernate.second.level.cache.puts").tags("region", "region2").functionCounter().count()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.elements").tags("store", "memory", "region", "region1").gauge().value()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.elements").tags("store", "memory", "region", "region2").gauge().value()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.elements").tags("store", "disk", "region", "region1").gauge().value()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.elements").tags("store", "disk", "region", "region2").gauge().value()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.size").tags("store", "memory", "region", "region1").gauge().value()).isEqualTo(42.0d);
-        assertThat(registry.get("hibernate.second.level.cache.size").tags("store", "memory", "region", "region2").gauge().value()).isEqualTo(42.0d);
 
         assertThat(registry.get("hibernate.entities.deletes").functionCounter().count()).isEqualTo(42.0d);
         assertThat(registry.get("hibernate.entities.fetches").functionCounter().count()).isEqualTo(42.0d);


### PR DESCRIPTION
As suggested in #2097, we can change `HibernateMetrics` so that rather than just exposing counters for the hits/misses/puts of the Level2 cache as a whole, we can drill down into individual cache regions.

This allows us to add the cache region as a tag to each meter, and also allows us to additionally expose the region element count and memory usage.

Noe that in this PR I've removed the existing counters for top-level hits/misses/puts, and added new ones on a per-region basis. This assumes that the top-level count is equal to the sum of the individual regions. I've checked the Hibernate source, and this is indeed the case, e.g. when the hit count is incremented for a region, the top-level counter is also incremented.

Therefore, existing users of these meters will see no change if they ignore the new region tags.

Note that I've targetted the master branch here. I could retarget at 1.5.x if required.

Resolves #2097 