### PR TITLE
Polish timer builder changes

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
@@ -22,8 +22,16 @@ import io.micrometer.core.lang.Nullable;
 import java.time.Duration;
 import java.util.Arrays;
 
+/**
+ * Base builder for {@link Timer}.
+ *
+ * @param <B> builder type
+ *
+ * @author Jon Schneider
+ * @since 1.6.0
+ */
 @SuppressWarnings("unchecked")
-public class AbstractTimerBuilder<B extends AbstractTimerBuilder<B>> {
+public abstract class AbstractTimerBuilder<B extends AbstractTimerBuilder<B>> {
     protected final String name;
     protected Tags tags = Tags.empty();
     protected final DistributionStatisticConfig.Builder distributionConfigBuilder;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -20,7 +20,6 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
-import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -310,81 +309,6 @@ public interface Timer extends Meter, HistogramSupport {
     class Builder extends AbstractTimerBuilder<Builder> {
         Builder(String name) {
             super(name);
-        }
-
-        @Override
-        public Builder tags(String... tags) {
-            return super.tags(tags);
-        }
-
-        @Override
-        public Builder tags(Iterable<Tag> tags) {
-            return super.tags(tags);
-        }
-
-        @Override
-        public Builder tag(String key, String value) {
-            return super.tag(key, value);
-        }
-
-        @Override
-        public Builder publishPercentiles(double... percentiles) {
-            return super.publishPercentiles(percentiles);
-        }
-
-        @Override
-        public Builder percentilePrecision(Integer digitsOfPrecision) {
-            return super.percentilePrecision(digitsOfPrecision);
-        }
-
-        @Override
-        public Builder publishPercentileHistogram() {
-            return super.publishPercentileHistogram();
-        }
-
-        @Override
-        public Builder publishPercentileHistogram(Boolean enabled) {
-            return super.publishPercentileHistogram(enabled);
-        }
-
-        @Override
-        public Builder sla(Duration... sla) {
-            return super.sla(sla);
-        }
-
-        @Override
-        public Builder serviceLevelObjectives(Duration... slos) {
-            return super.serviceLevelObjectives(slos);
-        }
-
-        @Override
-        public Builder minimumExpectedValue(Duration min) {
-            return super.minimumExpectedValue(min);
-        }
-
-        @Override
-        public Builder maximumExpectedValue(Duration max) {
-            return super.maximumExpectedValue(max);
-        }
-
-        @Override
-        public Builder distributionStatisticExpiry(Duration expiry) {
-            return super.distributionStatisticExpiry(expiry);
-        }
-
-        @Override
-        public Builder distributionStatisticBufferLength(Integer bufferLength) {
-            return super.distributionStatisticBufferLength(bufferLength);
-        }
-
-        @Override
-        public Builder pauseDetector(PauseDetector pauseDetector) {
-            return super.pauseDetector(pauseDetector);
-        }
-
-        @Override
-        public Builder description(String description) {
-            return super.description(description);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -20,6 +20,7 @@ import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -309,6 +310,82 @@ public interface Timer extends Meter, HistogramSupport {
     class Builder extends AbstractTimerBuilder<Builder> {
         Builder(String name) {
             super(name);
+        }
+
+        @Override
+        public Builder tags(String... tags) {
+            return super.tags(tags);
+        }
+
+        @Override
+        public Builder tags(Iterable<Tag> tags) {
+            return super.tags(tags);
+        }
+
+        @Override
+        public Builder tag(String key, String value) {
+            return super.tag(key, value);
+        }
+
+        @Override
+        public Builder publishPercentiles(double... percentiles) {
+            return super.publishPercentiles(percentiles);
+        }
+
+        @Override
+        public Builder percentilePrecision(Integer digitsOfPrecision) {
+            return super.percentilePrecision(digitsOfPrecision);
+        }
+
+        @Override
+        public Builder publishPercentileHistogram() {
+            return super.publishPercentileHistogram();
+        }
+
+        @Override
+        public Builder publishPercentileHistogram(Boolean enabled) {
+            return super.publishPercentileHistogram(enabled);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        public Builder sla(Duration... sla) {
+            return super.sla(sla);
+        }
+
+        @Override
+        public Builder serviceLevelObjectives(Duration... slos) {
+            return super.serviceLevelObjectives(slos);
+        }
+
+        @Override
+        public Builder minimumExpectedValue(Duration min) {
+            return super.minimumExpectedValue(min);
+        }
+
+        @Override
+        public Builder maximumExpectedValue(Duration max) {
+            return super.maximumExpectedValue(max);
+        }
+
+        @Override
+        public Builder distributionStatisticExpiry(Duration expiry) {
+            return super.distributionStatisticExpiry(expiry);
+        }
+
+        @Override
+        public Builder distributionStatisticBufferLength(Integer bufferLength) {
+            return super.distributionStatisticBufferLength(bufferLength);
+        }
+
+        @Override
+        public Builder pauseDetector(PauseDetector pauseDetector) {
+            return super.pauseDetector(pauseDetector);
+        }
+
+        @Override
+        public Builder description(String description) {
+            return super.description(description);
         }
 
         /**

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/TimerTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/TimerTest.java
@@ -68,13 +68,12 @@ interface TimerTest {
                 .isEqualTo(1);
     }
 
-    @DisplayName("record callables")
+    @DisplayName("record callable")
     @Test
-    default void recordThrowable() {
+    default void recordCallable() throws Exception {
         MeterRegistry registry = new SimpleMeterRegistry();
 
-        Supplier<String> timed = () -> registry.timer("timer").record(() -> "");
-        timed.get();
+        registry.timer("timer").recordCallable(() -> "");
     }
 
     @Test


### PR DESCRIPTION
This PR polishes timer builder changes.

> - Is the name `Timer.ResourceSample` as bad as I feel it is?

While doing this, I was wondering if `Timer.AutoCloseableSample` or `Timer.AutoCloseableBuilder` might be easier to understand. I didn't do so as I wasn't sure.