### PR TITLE
Add Javadoc since tag to changes from tags providers for MongoDB metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoMetricsCommandTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoMetricsCommandTagsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.Tags;
  * Default implementation for {@link MongoMetricsCommandTagsProvider}.
  *
  * @author Chris Bono
+ * @since 1.7.0
  */
 public class DefaultMongoMetricsCommandTagsProvider implements MongoMetricsCommandTagsProvider {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoMetricsConnectionPoolTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoMetricsConnectionPoolTagsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,10 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 
 /**
- * Default implementation for {@link MongoMetricsConnectionPoolTagsProvider}
+ * Default implementation for {@link MongoMetricsConnectionPoolTagsProvider}.
  *
  * @author Gustavo Monarin
+ * @since 1.7.0
  */
 public class DefaultMongoMetricsConnectionPoolTagsProvider implements MongoMetricsConnectionPoolTagsProvider {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListener.java
@@ -55,6 +55,7 @@ public class MongoMetricsCommandListener implements CommandListener {
      *
      * @param registry meter registry
      * @param tagsProvider provides tags to be associated with metrics for the given Mongo command
+     * @since 1.7.0
      */
     public MongoMetricsCommandListener(MeterRegistry registry, MongoMetricsCommandTagsProvider tagsProvider) {
         this.registry = registry;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandTagsProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Tag;
  * Provides {@link Tag Tags} for Mongo command metrics.
  *
  * @author Chris Bono
+ * @since 1.7.0
  */
 @FunctionalInterface
 public interface MongoMetricsCommandTagsProvider {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListener.java
@@ -54,10 +54,22 @@ public class MongoMetricsConnectionPoolListener implements ConnectionPoolListene
     private final MeterRegistry registry;
     private final MongoMetricsConnectionPoolTagsProvider tagsProvider;
 
+    /**
+     * Create a new {@code MongoMetricsConnectionPoolListener}.
+     *
+     * @param registry registry to use
+     */
     public MongoMetricsConnectionPoolListener(MeterRegistry registry) {
         this(registry, new DefaultMongoMetricsConnectionPoolTagsProvider());
     }
 
+    /**
+     * Create a new {@code MongoMetricsConnectionPoolListener}.
+     *
+     * @param registry registry to use
+     * @param tagsProvider tags provider to use
+     * @since 1.7.0
+     */
     public MongoMetricsConnectionPoolListener(MeterRegistry registry, MongoMetricsConnectionPoolTagsProvider tagsProvider) {
         this.registry = registry;
         this.tagsProvider = tagsProvider;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolTagsProvider.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument.binder.mongodb;
 
-
 import com.mongodb.event.ConnectionPoolCreatedEvent;
 import io.micrometer.core.instrument.Tag;
 
@@ -23,6 +22,7 @@ import io.micrometer.core.instrument.Tag;
  * Provides {@link Tag Tags} for Mongo connection pool metrics.
  *
  * @author Gustavo Monarin
+ * @since 1.7.0
  */
 @FunctionalInterface
 public interface MongoMetricsConnectionPoolTagsProvider {


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to changes from tags providers for MongoDB metrics.

See gh-2360
See gh-2437