### PR TITLE
Add additional methods to DatadogMeterRegistry to allow sending events.

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogEvent.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogEvent.java
@@ -1,0 +1,265 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.datadog;
+
+import java.time.Instant;
+import java.util.List;
+
+public class DatadogEvent {
+    String aggregationKey;
+    String alertType;
+    Instant dateHappened = Instant.now();
+    List<String> deviceName;
+    String host;
+    String priority;
+    Long relatedEventId;
+    String sourceTypeName = "SYSTEM";
+    List<String> tags;
+    String title;
+    String text;
+
+    public DatadogEvent() {
+    }
+
+    public String getAggregationKey() {
+        return this.aggregationKey;
+    }
+
+    public String getAlertType() {
+        return this.alertType;
+    }
+
+    public Instant getDateHappened() {
+        return this.dateHappened;
+    }
+
+    public List<String> getDeviceName() {
+        return this.deviceName;
+    }
+
+    public String getHost() {
+        return this.host;
+    }
+
+    public String getPriority() {
+        return this.priority;
+    }
+
+    public Long getRelatedEventId() {
+        return this.relatedEventId;
+    }
+
+    public String getSourceTypeName() {
+        return this.sourceTypeName;
+    }
+
+    public List<String> getTags() {
+        return this.tags;
+    }
+
+    public String getTitle() {
+        return this.title;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public void setAggregationKey(String aggregationKey) {
+        this.aggregationKey = aggregationKey;
+    }
+
+    public void setAlertType(String alertType) {
+        this.alertType = alertType;
+    }
+
+    public void setDateHappened(Instant dateHappened) {
+        this.dateHappened = dateHappened;
+    }
+
+    public void setDeviceName(List<String> deviceName) {
+        this.deviceName = deviceName;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public void setPriority(String priority) {
+        this.priority = priority;
+    }
+
+    public void setRelatedEventId(Long relatedEventId) {
+        this.relatedEventId = relatedEventId;
+    }
+
+    public void setSourceTypeName(String sourceTypeName) {
+        this.sourceTypeName = sourceTypeName;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (!(o instanceof DatadogEvent)) {
+            return false;
+        }
+        final DatadogEvent other = (DatadogEvent)o;
+        if (!other.canEqual((Object)this)) {
+            return false;
+        }
+        final Object this$aggregationKey = this.getAggregationKey();
+        final Object other$aggregationKey = other.getAggregationKey();
+        if (this$aggregationKey == null
+                ? other$aggregationKey != null
+                : !this$aggregationKey.equals(other$aggregationKey)) {
+            return false;
+        }
+        final Object this$alertType = this.getAlertType();
+        final Object other$alertType = other.getAlertType();
+        if (this$alertType == null
+                ? other$alertType != null
+                : !this$alertType.equals(other$alertType)) {
+            return false;
+        }
+        final Object this$dateHappened = this.getDateHappened();
+        final Object other$dateHappened = other.getDateHappened();
+        if (this$dateHappened == null
+                ? other$dateHappened != null
+                : !this$dateHappened.equals(other$dateHappened)) {
+            return false;
+        }
+        final Object this$deviceName = this.getDeviceName();
+        final Object other$deviceName = other.getDeviceName();
+        if (this$deviceName == null
+                ? other$deviceName != null
+                : !this$deviceName.equals(other$deviceName)) {
+            return false;
+        }
+        final Object this$host = this.getHost();
+        final Object other$host = other.getHost();
+        if (this$host == null ? other$host != null : !this$host.equals(other$host)) {
+            return false;
+        }
+        final Object this$priority = this.getPriority();
+        final Object other$priority = other.getPriority();
+        if (this$priority == null
+                ? other$priority != null
+                : !this$priority.equals(other$priority)) {
+            return false;
+        }
+        final Object this$relatedEventId = this.getRelatedEventId();
+        final Object other$relatedEventId = other.getRelatedEventId();
+        if (this$relatedEventId == null
+                ? other$relatedEventId != null
+                : !this$relatedEventId.equals(other$relatedEventId)) {
+            return false;
+        }
+        final Object this$sourceTypeName = this.getSourceTypeName();
+        final Object other$sourceTypeName = other.getSourceTypeName();
+        if (this$sourceTypeName == null
+                ? other$sourceTypeName != null
+                : !this$sourceTypeName.equals(other$sourceTypeName)) {
+            return false;
+        }
+        final Object this$tags = this.getTags();
+        final Object other$tags = other.getTags();
+        if (this$tags == null ? other$tags != null : !this$tags.equals(other$tags)) {
+            return false;
+        }
+        final Object this$title = this.getTitle();
+        final Object other$title = other.getTitle();
+        if (this$title == null ? other$title != null : !this$title.equals(other$title)) {
+            return false;
+        }
+        final Object this$text = this.getText();
+        final Object other$text = other.getText();
+        if (this$text == null ? other$text != null : !this$text.equals(other$text)) {
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof DatadogEvent;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $aggregationKey = this.getAggregationKey();
+        result = result * PRIME + ($aggregationKey == null ? 43 : $aggregationKey.hashCode());
+        final Object $alertType = this.getAlertType();
+        result = result * PRIME + ($alertType == null ? 43 : $alertType.hashCode());
+        final Object $dateHappened = this.getDateHappened();
+        result = result * PRIME + ($dateHappened == null ? 43 : $dateHappened.hashCode());
+        final Object $deviceName = this.getDeviceName();
+        result = result * PRIME + ($deviceName == null ? 43 : $deviceName.hashCode());
+        final Object $host = this.getHost();
+        result = result * PRIME + ($host == null ? 43 : $host.hashCode());
+        final Object $priority = this.getPriority();
+        result = result * PRIME + ($priority == null ? 43 : $priority.hashCode());
+        final Object $relatedEventId = this.getRelatedEventId();
+        result = result * PRIME + ($relatedEventId == null ? 43 : $relatedEventId.hashCode());
+        final Object $sourceTypeName = this.getSourceTypeName();
+        result = result * PRIME + ($sourceTypeName == null ? 43 : $sourceTypeName.hashCode());
+        final Object $tags = this.getTags();
+        result = result * PRIME + ($tags == null ? 43 : $tags.hashCode());
+        final Object $title = this.getTitle();
+        result = result * PRIME + ($title == null ? 43 : $title.hashCode());
+        final Object $text = this.getText();
+        result = result * PRIME + ($text == null ? 43 : $text.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "DatadogEvent(aggregationKey=" +
+                this.getAggregationKey() +
+                ", alertType=" +
+                this.getAlertType() +
+                ", dateHappened=" +
+                this.getDateHappened() +
+                ", deviceName=" +
+                this.getDeviceName() +
+                ", host=" +
+                this.getHost() +
+                ", priority=" +
+                this.getPriority() +
+                ", relatedEventId=" +
+                this.getRelatedEventId() +
+                ", sourceTypeName=" +
+                this.getSourceTypeName() +
+                ", tags=" +
+                this.getTags() +
+                ", title=" +
+                this.getTitle() +
+                ", text=" +
+                this.getText() +
+                ")";
+    }
+}

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.StringEscapeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import io.micrometer.core.lang.Nullable;
@@ -26,13 +27,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URLEncoder;
+import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.micrometer.core.instrument.util.StringEscapeUtils.escapeJson;
@@ -54,6 +59,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
      * Metric names for which we have posted metadata concerning type and base unit
      */
     private final Set<String> verifiedMetadata = ConcurrentHashMap.newKeySet();
+    private final ConcurrentLinkedQueue<DatadogEvent> eventQueue;
 
     /**
      * @param config Configuration options for the registry that are describable as properties.
@@ -83,6 +89,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
         this.config = config;
         this.httpClient = httpClient;
+        this.eventQueue = new ConcurrentLinkedQueue<>();
 
         start(threadFactory);
     }
@@ -99,6 +106,11 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected void publish() {
+        publishMetrics();
+        publishEvents();
+    }
+
+    private void publishMetrics() {
         Map<String, DatadogMetricMetadata> metadataToSend = new HashMap<>();
 
         String datadogEndpoint = config.uri() + "/api/v1/series?api_key=" + config.apiKey();
@@ -333,5 +345,150 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         public DatadogMeterRegistry build() {
             return new DatadogMeterRegistry(config, clock, threadFactory, httpClient);
         }
+    }
+
+    private void publishEvents() {
+        String uri = config.uri() + "/api/v1/series?api_key=" + config.apiKey();
+        try {
+            DatadogEvent event = eventQueue.poll();
+            while (event != null) {
+                publishEvent(event, uri);
+                event = eventQueue.poll();
+            }
+        } catch (Throwable e) {
+            logger.error("Unable to publish event to datadog", e);
+        }
+
+    }
+
+    private void publishEvent(DatadogEvent event, String url) throws Throwable {
+        /*
+            {
+              "aggregation_key": "string",
+              "alert_type": "info",
+              "date_happened": "integer",
+              "device_name": [],
+              "host": "string",
+              "priority": "normal",
+              "related_event_id": "integer",
+              "source_type_name": "string",
+              "tags": [
+                "environment:test"
+              ],
+              "text": "Oh boy!",
+              "title": "Did you hear the news today?"
+            }
+         */
+        String body = encodeEvent(event);
+
+        logger.trace("sending event to datadog:{}{}", System.lineSeparator(), body);
+
+        httpClient.post(url)
+                .withJsonContent(body)
+                .send()
+                .onSuccess(response -> logger.debug("successfully sent event to datadog"))
+                .onError(response -> logger.error("failed to send event to datadog: {}", response.body()));
+    }
+
+    private String encodeEvent(DatadogEvent event) {
+        StringBuilder body = new StringBuilder();
+        body.append("{");
+        {
+            body.append("\"title\": ");
+            body.append(escapeJson(event.getTitle()));
+            body.append(", \"text\": ");
+            body.append(escapeJson(event.getText()));
+
+            if (event.getAggregationKey() != null) {
+                body.append(", \"aggregation_key\": ");
+                body.append(escapeJson(event.getAggregationKey()));
+            }
+            if (event.getDateHappened() != null) {
+                body.append(", \"date_happened\": ");
+                body.append(event.getDateHappened().getEpochSecond());
+            }
+            if (event.getAlertType() != null) {
+                body.append(", \"alert_type\": ");
+                body.append(escapeJson(event.getAlertType()));
+            }
+            if (event.getDeviceName() != null) {
+                body.append(", \"device_name\": [");
+                body.append(event.getDeviceName().stream()
+                        .map(StringEscapeUtils::escapeJson)
+                        .collect(joining(",")));
+                body.append("]");
+            }
+            if (event.getHost() != null) {
+                body.append(", \"alert_type\": ");
+                body.append(escapeJson(event.getAlertType()));
+            }
+            if (event.getPriority() != null) {
+                body.append(", \"priority\": ");
+                body.append(escapeJson(event.getPriority()));
+            }
+            if (event.getRelatedEventId() != null) {
+                body.append(", \"related_event_id\": ");
+                body.append(event.getRelatedEventId());
+            }
+
+            if (event.getSourceTypeName() != null) {
+                body.append(", \"source_type_name\": ");
+                body.append(escapeJson(event.getSourceTypeName()));
+            }
+            if (event.getTags() != null) {
+                body.append(", \"tags\": [");
+                body.append(event.getTags().stream()
+                        .map(StringEscapeUtils::escapeJson)
+                        .collect(joining(",")));
+                body.append("]");
+            }
+        }
+        body.append("}");
+        return body.toString();
+    }
+    public class EventPublisher {
+        private final String aggregationKey;
+        private final List<Tag> tags;
+        private final List<String> deviceName;
+
+        public EventPublisher(String aggregationKey, List<String> deviceName, List<Tag> tags) {
+            this.aggregationKey = aggregationKey;
+            this.deviceName = deviceName;
+            this.tags = tags;
+        }
+
+        public void publish(String title, String text) {
+            publish(title, text, null, null, null, null);
+        }
+
+        public void publish(String title, String text, Instant dateHappened, String alertType, String priority, Long relatedEventId) {
+            if (!config.enabled()) return;
+            DatadogEvent event = new DatadogEvent();
+            event.setAlertType(alertType);
+            event.setTitle(title);
+            event.setText(text);
+            event.setHost(config.hostTag());
+            event.setDateHappened(dateHappened);
+            event.setPriority(priority);
+            event.setRelatedEventId(relatedEventId);
+            event.setTags(tags.stream()
+                    .map(t -> t.getKey() + ":" + t.getValue()).collect(
+                    Collectors.toList()));
+            event.setAggregationKey(aggregationKey);
+            event.setSourceTypeName("SYSTEM");
+            event.setDeviceName(deviceName);
+            if (!eventQueue.offer(event)) logger.warn("Datadog event publish queue overflowed");
+        }
+    }
+
+    public EventPublisher events(String aggregationKey, List<String> deviceName, List<Tag> tags) {
+        return new EventPublisher(aggregationKey, deviceName, tags);
+    }
+    public EventPublisher events(String aggregationKey) {
+        return new EventPublisher(aggregationKey, null, null);
+    }
+
+    public EventPublisher events() {
+        return new EventPublisher(null, null, null);
     }
 }


### PR DESCRIPTION
For Datadog only, add additional functionality to the meter registry to send to their event stream. Users can directly pull in the datadog registry for the additional methods.

https://docs.datadoghq.com/events/

Design for EventPublisher closure is kind of rough, recommendations would be great.