### PR TITLE
Prevent StringIndexOutOfBoundsException in Datadog statsD on empty tag value

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -75,6 +75,9 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     }
 
     private String sanitizeTagValue(String value) {
+        if (value.isEmpty()) {
+            return value;
+        }
         return (value.charAt(value.length() - 1) == ':') ? value.substring(0, value.length() - 1) + '_' : value;
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -18,6 +18,7 @@ package io.micrometer.statsd.internal;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.lang.Nullable;
 import org.pcollections.HashTreePMap;
@@ -57,7 +58,7 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
                 this.tags = HashTreePMap.empty();
                 this.conventionTags = id.getTagsAsIterable().iterator().hasNext() ?
                         id.getConventionTags(next).stream()
-                                .map(t -> sanitizeName(t.getKey()) + ":" + sanitizeTagValue(t.getValue()))
+                                .map(t -> formatTag(t))
                                 .collect(Collectors.joining(","))
                         : null;
             }
@@ -65,6 +66,14 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
             this.tagsNoStat = tags(null, conventionTags, ":", "|#");
             this.namingConvention = next;
         }
+    }
+
+    private String formatTag(Tag t) {
+        String sanitizedTag = sanitizeName(t.getKey());
+        if (!t.getValue().isEmpty()) {
+            sanitizedTag += ":" + sanitizeTagValue(t.getValue());
+        }
+        return sanitizedTag;
     }
 
     private String sanitizeName(String value) {
@@ -75,9 +84,6 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     }
 
     private String sanitizeTagValue(String value) {
-        if (value.isEmpty()) {
-            return value;
-        }
         return (value.charAt(value.length() - 1) == ':') ? value.substring(0, value.length() - 1) + '_' : value;
     }
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
@@ -50,6 +50,15 @@ class DatadogStatsdLineBuilderTest {
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag:my_value");
     }
 
+    @Test
+    void allowEmptyTagValues() {
+        Counter c = registry.counter("my:counter", "my:tag", "");
+        DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(c.getId(), registry.config());
+
+        registry.config().namingConvention(NamingConvention.dot);
+        assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag:");
+    }
+
     @Issue("#1998")
     @Test
     void allowColonsInTagValues() {

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
@@ -51,12 +51,12 @@ class DatadogStatsdLineBuilderTest {
     }
 
     @Test
-    void allowEmptyTagValues() {
+    void interpretEmptyTagValuesAsValuelessTags() {
         Counter c = registry.counter("my:counter", "my:tag", "");
         DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(c.getId(), registry.config());
 
         registry.config().namingConvention(NamingConvention.dot);
-        assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag:");
+        assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag");
     }
 
     @Issue("#1998")


### PR DESCRIPTION

I'm unsure if this is the best approach. For example I noticed that on empty tag value InfluxDB seems to drop the tag.
Given guidance on the right approach, I'm happy to modify the PR.