### PR TITLE
Upgrade to Gradle Wrapper 6.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ nexusPublishing {
 }
 
 wrapper {
-    gradleVersion = '6.8.3'
+    gradleVersion = '6.9'
 }
 
 defaultTasks 'build'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades to Gradle Wrapper 6.9 as upgrading to Gradle Wrapper 7.0 is blocked at the moment.

See https://github.com/micrometer-metrics/micrometer/issues/2558