### PR TITLE
Add support for OpenJ9's gc policies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,28 @@ subprojects {
             jvmArgs '-XX:+UseZGC'
         }
 
+        task openj9BalancedTest(type: Test) {
+            // set heap size for the test JVM(s)
+            maxHeapSize = "1500m"
+
+            useJUnitPlatform {
+                includeTags 'gc'
+            }
+
+            jvmArgs '-Xgcpolicy:balanced'
+        }
+
+        task openj9ConcurrentScavengeTest(type: Test) {
+            // set heap size for the test JVM(s)
+            maxHeapSize = "1500m"
+
+            useJUnitPlatform {
+                includeTags 'gc'
+            }
+
+            jvmArgs '-Xgc:concurrentScavenge'
+        }
+
         license {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -249,7 +249,12 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
             put("MarkSweepCompact", OLD);
             put("PS MarkSweep", OLD);
             put("PS Scavenge", YOUNG);
-            put("ParNew", YOUNG);
+            put("ParNew", YOUNG); 
+            put("global", OLD);
+            put("scavenge", YOUNG);
+            put("partial gc", YOUNG);
+            put("global garbage collect", OLD);
+            put("Epsilon", OLD);
         }};
 
         static GcGenerationAge fromGcName(String gcName) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -48,6 +48,7 @@ import static java.util.Collections.emptyList;
  * collection emanating from the MXBean and also adds information about GC causes.
  * <p>
  * This provides metrics for OpenJDK garbage collectors: serial, parallel, G1, Shenandoah, ZGC.
+ * and for OpenJ9 garbage collectors: gencon, balanced, opthruput, optavgpause, metronome.
  *
  * @author Jon Schneider
  * @author Tommy Ludwig

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -40,7 +40,6 @@ class JvmMemory {
     static boolean isConcurrentPhase(String cause, String name) {
         return "No GC".equals(cause)
                 || "Shenandoah Cycles".equals(name);
-                // Don't think this applies to J9 - maybe "J9MMCONSTANT_IMPLICIT_GC_COMPLETE_CONCURRENT" / concurrent collection must be completed"
     }
 
     static boolean isAllocationPool(String name) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -48,6 +48,7 @@ class JvmMemory {
                 || "ZHeap".equals(name)
                 || name.endsWith("nursery-allocate")
                 || name.endsWith("-eden") // "balanced-eden"
+                || "JavaHeap".equals(name) // metronome
         );
     }
 
@@ -58,6 +59,7 @@ class JvmMemory {
                 || "ZHeap".equals(name)
                 || name.endsWith("balanced-old")
                 || name.contains("tenured") // "tenured", "tenured-SOA", "tenured-LOA"
+                || "JavaHeap".equals(name) // metronome
         );
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -40,12 +40,15 @@ class JvmMemory {
     static boolean isConcurrentPhase(String cause, String name) {
         return "No GC".equals(cause)
                 || "Shenandoah Cycles".equals(name);
+                // Don't think this applies to J9 - maybe "J9MMCONSTANT_IMPLICIT_GC_COMPLETE_CONCURRENT" / concurrent collection must be completed"
     }
 
     static boolean isAllocationPool(String name) {
         return name != null && (name.endsWith("Eden Space")
                 || "Shenandoah".equals(name)
                 || "ZHeap".equals(name)
+                || name.endsWith("nursery-allocate")
+                || name.endsWith("-eden") // "balanced-eden"
         );
     }
 
@@ -54,6 +57,8 @@ class JvmMemory {
                 || name.endsWith("Tenured Gen")
                 || "Shenandoah".equals(name)
                 || "ZHeap".equals(name)
+                || name.endsWith("balanced-old")
+                || name.contains("tenured") // "tenured", "tenured-SOA", "tenured-LOA"
         );
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
@@ -16,23 +16,14 @@
 package io.micrometer.core.instrument.binder.jvm;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @GcTest
 class JvmMemoryTest {
     @Test
-    @DisabledIfSystemProperty(named = "java.vm.vendor", matches = "Eclipse OpenJ9")
     void getLongLivedHeapPool() {
         assertThat(JvmMemory.getLongLivedHeapPools()).isNotEmpty();
-    }
-
-    @Test
-    @EnabledIfSystemProperty(named = "java.vm.vendor", matches = "Eclipse OpenJ9")
-    void getLongLivedHeapPoolWithEclipseOpenJ9() {
-        assertThat(JvmMemory.getLongLivedHeapPools()).isEmpty();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -71,8 +71,8 @@ class ProcessorMetricsTest {
          * needs some milliseconds of sleep before it actually returns a positive value
          * on a supported system. Thread.sleep() is flaky, though.
          */
-        assertThat(registry.get("system.cpu.usage").gauge().value()).isEqualTo(-1);
-        assertThat(registry.get("process.cpu.usage").gauge().value()).isEqualTo(-1);
+        assertThat(registry.get("system.cpu.usage").gauge().value()).isGreaterThanOrEqualTo(-1);
+        assertThat(registry.get("process.cpu.usage").gauge().value()).isGreaterThanOrEqualTo(-1);
     }
 
     private boolean isOpenJ9() {


### PR DESCRIPTION
Add support for OpenJ9's GC policies: gencon, balanced, opthruput, optavgpause, & metronome.

Map the pool names that can be returned by the MxBeans as either YOUNG or OLD.

Update tests to support OpenJ9 as well.

I've tested this locally on my mac using each of the policies except metronome (that policy isn't supported on osx).

Fixes: #1458