### PR TITLE
Make MultiGauge override work with ID-changing MeterFilters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -613,6 +613,14 @@ public abstract class MeterRegistry {
         return remove(meter.getId());
     }
 
+    @Nullable
+    Meter remove(Meter.Id id, boolean applyFilters) {
+        if (applyFilters) {
+            return remove(getMappedId(id));
+        }
+        return remove(id);
+    }
+
     /**
      * @param mappedId The id of the meter to remove
      * @return The removed meter, or null if no meter matched the provided id.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.MultiGauge.Row;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,10 @@ class MultiGaugeTest {
     }
 
     private void testOverwrite() {
+        testOverwrite("my.multi.gauge");
+    }
+
+    private void testOverwrite(String mappedMeterName) {
         String testKey = "key1";
         AtomicInteger testValue = new AtomicInteger(1);
 
@@ -117,7 +122,7 @@ class MultiGaugeTest {
                 .collect(Collectors.toList());
         gauge.register(rows, true);
 
-        assertThat(registry.get(meterName).tag(testTagKey, testKey).gauge().value())
+        assertThat(registry.get(mappedMeterName).tag(testTagKey, testKey).gauge().value())
                 .isEqualTo(testValue.intValue());
     }
 
@@ -126,6 +131,18 @@ class MultiGaugeTest {
         registry.config().commonTags("common1", "1");
 
         testOverwrite();
+    }
+
+    @Test
+    void overwriteWithPrefix() {
+        registry.config().meterFilter(new MeterFilter() {
+            @Override
+            public Meter.Id map(Meter.Id id) {
+                return id.withName("prefix." + id.getName());
+            }
+        });
+
+        testOverwrite("prefix.my.multi.gauge");
     }
 
     private static class Color {


### PR DESCRIPTION
This PR changes to make `MultiGauge` aware of common tags by applying [the same hack](https://github.com/micrometer-metrics/micrometer/blob/7e9b5b73d3f49d6dd038a6e8a6b5134501788295/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java#L106-L111) that has been applied to `KafkaMetrics`.

Closes gh-2250