### PR TITLE
Use Collections.addAll() to avoid ArrayList creation

### DIFF
--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/HealthMeterRegistry.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/HealthMeterRegistry.java
@@ -29,8 +29,8 @@ import io.micrometer.core.lang.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -138,7 +138,7 @@ public class HealthMeterRegistry extends SimpleMeterRegistry {
         }
 
         public Builder serviceLevelObjectives(ServiceLevelObjective... slos) {
-            this.serviceLevelObjectives.addAll(Arrays.asList(slos));
+            Collections.addAll(this.serviceLevelObjectives, slos);
             return this;
         }
 

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
@@ -194,7 +194,7 @@ public abstract class ServiceLevelObjective {
             }
 
             public final Builder requires(MeterBinder... requires) {
-                this.requires.addAll(Arrays.asList(requires));
+                Collections.addAll(this.requires, requires);
                 return this;
             }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -110,7 +110,7 @@ public final class RequiredSearch {
      * @return This search.
      */
     public RequiredSearch tagKeys(String... tagKeys) {
-        requiredTagKeys.addAll(Arrays.asList(tagKeys));
+        Collections.addAll(requiredTagKeys, tagKeys);
         return this;
     }
 


### PR DESCRIPTION
This PR changes to use `Collections.addAll()` to avoid `ArrayList` creation.