### PR TITLE
Enforce signing artifacts if circleci runs the deploy stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
         }
 
         signing {
-            required = hasProperty('SIGNING_KEY')
+            required = System.env.CIRCLE_STAGE == 'deploy'
             useInMemoryPgpKeys(findProperty('SIGNING_KEY'), findProperty('SIGNING_PASSWORD'))
             sign publishing.publications.nebula
         }


### PR DESCRIPTION
This couples the signing enforcement to circleci's `CIRCLE_STAGE` environment variable and its value.
On the other hand, as far as I know, there is not really another way to require the signing tasks automatically when we are deploying the artifacts.

Possible alternatives:
- Introducing a property `-Prequire-signature` and add it to the `SWITCHES` in `deploy.sh`
- Check if the nebula release tasks (`snapshot`, `candidate`, `final`) are in the `taskGraph`
The problem with this is you might want to run them locally and publish into a local repo.