### PR TITLE
Use latest.release for de.flapdoodle.embed.mongo

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@ def VERSIONS = [
         'com.signalfx.public:signalfx-java:latest.release',
         'com.squareup.okhttp3:okhttp:latest.release',
         'com.wavefront:wavefront-sdk-java:latest.release',
-        'de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.+',
+        'de.flapdoodle.embed:de.flapdoodle.embed.mongo:latest.release',
         'io.dropwizard.metrics:metrics-core:4.0.+',
         'io.dropwizard.metrics:metrics-graphite:4.1.+',
         'io.dropwizard.metrics:metrics-jmx:4.0.+',

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/AbstractMongoDbTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/AbstractMongoDbTest.java
@@ -17,8 +17,7 @@ package io.micrometer.core.instrument.binder.mongodb;
 
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.IMongodConfig;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
@@ -48,7 +47,7 @@ abstract class AbstractMongoDbTest {
 
         port = Network.getFreeServerPort();
 
-        IMongodConfig mongodConfig = new MongodConfigBuilder()
+        MongodConfig mongodConfig = MongodConfig.builder()
                 .version(Version.Main.PRODUCTION)
                 .net(new Net(HOST, port, Network.localhostIsIPv6()))
                 .build();


### PR DESCRIPTION
This PR changes to use `latest.release` for `de.flapdoodle.embed.mongo` again that has been pinned in c78f101f0e9c00a004fb52c774c155f5ee6678f9.