### PR TITLE
Support Javadoc @apiNote, @implSpec and @implNote

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,16 @@ subprojects {
                 sourceCompatibility = JavaVersion.VERSION_1_8
                 targetCompatibility = JavaVersion.VERSION_1_8
             }
+
+            javadoc {
+                configure(options) {
+                    tags(
+                        'apiNote:a:API Note:',
+                        'implSpec:a:Implementation Requirements:',
+                        'implNote:a:Implementation Note:'
+                    )
+                }
+            }
         }
 
         //noinspection GroovyAssignabilityCheck


### PR DESCRIPTION
I thought `@implNote` is supported out of the box, but it isn't. So the following error is thrown when generating Javadoc:

```
> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/HibernateMetrics.java:43: error: unknown tag: implNote
 * @implNote This implementation requires Hibernate 5.3 or later.
   ^
1 error
```

This PR changes to support Javadoc `@apiNote`, `@implSpec` and `@implNote` tags.