### PR TITLE
Newline character not allowed in tag values

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -217,7 +217,7 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
     private String influxLineProtocol(Meter.Id id, String metricType, Stream<Field> fields) {
         String tags = getConventionTags(id).stream()
                 .filter(t -> StringUtils.isNotBlank(t.getValue()))
-                .map(t -> "," + t.getKey() + "=" + t.getValue())
+                .map(t -> "," + t.getKey() + "=" + t.getValue().replaceAll("\n", " "))
                 .collect(joining(""));
 
         return getConventionName(id)


### PR DESCRIPTION
Influxdb's line protocol explicitly states it does not support newline character in tag values (see beginning of https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_reference) however they are not handled and if present cause the batch to failed and continuously retry.  The proposed change simply replace newlines with whitespaces.