### PR TITLE
Remove exclude in wiremock-junit5 dependencies

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -84,9 +84,7 @@ dependencies {
 
     testImplementation 'org.apache.commons:commons-pool2:2.+'
 
-    testImplementation 'ru.lanwen.wiremock:wiremock-junit5', {
-        exclude group: 'com.github.tomakehurst', module: 'wiremock'
-    }
+    testImplementation 'ru.lanwen.wiremock:wiremock-junit5'
     testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
 
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -5,9 +5,7 @@ dependencies {
 
     api 'org.junit.jupiter:junit-jupiter'
 
-    api 'ru.lanwen.wiremock:wiremock-junit5', {
-        exclude group: 'com.github.tomakehurst', module: 'wiremock'
-    }
+    api 'ru.lanwen.wiremock:wiremock-junit5'
     api 'com.github.tomakehurst:wiremock-jre8-standalone'
     api 'org.mockito:mockito-core'
     api 'org.testcontainers:testcontainers'


### PR DESCRIPTION
This PR removes `exclude` in `ru.lanwen.wiremock:wiremock-junit5` dependencies as it doesn't seem to be necessary.

See https://github.com/lanwen/wiremock-junit5/blob/0b8853e28894ad89c479a3d993ff242f58b7c523/pom.xml#L129-L133