### PR TITLE
Fix JDK source and target of published artifacts.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ subprojects {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true
         }
+
+        plugins.withId('maven-publish') {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
     }
 
     dependencyLocking {


### PR DESCRIPTION
Follow up to PR #2464, but this time targeting the 1.3.x branch. 
>_The gradle build task sets sourceCompatibility and targetCompatibility to be Java 8, however the artifacts uploaded to Maven Central indicate Java 15 (the version running on the CircleCI host)._

Tested this PR by running `./gradlew PublishToMavenLocal` and decompiling the resulting jar files. Resulting MANIFEST.MF file:
```
Manifest-Version: 1.0
Implementation-Title: io.micrometer#micrometer-core;1.4.0-SNAPSHOT
Implementation-Version: 1.4.0-SNAPSHOT
Built-Status: integration
Built-By: wrijeff
Built-OS: Linux
Build-Date: 2021-02-23_17:21:10
Gradle-Version: 5.6.4
Module-Source: /micrometer-core
Module-Origin: git@github.com:wrijeff/micrometer.git
Change: 773fc18
Branch: jdk_1_3
Build-Host: <my host>
Build-Job: LOCAL
Build-Number: LOCAL
Build-Id: LOCAL
Created-By: 11.0.10+9-LTS (Oracle Corporation)
Build-Java-Version: 11.0.10
Module-Owner: tludwig@vmware.com
Module-Email: tludwig@vmware.com
X-Compile-Target-JDK: 1.8
X-Compile-Source-JDK: 1.8
```
Also successfully tested applying the same code to the 1.5.x branch:
```
Manifest-Version: 1.0
Automatic-Module-Name: micrometer.core
Implementation-Title: io.micrometer#micrometer-core;1.6.0-SNAPSHOT
Implementation-Version: 1.6.0-SNAPSHOT
Built-Status: integration
Built-By: wrijeff
Built-OS: Linux
Build-Date: 2021-02-23_17:55:17
Gradle-Version: 6.8.2
Module-Source: /micrometer-core
Module-Origin: git@github.com:wrijeff/micrometer.git
Change: 512b9e8
Branch: local_1.5.x
Build-Host: <my host>
Build-Job: LOCAL
Build-Number: LOCAL
Build-Id: LOCAL
Created-By: 11.0.10+9-LTS (Oracle Corporation)
Build-Java-Version: 11.0.10
Module-Owner: tludwig@vmware.com
Module-Email: tludwig@vmware.com
X-Compile-Target-JDK: 1.8
X-Compile-Source-JDK: 1.8
```

I'll close the original PR to the master branch in favor of this PR.

@pivotal-issuemaster This is an Obvious Fix