### PR TITLE
Ensure to use single JooqExecuteListener

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/MetricsDSLContextTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/db/MetricsDSLContextTest.java
@@ -191,9 +191,15 @@ class MetricsDSLContextTest {
         ExecuteListener userExecuteListener = mock(ExecuteListener.class);
         Configuration configuration = new DefaultConfiguration().set(() -> userExecuteListener);
 
-        MetricsDSLContext context = withMetrics(using(configuration), meterRegistry, Tags.empty());
+        MetricsDSLContext jooq = withMetrics(using(configuration), meterRegistry, Tags.empty());
 
-        ExecuteListenerProvider[] executeListenerProviders = context.configuration().executeListenerProviders();
+        ExecuteListenerProvider[] executeListenerProviders = jooq.configuration().executeListenerProviders();
+        assertThat(executeListenerProviders).hasSize(2);
+        assertThat(executeListenerProviders[0].provide()).isSameAs(userExecuteListener);
+        assertThat(executeListenerProviders[1].provide()).isInstanceOf(JooqExecuteListener.class);
+
+        SelectSelectStep<Record> select = jooq.tag("name", "selectAllAuthors").select(asterisk());
+        executeListenerProviders = select.configuration().executeListenerProviders();
         assertThat(executeListenerProviders).hasSize(2);
         assertThat(executeListenerProviders[0].provide()).isSameAs(userExecuteListener);
         assertThat(executeListenerProviders[1].provide()).isInstanceOf(JooqExecuteListener.class);


### PR DESCRIPTION
This PR changes to ensure to use single `JooqExecuteListener`.

See gh-2158