### PR TITLE
Add Javadoc since tag to PrometheusMeterRegistry#scrape(Writer)

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -90,6 +90,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      *
      * @param writer Target that serves the content to be scraped by Prometheus.
      * @throws IOException if writing fails
+     * @since 1.2.0
      */
     public void scrape(Writer writer) throws IOException {
         TextFormat.write004(writer, registry.metricFamilySamples());


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to `PrometheusMeterRegistry#scrape(Writer)`.