### PR TITLE
Inject required meter binders into predefined SLOs

### DIFF
--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/HealthMeterRegistry.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/HealthMeterRegistry.java
@@ -31,6 +31,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -48,6 +50,7 @@ import java.util.stream.Collectors;
  * in order to perform their tests. These are automatically bound at construction time.
  *
  * @author Jon Schneider
+ * @author Johnny Lim
  * @since 1.6.0
  */
 @Incubating(since = "1.6.0")
@@ -98,9 +101,13 @@ public class HealthMeterRegistry extends SimpleMeterRegistry {
 
         // do this after the deny filter is set, because maybe only a portion of the metrics a binder registers are needed
         // for the SLOs that require the binder
+        Set<MeterBinder> boundMeterBinders = new HashSet<>();
         for (ServiceLevelObjective slo : serviceLevelObjectives) {
             for (MeterBinder require : slo.getRequires()) {
-                require.bindTo(this);
+                if (!boundMeterBinders.contains(require)) {
+                    require.bindTo(this);
+                    boundMeterBinders.add(require);
+                }
             }
         }
 

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/JvmServiceLevelObjectives.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/JvmServiceLevelObjectives.java
@@ -23,7 +23,10 @@ import io.micrometer.health.ServiceLevelObjective;
 import java.time.Duration;
 
 /**
+ * {@link ServiceLevelObjective ServiceLevelObjectives} for Java Virtual Machine.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  * @since 1.6.0
  */
 public class JvmServiceLevelObjectives {
@@ -31,56 +34,63 @@ public class JvmServiceLevelObjectives {
      * A series of high-level heap monitors originally defined in
      * <a href="https://www.jetbrains.com/help/teamcity/teamcity-memory-monitor.html">Team City's memory monitor</a>.
      */
-    public static final ServiceLevelObjective[] MEMORY = new ServiceLevelObjective[]{
-            ServiceLevelObjective
-                    .build("jvm.pool.memory")
-                    .failedMessage("Memory usage in a single memory pool exceeds 90% after garbage collection.")
-                    .requires(new JvmHeapPressureMetrics())
-                    .baseUnit("percent used")
-                    .value(s -> s.name("jvm.memory.usage.after.gc"))
-                    .isLessThan(0.9),
+    public static ServiceLevelObjective[] forMemory(
+            JvmHeapPressureMetrics jvmHeapPressureMetrics,
+            JvmMemoryMetrics jvmMemoryMetrics) {
+        return new ServiceLevelObjective[] {
+                ServiceLevelObjective
+                        .build("jvm.pool.memory")
+                        .failedMessage("Memory usage in a single memory pool exceeds 90% after garbage collection.")
+                        .requires(jvmHeapPressureMetrics)
+                        .baseUnit("percent used")
+                        .value(s -> s.name("jvm.memory.usage.after.gc"))
+                        .isLessThan(0.9),
 
-            ServiceLevelObjective
-                    .build("jvm.gc.load")
-                    .failedMessage("Memory cleaning is taking more than 50% of CPU resources on average. " +
-                            "This usually means really serious problems with memory resulting in high performance degradation.")
-                    .baseUnit("percent CPU time spent")
-                    .value(s -> s.name("jvm.gc.overhead"))
-                    .isLessThan(0.5),
+                ServiceLevelObjective
+                        .build("jvm.gc.load")
+                        .failedMessage("Memory cleaning is taking more than 50% of CPU resources on average. " +
+                                "This usually means really serious problems with memory resulting in high performance degradation.")
+                        .requires(jvmHeapPressureMetrics)
+                        .baseUnit("percent CPU time spent")
+                        .value(s -> s.name("jvm.gc.overhead"))
+                        .isLessThan(0.5),
 
-            ServiceLevelObjective
-                    .compose("jvm.total.memory",
-                            ServiceLevelObjective
-                                    .build("jvm.gc.overhead")
-                                    .failedMessage("More than 20% of CPU resources are being consumed by garbage collection.")
-                                    .baseUnit("percent CPU time spent")
-                                    .requires(new JvmHeapPressureMetrics())
-                                    .value(s -> s.name("jvm.gc.overhead"))
-                                    .isLessThan(0.2),
-                            ServiceLevelObjective
-                                    .build("jvm.memory.consumption")
-                                    .failedMessage("More than 90% of total memory has been in use during the last 5 minutes.")
-                                    .baseUnit("maximum percent used in last 5 minutes")
-                                    .requires(new JvmMemoryMetrics())
-                                    .value(s -> s.name("jvm.memory.used"))
-                                    .dividedBy(denom -> denom.value(s -> s.name("jvm.memory.committed")))
-                                    .maxOver(Duration.ofMinutes(5))
-                                    .isLessThan(0.9)
-                    )
-                    .failedMessage("More than 90% of total memory has been in use during the last 5 minutes and more than 20% of CPU resources are being consumed by garbage collection. " +
-                            "Lasting memory lack may result in performance degradation and server instability.")
-                    .and()
-    };
+                ServiceLevelObjective
+                        .compose("jvm.total.memory",
+                                ServiceLevelObjective
+                                        .build("jvm.gc.overhead")
+                                        .failedMessage("More than 20% of CPU resources are being consumed by garbage collection.")
+                                        .baseUnit("percent CPU time spent")
+                                        .requires(jvmHeapPressureMetrics)
+                                        .value(s -> s.name("jvm.gc.overhead"))
+                                        .isLessThan(0.2),
+                                ServiceLevelObjective
+                                        .build("jvm.memory.consumption")
+                                        .failedMessage("More than 90% of total memory has been in use during the last 5 minutes.")
+                                        .baseUnit("maximum percent used in last 5 minutes")
+                                        .requires(jvmMemoryMetrics)
+                                        .value(s -> s.name("jvm.memory.used"))
+                                        .dividedBy(denom -> denom.value(s -> s.name("jvm.memory.committed")))
+                                        .maxOver(Duration.ofMinutes(5))
+                                        .isLessThan(0.9)
+                        )
+                        .failedMessage("More than 90% of total memory has been in use during the last 5 minutes and more than 20% of CPU resources are being consumed by garbage collection. " +
+                                "Lasting memory lack may result in performance degradation and server instability.")
+                        .and()
+        };
+    }
 
-    public static final ServiceLevelObjective[] ALLOCATIONS = new ServiceLevelObjective[]{
-            ServiceLevelObjective
-                    .build("jvm.allocations.g1.humongous")
-                    .failedMessage("A single object was allocated that exceeded 50% of the total size of the eden space.")
-                    .baseUnit("allocations")
-                    .requires(new JvmGcMetrics())
-                    .count(s -> s.name("jvm.gc.pause").tag("cause", "G1 Humongous Allocation"))
-                    .isEqualTo(0)
-    };
+    public static ServiceLevelObjective[] forAllocations(JvmGcMetrics jvmGcMetrics) {
+        return new ServiceLevelObjective[]{
+                ServiceLevelObjective
+                        .build("jvm.allocations.g1.humongous")
+                        .failedMessage("A single object was allocated that exceeded 50% of the total size of the eden space.")
+                        .baseUnit("allocations")
+                        .requires(jvmGcMetrics)
+                        .count(s -> s.name("jvm.gc.pause").tag("cause", "G1 Humongous Allocation"))
+                        .isEqualTo(0)
+        };
+    }
 
     private JvmServiceLevelObjectives() {
     }

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/OperatingSystemServiceLevelObjectives.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/OperatingSystemServiceLevelObjectives.java
@@ -19,20 +19,25 @@ import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.health.ServiceLevelObjective;
 
 /**
+ * {@link ServiceLevelObjective ServiceLevelObjectives} for Operating System.
+ *
  * @author Jon Schneider
+ * @author Johnny Lim
  * @since 1.6.0
  */
 public class OperatingSystemServiceLevelObjectives {
-    public static final ServiceLevelObjective[] DISK = new ServiceLevelObjective[]{
-            ServiceLevelObjective.build("os.file.descriptors")
-                    .failedMessage("Too many file descriptors are open. When the max is reached, " +
-                            "further attempts to retrieve a file descriptor will block indefinitely.")
-                    .baseUnit("used / available (percent)")
-                    .requires(new FileDescriptorMetrics())
-                    .value(s -> s.name("process.open.fds"))
-                    .dividedBy(denom -> denom.value(s -> s.name("process.max.fds")))
-                    .isLessThan(0.8)
-    };
+    public static ServiceLevelObjective[] forDisk(FileDescriptorMetrics fileDescriptorMetrics) {
+        return new ServiceLevelObjective[] {
+                ServiceLevelObjective.build("os.file.descriptors")
+                        .failedMessage("Too many file descriptors are open. When the max is reached, " +
+                                "further attempts to retrieve a file descriptor will block indefinitely.")
+                        .baseUnit("used / available (percent)")
+                        .requires(fileDescriptorMetrics)
+                        .value(s -> s.name("process.open.fds"))
+                        .dividedBy(denom -> denom.value(s -> s.name("process.max.fds")))
+                        .isLessThan(0.8)
+        };
+    }
 
     private OperatingSystemServiceLevelObjectives() {
     }

--- a/implementations/micrometer-registry-health/src/test/java/io/micrometer/health/HealthMeterRegistryTest.java
+++ b/implementations/micrometer-registry-health/src/test/java/io/micrometer/health/HealthMeterRegistryTest.java
@@ -18,6 +18,7 @@ package io.micrometer.health;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.health.objectives.JvmServiceLevelObjectives;
@@ -131,7 +132,7 @@ class HealthMeterRegistryTest {
     void meterFiltersAffectServiceLevelObjectives() {
         HealthMeterRegistry registry = HealthMeterRegistry.builder(HealthConfig.DEFAULT)
                 .clock(new MockClock())
-                .serviceLevelObjectives(JvmServiceLevelObjectives.MEMORY)
+                .serviceLevelObjectives(JvmServiceLevelObjectives.forMemory(new JvmHeapPressureMetrics(), new JvmMemoryMetrics()))
                 .serviceLevelObjectiveFilter(MeterFilter.denyNameStartsWith("jvm.pool"))
                 .serviceLevelObjectiveFilter(new MeterFilter() {
                     @Override

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/ServiceLevelObjectiveConfiguration.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/ServiceLevelObjectiveConfiguration.java
@@ -18,6 +18,9 @@ package io.micrometer.boot2.samples.components;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.health.HealthConfig;
 import io.micrometer.health.HealthMeterRegistry;
@@ -50,8 +53,8 @@ public class ServiceLevelObjectiveConfiguration {
     @Bean
     HealthMeterRegistry healthMeterRegistry() {
         HealthMeterRegistry registry = HealthMeterRegistry.builder(HealthConfig.DEFAULT)
-                .serviceLevelObjectives(JvmServiceLevelObjectives.MEMORY)
-                .serviceLevelObjectives(OperatingSystemServiceLevelObjectives.DISK)
+                .serviceLevelObjectives(JvmServiceLevelObjectives.forMemory(new JvmHeapPressureMetrics(), new JvmMemoryMetrics()))
+                .serviceLevelObjectives(OperatingSystemServiceLevelObjectives.forDisk(new FileDescriptorMetrics()))
                 .serviceLevelObjectives(
                         ServiceLevelObjective.build("api.error.ratio")
                                 .failedMessage("API error ratio")


### PR DESCRIPTION
There are some `MeterBinder`s like `JvmHeapPressureMetrics` that implement `AutoCloseable`, and it's not possible to manage their lifecycles in the predefined SLOs.

One possible solution is to inject required meter binders into the predefined SLOs. This PR changes to do so to try to resolve it.