### PR TITLE
Fix publishing on Gradle 7 with a hack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,6 +142,8 @@ subprojects {
                             }
                         }
 
+                        // MYSTERY: from Gradle 7.0 the publish tasks fail without the following line
+                        configurations.compileOnly.setCanBeResolved(true)
                         // We publish resolved versions so don't need to publish our dependencyManagement
                         // too. This is different from many Maven projects, where published artifacts often
                         // don't include resolved versions and have a parent POM including dependencyManagement.


### PR DESCRIPTION
I don't pretend to understand at all why this is needed, but as far as I can tell it restores the previous behavior without errors.

Hack for #2597

Tested locally with `./gradlew pTML` and comparing one of the produced POM files to a previous release.