### PR TITLE
Use a fixed version for Kafka Docker image

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("docker")
 class KafkaClientMetricsIntegrationTest {
     @Container
-    private KafkaContainer kafkaContainer = new KafkaContainer();
+    private KafkaContainer kafkaContainer = new KafkaContainer("5.5.1");
 
     @Test
     void shouldManageProducerAndConsumerMetrics() {


### PR DESCRIPTION
This PR changes to use a fixed version for the Kafka Docker image.

See https://github.com/micrometer-metrics/micrometer/pull/2210#discussion_r460374459