### PR TITLE
Rename OneAgentMetadataEnrichment to DynatraceMetadataEnrichment

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -107,13 +107,13 @@ public interface DynatraceConfig extends StepRegistryConfig {
     }
 
     /**
-     * Return whether to enrich with OneAgent metadata.
+     * Return whether to enrich with Dynatrace metadata.
      *
-     * @return whether to enrich with OneAgent metadata
+     * @return whether to enrich with Dynatrace metadata
      * @since 1.8.0
      */
-    default boolean enrichWithOneAgentMetadata() {
-        return getBoolean(this, "enrichWithOneAgentMetadata").orElse(true);
+    default boolean enrichWithDynatraceMetadata() {
+        return getBoolean(this, "enrichWithDynatraceMetadata").orElse(true);
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -71,7 +71,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 .withPrefix(config.metricKeyPrefix())
                 .withDefaultDimensions(parseDefaultDimensions(config.defaultDimensions()));
 
-        if (config.enrichWithOneAgentMetadata()) {
+        if (config.enrichWithDynatraceMetadata()) {
             factoryBuilder.withOneAgentMetadata();
         }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
@@ -117,7 +117,7 @@ class DynatraceConfigTest {
         assertThat(config.uri()).isSameAs(DynatraceMetricApiConstants.getDefaultOneAgentEndpoint());
         assertThat(config.metricKeyPrefix()).isEmpty();
         assertThat(config.defaultDimensions()).isEmpty();
-        assertThat(config.enrichWithOneAgentMetadata()).isTrue();
+        assertThat(config.enrichWithDynatraceMetadata()).isTrue();
 
         Validated<?> validated = config.validate();
         assertThat(validated.isValid()).isTrue();


### PR DESCRIPTION
This renames the config property from OneAgent metadata to Dynatrace metadata since the metadata retrieved is not restricted to only the OneAgent but might come from other components in the future.

I will update both https://github.com/spring-projects/spring-boot/pull/26258 and https://github.com/micrometer-metrics/micrometer-docs/pull/160 as soon as this is merged.