### PR TITLE
Introduce a skip predicate to the TimedAspect and CountedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -33,10 +33,40 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * Aspect responsible for intercepting all methods annotated with the {@link Counted}
- * annotation and record a few counter metrics about their execution status.
+ * <p>
+ * Aspect responsible for intercepting all methods annotated with the {@link Counted @Counted}
+ * annotation and record a few counter metrics about their execution status.<br />
+ * The aspect supports programmatic customizations through constructor-injectable custom logic.
+ * </p>
+ * <p>
+ * You might want to add tags programmatically to the {@link Counter}.<br />
+ * In this case, the tags provider function (<code>Function&lt;ProceedingJoinPoint, Iterable&lt;Tag&gt;&gt;</code>) can help.
+ * It receives a {@link ProceedingJoinPoint} and returns the {@link Tag}s that will be attached to the {@link Counter}.
+ * </p>
+ * <p>
+ * You might also want to skip the {@link Counter} creation programmatically.<br />
+ * One use-case can be having another component in your application that already processes the {@link Counted @Counted} annotation
+ * in some cases so that {@code CountedAspect} should not intercept these methods.
+ * By using the skip predicate (<code>Predicate&lt;ProceedingJoinPoint&gt;</code>)
+ * you can tell the {@code CountedAspect} when not to create a {@link Counter}.
+ *
+ * Here's a theoretic example to disable {@link Counter} creation for Spring controllers:
+ *
+ * <pre>
+ * &#064;Bean
+ * public CountedAspect countedAspect(MeterRegistry meterRegistry) {
+ *     return new CountedAspect(meterRegistry, this::skipControllers);
+ * }
+ *
+ * private boolean skipControllers(ProceedingJoinPoint pjp) {
+ *     Class<?> targetClass = pjp.getTarget().getClass();
+ *     return targetClass.isAnnotationPresent(RestController.class) || targetClass.isAnnotationPresent(Controller.class);
+ * }
+ * </pre>
+ * </p>
  *
  * @author Ali Dehghani
+ * @author Jonatan Ivanov
  * @since 1.2.0
  * @see Counted
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -40,7 +40,6 @@ import java.util.function.Predicate;
  * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.<br />
  * The aspect supports programmatic customizations through constructor-injectable custom logic.
  * </p>
- *
  * <p>
  * You might want to add tags programmatically to the {@link Timer}.<br />
  * In this case, the tags provider function (<code>Function&lt;ProceedingJoinPoint, Iterable&lt;Tag&gt;&gt;</code>) can help.

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -36,7 +36,37 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.
+ * <p>
+ * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.<br />
+ * The aspect supports programmatic customizations through constructor-injectable custom logic.
+ * </p>
+ *
+ * <p>
+ * You might want to add tags programmatically to the {@link Timer}.<br />
+ * In this case, the tags provider function (<code>Function&lt;ProceedingJoinPoint, Iterable&lt;Tag&gt;&gt;</code>) can help.
+ * It receives a {@link ProceedingJoinPoint} and returns the {@link Tag}s that will be attached to the {@link Timer}.
+ * </p>
+ * <p>
+ * You might also want to skip the {@link Timer} creation programmatically.<br />
+ * One use-case can be having another component in your application that already processes the {@link Timed @Timed} annotation
+ * in some cases so that {@code TimedAspect} should not intercept these methods. E.g.: Spring Boot does this for its controllers.
+ * By using the skip predicate (<code>Predicate&lt;ProceedingJoinPoint&gt;</code>)
+ * you can tell the {@code TimedAspect} when not to create a {@link Timer}.
+ *
+ * Here's an example to disable {@link Timer} creation for Spring controllers:
+ *
+ * <pre>
+ * &#064;Bean
+ * public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+ *     return new TimedAspect(meterRegistry, this::skipControllers);
+ * }
+ *
+ * private boolean skipControllers(ProceedingJoinPoint pjp) {
+ *     Class<?> targetClass = pjp.getTarget().getClass();
+ *     return targetClass.isAnnotationPresent(RestController.class) || targetClass.isAnnotationPresent(Controller.class);
+ * }
+ * </pre>
+ * </p>
  *
  * @author David J. M. Karlsen
  * @author Jon Schneider


### PR DESCRIPTION
 So that users can skip Timer creation based on the JoinPoint, fixes gh-780