### PR TITLE
Rename Prometheus API Collector.Type enum' value UNTYPED to UNKNOWN

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/MicrometerCollector.java
@@ -98,11 +98,11 @@ class MicrometerCollector extends Collector implements Collector.Describable {
             case LONG_TASK_TIMER:
                 return Arrays.asList(
                         new MetricFamilySamples(conventionName, Type.HISTOGRAM, help, Collections.emptyList()),
-                        new MetricFamilySamples(conventionName, Type.UNTYPED, help, Collections.emptyList()));
+                        new MetricFamilySamples(conventionName, Type.UNKNOWN, help, Collections.emptyList()));
 
             default:
                 return Collections.singletonList(
-                        new MetricFamilySamples(conventionName, Type.UNTYPED, help, Collections.emptyList()));
+                        new MetricFamilySamples(conventionName, Type.UNKNOWN, help, Collections.emptyList()));
         }
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -248,7 +248,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     @Override
     protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
-        Collector.Type promType = Collector.Type.UNTYPED;
+        Collector.Type promType = Collector.Type.UNKNOWN;
         switch (type) {
             case COUNTER:
                 promType = Collector.Type.COUNTER;


### PR DESCRIPTION
The io.prometheus.client.Collector.Type enum' value UNTYPED was renamed to UNKNOWN, since the release 0.10.0 / 2021-01-25

The gradle settings for the versioning of the prometheus API are set to always get the latest version. Consequently, there has been a compilation error on the master branch since this change was released.