### PR TITLE
Upgrade to Gradle Wrapper 6.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,7 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = '6.7.1'
+    gradleVersion = '6.8'
 }
 
 defaultTasks 'build'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to Gradle Wrapper 6.8.