### PR TITLE
Include index date separator in index pattern for ElasticMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -197,7 +197,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     }
 
     private String getTemplateBody() {
-        return majorVersion < 7 ? TEMPLATE_BODY_BEFORE_VERSION_7.apply(config.index()) : TEMPLATE_BODY_AFTER_VERSION_7.apply(config.index());
+        String indexPrefix = config.index() + config.indexDateSeparator();
+        return majorVersion < 7 ? TEMPLATE_BODY_BEFORE_VERSION_7.apply(indexPrefix) : TEMPLATE_BODY_AFTER_VERSION_7.apply(indexPrefix);
     }
 
     @Override


### PR DESCRIPTION
This PR changes to include index date separator in index pattern for `ElasticMeterRegistry`.

See https://github.com/micrometer-metrics/micrometer/pull/2197#pullrequestreview-451598881