### PR TITLE
Isolate polling of each pollable meter in StatsdMeterRegistry poll()

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -161,7 +161,11 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     void poll() {
         for (StatsdPollable pollableMeter : pollableMeters.values()) {
-            pollableMeter.poll();
+            try {
+                pollableMeter.poll();
+            } catch (RuntimeException e) {
+                // Silently ignore misbehaving pollable meter
+            }
         }
     }
 


### PR DESCRIPTION
Relates to #2543.

This change prevents a misbehaving pollable meter (a gauge with a custom value function that might throw an NPE, for example) from preventing ongoing polling of other pollable meters.