### PR TITLE
Fix logic to remove Kafka meters with less tags

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -155,11 +155,11 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                 for (Meter other : registry.find(meterName).meters()) {
                     List<Tag> tags = other.getId().getTags();
                     // Only consider meters from the same client before filtering
-                    if (differentClient(tags)) break;
+                    if (differentClient(tags, metric.metricName().tags().get(CLIENT_ID_TAG_NAME))) continue;
                     if (tags.size() < meterTagsWithCommonTags.size()) registry.remove(other);
                     // Check if already exists
                     else if (tags.size() == meterTagsWithCommonTags.size())
-                        if (tags.equals(meterTagsWithCommonTags)) return;
+                        if (tags.containsAll(meterTagsWithCommonTags) && meterTagsWithCommonTags.containsAll(tags)) return;
                         else break;
                     else hasLessTags = true;
                 }
@@ -182,7 +182,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         }
     }
 
-    private boolean differentClient(List<Tag> tags) {
+    private boolean differentClient(List<Tag> tags, String clientId) {
         for (Tag tag : tags)
             if (tag.getKey().equals(CLIENT_ID_TAG_NAME))
                 if (!clientId.equals(tag.getValue())) return true;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -241,4 +241,60 @@ class KafkaMetricsTest {
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.getMeters().get(0).getId().getTags()).containsExactlyInAnyOrder(Tag.of("kafka-version", "unknown"), Tag.of("key0", "value0"), Tag.of("common", "value"));
     }
+
+    @Issue("#2212")
+    @Test
+    void shouldRemoveMeterWithLessTagsWithMultipleClients() {
+        //Given
+        AtomicReference<Map<MetricName, KafkaMetric>> metrics = new AtomicReference<>(new LinkedHashMap<>());
+        Supplier<Map<MetricName, ? extends Metric>> supplier = () -> metrics.updateAndGet(map -> {
+            Map<String, String> firstTags = new LinkedHashMap<>();
+            Map<String, String> secondTags = new LinkedHashMap<>();
+            firstTags.put("key0", "value0");
+            firstTags.put("client-id", "client0");
+            secondTags.put("key0", "value0");
+            secondTags.put("client-id", "client1");
+            MetricName firstName = new MetricName("a", "b", "c", firstTags);
+            MetricName secondName = new MetricName("a", "b", "c", secondTags);
+            KafkaMetric firstMetric = new KafkaMetric(this, firstName, new Value(), new MetricConfig(), Time.SYSTEM);
+            KafkaMetric secondMetric = new KafkaMetric(this, secondName, new Value(), new MetricConfig(), Time.SYSTEM);
+
+            map.put(firstName, firstMetric);
+            map.put(secondName, secondMetric);
+            return map;
+        });
+        kafkaMetrics = new KafkaMetrics(supplier);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        //When
+        kafkaMetrics.bindTo(registry);
+        //Then
+        assertThat(registry.getMeters()).hasSize(2);
+        // Given
+        metrics.updateAndGet(map -> {
+            Map<String, String> firstTags = new LinkedHashMap<>();
+            Map<String, String> secondTags = new LinkedHashMap<>();
+            firstTags.put("key0", "value0");
+            firstTags.put("client-id", "client0");
+            secondTags.put("key0", "value0");
+            secondTags.put("client-id", "client1");
+            // more tags than before
+            firstTags.put("key1", "value1");
+            secondTags.put("key1", "value1");
+
+            MetricName firstName = new MetricName("a", "b", "c", firstTags);
+            MetricName secondName = new MetricName("a", "b", "c", secondTags);
+            KafkaMetric firstMetric = new KafkaMetric(this, firstName, new Value(), new MetricConfig(), Time.SYSTEM);
+            KafkaMetric secondMetric = new KafkaMetric(this, secondName, new Value(), new MetricConfig(), Time.SYSTEM);
+
+            map.put(firstName, firstMetric);
+            map.put(secondName, secondMetric);
+            return map;
+        });
+        // When
+        kafkaMetrics.checkAndBindMetrics(registry);
+        // Then
+        assertThat(registry.getMeters()).hasSize(2);
+        registry.getMeters().forEach(meter -> assertThat(meter.getId().getTags())
+                .extracting(Tag::getKey).containsOnly("key0", "key1", "client-id", "kafka-version"));
+    }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -209,7 +209,7 @@ class KafkaMetricsTest {
         };
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
-        registry.counter("kafka.b.a", "client-id", "client1", "key0", "value0");
+        registry.counter("kafka.b.a", "client-id", "client1", "key0", "value0", "kafka-version", "unknown");
         //When
         kafkaMetrics.bindTo(registry);
         //Then
@@ -265,6 +265,13 @@ class KafkaMetricsTest {
         });
         kafkaMetrics = new KafkaMetrics(supplier);
         MeterRegistry registry = new SimpleMeterRegistry();
+        // simulate PrometheusMeterRegistry restriction
+        registry.config()
+                .onMeterAdded(meter -> registry.find(meter.getId().getName()).meters().stream()
+                        .filter(m -> m.getId().getTags().size() != meter.getId().getTags().size())
+                        .findAny().ifPresent(m -> {
+                            throw new RuntimeException("meter exists with different number of tags");
+                        }));
         //When
         kafkaMetrics.bindTo(registry);
         //Then


### PR DESCRIPTION
This lead to many exceptions when using Prometheus with multiple Kafka client IDs and some meters with topic tags never being registered.

Resolves #2212

/cc @jeqo 