### PR TITLE
Use latest.release for Hazelcast version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,7 @@ def VERSIONS = [
         'com.google.dagger:dagger-compiler:2.11',
         'com.google.guava:guava:latest.release',
         'com.google.inject:guice:4.1.0',
-        'com.hazelcast:hazelcast:4.+',
+        'com.hazelcast:hazelcast:latest.release',
         'com.h2database:h2:latest.release',
         'com.microsoft.azure:applicationinsights-core:latest.release',
         // metrics are better with https://github.com/Netflix/Hystrix/pull/1568 introduced


### PR DESCRIPTION
This PR changes to use `latest.release` for Hazelcast version.