### PR TITLE
Update Dynatrace samples for Spring Boot autoconfiguration

### DIFF
--- a/samples/micrometer-samples-boot2/src/main/resources/application-dynatrace-v1.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application-dynatrace-v1.yml
@@ -28,5 +28,7 @@ management.metrics.export.dynatrace:
 
   api-token: "YOUR_TOKEN" # should be read from a secure property source
 
-  # The v1 exporter requires a device name.
-  device-id: "YOUR_DEVICE_NAME"
+  # The v1 exporter requires a device id.
+  # Only when this property is set, metrics are exported to the Dynatrace v1 endpoint.
+  v1:
+    device-id: "YOUR_DEVICE_NAME"

--- a/samples/micrometer-samples-boot2/src/main/resources/application-dynatrace-v2.yml
+++ b/samples/micrometer-samples-boot2/src/main/resources/application-dynatrace-v2.yml
@@ -16,10 +16,12 @@
 
 management.metrics.export.dynatrace:
   enabled: true
-  api-version: v2
+  # If no v1.device-id is specified, v2 is used as the default.
 
   # If you are not using the OneAgent on your host, additionally specify your Dynatrace environment and API token:
-  uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest"
+  # uri: "https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest" for SaaS
   # uri: "https://{your-domain}/e/{your-environment-id}/api/v2/metrics/ingest" for managed deployments
+  uri: ${DT_METRICS_INGEST_URL}
 
-  api-token: "YOUR_TOKEN" # should be read from a secure property source
+  # should be read from a secure property source, in this case the environment variable DT_METRICS_INGEST_API_TOKEN will be read.
+  api-token: ${DT_METRICS_INGEST_API_TOKEN}


### PR DESCRIPTION
Due to the changes introduced in https://github.com/spring-projects/spring-boot/pull/26258, we updated the samples for the Dynatrace meter registry. We also updated the docs in https://github.com/micrometer-metrics/micrometer-docs/pull/160. 