### PR TITLE
Use implicit default values for volatile fields

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -119,7 +119,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     @Nullable
     private volatile Integer majorVersion;
 
-    private volatile boolean checkedForIndexTemplate = false;
+    private volatile boolean checkedForIndexTemplate;
 
     @SuppressWarnings("deprecation")
     public ElasticMeterRegistry(ElasticConfig config, Clock clock) {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
@@ -29,7 +29,7 @@ public class StatsdCounter extends AbstractMeter implements Counter {
     private final StatsdLineBuilder lineBuilder;
     private final FluxSink<String> sink;
     private DoubleAdder count = new DoubleAdder();
-    private volatile boolean shutdown = false;
+    private volatile boolean shutdown;
 
     StatsdCounter(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink) {
         super(id);

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
@@ -33,7 +33,7 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
     private final TimeWindowMax max;
     private final StatsdLineBuilder lineBuilder;
     private final FluxSink<String> sink;
-    private volatile boolean shutdown = false;
+    private volatile boolean shutdown;
 
     StatsdDistributionSummary(Meter.Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock,
                               DistributionStatisticConfig distributionStatisticConfig, double scale) {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
@@ -33,7 +33,7 @@ public class StatsdTimer extends AbstractTimer {
     private final StatsdLineBuilder lineBuilder;
     private final FluxSink<String> sink;
     private StepDouble max;
-    private volatile boolean shutdown = false;
+    private volatile boolean shutdown;
 
     StatsdTimer(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock,
                 DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepMillis) {

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -56,7 +56,7 @@ class StatsdMeterRegistryPublishTest {
     DisposableChannel server;
     CountDownLatch serverLatch;
 
-    volatile boolean bound = false;
+    volatile boolean bound;
 
     @AfterEach
     void cleanUp() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeFunctionTimer.java
@@ -38,8 +38,8 @@ public class CumulativeFunctionTimer<T> implements FunctionTimer {
     private final TimeUnit totalTimeFunctionUnit;
     private final TimeUnit baseTimeUnit;
 
-    private volatile long lastCount = 0;
-    private volatile double lastTime = 0.0;
+    private volatile long lastCount;
+    private volatile double lastTime;
 
     public CumulativeFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction,
                                    TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
@@ -40,7 +40,7 @@ public class TimeWindowMax {
     private volatile long lastRotateTimestampMillis;
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private volatile int rotating = 0; // 0 - not rotating, 1 - rotating
+    private volatile int rotating; // 0 - not rotating, 1 - rotating
 
     @SuppressWarnings("ConstantConditions")
     public TimeWindowMax(Clock clock, DistributionStatisticConfig config) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowSum.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowSum.java
@@ -35,7 +35,7 @@ public class TimeWindowSum {
     private volatile long lastRotateTimestampMillis;
 
     @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private volatile int rotating = 0; // 0 - not rotating, 1 - rotating
+    private volatile int rotating; // 0 - not rotating, 1 - rotating
 
     public TimeWindowSum(int bufferLength, Duration expiry) {
         this.durationBetweenRotatesMillis = expiry.toMillis();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
@@ -46,7 +46,7 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
     private final DropwizardRate rate;
     private final Timer dropwizardMeter;
     private final TimeUnit registryBaseTimeUnit;
-    private volatile double lastTime = 0.0;
+    private volatile double lastTime;
 
     DropwizardFunctionTimer(Meter.Id id, Clock clock,
                             T obj, ToLongFunction<T> countFunction,

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -220,7 +220,7 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
 
     class SampleImpl extends Sample {
         private final long startTime;
-        private volatile boolean stopped = false;
+        private volatile boolean stopped;
 
         private SampleImpl() {
             this.startTime = clock.monotonicTime();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -43,8 +43,8 @@ public class StepFunctionTimer<T> implements FunctionTimer {
     private final Clock clock;
     private volatile long lastUpdateTime = (long) (-2e6);
 
-    private volatile long lastCount = 0;
-    private volatile double lastTime = 0.0;
+    private volatile long lastCount;
+    private volatile double lastTime;
 
     private final LongAdder count = new LongAdder();
     private final DoubleAdder total = new DoubleAdder();


### PR DESCRIPTION
This PR changes to use implicit default values for `volatile` fields as it's better than having explicit default values in perspective of performance.

See https://github.com/spring-projects/spring-framework/pull/25261