### PR TITLE
Restore meter name suffixes for LongTaskTimer in PrometheusMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -194,11 +194,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     protected io.micrometer.core.instrument.Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
         PrometheusTimer timer = new PrometheusTimer(id, clock, distributionStatisticConfig, pauseDetector, prometheusConfig.histogramFlavor());
-        applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
-
-            addDistributionStatisticSamples(distributionStatisticConfig, collector, timer, tagValues);
-        });
+        applyToCollector(id, (collector) ->
+                addDistributionStatisticSamples(distributionStatisticConfig, collector, timer, tagValues(id), false));
         return timer;
     }
 
@@ -216,16 +213,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
         LongTaskTimer ltt = new CumulativeHistogramLongTaskTimer(id, clock, getBaseTimeUnit(), distributionStatisticConfig);
-        applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
-            collector.add(tagValues, (conventionName, tagKeys) -> Stream.of(new MicrometerCollector.Family(Collector.Type.UNTYPED, conventionName,
-                    new Collector.MetricFamilySamples.Sample(conventionName + "_active_count", tagKeys, tagValues, ltt.activeTasks()),
-                    new Collector.MetricFamilySamples.Sample(conventionName + "_duration_sum", tagKeys, tagValues, ltt.duration(getBaseTimeUnit())),
-            new Collector.MetricFamilySamples.Sample(conventionName + "_max", tagKeys, tagValues, ltt.max(getBaseTimeUnit()))
-            )));
-
-            addDistributionStatisticSamples(distributionStatisticConfig, collector, ltt, tagValues);
-        });
+        applyToCollector(id, (collector) ->
+                addDistributionStatisticSamples(distributionStatisticConfig, collector, ltt, tagValues(id), true));
         return ltt;
     }
 
@@ -322,7 +311,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private void addDistributionStatisticSamples(DistributionStatisticConfig distributionStatisticConfig, MicrometerCollector collector,
-                                                 HistogramSupport histogramSupport, List<String> tagValues) {
+                                                 HistogramSupport histogramSupport, List<String> tagValues, boolean forLongTaskTimer) {
         collector.add(tagValues, (conventionName, tagKeys) -> {
             Stream.Builder<Collector.MetricFamilySamples.Sample> samples = Stream.builder();
 
@@ -387,10 +376,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             samples.add(new Collector.MetricFamilySamples.Sample(
-                    conventionName + "_count", tagKeys, tagValues, count));
+                    conventionName + (forLongTaskTimer ? "_active_count" : "_count"), tagKeys, tagValues, count));
 
             samples.add(new Collector.MetricFamilySamples.Sample(
-                    conventionName + "_sum", tagKeys, tagValues, histogramSnapshot.total(TimeUnit.SECONDS)));
+                    conventionName + (forLongTaskTimer ? "_duration_sum" : "_sum"), tagKeys, tagValues, histogramSnapshot.total(TimeUnit.SECONDS)));
 
             return Stream.of(new MicrometerCollector.Family(type, conventionName, samples.build()),
                     new MicrometerCollector.Family(Collector.Type.GAUGE, conventionName + "_max", Stream.of(

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -442,4 +442,14 @@ class PrometheusMeterRegistryTest {
         HistogramSnapshot histogramSnapshot = timer.takeSnapshot();
         assertThat(histogramSnapshot.total(TimeUnit.SECONDS)).isEqualTo(1);
     }
+
+    @Test
+    void scrapeWithLongTaskTimer() {
+        LongTaskTimer.builder("my.long.task.timer").register(registry);
+        assertThat(registry.scrape())
+                .contains("my_long_task_timer_duration_seconds_max")
+                .contains("my_long_task_timer_duration_seconds_active_count")
+                .contains("my_long_task_timer_duration_seconds_duration_sum");
+    }
+
 }


### PR DESCRIPTION
Since 9fa83e3d3638edf725aa5d803ae0b52b9017456f, meter name suffixes have been changed from `_active_count` and `_duration_sum` to `_count` and `_sum`.

This PR restores the previous meter name suffixes for `LongTaskTimer` in `PrometheusMeterRegistry`.

Note that `collector.add()` actually replaces the previously added one.