### PR TITLE
Remove io.projectreactor:reactor-core dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -28,7 +28,6 @@ def VERSIONS = [
         'io.dropwizard.metrics:metrics-graphite:4.1.+',
         'io.dropwizard.metrics:metrics-jmx:4.0.+',
         'info.ganglia.gmetric4j:gmetric4j:latest.release',
-        'io.projectreactor:reactor-core:latest.release',
         'io.projectreactor:reactor-test:latest.release',
         'io.projectreactor.netty:reactor-netty:latest.release',
         'io.prometheus:simpleclient_common:latest.release',

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -5,7 +5,6 @@ plugins {
 dependencies {
     api project(':micrometer-core')
 
-    implementation 'io.projectreactor:reactor-core'
     implementation 'io.projectreactor.netty:reactor-netty'
 
     testImplementation project(':micrometer-test')

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     optionalApi 'org.apache.logging.log4j:log4j-core'
 
     // reactor
-    optionalApi 'io.projectreactor:reactor-core'
     optionalApi 'io.projectreactor.netty:reactor-netty'
 
     // @Timed AOP


### PR DESCRIPTION
This PR removes `io.projectreactor:reactor-core` dependencies as it's a transitive dependency from `io.projectreactor.netty:reactor-netty`.