### PR TITLE
Check for null long-lived pool name

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
@@ -73,20 +73,21 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
 
     @Override
     public void bindTo(@NonNull MeterRegistry registry) {
-        Gauge.Builder<AtomicReference<Double>> builder = Gauge.builder("jvm.memory.usage.after.gc", lastOldGenUsageAfterGc, AtomicReference::get)
-                .tags(tags)
-                .tag("area", "heap")
-                .description("The percentage of old gen heap used after the last GC event, in the range [0..1]")
-                .baseUnit(BaseUnits.PERCENT);
 
         if ( longLivedPoolName != null ) {
+            Gauge.Builder<AtomicReference<Double>> builder = Gauge.builder("jvm.memory.usage.after.gc", lastOldGenUsageAfterGc, AtomicReference::get)
+                    .tags(tags)
+                    .tag("area", "heap")
+                    .description("The percentage of old gen heap used after the last GC event, in the range [0..1]")
+                    .baseUnit(BaseUnits.PERCENT);
+
             if (JvmMemory.isOldGenPool(longLivedPoolName))
                 builder.tag("generation", "old");
             else
                 builder.tag("pool", longLivedPoolName);
-        }
 
-        builder.register(registry);
+            builder.register(registry);
+        }
 
         Gauge.builder("jvm.gc.overhead", gcPauseSum,
                 pauseSum -> {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
@@ -78,10 +78,14 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
                 .tag("area", "heap")
                 .description("The percentage of old gen heap used after the last GC event, in the range [0..1]")
                 .baseUnit(BaseUnits.PERCENT);
-        if (JvmMemory.isOldGenPool(longLivedPoolName))
-            builder.tag("generation", "old");
-        else
-            builder.tag("pool", longLivedPoolName);
+
+        if ( longLivedPoolName != null ) {
+            if (JvmMemory.isOldGenPool(longLivedPoolName))
+                builder.tag("generation", "old");
+            else
+                builder.tag("pool", longLivedPoolName);
+        }
+
         builder.register(registry);
 
         Gauge.builder("jvm.gc.overhead", gcPauseSum,

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -43,11 +43,11 @@ class JvmMemory {
     }
 
     static boolean isYoungGenPool(String name) {
-        return name.endsWith("Eden Space");
+        return name != null && name.endsWith("Eden Space");
     }
 
     static boolean isOldGenPool(String name) {
-        return name.endsWith("Old Gen") || name.endsWith("Tenured Gen");
+        return name != null && (name.endsWith("Old Gen") || name.endsWith("Tenured Gen"));
     }
 
     static boolean isNonGenerationalHeapPool(String name) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
@@ -24,10 +24,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @GcTest
 class JvmMemoryTest {
+    static String runtimeVendor = System.getProperty("java.vm.vendor", "unknown");
 
     @Test
     void assertJvmMemoryGetLongLivedHeapPool() {
         Optional<MemoryPoolMXBean> longLivedHeapPool = JvmMemory.getLongLivedHeapPool();
-        assertThat(longLivedHeapPool).isNotEmpty();
+        if ( !runtimeVendor.contains("OpenJ9") ) {
+            assertThat(longLivedHeapPool).isNotEmpty();
+        }
+    }
+
+    @Test
+    void assertTolerateNullName() {
+        // There is a way for the name passed to these methods to be null.
+        // Ensure they don't fail;
+        assertThat(JvmMemory.isOldGenPool(null)).isFalse();
+        assertThat(JvmMemory.isYoungGenPool(null)).isFalse();
     }
 }


### PR DESCRIPTION
OpenJ9 uses a different naming scheme for memory pools, which means certain existing checks will fail (return a null value).

Let's make sure we don't throw NullPointerExceptions when registering heap metrics.

Resolves #2330 
Supersedes #2333 
