### PR TITLE
Fix MultipleIndicator.combine()

### DIFF
--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
@@ -679,7 +679,27 @@ public abstract class ServiceLevelObjective {
                 return new MultipleIndicator(name, tags, failedMessage, objectives, (o1, o2) -> o1 || o2);
             }
 
+            /**
+             * Combine {@link ServiceLevelObjective ServiceLevelObjectives} with the provided {@code combiner}.
+             *
+             * @param combiner combiner to combine {@link ServiceLevelObjective ServiceLevelObjectives}
+             * @param objectives {@link ServiceLevelObjective ServiceLevelObjectives} to combine
+             * @return combined {@code MultipleIndicator}
+             * @deprecated Use {@link #combine(BinaryOperator)} instead as this is broken with {@link #compose(String, ServiceLevelObjective...)}.
+             */
             public final MultipleIndicator combine(BinaryOperator<Boolean> combiner, ServiceLevelObjective... objectives) {
+                return new MultipleIndicator(name, tags, failedMessage, objectives, combiner);
+            }
+
+
+            /**
+             * Combine {@link ServiceLevelObjective ServiceLevelObjectives} with the provided {@code combiner}.
+             *
+             * @param combiner combiner to combine {@link ServiceLevelObjective ServiceLevelObjectives}
+             * @return combined {@code MultipleIndicator}
+             * @since 1.6.4
+             */
+            public final MultipleIndicator combine(BinaryOperator<Boolean> combiner) {
                 return new MultipleIndicator(name, tags, failedMessage, objectives, combiner);
             }
         }


### PR DESCRIPTION
`MultipleIndicator.combine()` has a parameter named `objectives` somehow, so it uses the parameter instead of `this.objectives`.

This PR changes to use `this.objectives` simply by removing the parameter that seems to be added accidentally.