### PR TITLE
Suppress `IllegalImport` check for samples

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -6,6 +6,7 @@
 	<suppress files="io[\\/]micrometer[\\/]core[\\/]instrument[\\/]binder[\\/]logging[\\/].+" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]core[\\/]util[\\/]internal[\\/]logging[\\/].+" checks="IllegalImport" />
 	<suppress files="implementations[\\/].+" checks="IllegalImport" />
+	<suppress files="samples[\\/].+" checks="IllegalImport" />
 	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]jersey2[\\/]server[\\/].+" checks="SpringJUnit5" />
 </suppressions>


### PR DESCRIPTION
This PR changes to suppress the `IllegalImport` check for the samples.

See https://github.com/micrometer-metrics/micrometer/pull/2658#issuecomment-872848875