### PR TITLE
Use default constructor for atomic objects with default initial value

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -83,7 +83,7 @@ class PrometheusMeterRegistryTest {
 
     @Test
     void baseUnitMakesItToScrape() {
-        AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger n = new AtomicInteger();
         Gauge.builder("gauge", n, AtomicInteger::get).tags("a", "b").baseUnit(BaseUnits.BYTES).register(registry);
         assertThat(registry.scrape()).contains("gauge_bytes");
     }
@@ -443,7 +443,7 @@ class PrometheusMeterRegistryTest {
     @Issue("#1883")
     @Test
     void namesToCollectors() {
-        AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger n = new AtomicInteger();
         Gauge.builder("gauge", n, AtomicInteger::get).tags("a", "b").baseUnit(BaseUnits.BYTES).register(registry);
         assertThat(prometheusRegistry).extracting("namesToCollectors").extracting("gauge_bytes").isNotNull();
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -76,7 +76,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     private final StatsdConfig statsdConfig;
     private final HierarchicalNameMapper nameMapper;
     private final Map<Meter.Id, StatsdPollable> pollableMeters = new ConcurrentHashMap<>();
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean started = new AtomicBoolean();
     DirectProcessor<String> processor = DirectProcessor.create();
     FluxSink<String> fluxSink = new NoopFluxSink();
     Disposable.Swap statsdConnection = Disposables.swap();

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
@@ -43,8 +43,8 @@ public class BufferingFlux {
     public static Flux<String> create(final Flux<String> source, final String delimiter, final int maxByteArraySize, final long maxMillisecondsBetweenEmits) {
         return Flux.defer(() -> {
             final int delimiterSize = delimiter.getBytes().length;
-            final AtomicInteger byteSize = new AtomicInteger(0);
-            final AtomicLong lastTime = new AtomicLong(0);
+            final AtomicInteger byteSize = new AtomicInteger();
+            final AtomicLong lastTime = new AtomicLong();
 
             final DirectProcessor<Void> intervalEnd = DirectProcessor.create();
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdGaugeTest.java
@@ -28,7 +28,7 @@ class StatsdGaugeTest {
 
     @Test
     void shouldAlwaysPublishValue() {
-        AtomicInteger lines = new AtomicInteger(0);
+        AtomicInteger lines = new AtomicInteger();
         MeterRegistry registry = StatsdMeterRegistry.builder(StatsdConfig.DEFAULT)
                 .lineSink(l -> lines.incrementAndGet())
                 .build();
@@ -44,7 +44,7 @@ class StatsdGaugeTest {
 
     @Test
     void shouldOnlyPublishValueWhenValueChanges() {
-        AtomicInteger lines = new AtomicInteger(0);
+        AtomicInteger lines = new AtomicInteger();
         MeterRegistry registry = StatsdMeterRegistry
                 .builder(new StatsdConfig() {
                     @Override

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -384,7 +384,7 @@ class StatsdMeterRegistryTest {
     @EnumSource(StatsdFlavor.class)
     @Issue("#600")
     void memoryPerformanceOfNamingConventionInHotLoops(StatsdFlavor flavor) {
-        AtomicInteger namingConventionUses = new AtomicInteger(0);
+        AtomicInteger namingConventionUses = new AtomicInteger();
 
         registry = new StatsdMeterRegistry(configWithFlavor(flavor), clock);
 
@@ -425,7 +425,7 @@ class StatsdMeterRegistryTest {
     @Test
     @Issue("#778")
     void doNotPublishNanOrInfiniteGaugeValues() {
-        AtomicInteger lineCount = new AtomicInteger(0);
+        AtomicInteger lineCount = new AtomicInteger();
         registry = StatsdMeterRegistry.builder(StatsdConfig.DEFAULT)
                 .lineSink(l -> lineCount.incrementAndGet())
                 .build();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -96,7 +96,7 @@ public abstract class MeterRegistry {
     // Guarded by meterMapLock for both reads and writes
     private final Map<Id, Set<Id>> syntheticAssociations = new HashMap<>();
 
-    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean();
     private PauseDetector pauseDetector = new NoPauseDetector();
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -100,7 +100,7 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
             .baseUnit(BaseUnits.BYTES)
             .register(registry);
 
-        AtomicLong liveDataSize = new AtomicLong(0L);
+        AtomicLong liveDataSize = new AtomicLong();
 
         Gauge.builder("jvm.gc.live.data.size", liveDataSize, AtomicLong::get)
             .tags(tags)
@@ -119,7 +119,7 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
             .register(registry);
 
         // start watching for GC notifications
-        final AtomicLong youngGenSizeAfter = new AtomicLong(0L);
+        final AtomicLong youngGenSizeAfter = new AtomicLong();
 
         for (GarbageCollectorMXBean mbean : ManagementFactory.getGarbageCollectorMXBeans()) {
             if (!(mbean instanceof NotificationEmitter)) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -38,14 +38,14 @@ import java.util.function.ToLongFunction;
  * @author Johnny Lim
  */
 public class CompositeMeterRegistry extends MeterRegistry {
-    private final AtomicBoolean registriesLock = new AtomicBoolean(false);
+    private final AtomicBoolean registriesLock = new AtomicBoolean();
     private final Set<MeterRegistry> registries = Collections.newSetFromMap(new IdentityHashMap<>());
     private final Set<MeterRegistry> unmodifiableRegistries = Collections.unmodifiableSet(registries);
 
     // VisibleForTesting
     volatile Set<MeterRegistry> nonCompositeDescendants = Collections.emptySet();
 
-    private final AtomicBoolean parentLock = new AtomicBoolean(false);
+    private final AtomicBoolean parentLock = new AtomicBoolean();
     private volatile Set<CompositeMeterRegistry> parents = Collections.newSetFromMap(new IdentityHashMap<>());
 
     public CompositeMeterRegistry() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryVictoriaMetricsHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryVictoriaMetricsHistogram.java
@@ -95,9 +95,9 @@ public class FixedBoundaryVictoriaMetricsHistogram implements Histogram {
     final DoubleAdder sum;
 
     public FixedBoundaryVictoriaMetricsHistogram() {
-        this.zeros = new AtomicLong(0);
-        this.lower = new AtomicLong(0);
-        this.upper = new AtomicLong(0);
+        this.zeros = new AtomicLong();
+        this.lower = new AtomicLong();
+        this.upper = new AtomicLong();
         this.sum = new DoubleAdder();
 
         this.values = new AtomicReferenceArray<>(BUCKETS_COUNT);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionCounter.java
@@ -30,7 +30,7 @@ import java.util.function.ToDoubleFunction;
 public class DropwizardFunctionCounter<T> extends AbstractMeter implements FunctionCounter {
     private final WeakReference<T> ref;
     private final ToDoubleFunction<T> f;
-    private final AtomicLong last = new AtomicLong(0);
+    private final AtomicLong last = new AtomicLong();
     private final DropwizardRate rate;
     private final Meter dropwizardMeter;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardFunctionTimer.java
@@ -42,7 +42,7 @@ public class DropwizardFunctionTimer<T> extends AbstractMeter implements Functio
     private final ToDoubleFunction<T> totalTimeFunction;
     private final TimeUnit totalTimeFunctionUnit;
 
-    private final AtomicLong lastCount = new AtomicLong(0);
+    private final AtomicLong lastCount = new AtomicLong();
     private final DropwizardRate rate;
     private final Timer dropwizardMeter;
     private final TimeUnit registryBaseTimeUnit;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardTimer.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class DropwizardTimer extends AbstractTimer {
     private final Timer impl;
-    private final AtomicLong totalTime = new AtomicLong(0);
+    private final AtomicLong totalTime = new AtomicLong();
     private final TimeWindowMax max;
 
     DropwizardTimer(Id id, Timer impl, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/CumulativeHistogramLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/CumulativeHistogramLongTaskTimer.java
@@ -44,7 +44,7 @@ public class CumulativeHistogramLongTaskTimer extends DefaultLongTaskTimer {
     public HistogramSnapshot takeSnapshot() {
         HistogramSnapshot snapshot = super.takeSnapshot();
 
-        AtomicInteger i = new AtomicInteger(0);
+        AtomicInteger i = new AtomicInteger();
 
         snapshot = new HistogramSnapshot(
                 snapshot.count(),

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/OnlyOnceLoggingDenyMeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/OnlyOnceLoggingDenyMeterFilter.java
@@ -36,7 +36,7 @@ public final class OnlyOnceLoggingDenyMeterFilter implements MeterFilter {
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(OnlyOnceLoggingDenyMeterFilter.class);
 
-    private final AtomicBoolean alreadyWarned = new AtomicBoolean(false);
+    private final AtomicBoolean alreadyWarned = new AtomicBoolean();
 
     private final Supplier<String> message;
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -108,7 +108,7 @@ class MeterFilterTest {
 
     @Test
     void maximumAllowableTags() {
-        AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger n = new AtomicInteger();
 
         MeterFilter filter = MeterFilter.maximumAllowableTags("name", "k", 2, new MeterFilter() {
             @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TimeGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TimeGaugeTest.java
@@ -28,7 +28,7 @@ class TimeGaugeTest {
     void hasBaseTimeUnit() {
         MeterRegistry registry = new SimpleMeterRegistry();
 
-        AtomicLong n = new AtomicLong(0);
+        AtomicLong n = new AtomicLong();
         TimeGauge g = registry.more().timeGauge("my.time.gauge", Tags.empty(), n, TimeUnit.SECONDS, AtomicLong::doubleValue);
 
         assertThat(g.getId().getBaseUnit()).isEqualTo("seconds");

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -71,7 +71,7 @@ class CompositeMeterRegistryTest {
 
         Counter.builder("counter").baseUnit(BaseUnits.BYTES).register(composite);
         DistributionSummary.builder("summary").baseUnit(BaseUnits.BYTES).register(composite);
-        Gauge.builder("gauge", new AtomicInteger(0), AtomicInteger::get).baseUnit(BaseUnits.BYTES).register(composite);
+        Gauge.builder("gauge", new AtomicInteger(), AtomicInteger::get).baseUnit(BaseUnits.BYTES).register(composite);
 
         assertThat(simple.get("counter").counter().getId().getBaseUnit()).isEqualTo(BaseUnits.BYTES);
         assertThat(simple.get("summary").summary().getId().getBaseUnit()).isEqualTo(BaseUnits.BYTES);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * @author Johnny Lim
  */
 class StepMeterRegistryTest {
-    private AtomicInteger publishes = new AtomicInteger(0);
+    private AtomicInteger publishes = new AtomicInteger();
     private MockClock clock = new MockClock();
 
     private StepRegistryConfig config = new StepRegistryConfig() {

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/CounterTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/CounterTest.java
@@ -62,7 +62,7 @@ interface CounterTest {
     @Test
     @DisplayName("function-tracking counter increments by change in a monotonically increasing function when observed")
     default void functionTrackingCounter(MeterRegistry registry) {
-        AtomicLong n = new AtomicLong(0);
+        AtomicLong n = new AtomicLong();
         registry.more().counter("tracking", emptyList(), n);
         n.incrementAndGet();
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/GaugeTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/GaugeTest.java
@@ -31,7 +31,7 @@ interface GaugeTest {
     @Test
     @DisplayName("gauges attached to a number are updated when their values are observed")
     default void numericGauge(MeterRegistry registry) {
-        AtomicInteger n = registry.gauge("my.gauge", new AtomicInteger(0));
+        AtomicInteger n = registry.gauge("my.gauge", new AtomicInteger());
         n.set(1);
 
         Gauge g = registry.get("my.gauge").gauge();

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/CounterSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/CounterSample.java
@@ -32,7 +32,7 @@ public class CounterSample {
         MeterRegistry registry = SampleConfig.myMonitoringSystem();
         Counter counter = registry.counter("counter", "method", "actual");
 
-        AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger n = new AtomicInteger();
         registry.more().counter("counter", Tags.of("method", "function"), n);
 
         RandomEngine r = new MersenneTwister64(0);

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/FunctionCounterSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/FunctionCounterSample.java
@@ -28,7 +28,7 @@ public class FunctionCounterSample {
     public static void main(String[] args) {
         MeterRegistry registry = SampleConfig.myMonitoringSystem();
 
-        AtomicInteger n = new AtomicInteger(0);
+        AtomicInteger n = new AtomicInteger();
 
         FunctionCounter.builder("my.fcounter", n, AtomicInteger::get)
             .baseUnit("happiness")

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/FunctionTimerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/FunctionTimerSample.java
@@ -40,8 +40,8 @@ public class FunctionTimerSample {
             .register(registry);
 
         Object placeholder = new Object();
-        AtomicLong totalTimeNanos = new AtomicLong(0);
-        AtomicLong totalCount = new AtomicLong(0);
+        AtomicLong totalTimeNanos = new AtomicLong();
+        AtomicLong totalCount = new AtomicLong();
 
         FunctionTimer.builder("ftimer", placeholder, p -> totalCount.get(), p -> totalTimeNanos.get(), TimeUnit.NANOSECONDS)
             .register(registry);


### PR DESCRIPTION
This PR changes to use default constructor for atomic objects with default initial value.

See https://github.com/spring-projects/spring-framework/pull/25846