### PR TITLE
Apply Test Retry Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:3.4.0'
         classpath "io.spring.nohttp:nohttp-gradle:0.0.4.RELEASE"
+        classpath "org.gradle:test-retry-gradle-plugin:1.1.6"
 
         constraints {
             classpath('org.ow2.asm:asm:7.3.1') {
@@ -49,6 +50,7 @@ subprojects {
         }
         apply plugin: 'checkstyle'
         apply plugin: 'io.spring.nohttp'
+        apply plugin: 'org.gradle.test-retry'
 
         java {
             // It is more idiomatic to define different features for different sets of optional
@@ -98,6 +100,11 @@ subprojects {
 
             useJUnitPlatform {
                 excludeTags 'docker'
+            }
+
+            retry {
+                maxFailures = 5
+                maxRetries = 3
             }
         }
 


### PR DESCRIPTION
I see the following test failures intermittently in my local environment:

```
StatsdMeterRegistryPublishTest > [2] TCP FAILED
    reactor.netty.ChannelBindException: Failed to bind on [localhost:60590]

StatsdMeterRegistryPublishTest > [1] UDP FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <false>
    to be equal to:
     <true>
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at io.micrometer.statsd.StatsdMeterRegistryPublishTest.whenBackendInitiallyDown_metricsSentAfterBackendStarts(StatsdMeterRegistryPublishTest.java:208)
```

I'm not sure how those failures could be resolved at the moment, so applying the Test Retry Gradle plugin seems to be useful here.