### PR TITLE
Use OperatingSystemMXBean.getCpuLoad() first in ProcessorMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -78,7 +78,8 @@ public class ProcessorMetrics implements MeterBinder {
         this.tags = tags;
         this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
         this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
-        this.systemCpuUsage = detectMethod("getSystemCpuLoad");
+        Method getCpuLoad = detectMethod("getCpuLoad");
+        this.systemCpuUsage = getCpuLoad != null ? getCpuLoad : detectMethod("getSystemCpuLoad");
         this.processCpuUsage = detectMethod("getProcessCpuLoad");
     }
 


### PR DESCRIPTION
This PR changes to use `OperatingSystemMXBean.getCpuLoad()` first in `ProcessorMetrics` as `OperatingSystemMXBean.getSystemCpuLoad()` has been deprecated in favour of `OperatingSystemMXBean.getCpuLoad()` since Java 14.