### PR TITLE
Add Neo4j Java driver metrics.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,10 +70,12 @@ def VERSIONS = [
         'org.mockito:mockito-core:latest.release',
         'org.mockito:mockito-inline:latest.release',
         'org.mongodb:mongodb-driver-sync:latest.release',
+        'org.neo4j.driver:neo4j-java-driver:4.1.+',
         'org.slf4j:slf4j-api:1.7.+',
         'org.springframework:spring-context:latest.release',
         'org.testcontainers:junit-jupiter:latest.release',
         'org.testcontainers:kafka:latest.release',
+        'org.testcontainers:neo4j:latest.release',
         'org.testcontainers:testcontainers:latest.release',
         'ru.lanwen.wiremock:wiremock-junit5:latest.release',
         'software.amazon.awssdk:cloudwatch:latest.release'

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,7 +70,7 @@ def VERSIONS = [
         'org.mockito:mockito-core:latest.release',
         'org.mockito:mockito-inline:latest.release',
         'org.mongodb:mongodb-driver-sync:latest.release',
-        'org.neo4j.driver:neo4j-java-driver:4.1.+',
+        'org.neo4j.driver:neo4j-java-driver:latest.release',
         'org.slf4j:slf4j-api:1.7.+',
         'org.springframework:spring-context:latest.release',
         'org.testcontainers:junit-jupiter:latest.release',

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     optionalApi 'org.mongodb:mongodb-driver-sync'
 
+    optionalApi 'org.neo4j.driver:neo4j-java-driver'
+
     optionalApi 'org.jooq:jooq'
 
     optionalApi 'org.apache.kafka:kafka-clients'
@@ -105,6 +107,9 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:kafka'
+
+    // Neo4j binder IT dependencies
+    testImplementation 'org.testcontainers:neo4j'
 }
 
 task shenandoahTest(type: Test) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
@@ -68,50 +68,43 @@ public class Neo4jMetrics implements MeterBinder {
 
             // acquisition attempts
             FunctionCounter.builder(PREFIX + ".acquisition", poolMetrics, ConnectionPoolMetrics::acquired)
-                    .tags(Tags.concat(poolTags, "result", "successful"))
+                    .tags(Tags.concat(poolTags, "outcome", "success"))
                     .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that have been acquired.")
                     .register(meterRegistry);
 
             FunctionCounter
                     .builder(PREFIX + ".acquisition", poolMetrics, ConnectionPoolMetrics::timedOutToAcquire)
-                    .tags(Tags.concat(poolTags, "result", "timedOutToAcquire"))
+                    .tags(Tags.concat(poolTags, "outcome", "timeout"))
                     .baseUnit(BASE_UNIT_CONNECTIONS)
                     .description("The amount of failures to acquire a connection from a pool within maximum connection "
                                     + "acquisition timeout.")
                     .register(meterRegistry);
 
-            // connections successfully created and closed
-            FunctionCounter.builder(PREFIX, poolMetrics, ConnectionPoolMetrics::created)
-                    .tags(Tags.concat(poolTags, "state", "created"))
-                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections have ever been created.")
-                    .register(meterRegistry);
-
-            FunctionCounter.builder(PREFIX, poolMetrics, ConnectionPoolMetrics::closed)
-                    .tags(Tags.concat(poolTags, "state", "closed"))
-                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections have been closed.")
-                    .register(meterRegistry);
-
             // creation attempts
             FunctionCounter.builder(PREFIX + ".creation", poolMetrics, ConnectionPoolMetrics::created)
-                    .tags(Tags.concat(poolTags, "state", "created"))
+                    .tags(Tags.concat(poolTags, "outcome", "success"))
                     .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections have ever been created.")
                     .register(meterRegistry);
 
             FunctionCounter.builder(PREFIX + ".creation", poolMetrics, ConnectionPoolMetrics::failedToCreate)
-                    .tags(Tags.concat(poolTags, "state", "failedToCreate"))
+                    .tags(Tags.concat(poolTags, "outcome", "failure"))
                     .baseUnit(BASE_UNIT_CONNECTIONS)
                     .description("The amount of connections have been failed to create.").register(meterRegistry);
 
             // active pool size
-            Gauge.builder(PREFIX + ".active", poolMetrics, ConnectionPoolMetrics::idle)
+            Gauge.builder(PREFIX + ".current", poolMetrics, ConnectionPoolMetrics::idle)
                     .tags(Tags.concat(poolTags, "state", "idle"))
                     .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that are currently idle.")
                     .register(meterRegistry);
 
-            Gauge.builder(PREFIX + ".active", poolMetrics, ConnectionPoolMetrics::inUse)
+            Gauge.builder(PREFIX + ".current", poolMetrics, ConnectionPoolMetrics::inUse)
                     .tags(Tags.concat(poolTags, "state", "inUse"))
                     .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that are currently in-use.")
                     .register(meterRegistry);
+
+            FunctionCounter.builder(PREFIX + ".closed", poolMetrics, ConnectionPoolMetrics::failedToCreate)
+                    .baseUnit(BASE_UNIT_CONNECTIONS)
+                    .description("The amount of connections have been closed.").register(meterRegistry);
         };
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
@@ -58,6 +58,9 @@ public class Neo4jMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry meterRegistry) {
+        if (!this.driver.isMetricsEnabled()) {
+            return;
+        }
         Metrics metrics = this.driver.metrics();
         metrics.connectionPoolMetrics().forEach(this.getPoolMetricsBinder(meterRegistry));
     }
@@ -102,7 +105,7 @@ public class Neo4jMetrics implements MeterBinder {
                     .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that are currently in-use.")
                     .register(meterRegistry);
 
-            FunctionCounter.builder(PREFIX + ".closed", poolMetrics, ConnectionPoolMetrics::failedToCreate)
+            FunctionCounter.builder(PREFIX + ".closed", poolMetrics, ConnectionPoolMetrics::closed)
                     .baseUnit(BASE_UNIT_CONNECTIONS)
                     .description("The amount of connections have been closed.").register(meterRegistry);
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetrics.java
@@ -1,0 +1,87 @@
+package io.micrometer.core.instrument.binder.neo4j;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNullApi;
+import io.micrometer.core.lang.NonNullFields;
+
+import java.util.function.Consumer;
+
+import org.neo4j.driver.ConnectionPoolMetrics;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Metrics;
+
+/**
+ * {@link MeterBinder} that binds all available Neo4j driver metrics.
+ *
+ * @author Michael J. Simons
+ * @author Gerrit Meier
+ */
+@NonNullApi
+@NonNullFields
+public class Neo4jMetrics implements MeterBinder {
+
+    /**
+     * Prefixed used for driver metrics.
+     */
+    public static final String PREFIX = "neo4j.driver.connections";
+
+    private static final String BASE_UNIT_CONNECTIONS = "connections";
+
+    private final Driver driver;
+
+    private final Iterable<Tag> tags;
+
+    public Neo4jMetrics(String name, Driver driver, Iterable<Tag> tags) {
+        this.driver = driver;
+        this.tags = Tags.concat(tags, "name", name);
+    }
+
+    @Override
+    public void bindTo(MeterRegistry meterRegistry) {
+        Metrics metrics = this.driver.metrics();
+        metrics.connectionPoolMetrics().forEach(this.getPoolMetricsBinder(meterRegistry));
+    }
+
+    Consumer<ConnectionPoolMetrics> getPoolMetricsBinder(MeterRegistry meterRegistry) {
+        return (poolMetrics) -> {
+            Iterable<Tag> poolTags = Tags.concat(this.tags, "poolId", poolMetrics.id());
+
+            FunctionCounter.builder(PREFIX + ".acquired", poolMetrics, ConnectionPoolMetrics::acquired).tags(poolTags)
+                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that have been acquired.")
+                    .register(meterRegistry);
+
+            FunctionCounter.builder(PREFIX + ".closed", poolMetrics, ConnectionPoolMetrics::closed).tags(poolTags)
+                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections have been closed.")
+                    .register(meterRegistry);
+
+            FunctionCounter.builder(PREFIX + ".created", poolMetrics, ConnectionPoolMetrics::created).tags(poolTags)
+                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections have ever been created.")
+                    .register(meterRegistry);
+
+            FunctionCounter.builder(PREFIX + ".failedToCreate", poolMetrics, ConnectionPoolMetrics::failedToCreate)
+                    .tags(poolTags).baseUnit(BASE_UNIT_CONNECTIONS)
+                    .description("The amount of connections have been failed to create.").register(meterRegistry);
+
+            Gauge.builder(PREFIX + ".idle", poolMetrics, ConnectionPoolMetrics::idle).tags(poolTags)
+                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that are currently idle.")
+                    .register(meterRegistry);
+
+            Gauge.builder(PREFIX + ".inUse", poolMetrics, ConnectionPoolMetrics::inUse).tags(poolTags)
+                    .baseUnit(BASE_UNIT_CONNECTIONS).description("The amount of connections that are currently in-use.")
+                    .register(meterRegistry);
+
+            FunctionCounter
+                    .builder(PREFIX + ".timedOutToAcquire", poolMetrics, ConnectionPoolMetrics::timedOutToAcquire)
+                    .tags(poolTags).baseUnit(BASE_UNIT_CONNECTIONS)
+                    .description(
+                            "The amount of failures to acquire a connection from a pool within maximum connection acquisition timeout.")
+                    .register(meterRegistry);
+        };
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsIntegrationTest.java
@@ -55,27 +55,26 @@ public class Neo4jMetricsIntegrationTest {
         metrics.bindTo(registry);
 
         String connectionAcquisitionName = Neo4jMetrics.PREFIX + ".acquisition";
-        assertThat(registry.get(connectionAcquisitionName).tag("result", "successful").functionCounter().count())
+        assertThat(registry.get(connectionAcquisitionName).tag("outcome", "success").functionCounter().count())
                 .isEqualTo(1d);
-        assertThat(registry.get(connectionAcquisitionName).tag("result", "timedOutToAcquire").functionCounter().count())
+        assertThat(registry.get(connectionAcquisitionName).tag("outcome", "timeout").functionCounter().count())
                 .isEqualTo(0d);
 
-        String connectionsName = Neo4jMetrics.PREFIX;
-        assertThat(registry.get(connectionsName).tag("state", "created").functionCounter().count()).isEqualTo(1d);
-        assertThat(registry.get(connectionsName).tag("state", "closed").functionCounter().count()).isEqualTo(0d);
+        String connectionsName = Neo4jMetrics.PREFIX + ".closed";
+        assertThat(registry.get(connectionsName).functionCounter().count()).isEqualTo(0d);
 
         String connectionsCreatedName = Neo4jMetrics.PREFIX + ".creation";
-        assertThat(registry.get(connectionsCreatedName).tag("state", "created").functionCounter().count()).isEqualTo(1d);
-        assertThat(registry.get(connectionsCreatedName).tag("state", "failedToCreate").functionCounter().count())
+        assertThat(registry.get(connectionsCreatedName).tag("outcome", "success").functionCounter().count()).isEqualTo(1d);
+        assertThat(registry.get(connectionsCreatedName).tag("outcome", "failure").functionCounter().count())
                 .isEqualTo(0d);
 
-        String connectionsActiveName = Neo4jMetrics.PREFIX + ".active";
+        String connectionsActiveName = Neo4jMetrics.PREFIX + ".current";
         assertThat(registry.get(connectionsActiveName).tag("state", "idle").gauge().value()).isEqualTo(1d);
         assertThat(registry.get(connectionsActiveName).tag("state", "inUse").gauge().value()).isEqualTo(0d);
 
         // acquire a new connection
         driver.verifyConnectivity();
-        assertThat(registry.get(connectionAcquisitionName).tag("result", "successful").functionCounter().count())
+        assertThat(registry.get(connectionAcquisitionName).tag("outcome", "success").functionCounter().count())
                 .isEqualTo(2d);
 
         driver.close();
@@ -96,7 +95,7 @@ public class Neo4jMetricsIntegrationTest {
         metrics.bindTo(registry);
 
         String connectionsCreatedName = Neo4jMetrics.PREFIX + ".creation";
-        assertThat(registry.get(connectionsCreatedName).tag("state", "failedToCreate").functionCounter().count())
+        assertThat(registry.get(connectionsCreatedName).tag("outcome", "failure").functionCounter().count())
                 .isEqualTo(1d);
 
         driver.close();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsIntegrationTest.java
@@ -1,0 +1,86 @@
+package io.micrometer.core.instrument.binder.neo4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * @author Gerrit Meier
+ */
+@Testcontainers
+@Tag("docker")
+public class Neo4jMetricsIntegrationTest {
+
+    @Container
+    private final Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:4.1"))
+            .withAdminPassword(null);
+
+    @Test
+    void shouldExposeDriverMetrics() {
+
+        Driver driver = createDriverInstance();
+        // Create first connection to the database to populate the metrics.
+        driver.verifyConnectivity();
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+        Neo4jMetrics metrics = new Neo4jMetrics("neo4jMetrics", driver, Collections.emptyList());
+        metrics.bindTo(registry);
+
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".acquired").functionCounter().count()).isEqualTo(1d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".closed").functionCounter().count()).isEqualTo(0d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".created").functionCounter().count()).isEqualTo(1d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".failedToCreate").functionCounter().count()).isEqualTo(0d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".idle").gauge().value()).isEqualTo(1d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".inUse").gauge().value()).isEqualTo(0d);
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".timedOutToAcquire").functionCounter().count()).isEqualTo(0d);
+
+        // acquire a new connection
+        driver.verifyConnectivity();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".acquired").functionCounter().count()).isEqualTo(2d);
+
+        driver.close();
+    }
+
+    @Test
+    void shouldExposeDriverMetricForFailedConnectionAcquisition() {
+        Driver driver = createDriverInstanceWithWrongPort();
+        try {
+            driver.verifyConnectivity();
+        } catch (Exception e) {
+            // silently consume the expected exception
+        }
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+        Neo4jMetrics metrics = new Neo4jMetrics("neo4jMetrics", driver, Collections.emptyList());
+        metrics.bindTo(registry);
+
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".failedToCreate").functionCounter().count()).isEqualTo(1d);
+
+        driver.close();
+    }
+
+    private Driver createDriverInstance() {
+        return GraphDatabase.driver(neo4jContainer.getBoltUrl(), Config.builder().withDriverMetrics().build());
+    }
+
+    private Driver createDriverInstanceWithWrongPort() {
+        int nonOpenPort = 17687;
+        return GraphDatabase.driver("bolt://" + neo4jContainer.getHost() + ":" + nonOpenPort,
+                Config.builder().withDriverMetrics().build());
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.core.instrument.binder.neo4j;
 
 import static org.assertj.core.api.Assertions.*;
@@ -26,13 +41,25 @@ public class Neo4jMetricsTest {
         Neo4jMetrics metrics = new Neo4jMetrics("driver", mockDriverWithMetrics(), Collections.emptyList());
         metrics.bindTo(registry);
 
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".acquired").functionCounter()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".closed").functionCounter()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".created").functionCounter()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".failedToCreate").functionCounter()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".idle").gauge()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".inUse").gauge()).isNotNull();
-        assertThat(registry.get(Neo4jMetrics.PREFIX + ".timedOutToAcquire").functionCounter()).isNotNull();
+        String connectionAcquisitionName = Neo4jMetrics.PREFIX + ".acquisition";
+        assertThat(registry.get(connectionAcquisitionName).functionCounters()).hasSize(2);
+        assertThat(registry.get(connectionAcquisitionName).tag("result", "successful").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionAcquisitionName).tag("result", "timedOutToAcquire").functionCounter()).isNotNull();
+
+        String connectionsName = Neo4jMetrics.PREFIX;
+        assertThat(registry.get(connectionsName).functionCounters()).hasSize(2);
+        assertThat(registry.get(connectionsName).tag("state", "created").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionsName).tag("state", "closed").functionCounter()).isNotNull();
+
+        String connectionsCreatedName = Neo4jMetrics.PREFIX + ".creation";
+        assertThat(registry.get(connectionsCreatedName).functionCounters()).hasSize(2);
+        assertThat(registry.get(connectionsCreatedName).tag("state", "created").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionsCreatedName).tag("state", "failedToCreate").functionCounter()).isNotNull();
+
+        String connectionsActiveName = Neo4jMetrics.PREFIX + ".active";
+        assertThat(registry.get(connectionsActiveName).gauges()).hasSize(2);
+        assertThat(registry.get(connectionsActiveName).tag("state", "idle").gauge()).isNotNull();
+        assertThat(registry.get(connectionsActiveName).tag("state", "inUse").gauge()).isNotNull();
     }
 
     private static Driver mockDriverWithMetrics() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
@@ -43,23 +43,22 @@ public class Neo4jMetricsTest {
 
         String connectionAcquisitionName = Neo4jMetrics.PREFIX + ".acquisition";
         assertThat(registry.get(connectionAcquisitionName).functionCounters()).hasSize(2);
-        assertThat(registry.get(connectionAcquisitionName).tag("result", "successful").functionCounter()).isNotNull();
-        assertThat(registry.get(connectionAcquisitionName).tag("result", "timedOutToAcquire").functionCounter()).isNotNull();
-
-        String connectionsName = Neo4jMetrics.PREFIX;
-        assertThat(registry.get(connectionsName).functionCounters()).hasSize(2);
-        assertThat(registry.get(connectionsName).tag("state", "created").functionCounter()).isNotNull();
-        assertThat(registry.get(connectionsName).tag("state", "closed").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionAcquisitionName).tag("outcome", "success").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionAcquisitionName).tag("outcome", "timeout").functionCounter()).isNotNull();
 
         String connectionsCreatedName = Neo4jMetrics.PREFIX + ".creation";
         assertThat(registry.get(connectionsCreatedName).functionCounters()).hasSize(2);
-        assertThat(registry.get(connectionsCreatedName).tag("state", "created").functionCounter()).isNotNull();
-        assertThat(registry.get(connectionsCreatedName).tag("state", "failedToCreate").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionsCreatedName).tag("outcome", "success").functionCounter()).isNotNull();
+        assertThat(registry.get(connectionsCreatedName).tag("outcome", "failure").functionCounter()).isNotNull();
 
-        String connectionsActiveName = Neo4jMetrics.PREFIX + ".active";
+        String connectionsActiveName = Neo4jMetrics.PREFIX + ".current";
         assertThat(registry.get(connectionsActiveName).gauges()).hasSize(2);
         assertThat(registry.get(connectionsActiveName).tag("state", "idle").gauge()).isNotNull();
         assertThat(registry.get(connectionsActiveName).tag("state", "inUse").gauge()).isNotNull();
+
+        String connectionsName = Neo4jMetrics.PREFIX + ".closed";
+        assertThat(registry.get(connectionsName).functionCounters()).hasSize(1);
+        assertThat(registry.get(connectionsName).functionCounter()).isNotNull();
     }
 
     private static Driver mockDriverWithMetrics() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
@@ -69,6 +69,7 @@ public class Neo4jMetricsTest {
         when(metrics.connectionPoolMetrics()).thenReturn(Collections.singletonList(connectionPoolMetrics));
 
         Driver driver = mock(Driver.class);
+        when(driver.isMetricsEnabled()).thenReturn(true);
         when(driver.metrics()).thenReturn(metrics);
 
         when(driver.verifyConnectivityAsync()).thenReturn(CompletableFuture.completedFuture(null));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/neo4j/Neo4jMetricsTest.java
@@ -1,0 +1,52 @@
+package io.micrometer.core.instrument.binder.neo4j;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.ConnectionPoolMetrics;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Metrics;
+
+/**
+ * @author Michael J. Simons
+ * @author Gerrit Meier
+ */
+public class Neo4jMetricsTest {
+
+    @Test
+    void shouldRegisterCorrectMeters() {
+
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Neo4jMetrics metrics = new Neo4jMetrics("driver", mockDriverWithMetrics(), Collections.emptyList());
+        metrics.bindTo(registry);
+
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".acquired").functionCounter()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".closed").functionCounter()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".created").functionCounter()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".failedToCreate").functionCounter()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".idle").gauge()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".inUse").gauge()).isNotNull();
+        assertThat(registry.get(Neo4jMetrics.PREFIX + ".timedOutToAcquire").functionCounter()).isNotNull();
+    }
+
+    private static Driver mockDriverWithMetrics() {
+        ConnectionPoolMetrics connectionPoolMetrics = mock(ConnectionPoolMetrics.class);
+        when(connectionPoolMetrics.id()).thenReturn("p1");
+
+        Metrics metrics = mock(Metrics.class);
+        when(metrics.connectionPoolMetrics()).thenReturn(Collections.singletonList(connectionPoolMetrics));
+
+        Driver driver = mock(Driver.class);
+        when(driver.metrics()).thenReturn(metrics);
+
+        when(driver.verifyConnectivityAsync()).thenReturn(CompletableFuture.completedFuture(null));
+
+        return driver;
+    }
+}


### PR DESCRIPTION
This PR might come more or less out of the sudden for this project but it had a little bit of history that spawned in a Spring Boot pull request (https://github.com/spring-projects/spring-boot/pull/22302#issuecomment-664940792).

The idea is to expose the available Neo4j Java Driver metrics as (core) micrometer meters instead of keeping it only Spring Boot scoped.

If you have any questions, please feel free to ask me or @michael-simons (mentioning him here to pull him in).

Update: I can see that the build is failing due the missing licence header. I can go ahead and add the VMWare header (to be honest, I do not have any opinions on this), but is a signed Pivotal CLA enough or do I have to also sign a VMWare CLA somewhere? Cannot find the contribution information.