### PR TITLE
Fix NPE in MongoMetricsConnectionPoolListener.registerGauge()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
@@ -116,8 +116,9 @@ public class MongoMetricsConnectionPoolListener extends ConnectionPoolListenerAd
     }
 
     private Gauge registerGauge(ServerId serverId, String metricName, String description, Map<ServerId, AtomicInteger> metrics) {
-        metrics.put(serverId, new AtomicInteger());
-        return Gauge.builder(metricName, metrics, m -> m.get(serverId).doubleValue())
+        AtomicInteger value = new AtomicInteger();
+        metrics.put(serverId, value);
+        return Gauge.builder(metricName, value, AtomicInteger::doubleValue)
                     .description(description)
                     .tag("cluster.id", serverId.getClusterId().getValue())
                     .tag("server.address", serverId.getAddress().toString())


### PR DESCRIPTION
This PR fixes a posssible NPE in `MongoMetricsConnectionPoolListener.registerGauge()`.

Closes gh-2117