### PR TITLE
Update circle-jdk-executor.image to cimg/openjdk:15.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: cimg/openjdk:15.0
+      - image: cimg/openjdk:15.0.1
   machine-executor:
     working_directory: ~/micrometer
     machine:


### PR DESCRIPTION
This PR updates `circle-jdk-executor.image` to `cimg/openjdk:15.0.1`.