### PR TITLE
Align precedence of applying extra tags and tagsBasedOnJoinPoint between TimedAspect and CountedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -256,23 +256,16 @@ public class CountedAspect {
     }
 
     private void record(ProceedingJoinPoint pjp, Counted counted, String exception, String result) {
-        counter(pjp, counted).tag(EXCEPTION_TAG, exception)
-            .tag(RESULT_TAG, result)
+        Counter.Builder builder = Counter.builder(counted.value())
+            .description(counted.description().isEmpty() ? null : counted.description())
             .tags(counted.extraTags())
-            .register(registry)
-            .increment();
-    }
-
-    private Counter.Builder counter(ProceedingJoinPoint pjp, Counted counted) {
-        Counter.Builder builder = Counter.builder(counted.value()).tags(tagsBasedOnJoinPoint.apply(pjp));
-        String description = counted.description();
-        if (!description.isEmpty()) {
-            builder.description(description);
-        }
+            .tag(EXCEPTION_TAG, exception)
+            .tag(RESULT_TAG, result)
+            .tags(tagsBasedOnJoinPoint.apply(pjp));
         if (meterTagAnnotationHandler != null) {
             meterTagAnnotationHandler.addAnnotatedParameters(builder, pjp);
         }
-        return builder;
+        builder.register(registry).increment();
     }
 
     /**

--- a/samples/micrometer-samples-spring-framework6/build.gradle
+++ b/samples/micrometer-samples-spring-framework6/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(":micrometer-observation")
 
     testImplementation project(":micrometer-observation-test")
+    testImplementation project(":micrometer-test")
     testImplementation(libs.aspectjweaver)
     testImplementation libs.awaitility
     testImplementation(libs.contextPropagation)


### PR DESCRIPTION
## What problem does this PR solve?
The bahaviors between `TimedAspect` and `CountdAspect` for `extraTags` are different -
- `TimedAspect` applies `ProceedingJoinPoint` tags after `extraTags`.
- `CountdAspect` applies `ProceedingJoinPoint` tags before `extraTags`.

It causes issues when overwriting `extraTags` with customized `JoinPoint`.

## What is changed and how it works?
Move `extraTags` before applying `ProceedingJoinPoint` tags in `CountdAspect`.

Related issue
Resolves https://github.com/micrometer-metrics/micrometer/issues/2461

