### PR TITLE
Exclude netty http modules

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -6,7 +6,10 @@ dependencies {
     api project(':micrometer-core')
 
     implementation 'io.projectreactor:reactor-core'
-    implementation 'io.projectreactor.netty:reactor-netty'
+    implementation('io.projectreactor.netty:reactor-netty') {
+        exclude module: 'netty-codec-http2'
+        exclude module: 'netty-codec-http'
+    }
 
     testImplementation project(':micrometer-test')
     testImplementation 'io.projectreactor:reactor-test'

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/compileClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/compileClasspath.lockfile
@@ -3,8 +3,6 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2
 io.netty:netty-buffer:4.1.56.Final
-io.netty:netty-codec-http2:4.1.56.Final
-io.netty:netty-codec-http:4.1.56.Final
 io.netty:netty-codec-socks:4.1.56.Final
 io.netty:netty-codec:4.1.56.Final
 io.netty:netty-common:4.1.56.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/default.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/default.lockfile
@@ -2,8 +2,6 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 io.netty:netty-buffer:4.1.56.Final
-io.netty:netty-codec-http2:4.1.56.Final
-io.netty:netty-codec-http:4.1.56.Final
 io.netty:netty-codec-socks:4.1.56.Final
 io.netty:netty-codec:4.1.56.Final
 io.netty:netty-common:4.1.56.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -3,8 +3,6 @@
 # This file is expected to be part of source control.
 com.google.code.findbugs:jsr305:3.0.2
 io.netty:netty-buffer:4.1.56.Final
-io.netty:netty-codec-http2:4.1.56.Final
-io.netty:netty-codec-http:4.1.56.Final
 io.netty:netty-codec-socks:4.1.56.Final
 io.netty:netty-codec:4.1.56.Final
 io.netty:netty-common:4.1.56.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -24,8 +24,6 @@ commons-fileupload:commons-fileupload:1.4
 commons-io:commons-io:2.2
 commons-logging:commons-logging:1.2
 io.netty:netty-buffer:4.1.56.Final
-io.netty:netty-codec-http2:4.1.56.Final
-io.netty:netty-codec-http:4.1.56.Final
 io.netty:netty-codec-socks:4.1.56.Final
 io.netty:netty-codec:4.1.56.Final
 io.netty:netty-common:4.1.56.Final

--- a/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/implementations/micrometer-registry-statsd/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -24,8 +24,6 @@ commons-fileupload:commons-fileupload:1.4
 commons-io:commons-io:2.2
 commons-logging:commons-logging:1.2
 io.netty:netty-buffer:4.1.56.Final
-io.netty:netty-codec-http2:4.1.56.Final
-io.netty:netty-codec-http:4.1.56.Final
 io.netty:netty-codec-socks:4.1.56.Final
 io.netty:netty-codec:4.1.56.Final
 io.netty:netty-common:4.1.56.Final


### PR DESCRIPTION
We do not use HTTP in the StatsD registry implementation, so we would avoid some of the pain of false positive CVE detection on our shaded netty dependencies by excluding HTTP-related modules we don't use. This will also reduce the size of the statsd registry artifact.

See #2525 