### PR TITLE
Adding total JVM heap/non-heap memory usage metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -82,10 +82,10 @@ class JvmMemory {
     private static MemoryUsage getTotalAreaUsage(MemoryMXBean memoryMXBean, String area) {
         MemoryUsage usage = null;
         try {
-            if(area.equals("heap")){
+            if (area.equals("heap")) {
                 usage = memoryMXBean.getHeapMemoryUsage();
             }
-            else if(area.equals("nonheap")){
+            else if (area.equals("nonheap")) {
                 usage = memoryMXBean.getNonHeapMemoryUsage();
             }
             return usage;
@@ -96,12 +96,12 @@ class JvmMemory {
         }
     }
 
-    static double getHeapUsagePercent(MemoryMXBean memoryMXBean){
+    static double getHeapUsagePercent(MemoryMXBean memoryMXBean) {
         MemoryUsage usage = getTotalAreaUsage(memoryMXBean, "heap");
         if (usage == null) {
             return Double.NaN;
         }
-        return ((double)usage.getUsed()/usage.getMax()) * 100;
+        return ((double)usage.getUsed() / usage.getMax()) * 100;
     }
 
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -101,7 +101,7 @@ public class JvmMemoryMetrics implements MeterBinder {
 
         //The used and committed size of the returned memory usage is the sum of those values of all heap/non-heap memory pools
         // whereas the max size of the returned memory usage represents the setting of the non-heap/non-heap memory which may
-        // not be the sum of those of all non-heap memory pools. If the setting is missing for non-heap memory pools these values come as -1.
+        // not be the sum of those of all non-heap memory pools. If the setting is missing for heap/non-heap memory pools these values come as -1.
 
         MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -125,7 +125,7 @@ public class JvmMemoryMetrics implements MeterBinder {
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
 
-        Gauge.builder("jvm.memory.heap_used_percent", memoryMXBean, (mem) -> getHeapUsagePercent(mem))
+        Gauge.builder("jvm.memory.heap.used.percent", memoryMXBean, (mem) -> getHeapUsagePercent(mem))
                 .tags(tags)
                 .description("The percentage of used memory with respect to maximum amount of memory that can be used for memory management of heap")
                 .register(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -72,7 +72,7 @@ class JvmMemoryMetricsTest {
     }
 
     private void assertJvmHeapMemoryPercent(MeterRegistry registry) {
-        Gauge heapMemUsedPercent = registry.get("jvm.memory.heap_used_percent").gauge();
+        Gauge heapMemUsedPercent = registry.get("jvm.memory.heap.used.percent").gauge();
         assertThat(heapMemUsedPercent.value()).isNotNull();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -40,6 +40,8 @@ class JvmMemoryMetricsTest {
 
         assertJvmMemoryMetrics(registry, "heap");
         assertJvmMemoryMetrics(registry, "nonheap");
+
+        assertJvmHeapMemoryPercent(registry);
     }
 
     private void assertJvmMemoryMetrics(MeterRegistry registry, String area) {
@@ -67,6 +69,11 @@ class JvmMemoryMetricsTest {
         Gauge bufferTotal = registry.get("jvm.buffer.total.capacity").tags("id", bufferId).gauge();
         assertThat(bufferTotal.value()).isGreaterThanOrEqualTo(0);
         assertThat(bufferTotal.getId().getBaseUnit()).isEqualTo(BaseUnits.BYTES);
+    }
+
+    private void assertJvmHeapMemoryPercent(MeterRegistry registry) {
+        Gauge heapMemUsedPercent = registry.get("jvm.memory.heap_used_percent").gauge();
+        assertThat(heapMemUsedPercent.value()).isNotNull();
     }
 
 }


### PR DESCRIPTION
This PR adds total JVM heap/non-heap memory usage metrics to JvmMemoryMetrics meter binder