### PR TITLE
Log ExecutorServiceMetrics.bindTo() failure

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -25,6 +25,8 @@ import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.lang.NonNullApi;
 import io.micrometer.core.lang.NonNullFields;
 import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.util.internal.logging.InternalLogger;
+import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.*;
@@ -43,6 +45,9 @@ import static java.util.Arrays.asList;
 @NonNullApi
 @NonNullFields
 public class ExecutorServiceMetrics implements MeterBinder {
+
+    private final static InternalLogger log = InternalLoggerFactory.getInstance(JvmGcMetrics.class);
+
     static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "";
     @Nullable
     private final ExecutorService executorService;
@@ -277,6 +282,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
             monitor(registry, unwrapThreadPoolExecutor(executorService, executorService.getClass().getSuperclass()));
         } else if (executorService instanceof ForkJoinPool) {
             monitor(registry, (ForkJoinPool) executorService);
+        } else {
+            log.warn("Failed to bind as {} is unsupported.", className);
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -46,7 +46,7 @@ import static java.util.Arrays.asList;
 @NonNullFields
 public class ExecutorServiceMetrics implements MeterBinder {
 
-    private final static InternalLogger log = InternalLoggerFactory.getInstance(ExecutorServiceMetrics.class);
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(ExecutorServiceMetrics.class);
 
     static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "";
     @Nullable

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -46,7 +46,7 @@ import static java.util.Arrays.asList;
 @NonNullFields
 public class ExecutorServiceMetrics implements MeterBinder {
 
-    private final static InternalLogger log = InternalLoggerFactory.getInstance(JvmGcMetrics.class);
+    private final static InternalLogger log = InternalLoggerFactory.getInstance(ExecutorServiceMetrics.class);
 
     static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "";
     @Nullable


### PR DESCRIPTION
This PR changes to log `ExecutorServiceMetrics.bindTo()` failure.

See gh-2426