### PR TITLE
Update Dynatrace metric library usage

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -72,7 +72,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 .withDefaultDimensions(parseDefaultDimensions(config.defaultDimensions()));
 
         if (config.enrichWithDynatraceMetadata()) {
-            factoryBuilder.withOneAgentMetadata();
+            factoryBuilder.withDynatraceMetadata();
         }
 
         metricBuilderFactory = factoryBuilder.build();


### PR DESCRIPTION
We updated the Dynatrace metrics utility library to be in line with the config changes added in https://github.com/micrometer-metrics/micrometer/pull/2692. This PR updates the usage of the updated library.