### PR TITLE
Upgrade to Gradle Wrapper 6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ subprojects {
 
                 // ensure Java 8 baseline is enforced for main source
                 if (JavaVersion.current().isJava9Compatible()) {
-                    options.compilerArgs.addAll(['--release', '8'])
+                    options.release = 8
                 }
             }
             compileTestJava {
@@ -210,7 +210,7 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = '6.5.1'
+    gradleVersion = '6.6'
 }
 
 defaultTasks 'build'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to Gradle Wrapper 6.6.

This PR also changes to use `options.release` instead of `options.compilerArgs`.

See https://docs.gradle.org/6.6/release-notes.html