### PR TITLE
Call awaitTermination when stopping a PushMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -82,7 +82,14 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     public void stop() {
         if (scheduledExecutorService != null) {
             scheduledExecutorService.shutdown();
-            scheduledExecutorService = null;
+            try {
+                scheduledExecutorService.awaitTermination(config.shutdownTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ie) {
+                scheduledExecutorService.shutdownNow();
+                Thread.currentThread().interrupt();
+            } finally {
+                scheduledExecutorService = null;
+            }
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -91,6 +91,12 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
         return getInteger(this, "batchSize").orElse(10000);
     }
 
+    /**
+     * @return The timeout to use when calling awaitTermination while shutting down the ScheduledExecutorService. The
+     * default is 5 seconds.
+     */
+    default Duration shutdownTimeout() { return getDuration(this, "shutdownTimeout").orElse(Duration.ofSeconds(5)); }
+
     @Override
     default Validated<?> validate() {
         return validate(this);
@@ -109,7 +115,8 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
                 check("connectTimeout", PushRegistryConfig::connectTimeout),
                 check("readTimeout", PushRegistryConfig::readTimeout),
                 check("batchSize", PushRegistryConfig::batchSize),
-                check("numThreads", PushRegistryConfig::numThreads)
+                check("numThreads", PushRegistryConfig::numThreads),
+                check("shutdownTimeout", PushRegistryConfig::shutdownTimeout)
         );
     }
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
@@ -49,6 +49,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1w");
         props.put("push.batchSize", "Z");
         props.put("push.step", "up");
+        props.put("push.shutdownTimeout", "down");
 
         // overall not valid
         assertThat(config.validate().isValid()).isFalse();
@@ -56,12 +57,13 @@ class PushRegistryConfigTest {
         // can iterate over failures to display messages
         List<Validated.Invalid<?>> failures = config.validate().failures();
 
-        assertThat(failures.size()).isEqualTo(5);
+        assertThat(failures.size()).isEqualTo(6);
         assertThat(failures.stream().map(Validated.Invalid::getMessage))
                 .containsOnly(
                         "must be a valid duration",
                         "must contain a valid time unit",
-                        "must be an integer"
+                        "must be an integer",
+                        "must be a valid duration value"
                 );
 
         assertThatThrownBy(config::batchSize).isInstanceOf(ValidationException.class);
@@ -74,6 +76,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1s");
         props.put("push.batchSize", "3");
         props.put("push.step", "1s");
+        props.put("push.shutdownTimeout", "10s");
 
         assertThat(config.validate().isValid()).isTrue();
     }


### PR DESCRIPTION
Currently any in-flight publishes from a `PushMeterRegistry ` are discarded when the `PushMeterRegistry` is stopped. 

This PR adds a call to `ScheduledExecutorService#awaitTermination()` when stopping the `PushMeterRegistry ` to let those calls finish (up to the timeout). The timeout used in the `awaitTermination()` call is configurable.