### PR TITLE
Use implementation for dependency declaration in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.micrometer:micrometer-core:latest.integration'
+    implementation 'io.micrometer:micrometer-core:latest.integration'
 }
 ```
 
@@ -56,7 +56,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.micrometer:micrometer-core:latest.integration'
+    implementation 'io.micrometer:micrometer-core:latest.integration'
 }
 ```
 


### PR DESCRIPTION
This PR changes to use `implementation` configuration instead of deprecated `compile` configuration for dependency declaration in `README.md`.