### PR TITLE
Make _source.enabled configurable for ElasticMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -181,6 +181,17 @@ public interface ElasticConfig extends StepRegistryConfig {
         return getSecret(this, "apiKeyCredentials").orElse(null);
     }
 
+    /**
+     * Enable {@literal _source} in the index template.
+     * Default is: {@code false}
+     *
+     * @return whether {@literal _source} will be enabled in the index template
+     * @since 2.0.0
+     */
+    default boolean enableSource() {
+        return getBoolean(this, "enableSource").orElse(false);
+    }
+
     @Override
     default Validated<?> validate() {
         return checkAll(this,

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -98,14 +97,6 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             "  \"active\": {\n" +
             "    \"type\": \"double\",\n" +
             "    \"index\": false\n" +
-            "  }\n" +
-            "}";
-    private static final BiFunction<String, Boolean, String> TEMPLATE_BODY_AFTER_VERSION_7 = (indexPrefix, enableSource) -> "{\n" +
-            "  \"index_patterns\": [\"" + indexPrefix + "*\"],\n" +
-            "  \"mappings\": {\n" +
-            "    \"_source\": {\n" +
-            "      \"enabled\": " + enableSource + "\n" +
-            "    },\n" + TEMPLATE_PROPERTIES +
             "  }\n" +
             "}";
 
@@ -192,7 +183,15 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     }
 
     private String getTemplateBody() {
-        return TEMPLATE_BODY_AFTER_VERSION_7.apply(config.index() + config.indexDateSeparator(), config.enableSource());
+        String indexPrefix = config.index() + config.indexDateSeparator();
+        return "{\n" +
+                "  \"index_patterns\": [\"" + indexPrefix + "*\"],\n" +
+                "  \"mappings\": {\n" +
+                "    \"_source\": {\n" +
+                "      \"enabled\": " + config.enableSource() + "\n" +
+                "    },\n" + TEMPLATE_PROPERTIES +
+                "  }\n" +
+                "}";
     }
 
     private HttpSender.Request.Builder connect(HttpSender.Method method, String uri) {


### PR DESCRIPTION
This PR changes to make `_source.enabled` configurable for `ElasticMeterRegistry`. While working on this, I noticed that there's no `_source.enabled` setting for Elasticsearch 6. So `_source` field does exist by default in Elasticsearch 6. I didn't touch the code related to Elasticsearch 6 as it seems to be going to be dropped soon in #1906.

Closes gh-1629