### PR TITLE
Pin version for org.hsqldb:hsqldb to 2.5.+

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -61,7 +61,7 @@ def VERSIONS = [
         'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+',
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:5.+',
-        'org.hsqldb:hsqldb:latest.release',
+        'org.hsqldb:hsqldb:2.5.+', // 2.6.0 requires JDK 11.
         'org.jooq:jooq:3.14.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
         'org.junit.jupiter:junit-jupiter:5.7.+',


### PR DESCRIPTION
This PR pins the version for `org.hsqldb:hsqldb` to `2.5.+` to allow this repo to be built on JDK 8 again as 2.6.0 requires JDK 11.