### PR TITLE
Support metrics for multiple Tomcat MBeans of same type

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -26,7 +26,6 @@ import org.apache.catalina.Manager;
 import javax.management.*;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -135,7 +134,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void registerThreadPoolMetrics(MeterRegistry registry) {
-        registerMetricsEventually("type", "ThreadPool", (name, allTags) -> {
+        registerMetricsEventually(":type=ThreadPool,name=*", (name, allTags) -> {
             Gauge.builder("tomcat.threads.config.max", mBeanServer,
                     s -> safeDouble(() -> s.getAttribute(name, "maxThreads")))
                     .tags(allTags)
@@ -157,7 +156,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void registerCacheMetrics(MeterRegistry registry) {
-        registerMetricsEventually("type", "StringCache", (name, allTags) -> {
+        registerMetricsEventually(":type=StringCache", (name, allTags) -> {
             FunctionCounter.builder("tomcat.cache.access", mBeanServer,
                     s -> safeDouble(() -> s.getAttribute(name, "accessCount")))
                     .tags(allTags)
@@ -167,11 +166,11 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
                     s -> safeDouble(() -> s.getAttribute(name, "hitCount")))
                     .tags(allTags)
                     .register(registry);
-        }, false);
+        });
     }
 
     private void registerServletMetrics(MeterRegistry registry) {
-        registerMetricsEventually("j2eeType", "Servlet", (name, allTags) -> {
+        registerMetricsEventually(":j2eeType=Servlet,name=*,*", (name, allTags) -> {
             FunctionCounter.builder("tomcat.servlet.error", mBeanServer,
                     s -> safeDouble(() -> s.getAttribute(name, "errorCount")))
                     .tags(allTags)
@@ -191,7 +190,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void registerGlobalRequestMetrics(MeterRegistry registry) {
-        registerMetricsEventually("type", "GlobalRequestProcessor", (name, allTags) -> {
+        registerMetricsEventually(":type=GlobalRequestProcessor,name=*", (name, allTags) -> {
             FunctionCounter.builder("tomcat.global.sent", mBeanServer,
                 s -> safeDouble(() -> s.getAttribute(name, "bytesSent")))
                 .tags(allTags)
@@ -222,28 +221,17 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
         });
     }
 
-    private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
-        registerMetricsEventually(key, value, perObject, true);
-    }
-
     /**
-     * If the MBean already exists, register metrics immediately. Otherwise register an MBean registration listener
-     * with the MBeanServer and register metrics when/if the MBean becomes available.
+     * If the Tomcat MBeans already exist, register metrics immediately. Otherwise register an MBean registration listener
+     * with the MBeanServer and register metrics when/if the MBeans becomes available.
      */
-    private void registerMetricsEventually(String key, String value, BiConsumer<ObjectName, Iterable<Tag>> perObject, boolean hasName) {
+    private void registerMetricsEventually(String namePatternSuffix, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
         if (getJmxDomain() != null) {
-            try {
-                String name = getJmxDomain() + ":" + key + "=" + value + (hasName ? ",name=*,*" : "");
-                Set<ObjectName> objectNames = this.mBeanServer.queryNames(new ObjectName(name), null);
-                if (!objectNames.isEmpty()) {
-                    // MBean is present, so we can register metrics now.
-                    objectNames.stream().sorted(Comparator.reverseOrder()).findFirst()
-                            .ifPresent(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));
-                    return;
-                }
-            } catch (MalformedObjectNameException e) {
-                // should never happen
-                throw new RuntimeException("Error registering Tomcat JMX based metrics", e);
+            Set<ObjectName> objectNames = this.mBeanServer.queryNames(getNamePattern(namePatternSuffix), null);
+            if (!objectNames.isEmpty()) {
+                // MBeans are present, so we can register metrics now.
+                objectNames.forEach(objectName -> perObject.accept(objectName, Tags.concat(tags, nameTag(objectName))));
+                return;
             }
         }
 
@@ -255,6 +243,10 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
                 MBeanServerNotification mBeanServerNotification = (MBeanServerNotification) notification;
                 ObjectName objectName = mBeanServerNotification.getMBeanName();
                 perObject.accept(objectName, Tags.concat(tags, nameTag(objectName)));
+                if (getNamePattern(namePatternSuffix).isPattern()) {
+                    // patterns can match multiple MBeans so don't remove listener
+                    return;
+                }
                 try {
                     mBeanServer.removeNotificationListener(MBeanServerDelegate.DELEGATE_NAME, this);
                     notificationListeners.remove(this);
@@ -272,7 +264,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
 
             // we can safely downcast now
             ObjectName objectName = ((MBeanServerNotification) notification).getMBeanName();
-            return objectName.getDomain().equals(getJmxDomain()) && objectName.getKeyProperty(key).equals(value);
+            return getNamePattern(namePatternSuffix).apply(objectName);
         };
 
         try {
@@ -280,6 +272,15 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
         } catch (InstanceNotFoundException e) {
             // should never happen
             throw new RuntimeException("Error registering MBean listener", e);
+        }
+    }
+
+    private ObjectName getNamePattern(String namePatternSuffix) {
+        try {
+            return new ObjectName(getJmxDomain() + namePatternSuffix);
+        } catch (MalformedObjectNameException e) {
+            // should never happen
+            throw new RuntimeException("Error registering Tomcat JMX based metrics", e);
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.tomcat;
 
+import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -36,10 +38,15 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
 
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -120,7 +127,7 @@ class TomcatMetricsTest {
     }
 
     @Test
-    void mbeansAvailableAfterBinder() throws Exception {
+    void whenTomcatMetricsBoundBeforeTomcatStarted_mbeanMetricsRegisteredEventually() throws Exception {
         TomcatMetrics.monitor(registry, null);
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -139,17 +146,17 @@ class TomcatMetricsTest {
         };
 
         runTomcat(servlet, () -> {
-            assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 
             checkMbeansInitialState();
 
             try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-                HttpPost post = new HttpPost("http://localhost:" + this.port + "/");
+                HttpPost post = new HttpPost("http://localhost:" + this.port + "/0");
                 post.setEntity(new StringEntity("you there?"));
                 CloseableHttpResponse response1 = httpClient.execute(post);
 
                 CloseableHttpResponse response2 = httpClient.execute(
-                        new HttpGet("http://localhost:" + this.port + "/nowhere"));
+                        new HttpGet("http://localhost:" + this.port + "/0/no-get"));
 
                 long expectedSentBytes = response1.getEntity().getContentLength()
                         + response2.getEntity().getContentLength();
@@ -161,7 +168,7 @@ class TomcatMetricsTest {
     }
 
     @Test
-    void mbeansAvailableBeforeBinder() throws Exception {
+    void whenTomcatMetricsBoundAfterTomcatStarted_mbeanMetricsRegisteredImmediately() throws Exception {
         HttpServlet servlet = new HttpServlet() {
             @Override
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -177,12 +184,12 @@ class TomcatMetricsTest {
             checkMbeansInitialState();
 
             try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
-                HttpPost post = new HttpPost("http://localhost:" + this.port + "/");
+                HttpPost post = new HttpPost("http://localhost:" + this.port + "/0");
                 post.setEntity(new StringEntity("you there?"));
                 CloseableHttpResponse response1 = httpClient.execute(post);
 
                 CloseableHttpResponse response2 = httpClient.execute(
-                        new HttpGet("http://localhost:" + this.port + "/nowhere"));
+                        new HttpGet("http://localhost:" + this.port + "/0/no-get"));
 
                 long expectedSentBytes = response1.getEntity().getContentLength()
                         + response2.getEntity().getContentLength();
@@ -193,8 +200,113 @@ class TomcatMetricsTest {
         });
     }
 
+    @Test
+    @Issue("#1989")
+    void whenMultipleServlets_thenRegisterMetricsForAllServlets() throws Exception {
+        Collection<Servlet> servlets = Arrays.asList(new HttpServlet() {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                IOUtils.toString(req.getInputStream());
+                sleep();
+                resp.getOutputStream().write("yes".getBytes());
+            }
+        }, new HttpServlet() {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+                IOUtils.toString(req.getInputStream());
+                sleep();
+                resp.getOutputStream().write("hi".getBytes());
+            }
+        });
+
+        runTomcat(servlets, () -> {
+            TomcatMetrics.monitor(registry, null);
+
+            checkMbeansInitialState();
+
+            try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+                HttpPost post = new HttpPost("http://localhost:" + this.port + "/0");
+                post.setEntity(new StringEntity("you there?"));
+                CloseableHttpResponse response1 = httpClient.execute(post);
+
+                CloseableHttpResponse response2 = httpClient.execute(
+                        new HttpGet("http://localhost:" + this.port + "/1"));
+
+                FunctionTimer servlet0 = registry.get("tomcat.servlet.request").tag("name", "servlet0").functionTimer();
+                FunctionTimer servlet1 = registry.get("tomcat.servlet.request").tag("name", "servlet1").functionTimer();
+                assertThat(servlet0.count()).isEqualTo(1);
+                assertThat(servlet0.totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(PROCESSING_TIME_IN_MILLIS);
+                assertThat(servlet1.count()).isEqualTo(1);
+                assertThat(servlet1.totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(PROCESSING_TIME_IN_MILLIS);
+            }
+
+            return null;
+        });
+    }
+
+    @Test
+    @Issue("#1989")
+    void whenMultipleServletsAndTomcatMetricsBoundBeforeTomcatStarted_thenEventuallyRegisterMetricsForAllServlets() throws Exception {
+        TomcatMetrics.monitor(registry, null);
+        CountDownLatch latch0 = new CountDownLatch(1);
+        CountDownLatch latch1 = new CountDownLatch(1);
+        registry.config().onMeterAdded(m -> {
+            if (m.getId().getName().equals("tomcat.servlet.error")) {
+                if ("servlet0".equals(m.getId().getTag("name"))) {
+                    latch0.countDown();
+                } else if ("servlet1".equals(m.getId().getTag("name"))) {
+                    latch1.countDown();
+                }
+            }
+        });
+
+        Collection<Servlet> servlets = Arrays.asList(new HttpServlet() {
+            @Override
+            protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+                IOUtils.toString(req.getInputStream());
+                sleep();
+                resp.getOutputStream().write("yes".getBytes());
+            }
+        }, new HttpServlet() {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+                IOUtils.toString(req.getInputStream());
+                sleep();
+                resp.getOutputStream().write("hi".getBytes());
+            }
+        });
+
+        runTomcat(servlets, () -> {
+            assertThat(latch0.await(3, TimeUnit.SECONDS)).isTrue();
+            assertThat(latch1.await(3, TimeUnit.SECONDS)).isTrue();
+
+            checkMbeansInitialState();
+
+            try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+                HttpPost post = new HttpPost("http://localhost:" + this.port + "/0");
+                post.setEntity(new StringEntity("you there?"));
+                CloseableHttpResponse response1 = httpClient.execute(post);
+
+                CloseableHttpResponse response2 = httpClient.execute(
+                        new HttpGet("http://localhost:" + this.port + "/1"));
+
+                FunctionTimer servlet0 = registry.get("tomcat.servlet.request").tag("name", "servlet0").functionTimer();
+                FunctionTimer servlet1 = registry.get("tomcat.servlet.request").tag("name", "servlet1").functionTimer();
+                assertThat(servlet0.count()).isEqualTo(1);
+                assertThat(servlet0.totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(PROCESSING_TIME_IN_MILLIS);
+                assertThat(servlet1.count()).isEqualTo(1);
+                assertThat(servlet1.totalTime(TimeUnit.MILLISECONDS)).isGreaterThanOrEqualTo(PROCESSING_TIME_IN_MILLIS);
+            }
+
+            return null;
+        });
+    }
 
     void runTomcat(HttpServlet servlet, Callable<Void> doWithTomcat) throws Exception {
+        runTomcat(Collections.singleton(servlet), doWithTomcat);
+    }
+
+    void runTomcat(Collection<Servlet> servlets, Callable<Void> doWithTomcat) throws Exception {
         Tomcat server = new Tomcat();
         try {
             StandardHost host = new StandardHost();
@@ -206,8 +318,12 @@ class TomcatMetricsTest {
             this.port = server.getConnector().getLocalPort();
 
             Context context = server.addContext("", null);
-            server.addServlet("", "servletname", servlet);
-            context.addServletMappingDecoded("/", "servletname");
+            int i = 0;
+            for (Servlet servlet : servlets) {
+                server.addServlet("", "servlet" + i, servlet);
+                context.addServletMappingDecoded("/" + i + "/*", "servlet" + i);
+                i++;
+            }
 
             doWithTomcat.call();
 


### PR DESCRIPTION
This works with multiple MBeans for any of the metric types now, which would be expected when there are multiple servlets registered, for example. To support the case when TomcatMetrics is bound before Tomcat MBeans are available, the NotificationListener is no longer unregistered when multiple MBeans could be returned in the query since we have no way to know when all have been registered. All NotificationListeners are still unregistered when `close` is called.

Resolves #1989