### PR TITLE
Make PrometheusMeterRegistry continue silently on meters with same name and different tags

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -420,7 +420,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     " set of tag keys. There is already an existing meter named '" + id.getName() + "' containing tag keys [" +
                     String.join(", ", collectorMap.get(getConventionName(id)).getTagKeys()) + "]. The meter you are attempting to register" +
                     " has keys [" + getConventionTags(id).stream().map(Tag::getKey).collect(joining(", ")) + "].");
-            return null;
+            return existingCollector;
         });
     }
 


### PR DESCRIPTION
This PR changes to make `PrometheusMeterRegistry` continue silently on meters with same name and different tags as it seems to be an original intention based on #2068.

Fixes #2399