### PR TITLE
Support multiple long lived heap memory pools

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemory.java
@@ -21,21 +21,20 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
 import java.lang.management.MemoryUsage;
-import java.util.Optional;
 import java.util.function.ToLongFunction;
+import java.util.stream.Stream;
 
 class JvmMemory {
 
     private JvmMemory() {
     }
 
-    static Optional<MemoryPoolMXBean> getLongLivedHeapPool() {
+    static Stream<MemoryPoolMXBean> getLongLivedHeapPools() {
         return ManagementFactory
                 .getMemoryPoolMXBeans()
                 .stream()
                 .filter(JvmMemory::isHeap)
-                .filter(mem -> isLongLivedPool(mem.getName()))
-                .findAny();
+                .filter(mem -> isLongLivedPool(mem.getName()));
     }
 
     static boolean isConcurrentPhase(String cause, String name) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryTest.java
@@ -26,13 +26,13 @@ class JvmMemoryTest {
     @Test
     @DisabledIfSystemProperty(named = "java.vm.vendor", matches = "Eclipse OpenJ9")
     void getLongLivedHeapPool() {
-        assertThat(JvmMemory.getLongLivedHeapPool()).isNotEmpty();
+        assertThat(JvmMemory.getLongLivedHeapPools()).isNotEmpty();
     }
 
     @Test
     @EnabledIfSystemProperty(named = "java.vm.vendor", matches = "Eclipse OpenJ9")
     void getLongLivedHeapPoolWithEclipseOpenJ9() {
-        assertThat(JvmMemory.getLongLivedHeapPool()).isEmpty();
+        assertThat(JvmMemory.getLongLivedHeapPools()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
In order to support some of the OpenJ9 garbage collectors (see #1458), we will need to support there being multiple pools used for the long-lived heap memory. This sums the used/max memory for the long-lived pools.