### PR TITLE
Remove meters from child registries using mapped Id

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -604,6 +604,9 @@ public abstract class MeterRegistry {
     }
 
     /**
+     * Remove a {@link Meter} from this {@link MeterRegistry registry}. This is expected to be a {@link Meter} with
+     * the same {@link Id} returned when registering a meter - which will have {@link MeterFilter}s applied to it.
+     *
      * @param meter The meter to remove
      * @return The removed meter, or null if the provided meter is not currently registered.
      * @since 1.1.0
@@ -614,15 +617,25 @@ public abstract class MeterRegistry {
         return remove(meter.getId());
     }
 
+    /**
+     * Remove a {@link Meter} from this {@link MeterRegistry registry} based on its {@link Id}
+     * before applying this registry's {@link MeterFilter}s to the given {@link Id}.
+     *
+     * @param preFilterId the id of the meter to remove
+     * @return The removed meter, or null if the meter is not found
+     * @since 1.3.16
+     */
+    @Incubating(since = "1.3.16")
     @Nullable
-    Meter remove(Meter.Id id, boolean applyFilters) {
-        if (applyFilters) {
-            return remove(getMappedId(id));
-        }
-        return remove(id);
+    public Meter removeByPreFilterId(Meter.Id preFilterId) {
+        return remove(getMappedId(preFilterId));
     }
 
     /**
+     * Remove a {@link Meter} from this {@link MeterRegistry registry} based the given {@link Id} as-is. The registry's
+     * {@link MeterFilter}s will not be applied to it. You can use the {@link Id} of the {@link Meter} returned
+     * when registering a meter, since that will have {@link MeterFilter}s already applied to it.
+     *
      * @param mappedId The id of the meter to remove
      * @return The removed meter, or null if no meter matched the provided id.
      * @since 1.1.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
@@ -66,7 +66,7 @@ public class MultiGauge {
                         boolean previouslyDefined = oldRows.contains(rowId);
 
                         if (overwrite && previouslyDefined) {
-                            registry.remove(rowId, true);
+                            registry.removeByPreFilterId(rowId);
                         }
 
                         if (overwrite || !previouslyDefined) {
@@ -81,7 +81,7 @@ public class MultiGauge {
 
             for (Meter.Id oldRow : oldRows) {
                 if (!newRows.contains(oldRow))
-                    registry.remove(oldRow, true);
+                    registry.removeByPreFilterId(oldRow);
             }
 
             return newRows;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -67,7 +67,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
                 })
                 .onMeterRemoved(m -> {
                     if (m instanceof CompositeMeter) { // should always be
-                        lock(registriesLock, () -> nonCompositeDescendants.forEach(r -> r.remove(m)));
+                        lock(registriesLock, () -> nonCompositeDescendants.forEach(r -> r.removeByPreFilterId(m.getId())));
                     }
                 });
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -475,4 +475,17 @@ class CompositeMeterRegistryTest {
         }
     }
 
+    @Test
+    @Issue("#2354")
+    void meterRemovalPropagatesToChildRegistryWithModifyingFilter() {
+        this.simple.config().commonTags("host", "localhost");
+        this.composite.add(this.simple);
+
+        Counter counter = this.composite.counter("my.counter");
+        this.composite.remove(counter);
+
+        assertThat(this.composite.getMeters()).isEmpty();
+        assertThat(this.simple.getMeters()).isEmpty();
+    }
+
 }


### PR DESCRIPTION
Child registries may have `MeterFilter` configured that alter the Id of meters when registered. In this case, calling `remove` with the Id from the `CompositeMeterRegistry` will not match unless it also has the same `MeterFilter` configured. The behavior of the `remove` method has fluctuated as these cases come to light. This adds public API for removing a meter with its pre-mapped Id and clarifies the behavior in the JavaDoc of all `remove` methods. `CompositeMeterRegistry` can now use this new API to have the expected behavior.

Resolves gh-2354