### PR TITLE
Re-include units in Datadog metadata

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -142,7 +142,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
             logger.warn("failed to send metrics to datadog", e);
         }
 
-        metadataToSend.forEach(this::postMetricDescriptionMetadata);
+        metadataToSend.forEach(this::postMetricMetadata);
     }
 
     private Stream<String> writeTimer(FunctionTimer timer, Map<String, DatadogMetricMetadata> metadata) {
@@ -150,9 +150,9 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
         Meter.Id id = timer.getId();
 
-        addToMetadataList(metadata, id, "count");
-        addToMetadataList(metadata, id, "avg");
-        addToMetadataList(metadata, id, "sum");
+        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
+        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
+        addToMetadataList(metadata, id, "sum", Statistic.TOTAL_TIME, null);
 
         // we can't know anything about max and percentiles originating from a function timer
         return Stream.of(
@@ -171,10 +171,10 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         metrics.add(writeMetric(id, "avg", wallTime, timer.mean(getBaseTimeUnit()), Statistic.VALUE, null));
         metrics.add(writeMetric(id, "max", wallTime, timer.max(getBaseTimeUnit()), Statistic.MAX, null));
 
-        addToMetadataList(metadata, id, "sum");
-        addToMetadataList(metadata, id, "count");
-        addToMetadataList(metadata, id, "avg");
-        addToMetadataList(metadata, id, "max");
+        addToMetadataList(metadata, id, "sum", Statistic.TOTAL_TIME, null);
+        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
+        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
+        addToMetadataList(metadata, id, "max", Statistic.MAX, null);
 
         return metrics.build();
     }
@@ -189,10 +189,10 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         metrics.add(writeMetric(id, "avg", wallTime, summary.mean(), Statistic.VALUE, null));
         metrics.add(writeMetric(id, "max", wallTime, summary.max(), Statistic.MAX, null));
 
-        addToMetadataList(metadata, id, "sum");
-        addToMetadataList(metadata, id, "count");
-        addToMetadataList(metadata, id, "avg");
-        addToMetadataList(metadata, id, "max");
+        addToMetadataList(metadata, id, "sum", Statistic.TOTAL_TIME, null);
+        addToMetadataList(metadata, id, "count", Statistic.COUNT, "occurrence");
+        addToMetadataList(metadata, id, "avg", Statistic.VALUE, null);
+        addToMetadataList(metadata, id, "max", Statistic.MAX, null);
 
         return metrics.build();
     }
@@ -202,12 +202,13 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         return stream(m.measure().spliterator(), false)
                 .map(ms -> {
                     Meter.Id id = m.getId().withTag(ms.getStatistic());
-                    addToMetadataList(metadata, id, null);
+                    addToMetadataList(metadata, id, null, ms.getStatistic(), null);
                     return writeMetric(id, null, wallTime, ms.getValue(), ms.getStatistic(), null);
                 });
     }
 
-    private void addToMetadataList(Map<String, DatadogMetricMetadata> metadata, Meter.Id id, @Nullable String suffix) {
+    private void addToMetadataList(Map<String, DatadogMetricMetadata> metadata, Meter.Id id, @Nullable String suffix,
+                                   Statistic stat, @Nullable String overrideBaseUnit) {
         if (config.applicationKey() == null)
             return; // we can't set metadata correctly without the application key
 
@@ -217,7 +218,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
 
         String metricName = getConventionName(fullId);
         if (!verifiedMetadata.contains(metricName)) {
-            metadata.put(metricName, new DatadogMetricMetadata(fullId, config.descriptions()));
+            metadata.put(metricName, new DatadogMetricMetadata(fullId, stat, config.descriptions(), overrideBaseUnit));
         }
     }
 
@@ -238,10 +239,8 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         // Create type attribute
         String type = ",\"type\":\"" + DatadogMetricMetadata.sanitizeType(statistic) + "\"";
         // Create unit attribute
-        String unit = "";
-        if (id.getBaseUnit() != null || overrideBaseUnit != null) {
-            unit = ",\"unit\":\"" + DatadogMetricMetadata.sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit) + "\"";
-        }
+        String baseUnit = DatadogMetricMetadata.sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit);
+        String unit = baseUnit != null ? ",\"unit\":\"" + baseUnit + "\"" : "";
         // Create tags attribute
         String tagsArray = tags.iterator().hasNext()
                 ? stream(tags.spliterator(), false)
@@ -257,10 +256,9 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
      * Set up metric metadata once per time series
      */
     // VisibleForTesting
-    void postMetricDescriptionMetadata(String metricName, DatadogMetricMetadata metadata) {
-        // already posted the metadata for this metric
-        if (!metadata.isDescriptionsEnabled() || metadata.editDescriptionMetadataBody() == null
-                || verifiedMetadata.contains(metricName)) {
+    void postMetricMetadata(String metricName, DatadogMetricMetadata metadata) {
+        // already posted the metadata for this metric, or no data to post
+        if (metadata.editMetadataBody() == null || verifiedMetadata.contains(metricName)) {
             return;
         }
 
@@ -268,7 +266,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
             httpClient
                     .put(config.uri() + "/api/v1/metrics/" + URLEncoder.encode(metricName, "UTF-8")
                             + "?api_key=" + config.apiKey() + "&application_key=" + config.applicationKey())
-                    .withJsonContent(metadata.editDescriptionMetadataBody())
+                    .withJsonContent(metadata.editMetadataBody())
                     .send()
                     .onSuccess(response -> verifiedMetadata.add(metricName))
                     .onError(response -> {

--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMetricMetadata.java
@@ -56,20 +56,31 @@ class DatadogMetricMetadata {
     }
 
     private final Meter.Id id;
+    private final String type;
     private final boolean descriptionsEnabled;
 
-    DatadogMetricMetadata(Meter.Id id, boolean descriptionsEnabled) {
+    @Nullable
+    private final String overrideBaseUnit;
+
+    DatadogMetricMetadata(Meter.Id id, Statistic statistic, boolean descriptionsEnabled,
+                          @Nullable String overrideBaseUnit) {
         this.id = id;
         this.descriptionsEnabled = descriptionsEnabled;
+        this.overrideBaseUnit = overrideBaseUnit;
+
+        this.type = sanitizeType(statistic);
     }
 
-    public boolean isDescriptionsEnabled() {
-        return descriptionsEnabled;
-    }
-
-    String editDescriptionMetadataBody() {
+    String editMetadataBody() {
         if (descriptionsEnabled && id.getDescription() != null) {
-            return "{\"description\":\"" + StringEscapeUtils.escapeJson(id.getDescription()) + "\"}";
+            String body = "{\"type\":\"" + type + "\"";
+
+            String baseUnit = sanitizeBaseUnit(id.getBaseUnit(), overrideBaseUnit);
+            if (baseUnit != null) {
+                body += ",\"unit\":\"" + baseUnit + "\"";
+            }
+            body += ",\"description\":\"" + StringEscapeUtils.escapeJson(id.getDescription()) + "\"}";
+            return body;
         }
         return null;
     }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.ipc.http.HttpSender;
 import org.junit.jupiter.api.Test;
@@ -140,14 +141,14 @@ class DatadogMeterRegistryTest {
 
         server.verify(putRequestedFor(
                 urlEqualTo("/api/v1/metrics/my.counter%23abc?api_key=fake&application_key=fake"))
-                .withRequestBody(equalToJson("{\"description\":\"metric description\"}")
+                .withRequestBody(equalToJson("{\"type\":\"count\",\"unit\":\"microsecond\",\"description\":\"metric description\"}")
                 ));
 
         registry.close();
     }
 
     @Test
-    void postMetricDescriptionMetadataWhenDescriptionIsEnabledButNull() {
+    void postMetricMetadataWhenDescriptionIsEnabledButNull() {
         DatadogConfig config = new DatadogConfig() {
 
             @Override
@@ -164,7 +165,7 @@ class DatadogMeterRegistryTest {
         HttpSender httpSender = mock(HttpSender.class);
         DatadogMeterRegistry registry = DatadogMeterRegistry.builder(config).httpClient(httpSender).build();
         Meter.Id id = new Meter.Id("my.meter", Tags.empty(), null, null, Meter.Type.COUNTER);
-        registry.postMetricDescriptionMetadata("my.meter", new DatadogMetricMetadata(id, true));
+        registry.postMetricMetadata("my.meter", new DatadogMetricMetadata(id, Statistic.COUNT, true, null));
         verifyNoInteractions(httpSender);
     }
 }

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMetricMetadataTest.java
@@ -17,6 +17,7 @@ package io.micrometer.datadog;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -32,10 +33,12 @@ class DatadogMetricMetadataTest {
                         .tag("key", "value")
                         .description("The /\"recent cpu usage\" for the Java Virtual Machine process")
                         .register(new SimpleMeterRegistry()).getId(),
-                true
+                Statistic.COUNT,
+                true,
+                null
         );
 
-        assertThat(metricMetadata.editDescriptionMetadataBody()).isEqualTo("{\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
+        assertThat(metricMetadata.editMetadataBody()).isEqualTo("{\"type\":\"count\",\"description\":\"The /\\\"recent cpu usage\\\" for the Java Virtual Machine process\"}");
     }
 
     @Test
@@ -55,9 +58,11 @@ class DatadogMetricMetadataTest {
                         return null;
                     }
                 }, Clock.SYSTEM)).getId(),
-            false);
+            Statistic.TOTAL_TIME,
+            false,
+            null);
 
-        assertThat(metricMetadata.editDescriptionMetadataBody()).isNull();
+        assertThat(metricMetadata.editMetadataBody()).isNull();
     }
 
 }


### PR DESCRIPTION
When we added units to metric payload in #1864, we also removed it from
the metadata payload, only making the query when the description was
set. The problem is that the setting the descroption without the other
fields actually override them, which means it broke when descriptions
were enabled.

This fixes it by still checking if description is set to keep the
performance enhancement, but set all the fields in the metadata.

Closes #1977