### PR TITLE
Bintray Sunset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,14 @@ subprojects {
             }
             repositories {
                 maven {
+                    name = 'Milestone'
+                    url = 'https://repo.spring.io/milestone'
+                    credentials {
+                        username findProperty('MILESTONE_REPO_USER')
+                        password findProperty('MILESTONE_REPO_PASSWORD')
+                    }
+                }
+                maven {
                     name = 'MavenCentral'
                     url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
                     credentials {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ allprojects {
 }
 
 subprojects {
+    apply plugin: 'signing'
+
     if (project.name != 'micrometer-bom') {
         apply plugin: 'java'
         apply plugin: 'checkstyle'
@@ -74,6 +76,29 @@ subprojects {
         plugins.withId('maven-publish') {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+
+    plugins.withId('maven-publish') {
+        publishing {
+            publications {
+                nebula(MavenPublication)
+            }
+            repositories {
+                maven {
+                    name = 'MavenCentral'
+                    url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
+                    credentials {
+                        username findProperty('MAVEN_CENTRAL_USER')
+                        password findProperty('MAVEN_CENTRAL_PASSWORD')
+                    }
+                }
+            }
+        }
+
+        signing {
+            useInMemoryPgpKeys(findProperty('SIGNING_KEY'), findProperty('SIGNING_PASSWORD'))
+            sign publishing.publications.nebula
         }
     }
 

--- a/gradle/deploy.sh
+++ b/gradle/deploy.sh
@@ -15,12 +15,10 @@ elif [ $CIRCLE_TAG ]; then
   openssl aes-256-cbc -d -in gradle.properties.enc -out gradle.properties -k "$KEY" -md sha256
   case "$CIRCLE_TAG" in
   *-rc\.*)
-    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true candidate bintrayUpload $SWITCHES -x release -x bintrayPublish
-    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true :micrometer-core:bintrayPublish $SWITCHES -x bintrayUpload
+    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true candidate publishAllPublicationsToMilestoneRepository $SWITCHES -x release -x artifactoryPublish -x bintrayUpload -x bintrayPublish
     ;;
   *)
-    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true final bintrayUpload $SWITCHES -x release -x artifactoryPublish -x bintrayPublish
-    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true :micrometer-core:bintrayPublish $SWITCHES -x bintrayUpload
+    ./gradlew -Prelease.disableGitChecks=true -Prelease.useLastTag=true final publishAllPublicationsToMavenCentralRepository $SWITCHES -x release -x artifactoryPublish -x bintrayUpload -x bintrayPublish
     ;;
   esac
 else


### PR DESCRIPTION
Utilizing the `signing` and the `maven-publish` plugins to remove Bintray from the release process. 
Fixes gh-2455