### PR TITLE
Update machine-executor.image to ubuntu-2004:202101-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
   machine-executor:
     working_directory: ~/micrometer
     machine:
-      image: ubuntu-1604:202007-01
+      image: ubuntu-2004:202101-01
 
 commands:
   gradlew-build:


### PR DESCRIPTION
This PR updates `machine-executor.image` to `ubuntu-2004:202101-01` as the current image seems to be going to be EOLed soon as follows:

> Note: Ubuntu 16.04 reaches the end of its LTS window at the end of April 2021 and will no longer be supported by Canonical. As a result, the final 16.04 CircleCI machine image release by us will take place in April to include the most recent security patches. We suggest upgrading to the Ubuntu 20.04 image for continued releases past April. 2021.

See https://circleci.com/docs/2.0/configuration-reference/#machine