### PR TITLE
Upgrade from snapshots to reactor 2020.0.10

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -91,7 +91,7 @@ subprojects {
           runtimeOnly version
         }
       }
-      implementation platform('io.projectreactor:reactor-bom:2020.0.+')
+      implementation platform('io.projectreactor:reactor-bom:2020.0.10')
     }
   }
 }

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -2,27 +2,18 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
 }
 
-repositories {
-    // TODO remove when reactor-netty 1.0.10 is released
-    maven { url 'https://repo.spring.io/snapshot' }
-}
-
 dependencies {
     api project(':micrometer-core')
 
     implementation 'io.projectreactor:reactor-core'
     implementation 'io.projectreactor.netty:reactor-netty-core'
-    constraints {
-        // TODO remove when reactor-netty 1.0.10 is released
-        implementation 'io.projectreactor.netty:reactor-netty-core:1.0.10-SNAPSHOT'
-    }
 
     testImplementation project(':micrometer-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'ch.qos.logback:logback-classic'
     testImplementation 'org.awaitility:awaitility'
-    // for running tests with UDS on OSX
-    testImplementation 'io.netty:netty-transport-native-kqueue:4.1.66.Final:osx-x86_64'
+    // for running tests with UDS on OSX x86-64
+    testImplementation 'io.netty:netty-transport-native-kqueue:+:osx-x86_64'
 }
 
 shadowJar {

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -129,7 +129,7 @@ class StatsdMeterRegistryPublishTest {
         // For UDP, the first change seems to be lost frequently somehow.
         Counter.builder("another.counter").register(meterRegistry).increment();
 
-        if (protocol == StatsdProtocol.TCP) {
+        if (protocol == StatsdProtocol.TCP || protocol == StatsdProtocol.UDS_DATAGRAM) {
             await().until(() -> meterRegistry.statsdConnection.get() != firstClient);
         }
 

--- a/samples/micrometer-samples-core/build.gradle
+++ b/samples/micrometer-samples-core/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'java'
 }
 
-repositories {
-    // TODO remove when reactor-netty 1.0.10 is released
-    maven { url 'https://repo.spring.io/snapshot' }
-}
-
 dependencies {
     implementation platform('io.projectreactor:reactor-bom:2020.0.+')
 


### PR DESCRIPTION
Note that `2020.0.+` was resolving 2020.0.9 for me locally rather than the newer 2020.0.10. Surely Gradle isn't doing alphanumeric sorting rather than standard version number sorting?

Resolves gh-2721