### PR TITLE
Include the number of active instances in CommonsObjectPool2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -87,6 +87,9 @@ public class CommonsObjectPool2Metrics implements MeterBinder, AutoCloseable {
                                 "NumIdle", "num.idle", tags,
                                 "The number of instances currently idle in this pool", BaseUnits.OBJECTS);
                         registerGaugeForObject(registry, o,
+                                "NumActive", "num.active", tags,
+                                "The number of instances currently active in this pool", BaseUnits.OBJECTS);
+                        registerGaugeForObject(registry, o,
                                 "NumWaiters", "num.waiters", tags,
                                 "The estimate of the number of threads currently blocked waiting for an object from the pool",
                                 BaseUnits.THREADS);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2MetricsTest.java
@@ -31,6 +31,8 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Chao Chang
  */
@@ -43,68 +45,95 @@ class CommonsObjectPool2MetricsTest {
 
     @Test
     void verifyMetricsWithExpectedTags() {
-        createGenericObjectPool();
-        MeterRegistry registry = new SimpleMeterRegistry();
-        commonsObjectPool2Metrics.bindTo(registry);
+        try (GenericObjectPool<Object> p = createGenericObjectPool()) {
+            MeterRegistry registry = new SimpleMeterRegistry();
+            commonsObjectPool2Metrics.bindTo(registry);
 
-        registry.get("commons.pool2.num.idle").tags(tags).gauge();
-        registry.get("commons.pool2.num.waiters").tags(tags).gauge();
+            registry.get("commons.pool2.num.idle").tags(tags).gauge();
+            registry.get("commons.pool2.num.waiters").tags(tags).gauge();
 
-        Arrays.asList(
-                "commons.pool2.created",
-                "commons.pool2.borrowed",
-                "commons.pool2.returned",
-                "commons.pool2.destroyed",
-                "commons.pool2.destroyed.by.evictor",
-                "commons.pool2.destroyed.by.borrow.validation"
-        ).forEach(name -> registry.get(name).tags(tags).functionCounter());
+            Arrays.asList(
+                    "commons.pool2.created",
+                    "commons.pool2.borrowed",
+                    "commons.pool2.returned",
+                    "commons.pool2.destroyed",
+                    "commons.pool2.destroyed.by.evictor",
+                    "commons.pool2.destroyed.by.borrow.validation"
+            ).forEach(name -> registry.get(name).tags(tags).functionCounter());
 
-        Arrays.asList(
-                "commons.pool2.max.borrow.wait",
-                "commons.pool2.mean.active",
-                "commons.pool2.mean.idle",
-                "commons.pool2.mean.borrow.wait"
-        ).forEach(name -> registry.get(name).tags(tags).timeGauge());
+            Arrays.asList(
+                    "commons.pool2.max.borrow.wait",
+                    "commons.pool2.mean.active",
+                    "commons.pool2.mean.idle",
+                    "commons.pool2.mean.borrow.wait"
+            ).forEach(name -> registry.get(name).tags(tags).timeGauge());
+        }
     }
 
     @Test
     void verifyGenericKeyedObjectPoolMetricsWithExpectedTags() {
-        createGenericKeyedObjectPool();
-        Tags tagsToMatch = tags.and("type", "GenericKeyedObjectPool");
+        try (GenericKeyedObjectPool<Object, Object> p = createGenericKeyedObjectPool()) {
+            Tags tagsToMatch = tags.and("type", "GenericKeyedObjectPool");
+            commonsObjectPool2Metrics.bindTo(registry);
+
+            Arrays.asList(
+                    "commons.pool2.num.idle",
+                    "commons.pool2.num.waiters"
+            ).forEach(name -> registry.get(name).tags(tagsToMatch).gauge());
+
+            Arrays.asList(
+                    "commons.pool2.created",
+                    "commons.pool2.borrowed",
+                    "commons.pool2.returned",
+                    "commons.pool2.destroyed",
+                    "commons.pool2.destroyed.by.evictor",
+                    "commons.pool2.destroyed.by.borrow.validation"
+            ).forEach(name -> registry.get(name).tags(tagsToMatch).functionCounter());
+
+            Arrays.asList(
+                    "commons.pool2.max.borrow.wait",
+                    "commons.pool2.mean.active",
+                    "commons.pool2.mean.idle",
+                    "commons.pool2.mean.borrow.wait"
+            ).forEach(name -> registry.get(name).tags(tagsToMatch).timeGauge());
+        }
+    }
+
+    @Test
+    void verifyIdleAndActiveInstancesAreReported() throws Exception {
         commonsObjectPool2Metrics.bindTo(registry);
+        CountDownLatch latch = new CountDownLatch(1);
+        registry.config().onMeterAdded(m -> {
+            if (m.getId().getName().contains("commons.pool2"))
+                latch.countDown();
+        });
 
-        Arrays.asList(
-                "commons.pool2.num.idle",
-                "commons.pool2.num.waiters"
-        ).forEach(name -> registry.get(name).tags(tagsToMatch).gauge());
+        try (GenericObjectPool<Object> genericObjectPool = createGenericObjectPool()) {
+            latch.await(10, TimeUnit.SECONDS);
+            final Object o = genericObjectPool.borrowObject(10_000L);
 
-        Arrays.asList(
-                "commons.pool2.created",
-                "commons.pool2.borrowed",
-                "commons.pool2.returned",
-                "commons.pool2.destroyed",
-                "commons.pool2.destroyed.by.evictor",
-                "commons.pool2.destroyed.by.borrow.validation"
-        ).forEach(name -> registry.get(name).tags(tagsToMatch).functionCounter());
+            assertThat(registry.get("commons.pool2.num.active").gauge().value()).isEqualTo(1.0);
+            assertThat(registry.get("commons.pool2.num.idle").gauge().value()).isEqualTo(0.0);
 
-        Arrays.asList(
-                "commons.pool2.max.borrow.wait",
-                "commons.pool2.mean.active",
-                "commons.pool2.mean.idle",
-                "commons.pool2.mean.borrow.wait"
-        ).forEach(name -> registry.get(name).tags(tagsToMatch).timeGauge());
+            genericObjectPool.returnObject(o);
+
+            assertThat(registry.get("commons.pool2.num.active").gauge().value()).isEqualTo(0.0);
+            assertThat(registry.get("commons.pool2.num.idle").gauge().value()).isEqualTo(1.0);
+        }
     }
 
     @Test
     void metricsReportedPerMultiplePools() {
-        createGenericObjectPool();
-        createGenericObjectPool();
-        createGenericObjectPool();
-        MeterRegistry registry = new SimpleMeterRegistry();
-        commonsObjectPool2Metrics.bindTo(registry);
+        try (final GenericObjectPool<Object> p1 = createGenericObjectPool();
+            final GenericObjectPool<Object> p2 = createGenericObjectPool();
+            final GenericObjectPool<Object> p3 = createGenericObjectPool()) {
 
-        registry.get("commons.pool2.num.waiters").tag("name", "pool" + genericObjectPoolCount).gauge();
-        registry.get("commons.pool2.num.waiters").tag("name", "pool" + (genericObjectPoolCount - 1)).gauge();
+            MeterRegistry registry = new SimpleMeterRegistry();
+            commonsObjectPool2Metrics.bindTo(registry);
+
+            registry.get("commons.pool2.num.waiters").tag("name", "pool" + genericObjectPoolCount).gauge();
+            registry.get("commons.pool2.num.waiters").tag("name", "pool" + (genericObjectPoolCount - 1)).gauge();
+        }
     }
 
     @Test
@@ -118,16 +147,17 @@ class CommonsObjectPool2MetricsTest {
                 latch.countDown();
         });
 
-        createGenericObjectPool();
-        latch.await(10, TimeUnit.SECONDS);
+        try (GenericObjectPool<Object> p = createGenericObjectPool()) {
+            latch.await(10, TimeUnit.SECONDS);
+        }
     }
 
-    private void createGenericObjectPool() {
+    private GenericObjectPool<Object> createGenericObjectPool() {
         genericObjectPoolCount++;
         GenericObjectPoolConfig<Object> config = new GenericObjectPoolConfig<>();
         config.setMaxTotal(10);
 
-        new GenericObjectPool<>(new BasePooledObjectFactory<Object>() {
+        return new GenericObjectPool<>(new BasePooledObjectFactory<Object>() {
             @Override
             public Object create() {
                 return new Object();
@@ -140,8 +170,8 @@ class CommonsObjectPool2MetricsTest {
         }, config);
     }
 
-    private void createGenericKeyedObjectPool() {
-        new GenericKeyedObjectPool<>(new BaseKeyedPooledObjectFactory<Object, Object>() {
+    private GenericKeyedObjectPool<Object, Object> createGenericKeyedObjectPool() {
+        return new GenericKeyedObjectPool<>(new BaseKeyedPooledObjectFactory<Object, Object>() {
             @Override
             public Object create(Object key) {
                 return key;


### PR DESCRIPTION
This PR adds the number of currently active instances in the pool as a gauge, very much like the exisiting `num.idle` gauge.

(...I had to refactor the test a little bit. The "dangling" pool instances made the test very flaky. If you have a cleaner/nicer solution than try-with-resources I'm open for it 👍 )