### PR TITLE
Use latest.release for Javalin

### DIFF
--- a/samples/micrometer-samples-javalin/build.gradle
+++ b/samples/micrometer-samples-javalin/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     implementation project(":micrometer-core")
     implementation project(":micrometer-registry-prometheus")
 
-    implementation 'io.javalin:javalin:3.+'
+    implementation 'io.javalin:javalin:latest.release'
     implementation 'ch.qos.logback:logback-classic:latest.release'
 }

--- a/samples/micrometer-samples-javalin/src/main/java/io/micrometer/javalin/samples/PrometheusSample.java
+++ b/samples/micrometer-samples-javalin/src/main/java/io/micrometer/javalin/samples/PrometheusSample.java
@@ -115,7 +115,7 @@ class MicrometerPlugin implements Plugin {
 
     @Override
     public void apply(@NonNull Javalin app) {
-        Server server = app.server().server();
+        Server server = app.jettyServer().server();
 
         app.exception(Exception.class, EXCEPTION_HANDLER);
 
@@ -125,7 +125,7 @@ class MicrometerPlugin implements Plugin {
                 String exceptionName = response.getHeader(EXCEPTION_HEADER);
                 response.setHeader(EXCEPTION_HEADER, null);
 
-                String uri = app.servlet().getMatcher()
+                String uri = app.javalinServlet().getMatcher()
                         .findEntries(HandlerType.valueOf(request.getMethod()), request.getPathInfo())
                         .stream()
                         .findAny()


### PR DESCRIPTION
This PR changes to use `latest.release` for Javalin.

This PR also updates its sample to resolve its breaking changes.