### PR TITLE
Include LICENSE and NOTICE files in META-INF

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,13 @@ subprojects {
             }
         }
 
+        jar {
+            metaInf {
+                from "$rootDir/LICENSE"
+                from "$rootDir/NOTICE"
+            }
+        }
+
         if (project.extensions.findByName('bintray')) {
             bintray.labels = ['micrometer', 'atlas', 'metrics', 'prometheus', 'spectator', 'influx', 'new-relic', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'azure-monitor', 'appoptics', 'kairos', 'stackdriver']
             bintray.packageName = 'io.micrometer'

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -28,6 +28,10 @@ shadowJar {
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
     exclude 'META-INF/native/libnetty_transport_native_epoll_x86_64.so'
     relocate 'org.pcollections', 'io.micrometer.shaded.statsd.org.pcollections'
+    metaInf {
+        from "$rootDir/LICENSE"
+        from "$rootDir/NOTICE"
+    }
 }
 
 jar.deleteAllActions()

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -91,6 +91,10 @@ shadowJar {
         include(dependency('org.pcollections:'))
     }
     relocate 'org.pcollections', 'io.micrometer.shaded.org.pcollections'
+    metaInf {
+        from "$rootDir/LICENSE"
+        from "$rootDir/NOTICE"
+    }
 }
 
 jar.deleteAllActions()


### PR DESCRIPTION
TODO:
- [x] Figure out configuration for shadowJar plugin

Currently micrometer-core and micrometer-registry-statsd do not get the LICENSE and NOTICE files included, I believe related to their usage of the shadowJar plugin.

Resolves #2300