### PR TITLE
Use JMX domain from Manager by default in TomcatMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -70,6 +70,10 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
         this.manager = manager;
         this.tags = tags;
         this.mBeanServer = mBeanServer;
+
+        if (manager != null) {
+            this.jmxDomain = manager.getContext().getDomain();
+        }
     }
 
     public static void monitor(MeterRegistry registry, @Nullable Manager manager, String... tags) {


### PR DESCRIPTION
This PR changes to use JMX domain from `Manager` by default in `TomcatMetrics`.

See https://github.com/spring-projects/spring-boot/issues/23717