### PR TITLE
Add Javadoc since to Search.tagKeys(Collection<String>)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
@@ -114,6 +114,7 @@ public final class Search {
      *
      * @param tagKeys The tag keys to match.
      * @return This search.
+     * @since 1.7.0
      */
     public Search tagKeys(Collection<String> tagKeys) {
         requiredTagKeys.addAll(tagKeys);


### PR DESCRIPTION
This PR adds Javadoc `@since` to `Search.tagKeys(Collection<String>)`.

See gh-2310