### PR TITLE
Use wiremock-jre8-standalone

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ def VERSIONS = [
         'com.fasterxml.jackson.core:jackson-databind:latest.release',
         'com.github.ben-manes.caffeine:caffeine:latest.release',
         'com.github.charithe:kafka-junit:latest.release',
-        'com.github.tomakehurst:wiremock-jre8:latest.release',
+        'com.github.tomakehurst:wiremock-jre8-standalone:latest.release',
         'com.google.cloud:google-cloud-monitoring:latest.release',
         'com.google.dagger:dagger:2.11',
         'com.google.dagger:dagger-compiler:2.11',

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     testImplementation 'ru.lanwen.wiremock:wiremock-junit5', {
         exclude group: 'com.github.tomakehurst', module: 'wiremock'
     }
-    testImplementation 'com.github.tomakehurst:wiremock-jre8'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
 
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
 

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     api 'ru.lanwen.wiremock:wiremock-junit5', {
         exclude group: 'com.github.tomakehurst', module: 'wiremock'
     }
-    api 'com.github.tomakehurst:wiremock-jre8'
+    api 'com.github.tomakehurst:wiremock-jre8-standalone'
     api 'org.mockito:mockito-core'
     api 'org.testcontainers:testcontainers'
     api 'org.testcontainers:junit-jupiter'


### PR DESCRIPTION
`com.github.tomakehurst:wiremock-jre8:2.26.3` is not compatible with `org.eclipse.jetty:jetty-server:9.4.30.v20200611`, so a build on the current master is failing.

This PR changes to use `wiremock-jre8-standalone` to avoid the incompatibility.

See https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/616/workflows/ea738f75-fed7-45f7-aa89-ab5299392064/jobs/7044/steps