### PR TITLE
Add expected min/max Double variants for compatibility

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -251,6 +251,18 @@ public interface DistributionSummary extends Meter, HistogramSupport {
         }
 
         /**
+         * Sets the minimum value that this distribution summary is expected to observe. Sets a lower bound
+         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+         *
+         * @param min The minimum value that this distribution summary is expected to observe.
+         * @return This builder.
+         */
+        public Builder minimumExpectedValue(@Nullable Double min) {
+            this.distributionConfigBuilder.minimumExpectedValue(min);
+            return this;
+        }
+
+        /**
          * Sets the maximum value that this distribution summary is expected to observe. Sets an upper bound
          * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
          *
@@ -258,6 +270,18 @@ public interface DistributionSummary extends Meter, HistogramSupport {
          * @return This builder.
          */
         public Builder maximumExpectedValue(@Nullable Long max) {
+            this.distributionConfigBuilder.maximumExpectedValue(max);
+            return this;
+        }
+
+        /**
+         * Sets the maximum value that this distribution summary is expected to observe. Sets an upper bound
+         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+         *
+         * @param max The maximum value that this distribution summary is expected to observe.
+         * @return This builder.
+         */
+        public Builder maximumExpectedValue(@Nullable Double max) {
             this.distributionConfigBuilder.maximumExpectedValue(max);
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -320,6 +320,18 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
         }
 
         /**
+         * The minimum value that the meter is expected to observe. Sets a lower bound
+         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+         *
+         * @param min The minimum value that this distribution summary is expected to observe.
+         * @return This builder.
+         */
+        public Builder minimumExpectedValue(@Nullable Double min) {
+            config.minimumExpectedValue = min == null ? null : min.longValue();
+            return this;
+        }
+
+        /**
          * The maximum value that the meter is expected to observe. Sets an upper bound
          * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
          *
@@ -328,6 +340,18 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
          */
         public Builder maximumExpectedValue(@Nullable Long max) {
             config.maximumExpectedValue = max;
+            return this;
+        }
+
+        /**
+         * The maximum value that the meter is expected to observe. Sets an upper bound
+         * on histogram buckets that are shipped to monitoring systems that support aggregable percentile approximations.
+         *
+         * @param max The maximum value that the meter is expected to observe.
+         * @return This builder.
+         */
+        public Builder maximumExpectedValue(@Nullable Double max) {
+            config.maximumExpectedValue = max == null ? null : max.longValue();
             return this;
         }
 


### PR DESCRIPTION
For libraries using Micrometer that compile against 1.5.x but support 1.3.x at runtime, these missing methods caused NoSuchMethodErrors. This adds these so at least the next patch version of 1.3.x can be supported.

Resolves #2123

@imasahiro @minwoox @anuraaga Please take a look and let us know if this finally fixes all of the incompatibilities (hopefully).