### PR TITLE
Add reflection config for ProcessorMetrics and FileDescriptorMetrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ subprojects {
         license {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true
+            exclude '**/*.json' // comments not supported
         }
 
         // Publish resolved versions.

--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/native-image.properties
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/native-image.properties
@@ -1,0 +1,15 @@
+# Copyright 2021 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Args = -H:ReflectionConfigurationResources=${.}/reflect-config.json

--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name":"com.sun.management.OperatingSystemMXBean",
+    "methods":[
+      {"name":"getCpuLoad","parameterTypes":[] },
+      {"name":"getProcessCpuLoad","parameterTypes":[] },
+      {"name":"getSystemCpuLoad","parameterTypes":[] }
+    ]
+  },
+  {
+    "name":"com.sun.management.UnixOperatingSystemMXBean",
+    "methods":[
+      {"name":"getMaxFileDescriptorCount","parameterTypes":[] },
+      {"name":"getOpenFileDescriptorCount","parameterTypes":[] }
+    ]
+  }
+]


### PR DESCRIPTION
Without this configuration, ProcessorMetrics and FileDescriptorMetrics are not available in a Micrometer application run as a native image. This explicitly lets the native image compiler know what class and methods will have reflection used on them. With this configuration, the ProcessorMetrics and FileDescriptorMetrics are the same in applications run on the JVM or as native images.

Related to #2637 