### PR TITLE
Clarify internal naming in JvmGcMetrics implementation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -42,7 +42,7 @@ class JvmMemory {
         return "No GC".equals(cause);
     }
 
-    static boolean isYoungGenPool(String name) {
+    static boolean isAllocationPool(String name) {
         return name.endsWith("Eden Space");
     }
 


### PR DESCRIPTION
In light of supporting additional garbage collectors, it's come up that some of the existing internal naming is not as specific as it could be. While there is often more than one memory pool belonging to the young generation in garbage collectors, we are interested in the one used for allocation for our metrics. The logic remains the same as before, but the naming is more specific.

See https://github.com/micrometer-metrics/micrometer/pull/2514/files#r609246788