### PR TITLE
Spam less with KafkaMetrics and Prometheus

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -36,6 +36,7 @@ import java.util.function.ToDoubleFunction;
 
 import io.micrometer.core.util.internal.logging.InternalLogger;
 import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 
@@ -54,6 +55,7 @@ import static java.util.Collections.emptyList;
 @NonNullFields
 class KafkaMetrics implements MeterBinder, AutoCloseable {
     private final static InternalLogger log = InternalLoggerFactory.getInstance(KafkaMetrics.class);
+    private final static WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(KafkaMetrics.class);
 
     static final String METRIC_NAME_PREFIX = "kafka.";
     static final String METRIC_GROUP_APP_INFO = "app-info";
@@ -171,7 +173,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                 catch (Exception ex) {
                     String message = ex.getMessage();
                     if (message != null && message.contains("Prometheus requires")) {
-                        log.info("Failed to bind meter: " + meterName + " " + tags
+                        warnThenDebugLogger.log("Failed to bind meter: " + meterName + " " + tags
                                 + ". However, this could happen and might be restored in the next refresh.");
                     }
                     else {


### PR DESCRIPTION
Logging each occurrence of this at INFO level has been too verbose. Switch to logging the first occurrence at WARN and subsequent occurrences at DEBUG to create less spam for most common logging configurations. We have had reports of this log being spammy in various places (issues, Slack, Stackoverflow). While I do want to improve the situation so we avoid this happening so much, and part of that requires we get reports of when it happens, there is a balance to be had.