### PR TITLE
Polish error log message in `DynatraceExporterV2`

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -270,7 +270,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                     .onSuccess(response -> handleSuccess(metricLines.size(), response))
                     .onError(response -> logger.error("Failed metric ingestion: Error Code={}, Response Body={}", response.code(), response.body()));
         } catch (Throwable throwable) {
-            logger.error("Failed metric ingestion: {}" + throwable.getMessage(), throwable);
+            logger.error("Failed metric ingestion: " + throwable.getMessage(), throwable);
         }
     }
 


### PR DESCRIPTION
This PR polishes an error log message in `DynatraceExporterV2` by removing a spurious placeholder ("{}").