### PR TITLE
Remove flakiness in WavefrontMeterRegistryTest.publishMetric()

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryTest.java
+++ b/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryTest.java
@@ -79,7 +79,7 @@ class WavefrontMeterRegistryTest {
     void publishMetric() throws IOException {
         Meter.Id id = registry.counter("name").getId();
         long time = System.currentTimeMillis();
-        registry.publishMetric(id, null, System.currentTimeMillis(), 1d);
+        registry.publishMetric(id, null, time, 1d);
         verify(wavefrontSender, times(1)).sendMetric("name", 1d, time, "host", Collections.emptyMap());
         verifyNoMoreInteractions(wavefrontSender);
     }


### PR DESCRIPTION
This PR removes flakiness in `WavefrontMeterRegistryTest.publishMetric()` as it fails intermittently as follows:

```
WavefrontMeterRegistryTest > publishMetric() FAILED
    Argument(s) are different! Wanted:
    wavefrontSender.sendMetric(
        "name",
        1.0d,
        1608217738505L,
        "host",
        {}
    );
    -> at io.micrometer.wavefront.WavefrontMeterRegistryTest.publishMetric(WavefrontMeterRegistryTest.java:83)
    Actual invocations have different arguments:
    wavefrontSender.sendMetric(
        "name",
        1.0d,
        1608217738506L,
        "host",
        {}
    );
    -> at io.micrometer.wavefront.WavefrontMeterRegistry.publishMetric(WavefrontMeterRegistry.java:264)
        at io.micrometer.wavefront.WavefrontMeterRegistryTest.publishMetric(WavefrontMeterRegistryTest.java:83)
```