### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -135,7 +135,7 @@ public abstract class MeterRegistry {
      *
      * @param id The id that uniquely identifies the long task timer.
      * @return A new long task timer.
-     * @deprecated Implement {@link #newLongTaskTimer(Id, DistributionStatisticConfig)} instead.
+     * @deprecated Implement {@link #newLongTaskTimer(Meter.Id, DistributionStatisticConfig)} instead.
      */
     @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.internal;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
@@ -53,7 +54,7 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
      *
      * @param id ID
      * @param clock clock
-     * @deprecated Use {@link #DefaultLongTaskTimer(Id, Clock, TimeUnit, DistributionStatisticConfig, boolean)} instead.
+     * @deprecated Use {@link #DefaultLongTaskTimer(Meter.Id, Clock, TimeUnit, DistributionStatisticConfig, boolean)} instead.
      */
     @Deprecated
     public DefaultLongTaskTimer(Id id, Clock clock) {


### PR DESCRIPTION
This PR fixes the following Javadoc warnings:

```
> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java:59: warning - Tag @link: can't find DefaultLongTaskTimer(Id, Clock, TimeUnit, DistributionStatisticConfig, boolean) in io.micrometer.core.instrument.internal.DefaultLongTaskTimer
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java:142: warning - Tag @link: can't find newLongTaskTimer(Id, DistributionStatisticConfig) in io.micrometer.core.instrument.MeterRegistry
2 warnings
```

For the record, this happens with JDK 8, but it doesn't happen with JDK 11 or JDK 14.