### PR TITLE
Implement grpc-java metric collection

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,7 @@ def VERSIONS = [
         'io.dropwizard.metrics:metrics-core:4.0.+',
         'io.dropwizard.metrics:metrics-graphite:4.1.+',
         'io.dropwizard.metrics:metrics-jmx:4.0.+',
+        'io.grpc:grpc-api:latest.release',
         'info.ganglia.gmetric4j:gmetric4j:latest.release',
         'io.projectreactor:reactor-core:3.3.+',
         'io.projectreactor:reactor-test:3.3.+',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,7 +27,12 @@ def VERSIONS = [
         'io.dropwizard.metrics:metrics-core:4.0.+',
         'io.dropwizard.metrics:metrics-graphite:4.1.+',
         'io.dropwizard.metrics:metrics-jmx:4.0.+',
+        // all io.grpc libraries must use the same version
         'io.grpc:grpc-api:latest.release',
+        'io.grpc:grpc-core:latest.release',
+        'io.grpc:grpc-services:latest.release',
+        'io.grpc:grpc-stubs:latest.release',
+        'io.grpc:grpc-alts:latest.release',
         'info.ganglia.gmetric4j:gmetric4j:latest.release',
         'io.projectreactor:reactor-core:3.3.+',
         'io.projectreactor:reactor-test:3.3.+',

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     optionalApi 'org.eclipse.jetty:jetty-server'
     optionalApi 'org.eclipse.jetty:jetty-client'
     optionalApi 'org.apache.tomcat.embed:tomcat-embed-core'
+    optionalApi 'io.grpc:grpc-api'
 
     // apache httpcomponents monitoring
     optionalApi 'org.apache.httpcomponents:httpclient'

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 VMware, Inc. <p> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at <p>
+ * https://www.apache.org/licenses/LICENSE-2.0 <p> Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.Sample;
+
+/**
+ * An abstract gRPC interceptor that will collect metrics for micrometer.
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public abstract class AbstractMetricCollectingInterceptor {
+
+    /**
+     * The metrics tag key that belongs to the called service name.
+     */
+    public static final String TAG_SERVICE_NAME = "service";
+    /**
+     * The metrics tag key that belongs to the called method name.
+     */
+    public static final String TAG_METHOD_NAME = "method";
+    /**
+     * The metrics tag key that belongs to the type of the called method.
+     */
+    public static final String TAG_METHOD_TYPE = "methodType";
+    /**
+     * The metrics tag key that belongs to the result status code.
+     */
+    public static final String TAG_STATUS_CODE = "statusCode";
+
+    /**
+     * Creates a new counter builder for the given method. By default the base unit will be messages.
+     *
+     * @param method The method the counter will be created for.
+     * @param name The name of the counter to use.
+     * @param description The description of the counter to use.
+     * @return The newly created counter builder.
+     */
+    protected static Counter.Builder prepareCounterFor(final MethodDescriptor<?, ?> method,
+            final String name, final String description) {
+        return Counter.builder(name)
+                .description(description)
+                .baseUnit("messages")
+                .tag(TAG_SERVICE_NAME, method.getServiceName())
+                .tag(TAG_METHOD_NAME, method.getBareMethodName())
+                .tag(TAG_METHOD_TYPE, method.getType().name());
+    }
+
+    /**
+     * Creates a new timer builder for the given method.
+     *
+     * @param method The method the timer will be created for.
+     * @param name The name of the timer to use.
+     * @param description The description of the timer to use.
+     * @return The newly created timer builder.
+     */
+    protected static Timer.Builder prepareTimerFor(final MethodDescriptor<?, ?> method,
+            final String name, final String description) {
+        return Timer.builder(name)
+                .description(description)
+                .tag(TAG_SERVICE_NAME, method.getServiceName())
+                .tag(TAG_METHOD_NAME, method.getBareMethodName())
+                .tag(TAG_METHOD_TYPE, method.getType().name());
+    }
+
+    private final Map<MethodDescriptor<?, ?>, MetricSet> metricsForMethods = new ConcurrentHashMap<>();
+
+    protected final MeterRegistry registry;
+
+    protected final UnaryOperator<Counter.Builder> counterCustomizer;
+    protected final UnaryOperator<Timer.Builder> timerCustomizer;
+    protected final Status.Code[] eagerInitializedCodes;
+
+    /**
+     * Creates a new gRPC interceptor that will collect metrics into the given {@link MeterRegistry}. This method won't
+     * use any customizers and will only initialize the {@link Code#OK OK} status.
+     *
+     * @param registry The registry to use.
+     */
+    public AbstractMetricCollectingInterceptor(final MeterRegistry registry) {
+        this(registry, UnaryOperator.identity(), UnaryOperator.identity(), Code.OK);
+    }
+
+    /**
+     * Creates a new gRPC interceptor that will collect metrics into the given {@link MeterRegistry} and uses the given
+     * customizer to configure the {@link Counter}s and {@link Timer}s.
+     *
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public AbstractMetricCollectingInterceptor(final MeterRegistry registry,
+            final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final Status.Code... eagerInitializedCodes) {
+        this.registry = registry;
+        this.counterCustomizer = counterCustomizer;
+        this.timerCustomizer = timerCustomizer;
+        this.eagerInitializedCodes = eagerInitializedCodes;
+    }
+
+    /**
+     * Pre-registers the all methods provided by the given service. This will initialize all default counters and timers
+     * for those methods.
+     *
+     * @param service The service to initialize the meters for.
+     * @see #preregisterMethod(MethodDescriptor)
+     */
+    public void preregisterService(final ServiceDescriptor service) {
+        for (final MethodDescriptor<?, ?> method : service.getMethods()) {
+            preregisterMethod(method);
+        }
+    }
+
+    /**
+     * Pre-registers the given method. This will initialize all default counters and timers for that method.
+     *
+     * @param method The method to initialize the meters for.
+     */
+    public void preregisterMethod(final MethodDescriptor<?, ?> method) {
+        metricsFor(method);
+    }
+
+    /**
+     * Gets or creates a {@link MetricSet} for the given gRPC method. This will initialize all default counters and
+     * timers for that method.
+     *
+     * @param method The method to get the metric set for.
+     * @return The metric set for the given method.
+     * @see #newMetricsFor(MethodDescriptor)
+     */
+    protected final MetricSet metricsFor(final MethodDescriptor<?, ?> method) {
+        return this.metricsForMethods.computeIfAbsent(method, this::newMetricsFor);
+    }
+
+    /**
+     * Creates a {@link MetricSet} for the given gRPC method. This will initialize all default counters and timers for
+     * that method.
+     *
+     * @param method The method to get the metric set for.
+     * @return The newly created metric set for the given method.
+     */
+    protected MetricSet newMetricsFor(final MethodDescriptor<?, ?> method) {
+        return new MetricSet(newRequestCounterFor(method), newResponseCounterFor(method), newTimerFunction(method));
+    }
+
+    /**
+     * Creates a new request counter for the given method.
+     *
+     * @param method The method to create the counter for.
+     * @return The newly created request counter.
+     */
+    protected abstract Counter newRequestCounterFor(final MethodDescriptor<?, ?> method);
+
+    /**
+     * Creates a new response counter for the given method.
+     *
+     * @param method The method to create the counter for.
+     * @return The newly created response counter.
+     */
+    protected abstract Counter newResponseCounterFor(final MethodDescriptor<?, ?> method);
+
+    /**
+     * Creates a new timer function using the given template. This method initializes the default timers.
+     *
+     * @param timerTemplate The template to create the instances from.
+     * @return The newly created function that returns a timer for a given code.
+     */
+    protected Function<Code, Timer> asTimerFunction(final Supplier<Timer.Builder> timerTemplate) {
+        final Map<Code, Timer> cache = new EnumMap<>(Code.class);
+        final Function<Code, Timer> creator = code -> timerTemplate.get()
+                .tag(TAG_STATUS_CODE, code.name())
+                .register(this.registry);
+        final Function<Code, Timer> cacheResolver = code -> cache.computeIfAbsent(code, creator);
+        // Eager initialize
+        for (final Code code : this.eagerInitializedCodes) {
+            cacheResolver.apply(code);
+        }
+        return cacheResolver;
+    }
+
+    /**
+     * Creates a new timer for a given code for the given method.
+     *
+     * @param method The method to create the timer for.
+     * @return The newly created function that returns a timer for a given code.
+     */
+    protected abstract Function<Code, Timer> newTimerFunction(final MethodDescriptor<?, ?> method);
+
+    /**
+     * Container for all metrics of a certain call. Used instead of 3 maps to improve performance.
+     */
+    protected static class MetricSet {
+
+        private final Counter requestCounter;
+        private final Counter responseCounter;
+        private final Function<Code, Timer> timerFunction;
+
+        /**
+         * Creates a new metric set with the given meter instances.
+         *
+         * @param requestCounter The request counter to use.
+         * @param responseCounter The response counter to use.
+         * @param timerFunction The timer function to use.
+         */
+        public MetricSet(
+                final Counter requestCounter,
+                final Counter responseCounter,
+                final Function<Code, Timer> timerFunction) {
+
+            this.requestCounter = requestCounter;
+            this.responseCounter = responseCounter;
+            this.timerFunction = timerFunction;
+        }
+
+        /**
+         * Gets the Counter that counts the request messages.
+         *
+         * @return The Counter that counts the request messages.
+         */
+        public Counter getRequestCounter() {
+            return this.requestCounter;
+        }
+
+        /**
+         * Gets the Counter that counts the response messages.
+         *
+         * @return The Counter that counts the response messages.
+         */
+        public Counter getResponseCounter() {
+            return this.responseCounter;
+        }
+
+        /**
+         * Uses the given registry to create a {@link Sample Timer.Sample} that will be reported if the returned
+         * consumer is invoked.
+         *
+         * @param registry The registry used to create the sample.
+         * @return The newly created consumer that will report the processing duration since calling this method and
+         *         invoking the returned consumer along with the status code.
+         */
+        public Consumer<Status.Code> newProcessingDurationTiming(final MeterRegistry registry) {
+            final Timer.Sample timerSample = Timer.start(registry);
+            return code -> timerSample.stop(this.timerFunction.apply(code));
+        }
+
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientCall.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientCall.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.function.Consumer;
+
+import io.grpc.ClientCall;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * A simple forwarding client call that collects metrics for micrometer.
+ *
+ * @param <Q> The type of message sent one or more times to the server.
+ * @param <A> The type of message received one or more times from the server.
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+class MetricCollectingClientCall<Q, A> extends SimpleForwardingClientCall<Q, A> {
+
+    private final Counter requestCounter;
+    private final Counter responseCounter;
+    private final Consumer<Status.Code> processingDurationTiming;
+
+    /**
+     * Creates a new delegating ClientCall that will wrap the given client call to collect metrics.
+     *
+     * @param delegate The original call to wrap.
+     * @param requestCounter The counter for outgoing requests.
+     * @param responseCounter The counter for incoming responses.
+     * @param processingDurationTiming The consumer used to time the processing duration along with a response status.
+     */
+    public MetricCollectingClientCall(
+            final ClientCall<Q, A> delegate,
+            final Counter requestCounter,
+            final Counter responseCounter,
+            final Consumer<Status.Code> processingDurationTiming) {
+
+        super(delegate);
+        this.requestCounter = requestCounter;
+        this.responseCounter = responseCounter;
+        this.processingDurationTiming = processingDurationTiming;
+    }
+
+    @Override
+    public void start(final ClientCall.Listener<A> responseListener, final Metadata metadata) {
+        super.start(
+                new MetricCollectingClientCallListener<>(
+                        responseListener,
+                        this.responseCounter,
+                        this.processingDurationTiming),
+                metadata);
+    }
+
+    @Override
+    public void sendMessage(final Q requestMessage) {
+        this.requestCounter.increment();
+        super.sendMessage(requestMessage);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientCallListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientCallListener.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.function.Consumer;
+
+import io.grpc.ClientCall;
+import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * A simple forwarding client call listener that collects metrics for micrometer.
+ *
+ * @param <A> The type of message received one or more times from the server.
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+class MetricCollectingClientCallListener<A> extends SimpleForwardingClientCallListener<A> {
+
+    private final Counter responseCounter;
+    private final Consumer<Status.Code> processingDurationTiming;
+
+    /**
+     * Creates a new delegating ClientCallListener that will wrap the given client call listener to collect metrics.
+     *
+     * @param delegate The original call to wrap.
+     * @param responseCounter The counter for incoming responses.
+     * @param processingDurationTiming The consumer used to time the processing duration along with a response status.
+     */
+    public MetricCollectingClientCallListener(
+            final ClientCall.Listener<A> delegate,
+            final Counter responseCounter,
+            final Consumer<Status.Code> processingDurationTiming) {
+
+        super(delegate);
+        this.responseCounter = responseCounter;
+        this.processingDurationTiming = processingDurationTiming;
+    }
+
+    @Override
+    public void onClose(final Status status, final Metadata metadata) {
+        this.processingDurationTiming.accept(status.getCode());
+        super.onClose(status, metadata);
+    }
+
+    @Override
+    public void onMessage(final A responseMessage) {
+        this.responseCounter.increment();
+        super.onMessage(responseMessage);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 VMware, Inc. <p> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at <p>
+ * https://www.apache.org/licenses/LICENSE-2.0 <p> Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status.Code;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * A gRPC client interceptor that will collect metrics using the given {@link MeterRegistry}.
+ *
+ * <p>
+ * <b>Usage:</b>
+ * </p>
+ *
+ * <code>
+ * <pre>
+ * ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost:8080", 8080)
+ *     .intercept(new MetricCollectingClientInterceptor(meterRegistry))
+ *     .build();
+ *
+ * channel.newCall(method, options);
+ * </pre>
+ * </code>
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public class MetricCollectingClientInterceptor extends AbstractMetricCollectingInterceptor
+        implements ClientInterceptor {
+
+    /**
+     * The total number of requests sent
+     */
+    public static final String METRIC_NAME_CLIENT_REQUESTS_SENT = "grpc.client.requests.sent";
+    /**
+     * The total number of responses received
+     */
+    public static final String METRIC_NAME_CLIENT_RESPONSES_RECEIVED = "grpc.client.responses.received";
+    /**
+     * The total time taken for the client to complete the call, including network delay
+     */
+    public static final String METRIC_NAME_CLIENT_PROCESSING_DURATION = "grpc.client.processing.duration";
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given {@link MeterRegistry}.
+     *
+     * @param registry The registry to use.
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry) {
+        super(registry);
+    }
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given {@link MeterRegistry} and uses the
+     * given customizer to configure the {@link Counter}s and {@link Timer}s.
+     *
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry,
+            final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final Code... eagerInitializedCodes) {
+        super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    }
+
+    @Override
+    protected Counter newRequestCounterFor(final MethodDescriptor<?, ?> method) {
+        return this.counterCustomizer.apply(
+                prepareCounterFor(method,
+                        METRIC_NAME_CLIENT_REQUESTS_SENT,
+                        "The total number of requests sent"))
+                .register(this.registry);
+    }
+
+    @Override
+    protected Counter newResponseCounterFor(final MethodDescriptor<?, ?> method) {
+        return this.counterCustomizer.apply(
+                prepareCounterFor(method,
+                        METRIC_NAME_CLIENT_RESPONSES_RECEIVED,
+                        "The total number of responses received"))
+                .register(this.registry);
+    }
+
+    @Override
+    protected Function<Code, Timer> newTimerFunction(final MethodDescriptor<?, ?> method) {
+        return asTimerFunction(() -> this.timerCustomizer.apply(
+                prepareTimerFor(method,
+                        METRIC_NAME_CLIENT_PROCESSING_DURATION,
+                        "The total time taken for the client to complete the call, including network delay")));
+    }
+
+    @Override
+    public <Q, A> ClientCall<Q, A> interceptCall(
+            final MethodDescriptor<Q, A> methodDescriptor,
+            final CallOptions callOptions,
+            final Channel channel) {
+
+        final MetricSet metrics = metricsFor(methodDescriptor);
+        final Consumer<Code> processingDurationTiming = metrics.newProcessingDurationTiming(this.registry);
+
+        return new MetricCollectingClientCall<>(
+                channel.newCall(methodDescriptor, callOptions),
+                metrics.getRequestCounter(),
+                metrics.getResponseCounter(),
+                processingDurationTiming);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerCall.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerCall.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.grpc;
+
+import io.grpc.ForwardingServerCall.SimpleForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * A simple forwarding server call that collects metrics for micrometer.
+ *
+ * @param <Q> The type of message received one or more times from the client.
+ * @param <A> The type of message sent one or more times to the client.
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+class MetricCollectingServerCall<Q, A> extends SimpleForwardingServerCall<Q, A> {
+
+    private final Counter responseCounter;
+    private Code responseCode = Code.UNKNOWN;
+
+    /**
+     * Creates a new delegating ServerCall that will wrap the given server call to collect metrics.
+     *
+     * @param delegate The original call to wrap.
+     * @param responseCounter The counter for incoming responses.
+     */
+    public MetricCollectingServerCall(
+            final ServerCall<Q, A> delegate,
+            final Counter responseCounter) {
+
+        super(delegate);
+        this.responseCounter = responseCounter;
+    }
+
+    public Code getResponseCode() {
+        return this.responseCode;
+    }
+
+    @Override
+    public void close(final Status status, final Metadata responseHeaders) {
+        this.responseCode = status.getCode();
+        super.close(status, responseHeaders);
+    }
+
+    @Override
+    public void sendMessage(final A responseMessage) {
+        this.responseCounter.increment();
+        super.sendMessage(responseMessage);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerCallListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerCallListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import io.grpc.ForwardingServerCallListener.SimpleForwardingServerCallListener;
+import io.grpc.ServerCall.Listener;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Counter;
+
+/**
+ * A simple forwarding server call listener that collects metrics for micrometer.
+ *
+ * @param <Q> The type of message received one or more times from the client.
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+class MetricCollectingServerCallListener<Q> extends SimpleForwardingServerCallListener<Q> {
+
+    private final Counter requestCounter;
+    private final Supplier<Status.Code> responseCodeSupplier;
+    private final Consumer<Status.Code> responseStatusTiming;
+
+    /**
+     * Creates a new delegating ServerCallListener that will wrap the given server call listener to collect metrics.
+     *
+     * @param delegate The original listener to wrap.
+     * @param requestCounter The counter for incoming requests.
+     * @param responseCodeSupplier The supplier of the response code.
+     * @param responseStatusTiming The consumer used to time the processing duration along with a response status.
+     */
+
+    public MetricCollectingServerCallListener(
+            final Listener<Q> delegate,
+            final Counter requestCounter,
+            final Supplier<Status.Code> responseCodeSupplier,
+            final Consumer<Status.Code> responseStatusTiming) {
+
+        super(delegate);
+        this.requestCounter = requestCounter;
+        this.responseCodeSupplier = responseCodeSupplier;
+        this.responseStatusTiming = responseStatusTiming;
+    }
+
+    @Override
+    public void onMessage(final Q requestMessage) {
+        this.requestCounter.increment();
+        super.onMessage(requestMessage);
+    }
+
+    @Override
+    public void onComplete() {
+        report(this.responseCodeSupplier.get());
+        super.onComplete();
+    }
+
+    @Override
+    public void onCancel() {
+        report(Status.Code.CANCELLED);
+        super.onCancel();
+    }
+
+    private void report(final Status.Code code) {
+        this.responseStatusTiming.accept(code);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 VMware, Inc. <p> Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at <p>
+ * https://www.apache.org/licenses/LICENSE-2.0 <p> Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package io.micrometer.core.instrument.binder.grpc;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import io.grpc.BindableService;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * A gRPC server interceptor that will collect metrics using the given {@link MeterRegistry}
+ *
+ * <p>
+ * <b>Usage:</b>
+ * </p>
+ *
+ * <code>
+ * <pre>
+ * Server server = ServerBuilder.forPort(8080)
+ *         .intercept(new MetricCollectingServerInterceptor(meterRegistry))
+ *         .build();
+ *
+ * server.start()
+ * </pre>
+ * </code>
+ *
+ * @author Daniel Theuke (daniel.theuke@heuboe.de)
+ */
+public class MetricCollectingServerInterceptor extends AbstractMetricCollectingInterceptor
+        implements ServerInterceptor {
+
+    /**
+     * The total number of requests received
+     */
+    public static final String METRIC_NAME_SERVER_REQUESTS_RECEIVED = "grpc.server.requests.received";
+    /**
+     * The total number of responses sent
+     */
+    public static final String METRIC_NAME_SERVER_RESPONSES_SENT = "grpc.server.responses.sent";
+    /**
+     * The total time taken for the server to complete the call.
+     */
+    public static final String METRIC_NAME_SERVER_PROCESSING_DURATION = "grpc.server.processing.duration";
+
+    /**
+     * Creates a new gRPC server interceptor that will collect metrics into the given {@link MeterRegistry}.
+     *
+     * @param registry The registry to use.
+     */
+    public MetricCollectingServerInterceptor(final MeterRegistry registry) {
+        super(registry);
+    }
+
+    /**
+     * Creates a new gRPC server interceptor that will collect metrics into the given {@link MeterRegistry} and uses the
+     * given customizer to configure the {@link Counter}s and {@link Timer}s.
+     *
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingServerInterceptor(final MeterRegistry registry,
+            final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final Code... eagerInitializedCodes) {
+        super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    }
+
+    /**
+     * Pre-registers the all methods provided by the given service. This will initialize all default counters and timers
+     * for those methods.
+     *
+     * @param service The service to initialize the meters for.
+     * @see #preregisterService(ServerServiceDefinition)
+     */
+    public void preregisterService(final BindableService service) {
+        preregisterService(service.bindService());
+    }
+
+    /**
+     * Pre-registers the all methods provided by the given service. This will initialize all default counters and timers
+     * for those methods.
+     *
+     * @param serviceDefinition The service to initialize the meters for.
+     * @see #preregisterService(ServiceDescriptor)
+     */
+    public void preregisterService(final ServerServiceDefinition serviceDefinition) {
+        preregisterService(serviceDefinition.getServiceDescriptor());
+    }
+
+    @Override
+    protected Counter newRequestCounterFor(final MethodDescriptor<?, ?> method) {
+        return this.counterCustomizer.apply(
+                prepareCounterFor(method,
+                        METRIC_NAME_SERVER_REQUESTS_RECEIVED,
+                        "The total number of requests received"))
+                .register(this.registry);
+    }
+
+    @Override
+    protected Counter newResponseCounterFor(final MethodDescriptor<?, ?> method) {
+        return this.counterCustomizer.apply(
+                prepareCounterFor(method,
+                        METRIC_NAME_SERVER_RESPONSES_SENT,
+                        "The total number of responses sent"))
+                .register(this.registry);
+    }
+
+    @Override
+    protected Function<Code, Timer> newTimerFunction(final MethodDescriptor<?, ?> method) {
+        return asTimerFunction(() -> this.timerCustomizer.apply(
+                prepareTimerFor(method,
+                        METRIC_NAME_SERVER_PROCESSING_DURATION,
+                        "The total time taken for the server to complete the call")));
+    }
+
+    @Override
+    public <Q, A> ServerCall.Listener<Q> interceptCall(
+            final ServerCall<Q, A> call,
+            final Metadata requestHeaders,
+            final ServerCallHandler<Q, A> next) {
+
+        final MetricSet metrics = metricsFor(call.getMethodDescriptor());
+        final Consumer<Status.Code> responseStatusTiming = metrics.newProcessingDurationTiming(this.registry);
+
+        final MetricCollectingServerCall<Q, A> monitoringCall =
+                new MetricCollectingServerCall<>(call, metrics.getResponseCounter());
+
+        return new MetricCollectingServerCallListener<>(
+                next.startCall(monitoringCall, requestHeaders),
+                metrics.getRequestCounter(),
+                monitoringCall::getResponseCode,
+                responseStatusTiming);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Collect metrics for grpc-java clients and servers.
+ *
+ * Refer to {@link io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor
+ * MetricCollectingClientInterceptor} and
+ * {@link io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor MetricCollectingServerInterceptor}
+ * for usage examples.
+ */
+
+package io.micrometer.core.instrument.binder.grpc;

--- a/samples/micrometer-samples-core/build.gradle
+++ b/samples/micrometer-samples-core/build.gradle
@@ -16,4 +16,8 @@ dependencies {
     implementation 'io.projectreactor.netty:reactor-netty'
     implementation 'org.apache.kafka:kafka-clients'
     implementation 'com.github.charithe:kafka-junit'
+    implementation ('io.grpc:grpc-services') {
+        exclude module: 'io.grpc:grpc-netty-shaded'
+    }
+
 }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcMetricsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcMetricsSample.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.samples;
+
+import java.io.IOException;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import io.grpc.health.v1.HealthGrpc.HealthBlockingStub;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.services.HealthStatusManager;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
+import io.micrometer.core.instrument.binder.grpc.MetricCollectingServerInterceptor;
+import io.micrometer.core.samples.utils.SampleConfig;
+
+/**
+ * Demonstrates how to collect metrics for grpc-java clients and servers.
+ */
+public class GrpcMetricsSample {
+
+    public static void main(final String... args) throws IOException {
+        final MeterRegistry registry = SampleConfig.myMonitoringSystem();
+
+        final HealthStatusManager service = new HealthStatusManager();
+
+        final Server server = InProcessServerBuilder.forName("sample")
+                .addService(service.getHealthService()) // Or any other service(s)
+                .intercept(new MetricCollectingServerInterceptor(registry))
+                .build();
+
+        server.start();
+
+        final ManagedChannel channel = InProcessChannelBuilder.forName("sample")
+                .intercept(new MetricCollectingClientInterceptor(registry))
+                .build();
+
+        final HealthBlockingStub healthClient = HealthGrpc.newBlockingStub(channel); // Or any other stub(s)
+
+        final HealthCheckRequest request = HealthCheckRequest.getDefaultInstance();
+        final HealthCheckResponse response = healthClient.check(request);
+
+        System.out.println("Status: " + response.getStatus());
+
+        for (final Meter meter : registry.getMeters()) {
+            System.out.println(meter.getClass().getSimpleName() + "->" + meter.getId());
+        }
+
+        channel.shutdownNow();
+        server.shutdownNow();
+    }
+
+}


### PR DESCRIPTION
Fixes #656

Based on https://github.com/yidongnan/grpc-spring-boot-starter

I'm the author of the metrics code and the co-maintainer of that library.
I intent to move it from that library to this library to ease the use of the code and hopefully increase the adoption of the grpc metric collection across all libraries.
The relevant (Spring) configurer beans that add these interceptors to the client/server will remain in grpc-spring-boot-starter to not introduce an additional/circular dependency to the related code.

This code has already been tested in production for quite some time.

**Usage-Sample**

````java
MeterRegistry registry = SampleConfig.myMonitoringSystem();

HealthStatusManager service = new HealthStatusManager();

Server server = InProcessServerBuilder.forName("sample")
        .addService(service.getHealthService()) // Or any other service(s)
        .intercept(new MetricCollectingServerInterceptor(registry))
        .build();

server.start();

ManagedChannel channel = InProcessChannelBuilder.forName("sample")
        .intercept(new MetricCollectingClientInterceptor(registry))
        .build();

HealthBlockingStub healthClient = HealthGrpc.newBlockingStub(channel);  // Or any other stub(s)

HealthCheckRequest request = HealthCheckRequest.getDefaultInstance();
HealthCheckResponse response = healthClient.check(request);

System.out.println("Status: " + response.getStatus());

for (Meter meter : registry.getMeters()) {
    System.out.println(meter.getClass().getSimpleName() + "->" + meter.getId());
}

channel.shutdownNow();
server.shutdownNow();
````