### PR TITLE
More accurate metrics for 404 responses from Jersey2

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
@@ -95,7 +95,7 @@ public final class JerseyTags {
             if (isRedirection(status)) {
                 return URI_REDIRECTION;
             }
-            if (status == 404) {
+            if (status == 404 && event.getUriInfo().getMatchedResourceMethod() == null) {
                 return URI_NOT_FOUND;
             }
         }

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
@@ -92,19 +92,27 @@ public class MetricsRequestEventListenerTest extends JerseyTest {
     }
 
     @Test
-    public void notFoundIsAccumulatedUnderSameUri() {
+    public void notFoundIsAccumulatedUnderSameUriIfFromUnmatchedResource() {
         try {
             target("not-found").request().get();
         } catch (NotFoundException ignored) {
         }
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("NOT_FOUND", "404", "CLIENT_ERROR", null)).timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void notFoundIsReportedWithUriOfMatchedResource() {
         try {
             target("throws-not-found-exception").request().get();
         } catch (NotFoundException ignored) {
         }
 
         assertThat(registry.get(METRIC_NAME)
-            .tags(tagsFrom("NOT_FOUND", "404", "CLIENT_ERROR", null)).timer().count())
-            .isEqualTo(2);
+            .tags(tagsFrom("/throws-not-found-exception", "404", "CLIENT_ERROR", null)).timer().count())
+            .isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
I'm aware of the issue of tag explosion that motivates the mapping of 404 responses to a single URI such as "not_found". However, there are two distinct cases where the JAX-RS response can be 404:
- no REST resource could be matched to the incoming request
- a REST resource was matched to the request and the application code (via exception mapping or otherwise) created a response with 404 as status

I argue only the first case applies to the tag explosion concern. The second case however is not different than matched resources yielding HTTP 400.

With the proposed change, the HTTP 404 responses emitted by Jersey apps can be more appropriately attributed to the originating resource.