### PR TITLE
Use Dynatrace v2 export as default unless deviceId is set

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
@@ -46,7 +46,7 @@ class DynatraceConfigTest {
         assertThat(failures.stream().map(Validated::toString)).containsExactlyInAnyOrder(
                 "Invalid{property='dynatrace.apiToken', value='null', message='is required'}",
                 "Invalid{property='dynatrace.uri', value='null', message='is required'}",
-                "Invalid{property='dynatrace.deviceId', value='null', message='is required'}"
+                "Invalid{property='dynatrace.deviceId', value='', message='cannot be blank'}"
         );
     }
 
@@ -73,8 +73,33 @@ class DynatraceConfigTest {
         assertThat(validate.failures().stream().map(Validated::toString)).containsExactlyInAnyOrder(
                 "Invalid{property='dynatrace.apiToken', value='null', message='is required'}",
                 "Invalid{property='dynatrace.uri', value='null', message='is required'}",
-                "Invalid{property='dynatrace.deviceId', value='null', message='is required'}",
+                "Invalid{property='dynatrace.deviceId', value='', message='cannot be blank'}",
                 "Invalid{property='dynatrace.technologyType', value='', message='cannot be blank'}"
+        );
+    }
+
+    @Test
+    void invalidMissingUriInV2() {
+        Validated<?> validate = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V2;
+            }
+
+            @Override
+            public String uri() {
+                return null;
+            }
+        }.validate();
+
+        assertThat(validate.failures().size()).isEqualTo(1);
+        assertThat(validate.failures().stream().map(Validated::toString)).containsExactlyInAnyOrder(
+                "Invalid{property='dynatrace.uri', value='null', message='is required'}"
         );
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
@@ -29,8 +29,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DynatraceConfigTest {
     @Test
     void invalid() {
-        Map<String, String> properties = new HashMap<>();
-        DynatraceConfig config = properties::get;
+        DynatraceConfig config = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
+            }
+        };
 
         List<Validated.Invalid<?>> failures = config.validate().failures();
         assertThat(failures.size()).isEqualTo(3);
@@ -52,6 +61,11 @@ class DynatraceConfigTest {
             @Override
             public String get(String key) {
                 return null;
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
             }
         }.validate();
 
@@ -152,5 +166,74 @@ class DynatraceConfigTest {
 
         Validated<?> validated = config.validate();
         assertThat(validated.isValid()).isTrue();
+    }
+
+    @Test
+    void testDeviceIdNotSetFallsBackToV2() {
+        DynatraceConfig config = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
+
+        assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V2);
+    }
+
+    @Test
+    void testDeviceIdSetFallsBackToV1() {
+        DynatraceConfig config = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String deviceId() {
+                return "test";
+            }
+        };
+        assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V1);
+    }
+
+    @Test
+    void testDeviceIdSetAndVersionOverwritten() {
+        DynatraceConfig config = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String deviceId() {
+                return "test";
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V2;
+            }
+        };
+
+        assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V2);
+    }
+
+    @Test
+    void testDeviceIdNotSetAndVersionOverwritten() {
+        // This is a nonsense config, v1 always needs a deviceId, but it shows that it is possible
+        // to overwrite the version.
+        DynatraceConfig config = new DynatraceConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
+            }
+        };
+
+        assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V1);
     }
 }

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
@@ -90,6 +90,11 @@ class DynatraceExporterV1Test {
             public String apiToken() {
                 return "apiToken";
             }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
+            }
         }, Clock.SYSTEM)).isExactlyInstanceOf(ValidationException.class);
     }
 
@@ -110,6 +115,12 @@ class DynatraceExporterV1Test {
             public String apiToken() {
                 return "apiToken";
             }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
+            }
+
         }, Clock.SYSTEM)).isExactlyInstanceOf(ValidationException.class);
     }
 
@@ -129,6 +140,11 @@ class DynatraceExporterV1Test {
             @Override
             public String deviceId() {
                 return "deviceId";
+            }
+
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V1;
             }
         }, Clock.SYSTEM)).isExactlyInstanceOf(ValidationException.class);
     }


### PR DESCRIPTION
This PR introduces minor code changes to mimic the behavior of the Spring Boot integration for Dynatrace Micrometer Metrics. There, we changed the logic to fall back to the v2 exporter as a default, unless the `deviceId` property is set (https://github.com/spring-projects/spring-boot/pull/26258#issuecomment-880636873). This property is required for the v1 export, therefore all integrations currently using v1 will continue to work (since they specify the `deviceId` explicitly).