### PR TITLE
Handle NaN for FunctionTimer in InfluxMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -189,14 +189,20 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
         return Stream.empty();
     }
 
-    private Stream<String> writeFunctionTimer(FunctionTimer timer) {
-        Stream<Field> fields = Stream.of(
-                new Field("sum", timer.totalTime(getBaseTimeUnit())),
-                new Field("count", timer.count()),
-                new Field("mean", timer.mean(getBaseTimeUnit()))
-        );
-
-        return Stream.of(influxLineProtocol(timer.getId(), "histogram", fields));
+    // VisibleForTesting
+    Stream<String> writeFunctionTimer(FunctionTimer timer) {
+        double sum = timer.totalTime(getBaseTimeUnit());
+        if (Double.isFinite(sum)) {
+            Stream.Builder<Field> builder = Stream.builder();
+            builder.add(new Field("sum", sum));
+            builder.add(new Field("count", timer.count()));
+            double mean = timer.mean(getBaseTimeUnit());
+            if (Double.isFinite(mean)) {
+                builder.add(new Field("mean", mean));
+            }
+            return Stream.of(influxLineProtocol(timer.getId(), "histogram", builder.build()));
+        }
+        return Stream.empty();
     }
 
     private Stream<String> writeTimer(Timer timer) {

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
@@ -162,4 +162,36 @@ class InfluxMeterRegistryTest {
         clock.add(config.step());
         assertThat(meterRegistry.writeFunctionTimer(timer)).isEmpty();
     }
+
+    @Test
+    void nanMeanFunctionTimerShouldNotWriteMean() {
+        FunctionTimer functionTimer = new FunctionTimer() {
+            @Override
+            public double count() {
+                return 1;
+            }
+
+            @Override
+            public double totalTime(TimeUnit unit) {
+                return 1;
+            }
+
+            @Override
+            public TimeUnit baseTimeUnit() {
+                return TimeUnit.SECONDS;
+            }
+
+            @Override
+            public Id getId() {
+                return new Id("func.timer", Tags.empty(), null, null, Type.TIMER);
+            }
+
+            @Override
+            public double mean(TimeUnit unit) {
+                return Double.NaN;
+            }
+        };
+        assertThat(meterRegistry.writeFunctionTimer(functionTimer))
+                .containsOnly("func_timer,metric_type=histogram sum=1,count=1 1");
+    }
 }

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryTest.java
@@ -155,4 +155,11 @@ class InfluxMeterRegistryTest {
         Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.meterRegistry);
         assertThat(meterRegistry.writeMeter(meter)).containsExactly("my_meter,metric_type=unknown value=1,value=2 1");
     }
+
+    @Test
+    void nanFunctionTimerShouldNotBeWritten() {
+        FunctionTimer timer = FunctionTimer.builder("myFunctionTimer", Double.NaN, Number::longValue, Number::doubleValue, TimeUnit.MILLISECONDS).register(meterRegistry);
+        clock.add(config.step());
+        assertThat(meterRegistry.writeFunctionTimer(timer)).isEmpty();
+    }
 }


### PR DESCRIPTION
This PR changes to handle NaN for `FunctionTimer` in `InfluxMeterRegistry`.

Closes gh-2226