### PR TITLE
Attribute nullability annotations to Spring Framework

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,3 +43,10 @@ modified copy of the PCollections library by Harold Cooper.
   * Copyright 2008 Harold Cooper
   * License: MIT License
   * Homepage: https://github.com/hrldcpr/pcollections
+
+This product contains a modified portion of the 'org.springframework.lang'
+package in the Spring Framework library, distributed by Pivotal, Inc:
+
+  * Copyright 2002-2019 the original author or authors.
+  * License: Apache License v2.0
+  * Homepage: https://spring.io/projects/spring-framework

--- a/micrometer-core/src/main/java/io/micrometer/core/lang/NonNull.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/lang/NonNull.java
@@ -28,7 +28,11 @@ import java.lang.annotation.*;
  * <p>Use {@code @NonNullApi} (scope = parameters + return values) and/or {@code @NonNullFields}
  * (scope = fields) to set the default behavior to non-nullable in order to avoid annotating
  * your whole codebase with {@code @NonNull}.
+ * <p>
+ * NOTE: This file has been copied from {org.springframework.lang}.
  *
+ * @author Sebastien Deleuze
+ * @author Juergen Hoeller
  * @see NonNullApi
  * @see NonNullFields
  * @see Nullable

--- a/micrometer-core/src/main/java/io/micrometer/core/lang/NonNullApi.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/lang/NonNullApi.java
@@ -26,7 +26,11 @@ import java.lang.annotation.*;
  * tools with JSR-305 support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at package level in association with {@link Nullable}
  * annotations at parameter and return value level.
+ * <p>
+ * NOTE: This file has been copied from {org.springframework.lang}.
  *
+ * @author Sebastien Deleuze
+ * @author Juergen Hoeller
  * @see NonNullFields
  * @see Nullable
  * @see NonNull

--- a/micrometer-core/src/main/java/io/micrometer/core/lang/NonNullFields.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/lang/NonNullFields.java
@@ -26,7 +26,10 @@ import java.lang.annotation.*;
  * tools with JSR-305 support and used by Kotlin to infer nullability of the API.
  * <p>Should be used at package level in association with {@link Nullable}
  * annotations at field level.
+ * <p>
+ * NOTE: This file has been copied from {org.springframework.lang}.
  *
+ * @author Sebastien Deleuze
  * @see NonNullFields
  * @see Nullable
  * @see NonNull

--- a/micrometer-core/src/main/java/io/micrometer/core/lang/Nullable.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/lang/Nullable.java
@@ -28,7 +28,11 @@ import java.lang.annotation.*;
  * repeat parent {@code @Nullable} annotations unless they behave differently.
  * <p>Can be used in association with {@code NonNullApi} or {@code @NonNullFields} to
  * override the default non-nullable semantic to nullable.
+ * <p>
+ * NOTE: This file has been copied from {org.springframework.lang}.
  *
+ * @author Sebastien Deleuze
+ * @author Juergen Hoeller
  * @see NonNullApi
  * @see NonNullFields
  * @see NonNull


### PR DESCRIPTION
Includes a note in the class-level JavaDoc for each class, adds the `@author` tags from the original files, and adds an entry to the top-level NOTICE file.

See #2421