### PR TITLE
Add support for Datadog distributions

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -371,6 +371,20 @@ class StatsdMeterRegistryTest {
     }
 
     @Test
+    void supportsDatadogDistributions() {
+        final Sinks.Many<String> lines = sink();
+        registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.DATADOG))
+                .clock(clock)
+                .lineSink(toLineSink(lines))
+                .build();
+
+        StepVerifier.create(lines.asFlux())
+                .then(() -> DistributionSummary.builder("my.summary").publishPercentileHistogram(true).register(registry).record(1))
+                .expectNext("my.summary:1|d")
+                .verifyComplete();
+    }
+
+    @Test
     void interactWithStoppedRegistry() {
         registry = new StatsdMeterRegistry(configWithFlavor(StatsdFlavor.ETSY), clock);
         registry.stop();

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilderTest.java
@@ -17,9 +17,11 @@ package io.micrometer.statsd.internal;
 
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +40,26 @@ class DatadogStatsdLineBuilderTest {
 
         registry.config().namingConvention(NamingConvention.camelCase);
         assertThat(lb.line("1", Statistic.COUNT, "c")).isEqualTo("myCounter:1|c|#statistic:count,myTag:value");
+    }
+
+    @Test
+    void useDistributions() {
+        DistributionSummary s = registry.summary("my.summary", "tag", "value");
+        DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(s.getId(), registry.config(), DistributionStatisticConfig.builder()
+                .percentilesHistogram(true)
+                .build());
+
+        assertThat(lb.histogram(1.0)).isEqualTo("my_summary:1|d|#tag:value");
+    }
+
+    @Test
+    void useHistograms() {
+        DistributionSummary s = registry.summary("my.summary", "tag", "value");
+        DatadogStatsdLineBuilder lb = new DatadogStatsdLineBuilder(s.getId(), registry.config(), DistributionStatisticConfig.builder()
+                .percentilesHistogram(false)
+                .build());
+
+        assertThat(lb.histogram(1.0)).isEqualTo("my_summary:1|h|#tag:value");
     }
 
     @Issue("#739")


### PR DESCRIPTION
This uses Datadog distributions when `DistributionStatisticConfig` is set to publish percentile histograms for a metric, which allows to use them only for specific metrics.

Related to #1056, #1859.