### PR TITLE
Add support for multiple paths to DiskSpaceMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/DiskSpaceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/DiskSpaceMetrics.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument.binder.system;
 
-import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;


### PR DESCRIPTION
### What
This code proposal will allow consumers to add disk space metrics to multiple paths.

### Why
SpringBoot auto-configures a `DiskSpaceMetrics` and also has a `DiskSpaceHealthContributor`. There is a desire to keep their [configurability in parity](https://github.com/spring-projects/spring-boot/issues/27306).

The health contributor has a [request to support multiple paths](https://github.com/spring-projects/spring-boot/issues/18359). The first attempted proposal was closed quite some time ago due to concern of breaking actuator output compatibility (root disk threshold values vs. child path thresholds etc.). I intend to get a 2nd attempt going now that a breaking change should be ok in a minor version bump (2.6).

This change to `DiskSpaceMetrics` will be followed with an update to [JvmMetricsAutoConfiguration](https://github.com/spring-projects/spring-boot/blob/18349dc556f4c05fe68b36dc79a6be0e0b303a21/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/metrics/JvmMetricsAutoConfiguration.java#L75) to allow configuration of multiple paths.
