### PR TITLE
Honor configured step duration when building Wavefront senders

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -325,7 +325,8 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
      */
     public static WavefrontClient.Builder getDefaultSenderBuilder(WavefrontConfig config) {
         return new WavefrontClient.Builder(getWavefrontReportingUri(config),
-                config.apiToken()).batchSize(config.batchSize());
+                config.apiToken()).batchSize(config.batchSize())
+                .flushIntervalSeconds((int) config.step().getSeconds());
     }
 
     public static Builder builder(WavefrontConfig config) {


### PR DESCRIPTION
This fixes an issue with the Wavefront registry where, no matter what is set for a `step` duration in `WavefrontConfig`, the Wavefront sender will always emit metrics once per second. I'm fairly confident the once-per-second behavior is not intended because it seems to go against the documentation for `WavefrontConfig#step()` and also against Wavefront's own [example code](https://docs.wavefront.com/micrometer.html#example), which shows providing a `step` of `Duration.ofSeconds(10)` with an explanation that:

> The following code fragment creates a Wavefront registry that emits data every 10 seconds…

Cheers!