### PR TITLE
Fix JDK source and target of published artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,9 @@ subprojects {
 
         // Publish resolved versions.
         plugins.withId('maven-publish') {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+
             publishing {
                 publications {
                     nebula(MavenPublication) {


### PR DESCRIPTION
The gradle build task sets _sourceCompatibility_ and _targetCompatibility_ to be Java 8, however the artifacts uploaded to Maven Central indicate Java 15 (the version running on the CircleCI host).

Here's the MANIFEST.MF taken from **micrometer-core-1.6.4.jar**:
```
Manifest-Version: 1.0
Automatic-Module-Name: micrometer.core
Implementation-Title: io.micrometer#micrometer-core;1.6.4
Implementation-Version: 1.6.4
Built-Status: integration
Built-By: circleci
Built-OS: Linux
Build-Date: 2021-02-17_10:20:24
Gradle-Version: 6.8.2
Module-Source: /micrometer-core
Module-Origin: git@github.com:micrometer-metrics/micrometer.git
Change: de7d90d
Branch: de7d90d519e51e5d80cad5c76e3169e0b8ab2c24
Build-Host: dc3c476057dc
Build-Job: LOCAL
Build-Number: LOCAL
Build-Id: LOCAL
Created-By: 15.0.1+9 (Oracle Corporation)
Build-Java-Version: 15.0.1
Module-Owner: tludwig@vmware.com
Module-Email: tludwig@vmware.com
X-Compile-Target-JDK: 15
X-Compile-Source-JDK: 15
```
Notice the last two lines indicating Java 15. We can check which version was actually used to generate the jar by running the following command on a file taken from the jar:
```
[/home/wrijeff/testing] javap -v Gauge.class
Classfile /local/home/wrijeff/testing/Gauge.class
  Last modified Feb 17, 2021; size 3425 bytes
  MD5 checksum baefe6504fcc649be810536cc17397ff
  Compiled from "Gauge.java"
public interface io.micrometer.core.instrument.Gauge extends io.micrometer.core.instrument.Meter
  minor version: 0
  major version: 52
  flags: (0x0601) ACC_PUBLIC, ACC_INTERFACE, ACC_ABSTRACT
  this_class: #51                         // io/micrometer/core/instrument/Gauge
  super_class: #53                        // java/lang/Object
  interfaces: 1, fields: 0, methods: 5, attributes: 3
...
```
Notice `major version: 52` indicating Java 8.

I'm not very familiar with Maven plugins, but adding the 2 lines in this PR appears to fix the issue:
```
[/home/wrijeff/testing] cat /workplace/github/micrometer/micrometer-core/build/manifest/micrometer-core.properties
Manifest-Version=1.0
Implementation-Title=io.micrometer#micrometer-core;1.7.0-SNAPSHOT
Implementation-Version=1.7.0-SNAPSHOT
Built-Status=integration
Built-By=wrijeff
Built-OS=Linux
Build-Date=2021-02-22_23:39:34
Gradle-Version=6.7
Module-Source=/micrometer-core
Module-Origin=git@github.com:wrijeff/micrometer.git
Change=84cb93e
Branch=temp
Build-Host=<my host>
Build-Job=LOCAL
Build-Number=LOCAL
Build-Id=LOCAL
Created-By=11.0.10+9-LTS (Oracle Corporation)
Build-Java-Version=11.0.10
Module-Owner=tludwig@vmware.com
Module-Email=tludwig@vmware.com
X-Compile-Target-JDK=1.8
X-Compile-Source-JDK=1.8%              
```

Please let me know if you think this won't fix the uploaded artifacts - I noticed some code in `build.gradle` under `apply plugin: 'io.spring.publishing'` which also looked promising to set the Java version.

@pivotal-issuemaster This is an Obvious Fix
