### PR TITLE
Upgrade google-cloud-monitoring to latest

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ def VERSIONS = [
         'com.github.ben-manes.caffeine:caffeine:2.+',
         'com.github.charithe:kafka-junit:latest.release',
         'com.github.tomakehurst:wiremock-jre8-standalone:latest.release',
-        'com.google.cloud:google-cloud-monitoring:1.+',
+        'com.google.cloud:google-cloud-monitoring:latest.release',
         'com.google.dagger:dagger:2.11',
         'com.google.dagger:dagger-compiler:2.11',
         'com.google.guava:guava:latest.release',


### PR DESCRIPTION
The latest version seems to be compatible with our code, which wasn't previously the case. We want to ensure compatibility going forward so we should build with the latest version.

See gh-2249
See also #2235