### PR TITLE
feat: adding api-key for elastic meter registry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -163,6 +163,18 @@ public interface ElasticConfig extends StepRegistryConfig {
     }
 
     /**
+     * The Api Key to use instead of user/password authentication.
+     *
+     * @return The api key
+     * @since 1.8.0
+     */
+    @Nullable
+    default String apiKey() {
+        return getString(this, "apiKey").orElse(null);
+    }
+
+
+    /**
      * The type to be used when writing metrics documents to an index.
      * This configuration is only used with Elasticsearch versions before 7.
      * Default is: "doc"

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -166,8 +166,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
         try {
             String uri = config.host() + ES_METRICS_TEMPLATE;
-            if (httpClient.head(uri)
-                    .withBasicAuthentication(config.userName(), config.password())
+            if (connect(HttpSender.Method.HEAD, uri)
                     .send()
                     .onError(response -> {
                         if (response.code() != 404) {
@@ -180,8 +179,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                 return;
             }
 
-            httpClient.put(uri)
-                    .withBasicAuthentication(config.userName(), config.password())
+            connect(HttpSender.Method.PUT, uri)
                     .withJsonContent(getTemplateBody())
                     .send()
                     .onError(response -> logger.error("failed to add metrics template to elastic: {}", response.body()));
@@ -196,6 +194,19 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     private String getTemplateBody() {
         return TEMPLATE_BODY_AFTER_VERSION_7.apply(config.index() + config.indexDateSeparator());
     }
+
+    private HttpSender.Request.Builder connect(HttpSender.Method method, String uri) {
+        return authentication(this.httpClient.newRequest(uri).withMethod(method));
+    }
+
+    private HttpSender.Request.Builder authentication(HttpSender.Request.Builder request) {
+        if (StringUtils.isNotBlank(config.apiKey())) {
+            return request.withAuthentication("ApiKey", config.apiKey());
+        } else {
+            return request.withBasicAuthentication(config.userName(), config.password());
+        }
+    }
+
 
     @Override
     protected void publish() {
@@ -218,9 +229,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
                         .filter(Optional::isPresent)
                         .map(Optional::get)
                         .collect(joining("\n", "", "\n"));
-                httpClient
-                        .post(uri)
-                        .withBasicAuthentication(config.userName(), config.password())
+                connect(HttpSender.Method.POST, uri)
                         .withJsonContent(requestBody)
                         .send()
                         .onSuccess(response -> {

--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
@@ -167,6 +167,13 @@ public interface HttpSender {
                 return this;
             }
 
+            public final Builder withAuthentication(String type, @Nullable String value) {
+                if (value != null && StringUtils.isNotBlank(value)) {
+                    withHeader("Authorization", type + " " + value);
+                }
+                return this;
+            }
+
             /**
              * Set the request body as JSON content type.
              *


### PR DESCRIPTION
resolves micrometer-metrics/micrometer#2712

Open to any changes - specifically on the method in HttpSender, which is a core class (I could have used withHeader instead).

1. ./gradlew build completes successfully with styles checked and tests passed
2. I did not add any test cases, but would be happy to with a little direction
3. I tested this locally (pTML) and verified events were publishing to our elastisearch cluster (net new index)
4. To make this work out of the box in SpringBoot, I will need to provide a PR to that team to pull in the new property and supply it back to micrometer