### PR TITLE
Fix error log for custom metric put failures

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -214,13 +214,13 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                         createdCustomMetrics.add(customMetric.getMetricId());
                     })
                     .onError(response -> {
-                        if (logger.isErrorEnabled()) {
-                            logger.error("failed to create custom metric {} in dynatrace: {}", customMetric.getMetricId(),
-                                    response.body());
-                        }
+                        logger.error("failed to create custom metric {} in dynatrace: {}", customMetric.getMetricId(),
+                                response.body());
                     });
         } catch (Throwable e) {
-            logger.error("failed to create custom metric in dynatrace: {}", customMetric.getMetricId(), e);
+            if (logger.isErrorEnabled()) {
+                logger.error("failed to create custom metric in dynatrace: " + customMetric.getMetricId(), e);
+            }
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -213,10 +213,12 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                         logger.debug("created {} as custom metric in dynatrace", customMetric.getMetricId());
                         createdCustomMetrics.add(customMetric.getMetricId());
                     })
-                    .onError(response -> {
-                        logger.error("failed to create custom metric {} in dynatrace: {}", customMetric.getMetricId(),
-                                response.body());
-                    });
+                    .onError(response ->
+                        logger.error("failed to create custom metric {} in dynatrace: {}",
+                                customMetric.getMetricId(),
+                                response.body()
+                        )
+                    );
         } catch (Throwable e) {
             if (logger.isErrorEnabled()) {
                 logger.error("failed to create custom metric in dynatrace: " + customMetric.getMetricId(), e);


### PR DESCRIPTION
This PR fixes an error log for custom metric put failures as the `Throwable` parameter was ignored prior to this change.

This PR also removes an unnecessary log level guard.