### PR TITLE
Add reason parameter to meter registration failure listener

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -66,7 +66,7 @@ class PrometheusMeterRegistryTest {
     @Test
     void meterRegistrationFailedListenerCalledOnSameNameDifferentTags() throws InterruptedException {
         CountDownLatch failedLatch = new CountDownLatch(1);
-        registry.config().onMeterRegistrationFailed(id -> failedLatch.countDown());
+        registry.config().onMeterRegistrationFailed((id, reason) -> failedLatch.countDown());
         registry.counter("my.counter");
         registry.counter("my.counter", "k", "v").increment();
 


### PR DESCRIPTION
This PR adds a reason parameter to meter registration failure listener as failures can vary theoretically, and it's useful to know the reason for listener writers.