### PR TITLE
Support non-generational garbage collector metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ jobs:
     executor: circle-jdk-executor
     steps:
       - gradlew-build
+      - gradlew-build:
+          command: shenandoahTest
+      - gradlew-build:
+          command: zgcTest
 
   docker-tests:
     executor: machine-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,8 @@ jobs:
     executor: circle-jdk-executor
     steps:
       - gradlew-build
-      - gradlew-build:
-          command: shenandoahTest
-      - gradlew-build:
-          command: zgcTest
+      - run: ./gradlew shenandoahTest
+      - run: ./gradlew zgcTest
 
   docker-tests:
     executor: machine-executor

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,28 @@ subprojects {
             }
         }
 
+        task shenandoahTest(type: Test) {
+            // set heap size for the test JVM(s)
+            maxHeapSize = "1500m"
+
+            useJUnitPlatform {
+                includeTags 'gc'
+            }
+
+            jvmArgs '-XX:+UseShenandoahGC'
+        }
+
+        task zgcTest(type: Test) {
+            // set heap size for the test JVM(s)
+            maxHeapSize = "1500m"
+
+            useJUnitPlatform {
+                includeTags 'gc'
+            }
+
+            jvmArgs '-XX:+UseZGC'
+        }
+
         license {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
@@ -55,7 +55,7 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
     private final TimeWindowSum gcPauseSum;
     private final AtomicReference<Double> lastOldGenUsageAfterGc = new AtomicReference<>(0.0);
 
-    private String oldGenPoolName;
+    private final String longLivedPoolName;
 
     public JvmHeapPressureMetrics() {
         this(emptyList(), Duration.ofMinutes(5), Duration.ofMinutes(1));
@@ -66,26 +66,23 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
         this.lookback = lookback;
         this.gcPauseSum = new TimeWindowSum((int) lookback.dividedBy(testEvery.toMillis()).toMillis(), testEvery);
 
-        for (MemoryPoolMXBean mbean : ManagementFactory.getMemoryPoolMXBeans()) {
-            String name = mbean.getName();
-            if (JvmMemory.isOldGenPool(name)) {
-                oldGenPoolName = name;
-                break;
-            }
-        }
+        longLivedPoolName = JvmMemory.getLongLivedHeapPool().map(MemoryPoolMXBean::getName).orElse(null);
 
         monitor();
     }
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        Gauge.builder("jvm.memory.usage.after.gc", lastOldGenUsageAfterGc, AtomicReference::get)
+        Gauge.Builder<AtomicReference<Double>> builder = Gauge.builder("jvm.memory.usage.after.gc", lastOldGenUsageAfterGc, AtomicReference::get)
                 .tags(tags)
                 .tag("area", "heap")
-                .tag("generation", "old")
                 .description("The percentage of old gen heap used after the last GC event, in the range [0..1]")
-                .baseUnit(BaseUnits.PERCENT)
-                .register(registry);
+                .baseUnit(BaseUnits.PERCENT);
+        if (JvmMemory.isOldGenPool(longLivedPoolName))
+            builder.tag("generation", "old");
+        else
+            builder.tag("pool", longLivedPoolName);
+        builder.register(registry);
 
         Gauge.builder("jvm.gc.overhead", gcPauseSum,
                 pauseSum -> {
@@ -99,17 +96,11 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void monitor() {
-        double maxOldGen = JvmMemory.getOldGen().map(mem -> JvmMemory.getUsageValue(mem, MemoryUsage::getMax)).orElse(0.0);
-
         for (GarbageCollectorMXBean mbean : ManagementFactory.getGarbageCollectorMXBeans()) {
             if (!(mbean instanceof NotificationEmitter)) {
                 continue;
             }
             NotificationListener notificationListener = (notification, ref) -> {
-                if (!notification.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
-                    return;
-                }
-
                 CompositeData cd = (CompositeData) notification.getUserData();
                 GarbageCollectionNotificationInfo notificationInfo = GarbageCollectionNotificationInfo.from(cd);
 
@@ -123,13 +114,15 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
 
                 Map<String, MemoryUsage> after = gcInfo.getMemoryUsageAfterGc();
 
-                if (oldGenPoolName != null) {
-                    final long oldAfter = after.get(oldGenPoolName).getUsed();
-                    lastOldGenUsageAfterGc.set(oldAfter / maxOldGen);
+                if (longLivedPoolName != null) {
+                    final long oldAfter = after.get(longLivedPoolName).getUsed();
+                    lastOldGenUsageAfterGc.set(oldAfter / (double) after.get(longLivedPoolName).getMax());
                 }
             };
             NotificationEmitter notificationEmitter = (NotificationEmitter) mbean;
-            notificationEmitter.addNotificationListener(notificationListener, null, null);
+            notificationEmitter.addNotificationListener(notificationListener,
+                    notification -> notification.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION),
+                    null);
             notificationListenerCleanUpRunnables.add(() -> {
                 try {
                     notificationEmitter.removeNotificationListener(notificationListener);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -29,12 +29,12 @@ class JvmMemory {
     private JvmMemory() {
     }
 
-    static Optional<MemoryPoolMXBean> getOldGen() {
+    static Optional<MemoryPoolMXBean> getLongLivedHeapPool() {
         return ManagementFactory
                 .getPlatformMXBeans(MemoryPoolMXBean.class)
                 .stream()
                 .filter(JvmMemory::isHeap)
-                .filter(mem -> isOldGenPool(mem.getName()))
+                .filter(mem -> isOldGenPool(mem.getName()) || isNonGenerationalHeapPool(mem.getName()))
                 .findAny();
     }
 
@@ -48,6 +48,10 @@ class JvmMemory {
 
     static boolean isOldGenPool(String name) {
         return name.endsWith("Old Gen") || name.endsWith("Tenured Gen");
+    }
+
+    static boolean isNonGenerationalHeapPool(String name) {
+        return "Shenandoah".equals(name) || "ZHeap".equals(name);
     }
 
     private static boolean isHeap(MemoryPoolMXBean memoryPoolBean) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/GcTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/GcTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 VMware, Inc.
+ * Copyright 2020 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,19 +15,15 @@
  */
 package io.micrometer.core.instrument.binder.jvm;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
-import java.lang.management.MemoryPoolMXBean;
-import java.util.Optional;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@GcTest
-class JvmMemoryTest {
-
-    @Test
-    void assertJvmMemoryGetLongLivedHeapPool() {
-        Optional<MemoryPoolMXBean> longLivedHeapPool = JvmMemory.getLongLivedHeapPool();
-        assertThat(longLivedHeapPool).isNotEmpty();
-    }
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Tag("gc")
+public @interface GcTest {
 }


### PR DESCRIPTION
There were some assumptions in JvmGcMetrics that the garbage collector was generational, with a designated young and old region. ZGC and Shenandoah are examples of OpenJDK garbage collectors that are not generational. GC metrics should be properly recorded with these changes.

Resolves #1861
Resolves #2305