### PR TITLE
Fix LogbackMetrics ignoreMetrics will ignore forever

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -110,8 +110,11 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
      */
     public static void ignoreMetrics(Runnable r) {
         ignoreMetrics.set(true);
-        r.run();
-        ignoreMetrics.remove();
+        try {
+            r.run();
+        } finally {
+            ignoreMetrics.remove();
+        }  
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
@@ -73,6 +73,25 @@ class LogbackMetricsTest {
         registry.counter("my.counter").increment();
     }
 
+    @Issue("#2270")
+    @Test
+    void resetIgnoreMetricsAfterRunnable() {
+        RuntimeException exception = new RuntimeException("Thrown by runnable");
+
+        try (LogbackMetrics logbackMetrics = new LogbackMetrics()) {
+            assertThat(logbackMetrics.ignoreMetrics.get()).isNull();
+            try {
+                logbackMetrics.ignoreMetrics(() -> {
+                    assertThat(logbackMetrics.ignoreMetrics.get()).isTrue();
+                    throw exception;
+                });
+            } catch (RuntimeException e) {
+                assertThat(e).isEqualTo(exception);
+                assertThat(logbackMetrics.ignoreMetrics.get()).isNull();
+            }
+        }
+    }
+
     @Issue("#421")
     @Test
     void removeFilterFromLoggerContextOnClose() {


### PR DESCRIPTION
In case that the Runnable throws an exception the ThreadLocal variable ignoreMetrics will stay set.

Fixes https://github.com/micrometer-metrics/micrometer/issues/2270