### PR TITLE
Support Datadog UDP origin detection

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
@@ -59,6 +59,17 @@ class DatadogStatsdLineBuilderTest {
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,my_tag");
     }
 
+    @Issue("#2417")
+    @Test
+    void appendDdEntityIdTag() {
+        Counter c = registry.counter("my:counter", "mytag", "myvalue");
+        DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(c.getId(), registry.config());
+        lb.setDdEntityId("test-entity-id");
+
+        registry.config().namingConvention(NamingConvention.dot);
+        assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("my_counter:1|c|#statistic:count,mytag:myvalue,dd.internal.entity_id:test-entity-id");
+    }
+
     @Issue("#1998")
     @Test
     void allowColonsInTagValues() {


### PR DESCRIPTION
Resolves #2417 

Adds datadog internal entity id (from `DD_ENTITY_ID` environment variable) as a tag, so that UDP origin detection can work.

Similar to the Datadog official client implementation: https://github.com/DataDog/java-dogstatsd-client/blob/master/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L1759-L1770
