### PR TITLE
Upgrade to test-retry-gradle-plugin 1.1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:3.4.0'
         classpath "io.spring.nohttp:nohttp-gradle:0.0.4.RELEASE"
-        classpath "org.gradle:test-retry-gradle-plugin:1.1.6"
+        classpath "org.gradle:test-retry-gradle-plugin:1.1.9"
 
         constraints {
             classpath('org.ow2.asm:asm:7.3.1') {


### PR DESCRIPTION
This PR upgrades to `test-retry-gradle-plugin` 1.1.9 as the current version gives the following deprecation warning:

```
> Task :micrometer-core:test
The Test.getClassLoaderCache() method has been deprecated. This is scheduled to be removed in Gradle 7.0.
```

Before I saw https://github.com/spring-projects/spring-boot/issues/24055, I had been missing the warning as it had been buried with other warnings such as illegal reflective access operations.