### PR TITLE
Add implementation note to Javadoc for HibernateMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
@@ -40,6 +40,7 @@ import java.util.function.ToDoubleFunction;
  * @author Marten Deinum
  * @author Jon Schneider
  * @author Johnny Lim
+ * @implNote This implementation requires Hibernate 5.3 or later.
  */
 @NonNullApi
 @NonNullFields


### PR DESCRIPTION
This PR adds implementation node to Javadoc for `HibernateMetrics`.

See gh-2368