### PR TITLE
Upgrade machine executor image to ubuntu-1604:202007-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
   machine-executor:
     working_directory: ~/micrometer
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-1604:202007-01
 
 commands:
   gradlew-build:


### PR DESCRIPTION
I received an email from CircleCI support stating that a soon to be unsupported version of a machine image or remote docker version was being used. While the prior machine image is not in the list of soon to be unsupported versions, it is likely the remote docker version it pulled in was. This upgrade should upgrade the docker version to a supported one (19.03.0+).