### PR TITLE
Pin jOOQ to 3.14.+

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -60,7 +60,7 @@ def VERSIONS = [
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:5.+',
         'org.hsqldb:hsqldb:2.5.+', // 2.6.0 requires JDK 11.
-        'org.jooq:jooq:latest.release',
+        'org.jooq:jooq:3.14.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
         'org.junit.jupiter:junit-jupiter:5.7.+',
         'org.junit.platform:junit-platform-launcher:1.7.+',


### PR DESCRIPTION
This PR pins jOOQ to 3.14.+ as jOOQ 3.15.0 isn't compatible with the current `main`.