### PR TITLE
PrometheusTimer publishes wrong unit of time for max/sum when percentile histograms are enabled

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
@@ -103,8 +103,8 @@ public class PrometheusTimer extends AbstractTimer {
         }
 
         return new HistogramSnapshot(snapshot.count(),
-                snapshot.total(TimeUnit.SECONDS),
-                snapshot.max(TimeUnit.SECONDS),
+                snapshot.total(),
+                snapshot.max(),
                 snapshot.percentileValues(),
                 histogramCounts(),
                 snapshot::outputSummary);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSnapshot.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramSnapshot.java
@@ -37,6 +37,14 @@ public final class HistogramSnapshot {
     @Nullable
     private final BiConsumer<PrintStream, Double> summaryOutput;
 
+    /**
+     * @param count            Total number of recordings
+     * @param total            In nanos if a unit of time
+     * @param max              In nanos if a unit of time
+     * @param percentileValues Pre-computed percentiles.
+     * @param histogramCounts  Bucket counts.
+     * @param summaryOutput    A function defining how to print the histogram.
+     */
     public HistogramSnapshot(long count, double total, double max,
                              @Nullable ValueAtPercentile[] percentileValues,
                              @Nullable CountAtBucket[] histogramCounts,


### PR DESCRIPTION
backport of e6f6ef513c255d639dd85f00e9da43c120763228 commit to 1.3.x release branch