### PR TITLE
Pin jackson-databind to 2.12.0 temporarily

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ def VERSIONS = [
         'ch.qos.logback:logback-classic:1.2.+',
         'colt:colt:1.2.0',
         'com.amazonaws:aws-java-sdk-cloudwatch:latest.release',
-        'com.fasterxml.jackson.core:jackson-databind:latest.release',
+        'com.fasterxml.jackson.core:jackson-databind:2.12.0',
         'com.github.ben-manes.caffeine:caffeine:latest.release',
         'com.github.charithe:kafka-junit:latest.release',
         'com.github.tomakehurst:wiremock-jre8-standalone:latest.release',


### PR DESCRIPTION
Builds on master currently fail due to https://github.com/FasterXML/jackson-bom/issues/37. This PR pins `jackson-databind` to 2.12.0 temporarily to restore builds.