### PR TITLE
Replace deprecated HealthStatusManager references

### DIFF
--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcMetricsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcMetricsSample.java
@@ -25,7 +25,7 @@ import io.grpc.health.v1.HealthGrpc;
 import io.grpc.health.v1.HealthGrpc.HealthBlockingStub;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
-import io.grpc.services.HealthStatusManager;
+import io.grpc.protobuf.services.HealthStatusManager;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;


### PR DESCRIPTION
This PR replaces deprecated `HealthStatusManager` references in the `micrometer-samples-core`.