### PR TITLE
Add Mongo collection tag to MongoMetricsCommandListener

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListener.java
@@ -15,15 +15,25 @@
  */
 package io.micrometer.core.instrument.binder.mongodb;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.mongodb.MongoClient;
-import com.mongodb.event.*;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
-
+import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
 
 /**
  * {@link CommandListener} for collecting command metrics from {@link MongoClient}.
@@ -36,10 +46,20 @@ import java.util.concurrent.TimeUnit;
 @Incubating(since = "1.2.0")
 public class MongoMetricsCommandListener implements CommandListener {
 
-    private final Timer.Builder timerBuilder = Timer.builder("mongodb.driver.commands")
-            .description("Timer of mongodb commands");
+    /**
+     * The key under which the collection to which a MongoDB "get more" command pertains is stored.
+     */
+    private static final String GET_MORE_COMMAND_COLLECTION_KEY = "collection";
+    private static final String UNKNOWN_COLLECTION = "unknown";
+    private static final Timer.Builder TIMER_BUILDER =
+            Timer.builder("mongodb.driver.commands").description("Timer of MongoDB commands");
 
     private final MeterRegistry registry;
+    private final Cache<Integer, String> requestIdToCollectionName =
+            Caffeine.newBuilder()
+                    .expireAfterWrite(Duration.ofMinutes(10))
+                    .maximumSize(1000)
+                    .build();
 
     public MongoMetricsCommandListener(MeterRegistry registry) {
         this.registry = registry;
@@ -47,20 +67,70 @@ public class MongoMetricsCommandListener implements CommandListener {
 
     @Override
     public void commandStarted(CommandStartedEvent commandStartedEvent) {
+        registerRequest(commandStartedEvent);
     }
 
     @Override
     public void commandSucceeded(CommandSucceededEvent event) {
-        timeCommand(event, "SUCCESS", event.getElapsedTime(TimeUnit.NANOSECONDS));
+        timeCommand(
+                event,
+                "SUCCESS",
+                event.getElapsedTime(TimeUnit.NANOSECONDS),
+                deregisterRequest(event));
     }
 
     @Override
     public void commandFailed(CommandFailedEvent event) {
-        timeCommand(event, "FAILED", event.getElapsedTime(TimeUnit.NANOSECONDS));
+        timeCommand(event, "FAILED", event.getElapsedTime(TimeUnit.NANOSECONDS), deregisterRequest(event));
     }
 
-    private void timeCommand(CommandEvent event, String status, long elapsedTimeInNanoseconds) {
-        timerBuilder
+    /**
+     * Registers the tracking information associated with the given request ID, if any.
+     *
+     * @return The collection associated with the given request, or {@link #UNKNOWN_COLLECTION} if
+     *     unknown.
+     */
+    private String registerRequest(CommandStartedEvent event) {
+        String collection = getCollection(event);
+        requestIdToCollectionName.put(event.getRequestId(), collection);
+        return collection;
+    }
+
+    private static String getCollection(CommandStartedEvent event) {
+        return getCollectionFromCommand(event, event.getCommand())
+                .filter(BsonValue::isString)
+                .map(BsonValue::asString)
+                .map(BsonString::getValue)
+                .orElse(UNKNOWN_COLLECTION);
+    }
+
+    private static Optional<BsonValue> getCollectionFromCommand(
+            CommandStartedEvent event, BsonDocument document) {
+        Optional<BsonValue> collectionFromCommandName =
+                Optional.ofNullable(document.get(event.getCommandName()))
+                        .filter(BsonValue::isString);
+        Optional<BsonValue> collectionFromGetMoreCommand =
+                Optional.ofNullable(document.get(GET_MORE_COMMAND_COLLECTION_KEY));
+        return collectionFromCommandName.isPresent()
+                ? collectionFromCommandName
+                : collectionFromGetMoreCommand;
+    }
+
+    /**
+     * Removes the tracking information associated with the given request ID, if any.
+     *
+     * @return The collection associated with the given request, or {@link #UNKNOWN_COLLECTION} if
+     *     unknown.
+     */
+    private String deregisterRequest(CommandEvent event) {
+        return Optional.ofNullable(requestIdToCollectionName.asMap().remove(event.getRequestId()))
+                .orElse(UNKNOWN_COLLECTION);
+    }
+
+    private void timeCommand(
+            CommandEvent event, String status, long elapsedTimeInNanoseconds, String collection) {
+        TIMER_BUILDER
+                .tag("collection", collection)
                 .tag("command", event.getCommandName())
                 .tag("cluster.id", event.getConnectionDescription().getConnectionId().getServerId().getClusterId().getValue())
                 .tag("server.address", event.getConnectionDescription().getServerAddress().toString())

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
@@ -67,6 +67,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
+                "collection", "testCol",
                 "server.address", String.format("%s:%s", HOST, port),
                 "command", "insert",
                 "status", "SUCCESS"
@@ -82,6 +83,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
+                "collection", "testCol",
                 "server.address", String.format("%s:%s", HOST, port),
                 "command", "dropIndexes",
                 "status", "FAILED"


### PR DESCRIPTION
## What is this?
A suggested method to extract the `collection` from the `CommandStartedEvent` and propagating to `CommandListener#commandSucceeded` and `CommandListener#commandFailed`. Unfortunately, the collection name is not attainable from the `CommandSucceededEvent` and `CommandFailedEvent` and must be fished out by linking the `request_id` from the `CommandStartedEvent`. Hence the introduction of the Caffeine cache.

## Backstory
We introduced a `MongoMetricsCommandListener` for our organisation's Java services to track collection based usage statistics, as command alone did not provide us with the desired granularity of insights. We have used this across our organisation's services, and have noticed no issues, performance or otherwise. The cache size and expire after write duration were picked to suit our needs, this is unlikely suitable for instances which handle more than 1000 concurrent Mongo queries.