### PR TITLE
Guard against NPE in MongoMetricsConnectionPoolListener

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
@@ -81,38 +81,50 @@ public class MongoMetricsConnectionPoolListener extends ConnectionPoolListenerAd
 
     @Override
     public void connectionCheckedOut(ConnectionCheckedOutEvent event) {
-        checkedOutCount.get(event.getConnectionId().getServerId())
-                .incrementAndGet();
+        AtomicInteger gauge = checkedOutCount.get(event.getConnectionId().getServerId());
+        if (gauge != null) {
+            gauge.incrementAndGet();
+        }
     }
 
     @Override
     public void connectionCheckedIn(ConnectionCheckedInEvent event) {
-        checkedOutCount.get(event.getConnectionId().getServerId())
-                .decrementAndGet();
+        AtomicInteger gauge = checkedOutCount.get(event.getConnectionId().getServerId());
+        if (gauge != null) {
+            gauge.decrementAndGet();
+        }
     }
 
     @Override
     public void waitQueueEntered(ConnectionPoolWaitQueueEnteredEvent event) {
-        waitQueueSize.get(event.getServerId())
-                .incrementAndGet();
+        AtomicInteger gauge = waitQueueSize.get(event.getServerId());
+        if (gauge != null) {
+            gauge.incrementAndGet();
+        }
     }
 
     @Override
     public void waitQueueExited(ConnectionPoolWaitQueueExitedEvent event) {
-        waitQueueSize.get(event.getServerId())
-                .decrementAndGet();
+        AtomicInteger gauge = waitQueueSize.get(event.getServerId());
+        if (gauge != null) {
+            gauge.decrementAndGet();
+        }
     }
 
     @Override
     public void connectionAdded(ConnectionAddedEvent event) {
-        poolSize.get(event.getConnectionId().getServerId())
-                .incrementAndGet();
+        AtomicInteger gauge = poolSize.get(event.getConnectionId().getServerId());
+        if (gauge != null) {
+            gauge.incrementAndGet();
+        }
     }
 
     @Override
     public void connectionRemoved(ConnectionRemovedEvent event) {
-        poolSize.get(event.getConnectionId().getServerId())
-                .decrementAndGet();
+        AtomicInteger gauge = poolSize.get(event.getConnectionId().getServerId());
+        if (gauge != null) {
+            gauge.decrementAndGet();
+        }
     }
 
     private Gauge registerGauge(ServerId serverId, String metricName, String description, Map<ServerId, AtomicInteger> metrics) {


### PR DESCRIPTION
Logically, the other events should not happen after the connection pool has been closed, but it seems they sometimes do. When they do (e.g. on shutdown), a NPE was being thrown. This change guards against such NPEs.

Resolves gh-2384