### PR TITLE
Register NotificationListener unconditionally in CommonsObjectPool2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/BaseUnits.java
@@ -92,6 +92,12 @@ public final class BaseUnits {
      */
     public static final String PERCENT = "percent";
 
+    /**
+     * For objects.
+     * @since 1.6.0
+     */
+    public static final String OBJECTS = "objects";
+
     private BaseUnits() {
     }
 


### PR DESCRIPTION
This PR changes to register `NotificationListener` unconditionally in `CommonsObjectPool2Metrics` as it seems to intend to do so based on the Javadoc.

This PR also polishes it along the way.