### PR TITLE
Configure Micrometer-dedicated Gradle Enterprise server

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,15 @@ plugins {
 
 rootProject.name = 'micrometer'
 
+buildCache {
+    remote(HttpBuildCache) {
+        url = 'https://ge.micrometer.io/cache/'
+    }
+}
+gradleEnterprise {
+    server = "https://ge.micrometer.io"
+}
+
 include 'micrometer-core'
 include 'micrometer-jersey2'
 


### PR DESCRIPTION
Now that we have a dedicated Gradle Enterprise instance, configure it with the corresponding plugins for the cache and build scans.

I have tested the build scans locally. They fail to publish currently with Java 8 due to CloudFlare blocking the Java 8 user agent by default. We can configure it to not do that, but in practice, I don't think it is an issue since our CI runs on Java 15 which doesn't have the issue.

TODO:
- [x] Configure CI with credentials for publishing build cache