### PR TITLE
Replace deprecated MockitoAnnotations.initMocks() usages

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -41,10 +41,9 @@ import java.util.Random;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -54,11 +53,10 @@ import static org.mockito.Mockito.when;
  */
 class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
-    @Mock
-    private Cache<String, String> cache;
+    @SuppressWarnings("unchecked")
+    private Cache<String, String> cache = mock(Cache.class);
 
-    @Mock
-    private CacheManager cacheManager;
+    private CacheManager cacheManager = mock(CacheManager.class);
 
     private JCacheMetrics metrics;
     private MBeanServer mbeanServer;
@@ -66,7 +64,6 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @BeforeEach
     void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
         when(cache.getCacheManager()).thenReturn(cacheManager);
         when(cache.getName()).thenReturn("testCache");
         when(cacheManager.getURI()).thenReturn(new URI("http://localhost"));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettySslHandshakeMetricsTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.binder.jetty;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.micrometer.core.instrument.MockClock;
@@ -26,8 +27,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.eclipse.jetty.io.ssl.SslHandshakeListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
@@ -42,12 +41,11 @@ class JettySslHandshakeMetricsTest {
     private SimpleMeterRegistry registry;
     private JettySslHandshakeMetrics sslHandshakeMetrics;
 
-    @Mock SSLSession session;
-    @Mock SSLEngine engine;
+    SSLSession session = mock(SSLSession.class);
+    SSLEngine engine = mock(SSLEngine.class);
 
     @BeforeEach
     void setup() {
-        MockitoAnnotations.initMocks(this);
         when(engine.getSession()).thenReturn(session);
 
         registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());


### PR DESCRIPTION
This PR replaces deprecated `MockitoAnnotations.initMocks()` usages with `mock()` for consistency with others in the codebase.