### PR TITLE
Log meter polling failure in `StatsdMeterRegistry`

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
 import io.micrometer.core.lang.Nullable;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.statsd.internal.*;
 import org.reactivestreams.Processor;
 import org.reactivestreams.Publisher;
@@ -69,6 +70,8 @@ import java.util.stream.LongStream;
  * @since 1.0.0
  */
 public class StatsdMeterRegistry extends MeterRegistry {
+
+    private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(StatsdMeterRegistry.class);
 
     private static final Processor<String, String> NOOP_PROCESSOR = new NoopProcessor();
 
@@ -160,11 +163,11 @@ public class StatsdMeterRegistry extends MeterRegistry {
     }
 
     void poll() {
-        for (StatsdPollable pollableMeter : pollableMeters.values()) {
+        for (Map.Entry<Meter.Id, StatsdPollable> pollableMeter : pollableMeters.entrySet()) {
             try {
-                pollableMeter.poll();
+                pollableMeter.getValue().poll();
             } catch (RuntimeException e) {
-                // Silently ignore misbehaving pollable meter
+                warnThenDebugLogger.log("Failed to poll a meter '" + pollableMeter.getKey().getName() + "'.", e);
             }
         }
     }

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -545,7 +545,7 @@ class StatsdMeterRegistryTest {
     @Test
     void pollFailureNotFatal() {
         registry = StatsdMeterRegistry.builder(StatsdConfig.DEFAULT).build();
-        Gauge.builder("fails", "", o -> {
+        Gauge.builder("fails", () -> {
             throw new RuntimeException();
         }).register(registry);
         Gauge.builder("works", () -> 42).register(registry);


### PR DESCRIPTION
This PR changes to log meter polling failures once at warn and then at debug in `StatsdMeterRegistry`.

See gh-2549