### PR TITLE
Reduce flakiness in NewRelicMeterRegistryTest

### DIFF
--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -62,26 +62,22 @@ class NewRelicMeterRegistryTest {
 
     @Test
     void writeGauge() {
-        registry.gauge("my.gauge", 1d);
-        Gauge gauge = registry.find("my.gauge").gauge();
+        Gauge gauge = Gauge.builder("my.gauge", () -> 1d).register(registry);
         assertThat(registry.writeGauge(gauge)).hasSize(1);
     }
 
     @Test
     void writeGaugeShouldDropNanValue() {
-        registry.gauge("my.gauge", Double.NaN);
-        Gauge gauge = registry.find("my.gauge").gauge();
+        Gauge gauge = Gauge.builder("my.gauge", () -> Double.NaN).register(registry);
         assertThat(registry.writeGauge(gauge)).isEmpty();
     }
 
     @Test
     void writeGaugeShouldDropInfiniteValues() {
-        registry.gauge("my.gauge", Double.POSITIVE_INFINITY);
-        Gauge gauge = registry.find("my.gauge").gauge();
+        Gauge gauge = Gauge.builder("my.gauge", () -> Double.POSITIVE_INFINITY).register(registry);
         assertThat(registry.writeGauge(gauge)).isEmpty();
 
-        registry.gauge("my.gauge", Double.NEGATIVE_INFINITY);
-        gauge = registry.find("my.gauge").gauge();
+        gauge = Gauge.builder("my.gauge", () -> Double.NEGATIVE_INFINITY).register(registry);
         assertThat(registry.writeGauge(gauge)).isEmpty();
     }
 


### PR DESCRIPTION
`NewRelicMeterRegistryTest.writeGauge()` could fail due to GC as follows:

```
java.lang.AssertionError: 
Expected size:<1> but was:<0> in:
<[]>

	at io.micrometer.newrelic.NewRelicMeterRegistryTest.writeGauge(NewRelicMeterRegistryTest.java:68)
```

This PR changes to use a strong reference for gauges.