### PR TITLE
Support for non-integer SLOs in DistributionSummary

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -593,4 +593,25 @@ class PrometheusMeterRegistryTest {
         executorService.shutdownNow();
     }
 
+    @DisplayName("support for non-integer SLOs in DistributionSummary")
+    @Test
+    void nonIntegerSLOs() {
+        DistributionSummary ds = DistributionSummary
+                .builder("ds")
+                .serviceLevelObjectives(10, 1, 0.1, 0.01)
+                .register(registry);
+
+        ds.record(50);
+        ds.record(5);
+        ds.record(0.5);
+        ds.record(0.05);
+
+        assertThat(registry.scrape())
+                .contains("ds_bucket{le=\"0.01\",} 0.0")
+                .contains("ds_bucket{le=\"0.1\",} 1.0")
+                .contains("ds_bucket{le=\"1.0\",} 2.0")
+                .contains("ds_bucket{le=\"10.0\",} 3.0")
+                .contains("ds_bucket{le=\"+Inf\",} 4.0");
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
@@ -57,12 +57,12 @@ public class TimeWindowFixedBoundaryHistogram
 
     @Override
     void recordLong(FixedBoundaryHistogram bucket, long value) {
-        bucket.record(value);
+        recordDouble(bucket, value);
     }
 
     @Override
     final void recordDouble(FixedBoundaryHistogram bucket, double value) {
-        recordLong(bucket, (long) Math.ceil(value));
+        bucket.record(value);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class TimeWindowFixedBoundaryHistogram
             }
         }
 
-        void record(long value) {
+        void record(double value) {
             int index = leastLessThanOrEqualTo(value);
             if (index > -1)
                 values.incrementAndGet(index);
@@ -146,7 +146,7 @@ public class TimeWindowFixedBoundaryHistogram
         /**
          * The least bucket that is less than or equal to a sample.
          */
-        int leastLessThanOrEqualTo(long key) {
+        int leastLessThanOrEqualTo(double key) {
             int low = 0;
             int high = buckets.length - 1;
 


### PR DESCRIPTION
When migrating the use of native `Prometheus` components to the `Micrometer` facade, I realized that, although the `Micrometer` API allows the `double` type to be used to define an SLO, a rounding to integer numbers is always done to the recorded values.

Apparently, this rounding is not necessary, as the underlying implementation of `TimeWindowFixedBoundaryHistogram` already supports `double` to be used as buckets .

I implemented this change and added a unit test to the `MeterRegistryCompatibilityKit` - which is now green in all specific implementations. A specific unit test for `PrometheusMeterRegistry` was added as well, validating the output of the `scrape` method.

### Example

Consider the below code example and the consequent display in a Prometheus endpoint - **generated from a real execution environment.**

Creation and use of a `DistributionSummary` with the SLO parameter set to `{5.0, 1.0, 0.1, 0.01, 0.001}`, which makes it use the implementation of a `TimeWindowFixedBoundaryHistogram`:

```
DistributionSummary distributionSummary = DistributionSummary.builder("my.test.distribution.summary")
                .description("A test ds")
                .serviceLevelObjectives(5.0, 1.0, 0.1, 0.01, 0.001)
                .register(meterRegistry);

distributionSummary.record(0.0001);
distributionSummary.record(0.003);
distributionSummary.record(0.02);
distributionSummary.record(0.5);
distributionSummary.record(0.5);
distributionSummary.record(3.25);
```
The current code present in the master branch, and also in the 1.6.x and 1.5.x branches, generates the following inconsistent output - where values less than 1 are not grouped in their respective buckets:
```
# HELP my_test_distribution_summary_max A test ds
# TYPE my_test_distribution_summary_max gauge
my_test_distribution_summary_max 3.25
# HELP my_test_distribution_summary A test ds
# TYPE my_test_distribution_summary histogram
my_test_distribution_summary_bucket{le="0.001",} 0.0
my_test_distribution_summary_bucket{le="0.01",} 0.0
my_test_distribution_summary_bucket{le="0.1",} 0.0
my_test_distribution_summary_bucket{le="1.0",} 5.0
my_test_distribution_summary_bucket{le="5.0",} 6.0
my_test_distribution_summary_bucket{le="+Inf",} 6.0
my_test_distribution_summary_count 6.0
my_test_distribution_summary_sum 4.2730999999999995
```
With this correction applied, the histogram is displayed as below, with the values belonging to the 0.1, 0.01 and 0.001 buckets correctly grouped
```
# HELP my_test_distribution_summary_max A test ds
# TYPE my_test_distribution_summary_max gauge
my_test_distribution_summary_max 3.25
# HELP my_test_distribution_summary A test ds
# TYPE my_test_distribution_summary histogram
my_test_distribution_summary_bucket{le="0.001",} 1.0
my_test_distribution_summary_bucket{le="0.01",} 2.0
my_test_distribution_summary_bucket{le="0.1",} 3.0
my_test_distribution_summary_bucket{le="1.0",} 5.0
my_test_distribution_summary_bucket{le="5.0",} 6.0
my_test_distribution_summary_bucket{le="+Inf",} 6.0
my_test_distribution_summary_count 6.0
my_test_distribution_summary_sum 4.2730999999999995
```
