### PR TITLE
Attach missed @Nullable to ElasticConfig

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -45,6 +45,7 @@ public interface ElasticConfig extends StepRegistryConfig {
      * @param key Key to look up in the config.
      * @return Value for the key or null if no key is present.
      */
+    @Nullable
     String get(String key);
 
     /**


### PR DESCRIPTION
As its Javadoc, `io.micrometer.elastic.ElasticConfig#get(String)` could return `null`.
But, `@Nonnull` was attached to it in 3e1b71d62256f45fcf01f56ad5ab310586277358.