### PR TITLE
Add counters for QueryPlanCacheHit and QueryPlanCacheMiss in HibernateMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
@@ -233,6 +233,10 @@ public class HibernateMetrics implements MeterBinder {
             Statistics::getQueryCacheMissCount, "result", "miss");
         counter(registry, "hibernate.cache.query.puts", "The number of cacheable queries put in cache",
             Statistics::getQueryCachePutCount);
+        counter(registry,"hibernate.cache.query.plan", "The global number of query plans successfully retrieved from cache",
+                Statistics::getQueryPlanCacheHitCount, "result", "hit");
+        counter(registry,"hibernate.cache.query.plan", "The global number of query plans lookups not found in cache",
+                Statistics::getQueryPlanCacheMissCount, "result", "miss");
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -121,6 +121,8 @@ class HibernateMetricsTest {
         assertThat(registry.get("hibernate.cache.query.requests").tags("result", "hit").functionCounter().count()).isEqualTo(42.0d);
         assertThat(registry.get("hibernate.cache.query.requests").tags("result", "miss").functionCounter().count()).isEqualTo(42.0d);
         assertThat(registry.get("hibernate.cache.query.puts").functionCounter().count()).isEqualTo(42.0d);
+        assertThat(registry.get("hibernate.cache.query.plan").tags("result", "hit").functionCounter().count()).isEqualTo(42.0d);
+        assertThat(registry.get("hibernate.cache.query.plan").tags("result", "miss").functionCounter().count()).isEqualTo(42.0d);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This PR exposes in Micrometer two new Hibernate Metrics : QueryPlanCacheHit and QueryPlanCacheMiss.
