### PR TITLE
Add (optional) extra tags to mongo connection pool

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
@@ -19,9 +19,7 @@ import com.mongodb.MongoClient;
 import com.mongodb.connection.ServerId;
 import com.mongodb.event.*;
 import io.micrometer.core.annotation.Incubating;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
 
@@ -50,9 +48,11 @@ public class MongoMetricsConnectionPoolListener extends ConnectionPoolListenerAd
     private final Map<ServerId, List<Meter>> meters = new ConcurrentHashMap<>();
 
     private final MeterRegistry registry;
+    private final Tags extraTags;
 
-    public MongoMetricsConnectionPoolListener(MeterRegistry registry) {
+    public MongoMetricsConnectionPoolListener(MeterRegistry registry, Tag... extraTags) {
         this.registry = registry;
+        this.extraTags = Tags.of(extraTags);
     }
 
     @Override
@@ -124,6 +124,7 @@ public class MongoMetricsConnectionPoolListener extends ConnectionPoolListenerAd
                     .description(description)
                     .tag("cluster.id", serverId.getClusterId().getValue())
                     .tag("server.address", serverId.getAddress().toString())
+                    .tags(extraTags)
                     .register(registry);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
@@ -21,6 +21,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.event.ClusterListenerAdapter;
 import com.mongodb.event.ClusterOpeningEvent;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,8 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
         AtomicReference<String> clusterId = new AtomicReference<>();
         MongoClientOptions options = MongoClientOptions.builder()
                 .minConnectionsPerHost(2)
-                .addConnectionPoolListener(new MongoMetricsConnectionPoolListener(registry))
+                .addConnectionPoolListener(new MongoMetricsConnectionPoolListener(registry,
+                        Tag.of("pool_name", "mongoTemplate")))
                 .addClusterListener(new ClusterListenerAdapter() {
                     @Override
                     public void clusterOpening(ClusterOpeningEvent event) {
@@ -57,7 +59,8 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
-                "server.address", String.format("%s:%s", HOST, port)
+                "server.address", String.format("%s:%s", HOST, port),
+                "pool_name", "mongoTemplate"
         );
 
         assertThat(registry.get("mongodb.driver.pool.size").tags(tags).gauge().value()).isEqualTo(2);


### PR DESCRIPTION
This is extremely useful for example to differentiate the connection pool in an application with multiple different connections to different databases which could be in the same mongo server.

resolves #2355