### PR TITLE
Rename netty native files so they can be loaded

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -26,7 +26,7 @@ shadowJar {
     relocate 'reactor', 'io.micrometer.shaded.reactor'
     relocate 'org.reactivestreams', 'io.micrometer.shaded.org.reactorstreams'
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
-    exclude 'META-INF/native/libnetty_transport_native_epoll_x86_64.so'
+    relocate 'META-INF/native/libnetty', 'META-INF/native/libio_micrometer_shaded_netty'
     metaInf {
         from "$rootDir/LICENSE"
         from "$rootDir/NOTICE"


### PR DESCRIPTION
Without this, I was getting a failure using the statsd module on macOS because our shaded netty could not load the shaded macOS native DNS library. See similar error in https://github.com/netty/netty/pull/11260. The macos native DNS library is being used from reactor-netty 1.x, which is why we don't see this issue in prior release lines.

This change is a redo of #1027 which was previously reverted in #1058 due to #1054. Do we have a way to reproduce the scenario that was happening in #1054? I tried running an example app on linux with this change and didn't immediately see the error, but I don't know the exact conditions for it either.

/cc @izeye in case you know more about the previous issue and how to check it doesn't get reintroduced by this change again.