### PR TITLE
Disable bootJarMainClassName task in micrometer-samples-boot2

### DIFF
--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -20,3 +20,7 @@ dependencies {
 bootJar {
     enabled = false
 }
+
+bootJarMainClassName {
+    enabled = false
+}


### PR DESCRIPTION
This PR disables the `bootJarMainClassName` task in the `micrometer-samples-boot2` module. This restores the `build` task to work again.

See gh-2644