### PR TITLE
Remove Testcontainers from micrometer-test

### DIFF
--- a/implementations/micrometer-registry-elastic/build.gradle
+++ b/implementations/micrometer-registry-elastic/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 
     testImplementation project(':micrometer-test')
     testImplementation 'org.testcontainers:elasticsearch:latest.release'
+    testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'com.jayway.jsonpath:json-path:latest.release'
     testImplementation 'ch.qos.logback:logback-classic'
 }

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -8,8 +8,6 @@ dependencies {
     api 'ru.lanwen.wiremock:wiremock-junit5'
     api 'com.github.tomakehurst:wiremock-jre8-standalone'
     api 'org.mockito:mockito-core'
-    api 'org.testcontainers:testcontainers'
-    api 'org.testcontainers:junit-jupiter'
 
     testImplementation 'org.jsr107.ri:cache-ri-impl'
 


### PR DESCRIPTION
This PR removes Testcontainers from `micrometer-test`.

WireMock and Mockito also can be removed, but I'm not sure if there's any clear-cut rule for this. If they are good candidates to be removed, I'll update this PR accordingly.

See https://github.com/micrometer-metrics/micrometer/pull/2287#pullrequestreview-506283872