### PR TITLE
Add ch.qos.logback:logback-classic to micrometer-registry-elastic test scope

### DIFF
--- a/implementations/micrometer-registry-elastic/build.gradle
+++ b/implementations/micrometer-registry-elastic/build.gradle
@@ -6,4 +6,5 @@ dependencies {
     testImplementation project(':micrometer-test')
     testImplementation 'org.testcontainers:elasticsearch:latest.release'
     testImplementation 'com.jayway.jsonpath:json-path:latest.release'
+    testImplementation 'ch.qos.logback:logback-classic'
 }


### PR DESCRIPTION
When running `ElasticsearchMeterRegistryElasticsearch7IntegrationTest.indexTemplateShouldApply()`, the following logging failures occur:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
```

This PR adds `ch.qos.logback:logback-classic` to `micrometer-test` and removes it from `micrometer-registry-jmx` and `micrometer-registry-statsd` to make projects depending `micrometer-test` benefit from it.