### PR TITLE
Configure Gradle enterprise conventions

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://repo.spring.io/release' }
+    }
+}
+
+plugins {
+    id "com.gradle.enterprise" version "3.5"
+    id "io.spring.ge.conventions" version "0.0.7"
+}
+
 rootProject.name = 'micrometer'
 
 include 'micrometer-core'


### PR DESCRIPTION
This will allow us to use the build cache both locally and remotely on the Spring instance of Gradle Enterprise. It will also publish build scans so we have additional insight into our builds.

Also we should:
- [x] Configure Gradle Enterprise credentials on CI

Only trusted builds (e.g. NOT pull requests) will publish to the remote build cache and publish build scans.
Utilizes this plugin: https://github.com/spring-io/gradle-enterprise-conventions