### PR TITLE
Pin version for com.google.cloud:google-cloud-monitoring to 1.x

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ def VERSIONS = [
         'com.github.ben-manes.caffeine:caffeine:latest.release',
         'com.github.charithe:kafka-junit:latest.release',
         'com.github.tomakehurst:wiremock-jre8-standalone:latest.release',
-        'com.google.cloud:google-cloud-monitoring:latest.release',
+        'com.google.cloud:google-cloud-monitoring:1.+',
         'com.google.dagger:dagger:2.11',
         'com.google.dagger:dagger-compiler:2.11',
         'com.google.guava:guava:latest.release',


### PR DESCRIPTION
This PR pins the version for `com.google.cloud:google-cloud-monitoring` to 1.x to restore builds on the `master` branch as 2.0.0 has a breaking change as follows:

```
> Task :micrometer-registry-stackdriver:compileJava
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java:20: error: package com.google.auth.oauth2 does not exist
import com.google.auth.oauth2.GoogleCredentials;
                             ^
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java:82: error: cannot find symbol
                                GoogleCredentials.fromStream(new FileInputStream(credentials))
                                ^
  symbol:   variable GoogleCredentials
  location: interface StackdriverConfig
2 errors
```