### PR TITLE
#2494: add Timer.Sample.elapsed

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -270,6 +270,14 @@ public interface Timer extends Meter, HistogramSupport {
             this.startTime = clock.monotonicTime();
         }
 
+        public Duration elapsed() {
+          return Duration.ofNanos(clock.monotonicTime() - startTime);
+        }
+
+        public long elapsed(TimeUnit unit) {
+          return unit.convert(clock.monotonicTime() - startTime, TimeUnit.NANOSECONDS);
+        }
+
         /**
          * Records the duration of the operation.
          *


### PR DESCRIPTION
Add the ability to peek into Timer.Sample elapsed times, as the sample is progressing.

Resolved #2494 .