### PR TITLE
Move tasks for GC tests to micrometer-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,28 +130,6 @@ subprojects {
             }
         }
 
-        task shenandoahTest(type: Test) {
-            // set heap size for the test JVM(s)
-            maxHeapSize = "1500m"
-
-            useJUnitPlatform {
-                includeTags 'gc'
-            }
-
-            jvmArgs '-XX:+UseShenandoahGC'
-        }
-
-        task zgcTest(type: Test) {
-            // set heap size for the test JVM(s)
-            maxHeapSize = "1500m"
-
-            useJUnitPlatform {
-                includeTags 'gc'
-            }
-
-            jvmArgs '-XX:+UseZGC'
-        }
-
         license {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -97,3 +97,25 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:kafka'
 }
+
+task shenandoahTest(type: Test) {
+    // set heap size for the test JVM(s)
+    maxHeapSize = "1500m"
+
+    useJUnitPlatform {
+        includeTags 'gc'
+    }
+
+    jvmArgs '-XX:+UseShenandoahGC'
+}
+
+task zgcTest(type: Test) {
+    // set heap size for the test JVM(s)
+    maxHeapSize = "1500m"
+
+    useJUnitPlatform {
+        includeTags 'gc'
+    }
+
+    jvmArgs '-XX:+UseZGC'
+}


### PR DESCRIPTION
This PR moves the tasks for GC tests to the `micrometer-core` module as they are specific to the `micrometer-core` module.

`./gradlew clean shenandoahTest` took 47 seconds locally, but after this change, it took 11 seconds.