### PR TITLE
Clean up listeners for unregistration notification early in KafkaConsumerMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -291,14 +291,26 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
         NotificationFilter registrationFilter = createNotificationFilter(type,
                 MBeanServerNotification.REGISTRATION_NOTIFICATION);
         addNotificationListener(registrationListener, registrationFilter);
+        notificationListenerCleanUpRunnables.add(() -> removeNotificationListener(registrationListener));
+    }
+
+    private void removeNotificationListener(NotificationListener notificationListener) {
+        try {
+            mBeanServer.removeNotificationListener(MBeanServerDelegate.DELEGATE_NAME, notificationListener);
+        } catch (InstanceNotFoundException | ListenerNotFoundException ignored) {
+        }
     }
 
     private void addUnregistrationListener(MeterRegistry registry, String type, ObjectName o, List<Meter> meters) {
-        NotificationListener unregistrationListener = (notification2, handback2) -> {
-            MBeanServerNotification mbs2 = (MBeanServerNotification) notification2;
-            ObjectName o2 = mbs2.getMBeanName();
-            if (o2.equals(o)) {
-                meters.stream().forEach(registry::remove);
+        NotificationListener unregistrationListener = new NotificationListener() {
+            @Override
+            public void handleNotification(Notification notification2, Object handback2) {
+                MBeanServerNotification mbs2 = (MBeanServerNotification) notification2;
+                ObjectName o2 = mbs2.getMBeanName();
+                if (o2.equals(o)) {
+                    meters.stream().forEach(registry::remove);
+                }
+                removeNotificationListener(this);
             }
         };
         NotificationFilter unregistrationFilter = createNotificationFilter(type,
@@ -319,12 +331,6 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
     private void addNotificationListener(NotificationListener listener, NotificationFilter filter) {
         try {
             mBeanServer.addNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
-            notificationListenerCleanUpRunnables.add(() -> {
-                try {
-                    mBeanServer.removeNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener);
-                } catch (InstanceNotFoundException | ListenerNotFoundException ignored) {
-                }
-            });
         } catch (InstanceNotFoundException e) {
             throw new RuntimeException("Error registering Kafka MBean listener", e);
         }


### PR DESCRIPTION
This PR changes to clean up listeners for unregistration notification early in `KafkaConsumerMetrics` as they seem to be retained longer than necessary.

Closes gh-2096