### PR TITLE
Mark 1.3.20 as a final patch for 1.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See [Micrometer's support policy](https://micrometer.io/docs/support) for more d
 | `1.0.x`            | Yes | `1.0.11`    |
 | `1.1.x`            | Yes | `1.1.19`    |
 | `1.2.x`            | No  | `1.2.2`     |
-| `1.3.x`            | Yes |  |
+| `1.3.x`            | Yes | `1.3.20`    |
 | `1.4.x`            | No  | `1.4.2`     |
 | `1.5.x`            | Yes |  |
 | `1.6.x`            | Yes |  |


### PR DESCRIPTION
This PR marks 1.3.20 as a final patch for 1.3.x as looking at https://github.com/micrometer-metrics/micrometer-docs/commit/42a8ba3a127851f6d8a64d34131250a993d4562b, 1.3.x seems to have been EOLed.