### PR TITLE
Use latest.release for Caffeine

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,7 +3,7 @@ def VERSIONS = [
         'colt:colt:1.2.0',
         'com.amazonaws:aws-java-sdk-cloudwatch:latest.release',
         'com.fasterxml.jackson.core:jackson-databind:latest.release',
-        'com.github.ben-manes.caffeine:caffeine:2.+',
+        'com.github.ben-manes.caffeine:caffeine:latest.release',
         'com.github.charithe:kafka-junit:latest.release',
         'com.github.tomakehurst:wiremock-jre8-standalone:latest.release',
         'com.google.cloud:google-cloud-monitoring:1.+',

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineStatsCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineStatsCounter.java
@@ -145,7 +145,6 @@ public final class CaffeineStatsCounter implements StatsCounter {
     }
 
     @SuppressWarnings("deprecation")
-    @Override
     public void recordEviction() {
     }
 
@@ -156,7 +155,7 @@ public final class CaffeineStatsCounter implements StatsCounter {
 
     @Override
     public CacheStats snapshot() {
-        return new CacheStats(
+        return CacheStats.of(
                 (long) hitCount.count(),
                 (long) missCount.count(),
                 loadSuccesses.count(),


### PR DESCRIPTION
This PR changes to use `latest.release` for Caffeine.

This PR also updates `CaffeineStatsCounter` to support Caffeine 3+ while maintaining Caffeine 2+ support.

Closes gh-2465