### PR TITLE
Change default index name prefix to "micrometer-metrics"

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -68,12 +68,12 @@ public interface ElasticConfig extends StepRegistryConfig {
 
     /**
      * The index name to write metrics to.
-     * Default is: "metrics"
+     * Default is: "micrometer-metrics"
      *
      * @return index name
      */
     default String index() {
-        return getString(this, "index").orElse("metrics");
+        return getString(this, "index").orElse("micrometer-metrics");
     }
 
     /**

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
@@ -113,7 +113,7 @@ abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
     }
 
     private static String getDockerImageName(String version) {
-        return "docker.elastic.co/elasticsearch/elasticsearch-oss:" + version;
+        return "docker.elastic.co/elasticsearch/elasticsearch:" + version;
     }
 
 }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch6IntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch6IntegrationTest.java
@@ -25,7 +25,7 @@ class ElasticsearchMeterRegistryElasticsearch6IntegrationTest
 
     @Override
     protected String getVersion() {
-        return "6.8.6";
+        return "6.8.12";
     }
 
 }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
@@ -25,7 +25,7 @@ class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
 
     @Override
     protected String getVersion() {
-        return "7.6.0";
+        return "7.9.2";
     }
 
     @Override


### PR DESCRIPTION
This PR upgrades Elasticsearch in integration tests to the latest.