### PR TITLE
Polish Javadoc for Search

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
@@ -64,7 +64,7 @@ public final class Search {
     }
 
     /**
-     * Meter contains a tag with the matching tag keys and values.
+     * Meter contains tags with the matching tag keys and values.
      *
      * @param tags The tags to match.
      * @return This search.
@@ -75,7 +75,7 @@ public final class Search {
     }
 
     /**
-     * Meter contains a tag with the matching tag keys and values.
+     * Meter contains tags with the matching tag keys and values.
      *
      * @param tags Must be an even number of arguments representing key/value pairs of tags.
      * @return This search.
@@ -96,7 +96,7 @@ public final class Search {
     }
 
     /**
-     * Meter contains a tag with the matching keys.
+     * Meter contains tags with the matching keys.
      *
      * @param tagKeys The tag keys to match.
      * @return This search.


### PR DESCRIPTION
This PR polishes Javadoc for `Search`.