### PR TITLE
Update samples to use Spring Boot 2.6.0-M1

### DIFF
--- a/samples/micrometer-samples-boot2-reactive/build.gradle
+++ b/samples/micrometer-samples-boot2-reactive/build.gradle
@@ -1,9 +1,14 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.3'
+    id 'org.springframework.boot' version '2.6.0-M1'
 }
 
 apply plugin: 'io.spring.dependency-management'
+
+repositories {
+    mavenCentral()
+    maven { url "https://repo.spring.io/milestone" }
+}
 
 dependencies {
     implementation project(":micrometer-core")

--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -1,9 +1,14 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.3'
+    id 'org.springframework.boot' version '2.6.0-M1'
 }
 
 apply plugin: 'io.spring.dependency-management'
+
+repositories {
+    mavenCentral()
+    maven { url "https://repo.spring.io/milestone" }
+}
 
 dependencies {
     implementation project(":micrometer-core")

--- a/samples/micrometer-samples-spring-integration/build.gradle
+++ b/samples/micrometer-samples-spring-integration/build.gradle
@@ -1,9 +1,14 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.3'
+    id 'org.springframework.boot' version '2.6.0-M1'
 }
 
 apply plugin: 'io.spring.dependency-management'
+
+repositories {
+    mavenCentral()
+    maven { url "https://repo.spring.io/milestone" }
+}
 
 dependencies {
     implementation project(":micrometer-core")

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url 'https://repo.spring.io/release' }
+        maven { url "https://repo.spring.io/milestone" }
     }
 }
 


### PR DESCRIPTION
This PR updates the samples to use Spring Boot 2.6.0-M1 as 86ace4ca0495a499322bff17c64a10b64f1afaee requires Spring Boot 2.6.0-M1.