### PR TITLE
Use replaceTags() in MeterFilter.commonTags()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -227,10 +227,10 @@ public interface Meter {
         }
 
         /**
-         * Generate a new id with an additional tag. If the key of the provided tag already exists, this overwrites
+         * Generate a new id with additional tags. If the key of the provided tag already exists, this overwrites
          * the tag value.
          *
-         * @param tags The tag to add.
+         * @param tags The tags to add.
          * @return A new id with the provided tags added. The source id remains unchanged.
          * @since 1.1.0
          */
@@ -241,7 +241,7 @@ public interface Meter {
         /**
          * Generate a new id replacing all tags with new ones.
          *
-         * @param tags The tag to add.
+         * @param tags The tags to add.
          * @return A new id with the only the provided tags. The source id remains unchanged.
          * @since 1.1.0
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterFilter.java
@@ -45,6 +45,9 @@ public interface MeterFilter {
     /**
      * Add common tags that are applied to every meter created afterward.
      *
+     * The common tags will not override tag values from a meter ID. They will also not override previously configured
+     * common tag MeterFilters that have the same tag key.
+     *
      * @param tags Common tags.
      * @return A common tag filter.
      */
@@ -52,7 +55,7 @@ public interface MeterFilter {
         return new MeterFilter() {
             @Override
             public Meter.Id map(Meter.Id id) {
-                return id.withTags(Tags.concat(tags, id.getTagsAsIterable()));
+                return id.replaceTags(Tags.concat(tags, id.getTagsAsIterable()));
             }
         };
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterFilterTest.java
@@ -61,6 +61,15 @@ class MeterFilterTest {
     }
 
     @Test
+    void commonTagsShouldNotOverrideTagValuesFromMeterId() {
+        MeterFilter filter = MeterFilter.commonTags(Tags.of("k0", "c0", "k1", "c1", "k2", "c2"));
+        Meter.Id id = new Meter.Id("name", Tags.of("k1", "m1", "k2", "m2", "k3", "m3"), null, null, Meter.Type.COUNTER);
+        Meter.Id filteredId = filter.map(id);
+        assertThat(filteredId.getTags())
+                .containsExactlyElementsOf(Tags.of("k0", "c0", "k1", "m1", "k2", "m2", "k3", "m3"));
+    }
+
+    @Test
     void ignoreTags() {
         MeterFilter filter = MeterFilter.ignoreTags("k1", "k2");
         Meter.Id id = new Meter.Id("name", Tags.of("k1", "v1", "k2", "v2", "k3", "v3"), null, null, Meter.Type.COUNTER);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterIdTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterIdTest.java
@@ -19,6 +19,12 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Tests for {@link Meter.Id}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 class MeterIdTest {
     @Test
     void withStatistic() {
@@ -33,5 +39,19 @@ class MeterIdTest {
 
         assertThat(id).isEqualTo(id2);
         assertThat(id.hashCode()).isEqualTo(id2.hashCode());
+    }
+
+    @Test
+    void withTags() {
+        Meter.Id id = new Meter.Id("my.id", Tags.of("k1", "v1", "k2", "v2"), null, null, Meter.Type.COUNTER);
+        Meter.Id newId = id.withTags(Tags.of("k1", "n1", "k", "n"));
+        assertThat(newId.getTags()).containsExactlyElementsOf(Tags.of("k2", "v2", "k1", "n1", "k", "n"));
+    }
+
+    @Test
+    void replaceTags() {
+        Meter.Id id = new Meter.Id("my.id", Tags.of("k1", "v1", "k2", "v2"), null, null, Meter.Type.COUNTER);
+        Meter.Id newId = id.replaceTags(Tags.of("k1", "n1", "k", "n"));
+        assertThat(newId.getTags()).containsExactlyElementsOf(Tags.of("k1", "n1", "k", "n"));
     }
 }


### PR DESCRIPTION
This PR changes to use `replaceTags()` in `MeterFilter.commonTags()`.

See gh-1019