### PR TITLE
Correct PostgreSQL metrics for dead tuples

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetrics.java
@@ -44,7 +44,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
 
     private static final String SELECT = "SELECT ";
 
-    private static final String QUERY_DEAD_TUPLE_COUNT = getUserTableQuery("n_dead_tup");
+    private static final String QUERY_DEAD_TUPLE_COUNT = getUserTableQuery("SUM(n_dead_tup)");
     private static final String QUERY_TIMED_CHECKPOINTS_COUNT = getBgWriterQuery("checkpoints_timed");
     private static final String QUERY_REQUESTED_CHECKPOINTS_COUNT = getBgWriterQuery("checkpoints_req");
     private static final String QUERY_BUFFERS_CLEAN = getBgWriterQuery("buffers_clean");
@@ -78,7 +78,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
         this.beforeResetValuesCacheMap = new ConcurrentHashMap<>();
         this.previousValueCacheMap = new ConcurrentHashMap<>();
 
-        this.queryConnectionCount = getDBStatQuery(database, "SUM(numbackends)");
+        this.queryConnectionCount = getDBStatQuery(database, "numbackends");
         this.queryReadCount = getDBStatQuery(database, "tup_fetched");
         this.queryInsertCount = getDBStatQuery(database, "tup_inserted");
         this.queryTempBytes = getDBStatQuery(database, "temp_bytes");
@@ -282,7 +282,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
              Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery(query)) {
             if (resultSet.next()) {
-                return resultSet.getObject(1, Long.class);
+                return resultSet.getLong(1);
             }
         } catch (SQLException ignored) {
         }


### PR DESCRIPTION
1. `pg_stat_user_tables` has a row for each table in the database, so selecting the first row of it results in "dead rows for a single random table". Calculating the sum over `n_dead_tup` results in all dead rows instead.

2. `pg_stat_database` has only one row for each database, so the sum() over `numbackends` was harmless but unnecessary, so I removed that one.

3. At least for PostgreSQL, there's a difference between `getObject(n, Long.class)` and `getLong(n)`. The former can only convert INT4 and INT8 (but not NUMERIC and DECIMAL) to Long, the latter converts all numeric types. `sum(n_dead_tup)` is such a case where this matters, since its type is NUMERIC.

See https://github.com/micrometer-metrics/micrometer/pull/2474 as well, which is a larger refactoring, but also has integration tests for this change.