### PR TITLE
Pin jOOQ version to 3.13.+

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -56,7 +56,7 @@ def VERSIONS = [
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:latest.release',
         'org.hsqldb:hsqldb:latest.release',
-        'org.jooq:jooq:latest.release',
+        'org.jooq:jooq:3.13.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
         'org.junit.jupiter:junit-jupiter:latest.release',
         'org.junit.platform:junit-platform-launcher:latest.release',


### PR DESCRIPTION
This PR pins jOOQ version to 3.13.+ to restore builds on the master branch as 3.14.0 contains a breaking change.