### PR TITLE
Fix Javadoc errors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -35,16 +35,16 @@ import java.util.function.Predicate;
 /**
  * <p>
  * Aspect responsible for intercepting all methods annotated with the {@link Counted @Counted}
- * annotation and recording a few counter metrics about their execution status.<br />
+ * annotation and recording a few counter metrics about their execution status.<br>
  * The aspect supports programmatic customizations through constructor-injectable custom logic.
  * </p>
  * <p>
- * You might want to add tags programmatically to the {@link Counter}.<br />
+ * You might want to add tags programmatically to the {@link Counter}.<br>
  * In this case, the tags provider function (<code>Function&lt;ProceedingJoinPoint, Iterable&lt;Tag&gt;&gt;</code>) can help.
  * It receives a {@link ProceedingJoinPoint} and returns the {@link Tag}s that will be attached to the {@link Counter}.
  * </p>
  * <p>
- * You might also want to skip the {@link Counter} creation programmatically.<br />
+ * You might also want to skip the {@link Counter} creation programmatically.<br>
  * One use-case can be having another component in your application that already processes the {@link Counted @Counted} annotation
  * in some cases so that {@code CountedAspect} should not intercept these methods.
  * By using the skip predicate (<code>Predicate&lt;ProceedingJoinPoint&gt;</code>)

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -37,16 +37,16 @@ import java.util.function.Predicate;
 
 /**
  * <p>
- * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.<br />
+ * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.<br>
  * The aspect supports programmatic customizations through constructor-injectable custom logic.
  * </p>
  * <p>
- * You might want to add tags programmatically to the {@link Timer}.<br />
+ * You might want to add tags programmatically to the {@link Timer}.<br>
  * In this case, the tags provider function (<code>Function&lt;ProceedingJoinPoint, Iterable&lt;Tag&gt;&gt;</code>) can help.
  * It receives a {@link ProceedingJoinPoint} and returns the {@link Tag}s that will be attached to the {@link Timer}.
  * </p>
  * <p>
- * You might also want to skip the {@link Timer} creation programmatically.<br />
+ * You might also want to skip the {@link Timer} creation programmatically.<br>
  * One use-case can be having another component in your application that already processes the {@link Timed @Timed} annotation
  * in some cases so that {@code TimedAspect} should not intercept these methods. E.g.: Spring Boot does this for its controllers.
  * By using the skip predicate (<code>Predicate&lt;ProceedingJoinPoint&gt;</code>)


### PR DESCRIPTION
This PR fixes the following Javadoc errors:

```
> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java:40: error: self-closing element not allowed
 * AspectJ aspect for intercepting types or methods annotated with {@link Timed @Timed}.<br />
                                                                                        ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java:44: error: self-closing element not allowed
 * You might want to add tags programmatically to the {@link Timer}.<br />
                                                                    ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java:49: error: self-closing element not allowed
 * You might also want to skip the {@link Timer} creation programmatically.<br />
                                                                           ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java:38: error: self-closing element not allowed
 * annotation and recording a few counter metrics about their execution status.<br />
                                                                               ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java:42: error: self-closing element not allowed
 * You might want to add tags programmatically to the {@link Counter}.<br />
                                                                      ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java:47: error: self-closing element not allowed
 * You might also want to skip the {@link Counter} creation programmatically.<br />
                                                                             ^
```