### PR TITLE
Guard against InaccessibleObjectException in ExecutorServiceMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -297,8 +297,10 @@ public class ExecutorServiceMetrics implements MeterBinder {
             Field e = wrapper.getDeclaredField("e");
             e.setAccessible(true);
             return (ThreadPoolExecutor) e.get(executor);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException | RuntimeException e) {
+            // Cannot use InaccessibleObjectException since it was introduced in Java 9, so catch all RuntimeExceptions instead
             // Do nothing. We simply can't get to the underlying ThreadPoolExecutor.
+            log.info("Cannot unwrap ThreadPoolExecutor for monitoring from {} due to {}: {}", wrapper.getName(), e.getClass().getName(), e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
This is an issue with our current implementation for getting at the wrapped ThreadPoolExecutor in some types returned by Executors, when --illegal-access=deny is set. This is the default from Java 16. Without these changes, an uncaught exception is thrown when trying to perform the reflective access on binding ExecutorServiceMetrics with one of the private type ExecutorService in Executors.

With these changes, the exception will be caught and logged. We end up catching all RuntimeExceptions since we cannot use the InaccessibleObjectException type introduced in Java 9, but this is probably fine in this implementation anyways.

Resolves gh-2447