### PR TITLE
Fix duplicate +Inf bucket in Prometheus histograms

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -156,11 +156,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                                     sampleName, histogramKeys, histogramValues, c.count()));
                         }
 
-                        // the +Inf bucket should always equal `count`
-                        final List<String> histogramValues = new LinkedList<>(tagValues);
-                        histogramValues.add("+Inf");
-                        samples.add(new Collector.MetricFamilySamples.Sample(
-                                sampleName, histogramKeys, histogramValues, count));
+                        if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
+                            // the +Inf bucket should always equal `count`
+                            final List<String> histogramValues = new LinkedList<>(tagValues);
+                            histogramValues.add("+Inf");
+                            samples.add(new Collector.MetricFamilySamples.Sample(
+                                    sampleName, histogramKeys, histogramValues, count));
+                        }
                         break;
                     case VictoriaMetrics:
                         histogramKeys.add("vmrange");


### PR DESCRIPTION
Histograms without an upper bound already have an `+Inf` bucket. The current implementation added an `+Inf` bucket regardless, resulting in two `+Inf` buckets.

This fix makes sure that the `+Inf` bucket is only added if the histogram is configured with a finite upper bound.