### PR TITLE
Refactor JvmGcMetrics with less specialized logic for non-gen collectors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
@@ -78,13 +78,9 @@ public class JvmHeapPressureMetrics implements MeterBinder, AutoCloseable {
             Gauge.Builder<AtomicReference<Double>> builder = Gauge.builder("jvm.memory.usage.after.gc", lastOldGenUsageAfterGc, AtomicReference::get)
                     .tags(tags)
                     .tag("area", "heap")
-                    .description("The percentage of old gen heap used after the last GC event, in the range [0..1]")
+                    .tag("pool", longLivedPoolName)
+                    .description("The percentage of long-lived heap pool used after the last GC event, in the range [0..1]")
                     .baseUnit(BaseUnits.PERCENT);
-
-            if (JvmMemory.isOldGenPool(longLivedPoolName))
-                builder.tag("generation", "old");
-            else
-                builder.tag("pool", longLivedPoolName);
 
             builder.register(registry);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -31,10 +31,10 @@ class JvmMemory {
 
     static Optional<MemoryPoolMXBean> getLongLivedHeapPool() {
         return ManagementFactory
-                .getPlatformMXBeans(MemoryPoolMXBean.class)
+                .getMemoryPoolMXBeans()
                 .stream()
                 .filter(JvmMemory::isHeap)
-                .filter(mem -> isOldGenPool(mem.getName()) || isNonGenerationalHeapPool(mem.getName()))
+                .filter(mem -> isLongLivedPool(mem.getName()))
                 .findAny();
     }
 
@@ -47,12 +47,12 @@ class JvmMemory {
         return name != null && name.endsWith("Eden Space");
     }
 
-    static boolean isOldGenPool(String name) {
-        return name != null && (name.endsWith("Old Gen") || name.endsWith("Tenured Gen"));
-    }
-
-    static boolean isNonGenerationalHeapPool(String name) {
-        return "Shenandoah".equals(name) || "ZHeap".equals(name);
+    static boolean isLongLivedPool(String name) {
+        return name != null && (name.endsWith("Old Gen")
+                || name.endsWith("Tenured Gen")
+                || "Shenandoah".equals(name)
+                || "ZHeap".equals(name)
+        );
     }
 
     private static boolean isHeap(MemoryPoolMXBean memoryPoolBean) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
@@ -18,8 +18,6 @@ package io.micrometer.core.instrument.binder.jvm;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
-import java.lang.management.MemoryPoolMXBean;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -40,12 +38,8 @@ class JvmGcMetricsTest {
         assertThat(registry.find("jvm.gc.memory.allocated").counter()).isNotNull();
         assertThat(registry.find("jvm.gc.max.data.size").gauge().value()).isGreaterThan(0);
 
-        assumeTrue(isGenerationalGc());
+        assumeTrue(binder.isGenerationalGc);
         assertThat(registry.find("jvm.gc.memory.promoted").counter()).isNotNull();
-    }
-
-    private boolean isGenerationalGc() {
-        return JvmMemory.getLongLivedHeapPool().map(MemoryPoolMXBean::getName).filter(JvmMemory::isOldGenPool).isPresent();
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
@@ -39,7 +39,7 @@ class JvmMemoryTest {
     void assertTolerateNullName() {
         // There is a way for the name passed to these methods to be null.
         // Ensure they don't fail;
-        assertThat(JvmMemory.isOldGenPool(null)).isFalse();
+        assertThat(JvmMemory.isLongLivedPool(null)).isFalse();
         assertThat(JvmMemory.isAllocationPool(null)).isFalse();
     }
 }


### PR DESCRIPTION
When we introduced support for non-generational collectors (Shenandoah, ZGC), the logic for their metrics was special case in the code. This refactor makes more code shared regardless of whether the collector is generational or not. The main difference with non-generational collectors is they do not have a promoted counter since there is no old generation. This refactoring should make it easier to support additional collectors (e.g. OpenJ9 collectors).