### PR TITLE
Issue-2717--CloudWatchMeterRegistry-must-use-seperate-thread-pool

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -110,7 +110,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                 .metricData(metricData)
                 .build();
         CountDownLatch latch = new CountDownLatch(1);
-        cloudWatchAsyncClient.putMetricData(putMetricDataRequest).whenCompleteAsync((response, t) -> {
+        cloudWatchAsyncClient.putMetricData(putMetricDataRequest).whenComplete((response, t) -> {
             if (t != null) {
                 if (t instanceof AbortedException) {
                     logger.warn("sending metric data was aborted: {}", t.getMessage());


### PR DESCRIPTION
This is regarding issue - https://github.com/micrometer-metrics/micrometer/issues/2717