### PR TITLE
Deprecate Micrometer Hibernate MeterBinder; recommend Hibernate community MeterBinder instead

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java
@@ -41,9 +41,13 @@ import java.util.function.ToDoubleFunction;
  * @author Jon Schneider
  * @author Johnny Lim
  * @implNote This implementation requires Hibernate 5.3 or later.
+ * @deprecated This implementation is deprecated in favor of the MeterBinder maintained
+ *    as part of the Hibernate project as of version 5.4.26. See
+ *    https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
 @NonNullApi
 @NonNullFields
+@Deprecated
 public class HibernateMetrics implements MeterBinder {
 
     private static final String SESSION_FACTORY_TAG_NAME = "entityManagerFactory";

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetrics.java
@@ -40,9 +40,13 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Pawel Stepien
  * @since 1.4.0
+ * @deprecated This implementation is deprecated in favor of the MeterBinder maintained
+ *    as part of the Hibernate project as of version 5.4.26. See
+ *    https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
 @NonNullApi
 @NonNullFields
+@Deprecated
 public class HibernateQueryMetrics implements MeterBinder {
 
     private static final String SESSION_FACTORY_TAG_NAME = "entityManagerFactory";

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsNoSecondLevelCacheTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsNoSecondLevelCacheTest.java
@@ -32,7 +32,11 @@ import org.mockito.stubbing.Answer;
  * Tests for {@link HibernateMetrics}.
  *
  * @author Erin Schnabel
+ * @deprecated This implementation is deprecated in favor of the MeterBinder maintained
+ *    as part of the Hibernate project as of version 5.4.26. See
+ *    https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
+@SuppressWarnings("deprecation")
 class HibernateMetricsNoSecondLevelCacheTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -39,7 +39,11 @@ import static org.mockito.Mockito.when;
  *
  * @author Marten Deinum
  * @author Johnny Lim
+ * @deprecated This implementation is deprecated in favor of the MeterBinder maintained
+ *    as part of the Hibernate project as of version 5.4.26. See
+ *    https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
+@SuppressWarnings("deprecation")
 class HibernateMetricsTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
@@ -65,7 +69,6 @@ class HibernateMetricsTest {
         return sf;
     }
 
-    @SuppressWarnings("deprecation")
     @Test
     void deprecatedMonitorShouldExposeMetricsWhenStatsEnabled() {
         HibernateMetrics.monitor(registry, entityManagerFactory, "entityManagerFactory");

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
@@ -34,7 +34,11 @@ import static org.mockito.Mockito.when;
  * Tests for {@link HibernateQueryMetrics}.
  *
  * @author Pawel Stepien
+ * @deprecated This implementation is deprecated in favor of the MeterBinder maintained
+ *    as part of the Hibernate project as of version 5.4.26. See
+ *    https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
+@SuppressWarnings("deprecation")
 class HibernateQueryMetricsTest {
 
     private MeterRegistry registry = new SimpleMeterRegistry();


### PR DESCRIPTION
Hibernate now maintains a Micrometer MeterBinder: 
https://github.com/hibernate/hibernate-orm/tree/master/hibernate-micrometer

Published artifacts are here:
https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/

