### PR TITLE
CloudWatch: add option to use StatisticsSet for Timer and Distributio…

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
@@ -27,8 +27,7 @@ import java.util.function.Predicate;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.check;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkAll;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkRequired;
-import static io.micrometer.core.instrument.config.validate.PropertyValidator.getInteger;
-import static io.micrometer.core.instrument.config.validate.PropertyValidator.getString;
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
 
 /**
  * Configuration for CloudWatch exporting.
@@ -47,6 +46,8 @@ public interface CloudWatchConfig extends StepRegistryConfig {
     default String namespace() {
         return getString(this, "namespace").required().get();
     }
+
+    default boolean useStatisticsSet() { return getBoolean(this, "useStatisticsSet").orElse(false); }
 
     @Override
     default int batchSize() {

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
@@ -24,9 +24,7 @@ import io.micrometer.core.instrument.step.StepRegistryConfig;
 import java.time.Duration;
 import java.util.function.Predicate;
 
-import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.check;
-import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkAll;
-import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkRequired;
+import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;
 import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
 
 /**
@@ -47,7 +45,7 @@ public interface CloudWatchConfig extends StepRegistryConfig {
         return getString(this, "namespace").required().get();
     }
 
-    default boolean useStatisticsSet() { return getBoolean(this, "useStatisticsSet").orElse(false); }
+    default boolean useLegacyPublish() { return getBoolean(this, "useLegacyPublish").orElse(true); }
 
     @Override
     default int batchSize() {
@@ -82,4 +80,6 @@ public interface CloudWatchConfig extends StepRegistryConfig {
                                 InvalidReason.MALFORMED))
         );
     }
+
+
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,11 +36,6 @@ public class CloudWatchDistributionSummary extends StepDistributionSummary {
     public CloudWatchDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
         this.min = new TimeWindowMin(clock, distributionStatisticConfig);
-    }
-
-    @Override
-    protected void recordNonNegative(double amount) {
-        super.recordNonNegative(amount);
     }
 
     public double min() {

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
@@ -31,10 +31,9 @@ public class CloudWatchDistributionSummary extends StepDistributionSummary {
      * @param distributionStatisticConfig   distribution static configuration
      * @param scale                         scale
      * @param stepMillis                    step in milliseconds
-     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
      */
-    public CloudWatchDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
-        super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
+    public CloudWatchDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis) {
+        super(id, clock, distributionStatisticConfig, scale, stepMillis, true);
         this.min = new TimeWindowMin(clock, distributionStatisticConfig);
     }
 

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchDistributionSummary.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch2;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.TimeWindowMin;
+import io.micrometer.core.instrument.step.StepDistributionSummary;
+
+public class CloudWatchDistributionSummary extends StepDistributionSummary {
+    private final TimeWindowMin min;
+
+    /**
+     * Create a new {@code StepDistributionSummary}.
+     *
+     * @param id                            ID
+     * @param clock                         clock
+     * @param distributionStatisticConfig   distribution static configuration
+     * @param scale                         scale
+     * @param stepMillis                    step in milliseconds
+     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
+     */
+    public CloudWatchDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+        super(id, clock, distributionStatisticConfig, scale, stepMillis, supportsAggregablePercentiles);
+        this.min = new TimeWindowMin(clock, distributionStatisticConfig);
+    }
+
+    @Override
+    protected void recordNonNegative(double amount) {
+        super.recordNonNegative(amount);
+    }
+
+    public double min() {
+        return min.poll();
+    }
+}

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         this.config = config;
 
         if (config.useStatisticsSet()) {
-            logger.info("publishing Timer and DistributionSummary as StatisticsSet");
+            logger.debug("publishing Timer and DistributionSummary as StatisticsSet");
         }
 
         config().namingConvention(new CloudWatchNamingConvention());

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
@@ -32,16 +32,15 @@ public class CloudWatchTimer extends StepTimer {
     /**
      * Create a new {@code StepTimer}.
      *
-     * @param id                            ID
-     * @param clock                         clock
-     * @param distributionStatisticConfig   distribution statistic configuration
-     * @param pauseDetector                 pause detector
-     * @param baseTimeUnit                  base time unit
-     * @param stepDurationMillis            step in milliseconds
-     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
+     * @param id                          ID
+     * @param clock                       clock
+     * @param distributionStatisticConfig distribution statistic configuration
+     * @param pauseDetector               pause detector
+     * @param baseTimeUnit                base time unit
+     * @param stepDurationMillis          step in milliseconds
      */
-    public CloudWatchTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
-        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
+    public CloudWatchTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, true);
         min = new TimeWindowMin(clock, distributionStatisticConfig);
     }
 
@@ -54,4 +53,5 @@ public class CloudWatchTimer extends StepTimer {
     public double min(final TimeUnit unit) {
         return TimeUtils.nanosToUnit(min.poll(), unit);
     }
+
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchTimer.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch2;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.TimeWindowMin;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.step.StepTimer;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.concurrent.TimeUnit;
+
+public class CloudWatchTimer extends StepTimer {
+
+    private final TimeWindowMin min;
+
+
+    /**
+     * Create a new {@code StepTimer}.
+     *
+     * @param id                            ID
+     * @param clock                         clock
+     * @param distributionStatisticConfig   distribution statistic configuration
+     * @param pauseDetector                 pause detector
+     * @param baseTimeUnit                  base time unit
+     * @param stepDurationMillis            step in milliseconds
+     * @param supportsAggregablePercentiles whether it supports aggregable percentiles
+     */
+    public CloudWatchTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis, boolean supportsAggregablePercentiles) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, supportsAggregablePercentiles);
+        min = new TimeWindowMin(clock, distributionStatisticConfig);
+    }
+
+    @Override
+    protected void recordNonNegative(long amount, TimeUnit unit) {
+        super.recordNonNegative(amount, unit);
+        min.record(TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS));
+    }
+
+    public double min(final TimeUnit unit) {
+        return TimeUtils.nanosToUnit(min.poll(), unit);
+    }
+}

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchUtils.java
@@ -67,7 +67,7 @@ final class CloudWatchUtils {
     }
 
     //VisibleForTesting
-    static public List<Pair<List<Double>, List<Double>>> histogramCountsToCloudWatchArrays(CountAtBucket[] histogramCounts, @Nullable TimeUnit baseTimeUnit) {
+    public static List<Pair<List<Double>, List<Double>>> histogramCountsToCloudWatchArrays(CountAtBucket[] histogramCounts, @Nullable TimeUnit baseTimeUnit) {
         List<Pair<List<Double>, List<Double>>> batches = new ArrayList<>();
         List<Double> values = new ArrayList<>();
         List<Double> counts = new ArrayList<>();

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/MetricDatumPartition.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/MetricDatumPartition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/package-info.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
@@ -97,4 +97,16 @@ class CloudWatchConfigTest {
 
         assertThat(config.validate().isValid()).isTrue();
     }
+
+    @Test
+    void useStatisticsSet() {
+        props.put("cloudwatch.useStatisticsSet", "true");
+        assertThat(config.useStatisticsSet()).isTrue();
+    }
+
+    @Test
+    void useLegacyPublish() {
+        props.put("cloudwatch.useStatisticsSet", "false");
+        assertThat(config.useStatisticsSet()).isFalse();
+    }
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
@@ -98,19 +98,20 @@ class CloudWatchConfigTest {
         assertThat(config.validate().isValid()).isTrue();
     }
 
-    @Test
-    void useStatisticsSet() {
-        props.put("cloudwatch.useStatisticsSet", "true");
-        assertThat(config.useStatisticsSet()).isTrue();
-    }
+
 
     @Test
     void useLegacyPublish() {
-        //config not set
-        assertThat(config.useStatisticsSet()).isFalse();
+        //config not set, default true
+        assertThat(config.useLegacyPublish()).isTrue();
 
-        props.put("cloudwatch.useStatisticsSet", "false");
-        assertThat(config.useStatisticsSet()).isFalse();
+        //config explicitly set to true
+        props.put("cloudwatch.useLegacyPublish", "true");
+        assertThat(config.useLegacyPublish()).isTrue();
+
+        //config explicitly set to false
+        props.put("cloudwatch.useLegacyPublish", "false");
+        assertThat(config.useLegacyPublish()).isFalse();
 
     }
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,11 @@ class CloudWatchConfigTest {
 
     @Test
     void useLegacyPublish() {
+        //config not set
+        assertThat(config.useStatisticsSet()).isFalse();
+
         props.put("cloudwatch.useStatisticsSet", "false");
         assertThat(config.useStatisticsSet()).isFalse();
+
     }
 }

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryHighResolutionTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryHighResolutionTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch2;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.micrometer.core.instrument.Meter.Id;
+import static io.micrometer.core.instrument.Meter.Type.DISTRIBUTION_SUMMARY;
+import static io.micrometer.core.instrument.Meter.Type.TIMER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link CloudWatchMeterRegistry} with high resolution metrics and histogram.
+ *
+ * @author Christoph Sitter
+ */
+class CloudWatchMeterRegistryHighResolutionTest {
+    private static final String METER_NAME = "test";
+    private final CloudWatchConfig config = new CloudWatchConfig() {
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public String namespace() {
+            return "namespace";
+        }
+
+        @Override
+        public boolean useLegacyPublish() {
+            return false;
+        }
+
+        @Override
+        public boolean highResolution() {
+            return true;
+        }
+    };
+
+    private final MockClock clock = new MockClock();
+    private final CloudWatchMeterRegistry registry = spy(new CloudWatchMeterRegistry(config, clock, null));
+    private CloudWatchMeterRegistry.Batch registryBatch = registry.new Batch();
+
+
+    @Test
+    void shouldSerialiseTimerHistogramIntoMetricDatum() {
+        Timer timer = mock(CloudWatchTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        final int histogramSamples = 50;
+        final HistogramSnapshot histogram = buildHistogram(histogramSamples);
+        when(timer.takeSnapshot()).thenReturn(histogram);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+
+        final List<MetricDatum> metricPuts = streamSupplier.get().collect(Collectors.toList());
+        assertThat(metricPuts).hasSize(1);
+        validateMetricPut(metricPuts.get(0), histogram, histogramSamples);
+    }
+
+    @Test
+    void shouldSerialiseTimerHistogramIntoMultipleMetricDatums() {
+        Timer timer = mock(CloudWatchTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        final int histogramSamples = 350;
+        final HistogramSnapshot histogram = buildHistogram(histogramSamples);
+        when(timer.takeSnapshot()).thenReturn(histogram);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+
+        final List<MetricDatum> metricPuts = streamSupplier.get().collect(Collectors.toList());
+        assertThat(metricPuts).hasSize(3);
+    }
+
+    @Test
+    void shouldSerialiseSummaryHistogramIntoMetricDatum() {
+        CloudWatchDistributionSummary summary = mock(CloudWatchDistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        final int histogramSamples = 50;
+        final HistogramSnapshot histogram = buildHistogram(histogramSamples);
+        when(summary.takeSnapshot()).thenReturn(histogram);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+
+        final List<MetricDatum> metricPuts = streamSupplier.get().collect(Collectors.toList());
+        assertThat(metricPuts).hasSize(1);
+        validateMetricPut(metricPuts.get(0), histogram, histogramSamples);
+    }
+
+    @Test
+    void shouldSerialiseSummaryHistogramIntoMultipleMetricDatums() {
+        CloudWatchDistributionSummary summary = mock(CloudWatchDistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        final int histogramSamples = 350;
+        final HistogramSnapshot histogram = buildHistogram(histogramSamples);
+        when(summary.takeSnapshot()).thenReturn(histogram);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+
+        final List<MetricDatum> metricPuts = streamSupplier.get().collect(Collectors.toList());
+        assertThat(metricPuts).hasSize(3);
+    }
+
+    private void validateMetricPut(MetricDatum metricPuts, HistogramSnapshot histogram, int histogramSamples) {
+        assertThat(metricPuts.storageResolution()).isEqualTo(1);
+        assertThat(metricPuts.values()).hasSize(histogramSamples);
+        assertThat(metricPuts.counts()).hasSize(histogramSamples);
+        assertThat(metricPuts.statisticValues()).isNotNull();
+        assertThat(metricPuts.statisticValues().maximum()).isEqualTo(histogram.max(TimeUnit.MILLISECONDS));
+        assertThat(metricPuts.statisticValues().minimum()).isEqualTo(0);
+        assertThat(metricPuts.statisticValues().sampleCount()).isEqualTo(histogram.count());
+    }
+
+    private HistogramSnapshot buildHistogram(int bucketCount) {
+        CountAtBucket[] histogramData = new CountAtBucket[bucketCount];
+
+        int sampleCount = 0;
+        int total = 0;
+        int max = 0;
+        for (int i = 0; i < bucketCount; i++) {
+            sampleCount += ThreadLocalRandom.current().nextInt(1, 5);
+            total += sampleCount * i;
+            max = Math.max(max, sampleCount > 0 ? i : max);
+            histogramData[i] = new CountAtBucket((double) i, sampleCount);
+        }
+
+        return new HistogramSnapshot(sampleCount, total, max, null, histogramData, null);
+    }
+
+
+}

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryLegacyTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryLegacyTest.java
@@ -31,11 +31,11 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static io.micrometer.core.instrument.Meter.Id;
 import static io.micrometer.core.instrument.Meter.Type;
 import static io.micrometer.core.instrument.Meter.Type.DISTRIBUTION_SUMMARY;
 import static io.micrometer.core.instrument.Meter.Type.TIMER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 /**
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Johnny Lim
  */
-class CloudWatchMeterRegistryTest {
+class CloudWatchMeterRegistryLegacyTest {
     private static final String METER_NAME = "test";
     private final CloudWatchConfig config = new CloudWatchConfig() {
         @Override
@@ -54,6 +54,11 @@ class CloudWatchMeterRegistryTest {
         @Override
         public String namespace() {
             return "namespace";
+        }
+
+        @Override
+        public boolean useLegacyPublish() {
+            return true;
         }
     };
 
@@ -185,7 +190,7 @@ class CloudWatchMeterRegistryTest {
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(2L);
 
-        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.legacyTimerData(timer);
 
         assertThat(streamSupplier.get().anyMatch(hasAvgMetric(meterId))).isTrue();
         assertThat(streamSupplier.get().anyMatch(hasMaxMetric(meterId))).isTrue();
@@ -198,7 +203,7 @@ class CloudWatchMeterRegistryTest {
         when(timer.getId()).thenReturn(meterId);
         when(timer.count()).thenReturn(0L);
 
-        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.legacyTimerData(timer);
 
         assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
         assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
@@ -211,7 +216,7 @@ class CloudWatchMeterRegistryTest {
         when(summary.getId()).thenReturn(meterId);
         when(summary.count()).thenReturn(2L);
 
-        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.legacySummaryData(summary);
 
         assertThat(streamSupplier.get().anyMatch(hasAvgMetric(meterId))).isTrue();
         assertThat(streamSupplier.get().anyMatch(hasMaxMetric(meterId))).isTrue();
@@ -224,7 +229,7 @@ class CloudWatchMeterRegistryTest {
         when(summary.getId()).thenReturn(meterId);
         when(summary.count()).thenReturn(0L);
 
-        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.legacySummaryData(summary);
 
         assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
         assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryStatisticsSetTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryStatisticsSetTest.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatch2;
+
+import io.micrometer.core.instrument.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static io.micrometer.core.instrument.Meter.Id;
+import static io.micrometer.core.instrument.Meter.Type;
+import static io.micrometer.core.instrument.Meter.Type.DISTRIBUTION_SUMMARY;
+import static io.micrometer.core.instrument.Meter.Type.TIMER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link CloudWatchMeterRegistry}.
+ *
+ * @author Christoph Sitter
+ */
+class CloudWatchMeterRegistryStatisticsSetTest {
+    private static final String METER_NAME = "test";
+    private final CloudWatchConfig config = new CloudWatchConfig() {
+        @Override
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public String namespace() {
+            return "namespace";
+        }
+
+        @Override
+        public boolean useStatisticsSet() {
+            return true;
+        }
+    };
+
+    private final MockClock clock = new MockClock();
+    private final CloudWatchMeterRegistry registry = spy(new CloudWatchMeterRegistry(config, clock, null));
+    private CloudWatchMeterRegistry.Batch registryBatch = registry.new Batch();
+
+    @Test
+    void metricData() {
+        registry.gauge("gauge", 1d);
+        List<MetricDatum> metricDatumStream = registry.metricData();
+        assertThat(metricDatumStream.size()).isEqualTo(1);
+    }
+
+    @Test
+    void metricDataWhenNaNShouldNotAdd() {
+        registry.gauge("gauge", Double.NaN);
+
+        AtomicReference<Double> value = new AtomicReference<>(Double.NaN);
+        registry.more().timeGauge("time.gauge", Tags.empty(), value, TimeUnit.MILLISECONDS, AtomicReference::get);
+
+        List<MetricDatum> metricDatumStream = registry.metricData();
+        assertThat(metricDatumStream.size()).isEqualTo(0);
+    }
+
+    @Test
+    void batchGetMetricName() {
+        Id id = new Id("name", Tags.empty(), null, null, Type.COUNTER);
+        assertThat(registry.new Batch().getMetricName(id, "suffix")).isEqualTo("name.suffix");
+    }
+
+    @Test
+    void batchGetMetricNameWhenSuffixIsNullShouldNotAppend() {
+        Id id = new Id("name", Tags.empty(), null, null, Type.COUNTER);
+        assertThat(registry.new Batch().getMetricName(id, null)).isEqualTo("name");
+    }
+
+    @Test
+    void batchFunctionCounterData() {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionCounterData(counter)).hasSize(1);
+    }
+
+    @Test
+    void batchFunctionCounterDataShouldClampInfiniteValues() {
+        FunctionCounter counter = FunctionCounter.builder("my.positive.infinity", Double.POSITIVE_INFINITY, Number::doubleValue).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionCounterData(counter).findFirst().get().value())
+                .isEqualTo(1.174271e+108);
+
+        counter = FunctionCounter.builder("my.negative.infinity", Double.NEGATIVE_INFINITY, Number::doubleValue).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionCounterData(counter).findFirst().get().value())
+                .isEqualTo(-1.174271e+108);
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterHasOnlyNaNValuesShouldNotBeWritten() {
+        Measurement measurement = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement);
+        Meter meter = Meter.builder("my.meter", Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.new Batch().metricData(meter)).isEmpty();
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterHasMixedNaNAndNonNaNValuesShouldSkipOnlyNaNValues() {
+        Measurement measurement1 = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        Measurement measurement2 = new Measurement(() -> 1d, Statistic.VALUE);
+        Measurement measurement3 = new Measurement(() -> 2d, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
+        Meter meter = Meter.builder("my.meter", Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.new Batch().metricData(meter)).hasSize(2);
+    }
+
+    @Test
+    void writeShouldDropTagWithBlankValue() {
+        registry.gauge("my.gauge", Tags.of("accepted", "foo").and("empty", ""), 1d);
+        assertThat(registry.metricData())
+                .hasSize(1)
+                .allSatisfy(datum -> assertThat(datum.dimensions()).hasSize(1).contains(
+                        Dimension.builder().name("accepted").value("foo").build()));
+    }
+
+    @Test
+    void functionTimerData() {
+        FunctionTimer timer = FunctionTimer.builder("my.function.timer", 1d, Number::longValue, Number::doubleValue,
+                TimeUnit.MILLISECONDS).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionTimerData(timer)).hasSize(3);
+    }
+
+    @Test
+    void functionTimerDataWhenSumIsNaNShouldReturnEmptyStream() {
+        FunctionTimer timer = FunctionTimer.builder("my.function.timer", Double.NaN, Number::longValue,
+                Number::doubleValue, TimeUnit.MILLISECONDS).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Batch().functionTimerData(timer)).isEmpty();
+    }
+
+    @Test
+    void shouldAddFunctionTimerAggregateMetricWhenAtLeastOneEventHappened() {
+        FunctionTimer timer = mock(FunctionTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(2.0);
+
+        Stream<MetricDatum> metricDatumStream = registryBatch.functionTimerData(timer);
+
+        assertThat(metricDatumStream.anyMatch(hasAvgMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldNotAddFunctionTimerAggregateMetricWhenNoEventHappened() {
+        FunctionTimer timer = mock(FunctionTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(0.0);
+
+        Stream<MetricDatum> metricDatumStream = registryBatch.functionTimerData(timer);
+
+        assertThat(metricDatumStream.noneMatch(hasAvgMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldAddTimerAggregateMetricWhenAtLeastOneEventHappened() {
+        CloudWatchTimer timer = mock(CloudWatchTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(2L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+
+        assertThat(streamSupplier.get()).anyMatch(hasStatisticsSet(meterId));
+    }
+
+    @Test
+    void shouldNotAddTimerAggregateMetricWhenNoEventHappened() {
+        Timer timer = mock(Timer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(0L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.timerData(timer);
+
+        assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldAddDistributionSumAggregateMetricWhenAtLeastOneEventHappened() {
+        CloudWatchDistributionSummary summary = mock(CloudWatchDistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        when(summary.min()).thenReturn(1.0);
+        when(summary.max()).thenReturn(5.0);
+        when(summary.totalAmount()).thenReturn(6.0);
+        when(summary.count()).thenReturn(2L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+
+        assertThat(streamSupplier.get()).anyMatch(hasStatisticsSet(meterId));
+    }
+
+
+    @Test
+    void shouldNotAddDistributionSumAggregateMetricWhenNoEventHappened() {
+        DistributionSummary summary = mock(DistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        when(summary.count()).thenReturn(0L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryBatch.summaryData(summary);
+
+        assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void batchSizeShouldWorkOnMetricDatum() throws InterruptedException {
+        List<Meter> meters = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Timer timer = Timer.builder("timer." + i).register(this.registry);
+            meters.add(timer);
+            timer.record(5, TimeUnit.SECONDS);
+        }
+        clock.add(1, TimeUnit.MINUTES);
+        when(this.registry.getMeters()).thenReturn(meters);
+        doNothing().when(this.registry).sendMetricData(any());
+        this.registry.publish();
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MetricDatum>> argumentCaptor = ArgumentCaptor.forClass(List.class);
+        verify(this.registry, times(1)).sendMetricData(argumentCaptor.capture());
+        List<List<MetricDatum>> allValues = argumentCaptor.getAllValues();
+        assertThat(allValues.get(0)).hasSize(20);
+    }
+
+    @Test
+    void batchToStandardUnitWhenUnitIsUnknownShouldReturnNone() {
+        assertThat(this.registry.new Batch().toStandardUnit("unknownUnit")).isEqualTo(StandardUnit.NONE);
+    }
+
+    private Predicate<MetricDatum> hasStatisticsSet(Id meterId) {
+        return e -> e.metricName().equals(meterId.getName()) && e.statisticValues() != null;
+    }
+
+    private Predicate<MetricDatum> hasAvgMetric(Id id) {
+        return e -> e.metricName().equals(id.getName().concat(".avg"));
+    }
+
+    private Predicate<MetricDatum> hasMaxMetric(Id id) {
+        return e -> e.metricName().equals(id.getName().concat(".max"));
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindow.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindow.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.distribution;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.util.TimeUtils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.DoubleSupplier;
+import java.util.function.LongSupplier;
+
+/**
+ * A template implementation for a decaying min/max for a distribution based on a configurable ring buffer.
+ *
+ * @author Jon Schneider
+ */
+public abstract class AbstractTimeWindow {
+    private static final AtomicIntegerFieldUpdater<AbstractTimeWindow> rotatingUpdater =
+            AtomicIntegerFieldUpdater.newUpdater(AbstractTimeWindow.class, "rotating");
+
+    private final Clock clock;
+    private final long durationBetweenRotatesMillis;
+    private final AtomicLong[] ringBuffer;
+    private int currentBucket;
+    private volatile long lastRotateTimestampMillis;
+
+    @SuppressWarnings({"unused", "FieldCanBeLocal"})
+    private volatile int rotating; // 0 - not rotating, 1 - rotating
+
+    @SuppressWarnings("ConstantConditions")
+    public AbstractTimeWindow(Clock clock, DistributionStatisticConfig config) {
+        this(clock, config.getExpiry().toMillis(), config.getBufferLength());
+    }
+
+    public AbstractTimeWindow(Clock clock, long rotateFrequencyMillis, int bufferLength) {
+        this.clock = clock;
+        this.durationBetweenRotatesMillis = rotateFrequencyMillis;
+        this.lastRotateTimestampMillis = clock.wallTime();
+        this.currentBucket = 0;
+
+        this.ringBuffer = new AtomicLong[bufferLength];
+        for (int i = 0; i < bufferLength; i++) {
+            this.ringBuffer[i] = new AtomicLong(initialValue());
+        }
+    }
+
+    /**
+     * For use by timer implementations.
+     *
+     * @param sample   The value to record.
+     * @param timeUnit The unit of time of the incoming sample.
+     */
+    public void record(double sample, TimeUnit timeUnit) {
+        record(() -> (long) TimeUtils.convert(sample, timeUnit, TimeUnit.NANOSECONDS));
+    }
+
+    private void record(LongSupplier sampleSupplier) {
+        rotate();
+        long sample = sampleSupplier.getAsLong();
+        for (AtomicLong recordedValue : ringBuffer) {
+            updateRecorded(recordedValue, sample);
+        }
+    }
+
+    /**
+     * @param timeUnit The base unit of time to scale the max to.
+     * @return Current min/max scaled to the base unit of time. For use by timer implementations.
+     */
+    public double poll(TimeUnit timeUnit) {
+        return poll(() -> TimeUtils.nanosToUnit(ringBuffer[currentBucket].get(), timeUnit));
+    }
+
+    private double poll(DoubleSupplier maxSupplier) {
+        rotate();
+        synchronized (this) {
+            return maxSupplier.getAsDouble();
+        }
+    }
+
+    /**
+     * @return An unscaled current value (min/max based on implementation). For use by distribution summary implementations.
+     */
+    public double poll() {
+        return poll(() -> Double.longBitsToDouble(ringBuffer[currentBucket].get()));
+    }
+
+    /**
+     * For use by distribution summary implementations.
+     *
+     * @param sample The value to record.
+     */
+    public void record(double sample) {
+        record(() -> Double.doubleToLongBits(sample));
+    }
+
+    private void updateRecorded(AtomicLong current, long sample) {
+        long curVal;
+        do {
+            curVal = current.get();
+        } while (shouldUpdate(curVal, sample) && !current.compareAndSet(curVal, sample));
+    }
+
+    private void rotate() {
+        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
+        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
+            // Need to wait more for next rotation.
+            return;
+        }
+
+        if (!rotatingUpdater.compareAndSet(this, 0, 1)) {
+            // Being rotated by other thread already.
+            return;
+        }
+
+        try {
+            int iterations = 0;
+            synchronized (this) {
+                do {
+                    ringBuffer[currentBucket].set(initialValue());
+                    if (++currentBucket >= ringBuffer.length) {
+                        currentBucket = 0;
+                    }
+                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
+                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
+                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
+            }
+        } finally {
+            rotating = 0;
+        }
+    }
+
+
+    protected abstract long initialValue();
+
+    protected abstract boolean shouldUpdate(long cached, long sample);
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
@@ -16,131 +16,29 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.util.TimeUtils;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.DoubleSupplier;
-import java.util.function.LongSupplier;
 
 /**
  * An implementation of a decaying maximum for a distribution based on a configurable ring buffer.
  *
  * @author Jon Schneider
  */
-public class TimeWindowMax {
-    private static final AtomicIntegerFieldUpdater<TimeWindowMax> rotatingUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(TimeWindowMax.class, "rotating");
-
-    private final Clock clock;
-    private final long durationBetweenRotatesMillis;
-    private final AtomicLong[] ringBuffer;
-    private int currentBucket;
-    private volatile long lastRotateTimestampMillis;
-
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private volatile int rotating; // 0 - not rotating, 1 - rotating
-
+public class TimeWindowMax extends AbstractTimeWindow {
     @SuppressWarnings("ConstantConditions")
     public TimeWindowMax(Clock clock, DistributionStatisticConfig config) {
         this(clock, config.getExpiry().toMillis(), config.getBufferLength());
     }
 
     public TimeWindowMax(Clock clock, long rotateFrequencyMillis, int bufferLength) {
-        this.clock = clock;
-        this.durationBetweenRotatesMillis = rotateFrequencyMillis;
-        this.lastRotateTimestampMillis = clock.wallTime();
-        this.currentBucket = 0;
-
-        this.ringBuffer = new AtomicLong[bufferLength];
-        for (int i = 0; i < bufferLength; i++) {
-            this.ringBuffer[i] = new AtomicLong();
-        }
+        super(clock, rotateFrequencyMillis, bufferLength);
     }
 
-    /**
-     * For use by timer implementations.
-     *
-     * @param sample   The value to record.
-     * @param timeUnit The unit of time of the incoming sample.
-     */
-    public void record(double sample, TimeUnit timeUnit) {
-        record(() -> (long) TimeUtils.convert(sample, timeUnit, TimeUnit.NANOSECONDS));
+    @Override
+    protected long initialValue() {
+        return 0;
     }
 
-    private void record(LongSupplier sampleSupplier) {
-        rotate();
-        long sample = sampleSupplier.getAsLong();
-        for (AtomicLong max : ringBuffer) {
-            updateMax(max, sample);
-        }
-    }
-
-    /**
-     * @param timeUnit The base unit of time to scale the max to.
-     * @return A max scaled to the base unit of time. For use by timer implementations.
-     */
-    public double poll(TimeUnit timeUnit) {
-        return poll(() -> TimeUtils.nanosToUnit(ringBuffer[currentBucket].get(), timeUnit));
-    }
-
-    private double poll(DoubleSupplier maxSupplier) {
-        rotate();
-        synchronized (this) {
-            return maxSupplier.getAsDouble();
-        }
-    }
-
-    /**
-     * @return An unscaled max. For use by distribution summary implementations.
-     */
-    public double poll() {
-        return poll(() -> Double.longBitsToDouble(ringBuffer[currentBucket].get()));
-    }
-
-    /**
-     * For use by distribution summary implementations.
-     *
-     * @param sample The value to record.
-     */
-    public void record(double sample) {
-        record(() -> Double.doubleToLongBits(sample));
-    }
-
-    private void updateMax(AtomicLong max, long sample) {
-        long curMax;
-        do {
-            curMax = max.get();
-        } while (curMax < sample && !max.compareAndSet(curMax, sample));
-    }
-
-    private void rotate() {
-        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
-        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
-            // Need to wait more for next rotation.
-            return;
-        }
-
-        if (!rotatingUpdater.compareAndSet(this, 0, 1)) {
-            // Being rotated by other thread already.
-            return;
-        }
-
-        try {
-            int iterations = 0;
-            synchronized (this) {
-                do {
-                    ringBuffer[currentBucket].set(0);
-                    if (++currentBucket >= ringBuffer.length) {
-                        currentBucket = 0;
-                    }
-                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
-                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
-                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
-            }
-        } finally {
-            rotating = 0;
-        }
+    @Override
+    protected boolean shouldUpdate(long cached, long sample) {
+        return cached < sample;
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMin.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 VMware, Inc.
+ * Copyright 2021 VMware, Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,131 +16,29 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.util.TimeUtils;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.DoubleSupplier;
-import java.util.function.LongSupplier;
 
 /**
  * An implementation of a decaying minimum for a distribution based on a configurable ring buffer.
  *
  * @author Jon Schneider
  */
-public class TimeWindowMin {
-    private static final AtomicIntegerFieldUpdater<TimeWindowMin> rotatingUpdater =
-            AtomicIntegerFieldUpdater.newUpdater(TimeWindowMin.class, "rotating");
-
-    private final Clock clock;
-    private final long durationBetweenRotatesMillis;
-    private final AtomicLong[] ringBuffer;
-    private int currentBucket;
-    private volatile long lastRotateTimestampMillis;
-
-    @SuppressWarnings({"unused", "FieldCanBeLocal"})
-    private volatile int rotating; // 0 - not rotating, 1 - rotating
-
+public class TimeWindowMin extends AbstractTimeWindow {
     @SuppressWarnings("ConstantConditions")
     public TimeWindowMin(Clock clock, DistributionStatisticConfig config) {
-        this(clock, config.getExpiry().toMillis(), config.getBufferLength());
+        super(clock, config.getExpiry().toMillis(), config.getBufferLength());
     }
 
     public TimeWindowMin(Clock clock, long rotateFrequencyMillis, int bufferLength) {
-        this.clock = clock;
-        this.durationBetweenRotatesMillis = rotateFrequencyMillis;
-        this.lastRotateTimestampMillis = clock.wallTime();
-        this.currentBucket = 0;
-
-        this.ringBuffer = new AtomicLong[bufferLength];
-        for (int i = 0; i < bufferLength; i++) {
-            this.ringBuffer[i] = new AtomicLong(Long.MAX_VALUE);
-        }
+        super(clock, rotateFrequencyMillis, bufferLength);
     }
 
-    /**
-     * For use by timer implementations.
-     *
-     * @param sample   The value to record.
-     * @param timeUnit The unit of time of the incoming sample.
-     */
-    public void record(double sample, TimeUnit timeUnit) {
-        record(() -> (long) TimeUtils.convert(sample, timeUnit, TimeUnit.NANOSECONDS));
+    @Override
+    protected long initialValue() {
+        return Long.MAX_VALUE;
     }
 
-    private void record(LongSupplier sampleSupplier) {
-        rotate();
-        long sample = sampleSupplier.getAsLong();
-        for (AtomicLong min : ringBuffer) {
-            updateMin(min, sample);
-        }
-    }
-
-    /**
-     * @param timeUnit The base unit of time to scale the max to.
-     * @return A max scaled to the base unit of time. For use by timer implementations.
-     */
-    public double poll(TimeUnit timeUnit) {
-        return poll(() -> TimeUtils.nanosToUnit(ringBuffer[currentBucket].get(), timeUnit));
-    }
-
-    private double poll(DoubleSupplier maxSupplier) {
-        rotate();
-        synchronized (this) {
-            return maxSupplier.getAsDouble();
-        }
-    }
-
-    /**
-     * @return An unscaled max. For use by distribution summary implementations.
-     */
-    public double poll() {
-        return poll(() -> Double.longBitsToDouble(ringBuffer[currentBucket].get()));
-    }
-
-    /**
-     * For use by distribution summary implementations.
-     *
-     * @param sample The value to record.
-     */
-    public void record(double sample) {
-        record(() -> Double.doubleToLongBits(sample));
-    }
-
-    private void updateMin(AtomicLong min, long sample) {
-        long curMin;
-        do {
-            curMin = min.get();
-        } while (curMin > sample && !min.compareAndSet(curMin, sample));
-    }
-
-    private void rotate() {
-        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
-        if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
-            // Need to wait more for next rotation.
-            return;
-        }
-
-        if (!rotatingUpdater.compareAndSet(this, 0, 1)) {
-            // Being rotated by other thread already.
-            return;
-        }
-
-        try {
-            int iterations = 0;
-            synchronized (this) {
-                do {
-                    ringBuffer[currentBucket].set(Long.MAX_VALUE);
-                    if (++currentBucket >= ringBuffer.length) {
-                        currentBucket = 0;
-                    }
-                    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
-                    lastRotateTimestampMillis += durationBetweenRotatesMillis;
-                } while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
-            }
-        } finally {
-            rotating = 0;
-        }
+    @Override
+    protected boolean shouldUpdate(long cached, long sample) {
+        return cached > sample;
     }
 }


### PR DESCRIPTION
Hi all,

I took a stab at publishing Timers and DistributionSummaries as StatisticsSet on the cloudwatch2 registry

This should address
* https://github.com/micrometer-metrics/micrometer/issues/1784
* https://github.com/micrometer-metrics/micrometer/issues/457

Let me know what you think, some immediate thoughts would be to merge the Min/Max window into a single class that takes a Comparator for min/max mode