### PR TITLE
Fix flakiness in Log4j2MetricsTest.asyncLogShouldNotBeDuplicated()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -34,9 +34,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for {@link Log4j2Metrics}.
@@ -171,7 +173,8 @@ class Log4j2MetricsTest {
 
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
         logger.info("Hello, world!");
-        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
+        await().atMost(Duration.ofSeconds(1))
+                .until(() -> registry.get("log4j2.events").tags("level", "info").counter().count() == 1);
     }
 
 }


### PR DESCRIPTION
`Log4j2MetricsTest.asyncLogShouldNotBeDuplicated()` failed as follows:

```
io.micrometer.core.instrument.binder.logging.Log4j2MetricsTest > asyncLogShouldNotBeDuplicated() FAILED
    org.opentest4j.AssertionFailedError: 
    Expecting:
     <0.0>
    to be equal to:
     <1.0>
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at io.micrometer.core.instrument.binder.logging.Log4j2MetricsTest.asyncLogShouldNotBeDuplicated(Log4j2MetricsTest.java:174)
```

This PR fixes the flakiness by waiting for up to 1 second for the meter to be updated.