### PR TITLE
Call awaitTermination when stopping a StepMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -65,6 +65,7 @@ public abstract class StepMeterRegistry extends MeterRegistry {
     public void stop() {
         if (scheduledExecutorService != null) {
             scheduledExecutorService.shutdown();
+            scheduledExecutorService.awaitTermination(config.shutdownTimeout().toMillis(), TimeUnit.MILLISECONDS);
             scheduledExecutorService = null;
         }
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepRegistryConfig.java
@@ -78,4 +78,13 @@ public interface StepRegistryConfig extends MeterRegistryConfig {
         String v = get(prefix() + ".batchSize");
         return v == null ? 10000 : Integer.parseInt(v);
     }
+
+    /**
+     * @return The timeout to use when calling awaitTermination while shutting down the
+     * ScheduledExecutorService. The default is 5 seconds.
+     */
+    default Duration shutdownTimeout() {
+        String v = get(prefix() + ".shutdownTimeout");
+        return v == null ? Duration.ofSeconds(5) : Duration.parse(v);
+    }
 }


### PR DESCRIPTION
Currently any in-flight publishes from a `StepMeterRegistry` are discarded when the `StepMeterRegistry` is stopped. This PR adds a call to `ScheduledExecutorService#awaitTermination()` when stopping the `StepMeterRegistry` to let them finish (up to the timeout). The timeout used in the `awaitTermination` call is configurable.