### PR TITLE
Remove requireNonNull() in DatadogMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
+++ b/implementations/micrometer-registry-datadog/src/main/java/io/micrometer/datadog/DatadogMeterRegistry.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static io.micrometer.core.instrument.util.StringEscapeUtils.escapeJson;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.StreamSupport.stream;
 
@@ -235,7 +234,7 @@ public class DatadogMeterRegistry extends StepMeterRegistry {
         Iterable<Tag> tags = getConventionTags(fullId);
 
         String host = config.hostTag() == null ? "" : stream(tags.spliterator(), false)
-                .filter(t -> requireNonNull(config.hostTag()).equals(t.getKey()))
+                .filter(t -> config.hostTag().equals(t.getKey()))
                 .findAny()
                 .map(t -> ",\"host\":\"" + escapeJson(t.getValue()) + "\"")
                 .orElse("");


### PR DESCRIPTION
This PR removes `Objects.requireNonNull()` in `DatadogMeterRegistry` as it doesn't seem to be possible to be `null` at the location.