### PR TITLE
Add support for Jersey3 which is based on Jakarta EE 9 (#2748)

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@
 	<suppress files="samples[\\/].+" checks="IllegalImport" />
 	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]jersey2[\\/]server[\\/].+" checks="SpringJUnit5" />
+	<suppress files="io[\\/]micrometer[\\/]jersey3[\\/]server[\\/].+" checks="SpringJUnit5" />
 </suppressions>

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,6 @@ def VERSIONS = [
         'javax.cache:cache-api:latest.release',
         'javax.inject:javax.inject:1',
         'javax.xml.bind:jaxb-api:2.3.+',
-        'junit:junit:4.12',
         'net.sf.ehcache:ehcache:latest.release',
         'org.apache.httpcomponents:httpasyncclient:latest.release',
         'org.apache.httpcomponents:httpclient:latest.release',
@@ -48,8 +47,6 @@ def VERSIONS = [
         'org.apache.kafka:kafka-streams:2.+',
         'org.apache.logging.log4j:log4j-core:2.+',
         'org.apache.tomcat.embed:tomcat-embed-core:8.+',
-        'org.aspectj:aspectjweaver:1.8.+',
-        'org.assertj:assertj-core:latest.release',
         'org.awaitility:awaitility:latest.release',
         'org.eclipse.jetty:jetty-client:9.+',
         'org.eclipse.jetty:jetty-server:9.+',
@@ -62,12 +59,7 @@ def VERSIONS = [
         'org.hsqldb:hsqldb:2.5.+', // 2.6.0 requires JDK 11.
         'org.jooq:jooq:3.14.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
-        'org.junit.jupiter:junit-jupiter:5.7.+',
-        'org.junit.platform:junit-platform-launcher:1.7.+',
-        'org.junit.vintage:junit-vintage-engine:5.7.+',
         'org.latencyutils:LatencyUtils:latest.release',
-        'org.mockito:mockito-core:latest.release',
-        'org.mockito:mockito-inline:latest.release',
         'org.mongodb:mongodb-driver-sync:latest.release',
         'org.slf4j:slf4j-api:1.7.+',
         'org.springframework:spring-context:latest.release',
@@ -78,20 +70,57 @@ def VERSIONS = [
         'software.amazon.awssdk:cloudwatch:latest.release'
 ]
 
+def COMMON_VERSIONS = [
+        'org.aspectj:aspectjweaver:1.8.+',
+        'org.assertj:assertj-core:latest.release',
+        'junit:junit:4.12',
+        'org.junit.jupiter:junit-jupiter:5.7.+',
+        'org.junit.platform:junit-platform-launcher:1.7.+',
+        'org.junit.vintage:junit-vintage-engine:5.7.+',
+        'org.mockito:mockito-core:latest.release',
+        'org.mockito:mockito-inline:latest.release',
+]
+
 subprojects {
-  plugins.withId('java-library') {
-    dependencies {
-      constraints {
-        // Direct dependencies
-        VERSIONS.each {version->
-          // java-library plugin has three root configurations, so we apply constraints too all of
-          // them so they all can use the managed versions.
-          api version
-          compileOnly version
-          runtimeOnly version
+  if (it.name != 'micrometer-jersey3') {
+    plugins.withId('java-library') {
+      dependencies {
+        constraints {
+          // Direct dependencies
+          COMMON_VERSIONS.each { version ->
+            // java-library plugin has three root configurations, so we apply constraints too all of
+            // them so they all can use the managed versions.
+            api version
+            compileOnly version
+            runtimeOnly version
+          }
+          // Direct dependencies
+          VERSIONS.each { version ->
+            // java-library plugin has three root configurations, so we apply constraints too all of
+            // them so they all can use the managed versions.
+            api version
+            compileOnly version
+            runtimeOnly version
+          }
+        }
+        implementation platform('io.projectreactor:reactor-bom:2020.0.10')
+      }
+    }
+  } else {
+    plugins.withId('java-library') {
+      dependencies {
+        constraints {
+          // Direct dependencies
+          COMMON_VERSIONS.each { version ->
+            // java-library plugin has three root configurations, so we apply constraints too all of
+            // them so they all can use the managed versions.
+            api version
+            compileOnly version
+            runtimeOnly version
+          }
         }
       }
-      implementation platform('io.projectreactor:reactor-bom:2020.0.10')
     }
   }
+
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,6 +40,7 @@ def VERSIONS = [
         'javax.cache:cache-api:latest.release',
         'javax.inject:javax.inject:1',
         'javax.xml.bind:jaxb-api:2.3.+',
+        'junit:junit:4.12',
         'net.sf.ehcache:ehcache:latest.release',
         'org.apache.httpcomponents:httpasyncclient:latest.release',
         'org.apache.httpcomponents:httpclient:latest.release',
@@ -47,19 +48,23 @@ def VERSIONS = [
         'org.apache.kafka:kafka-streams:2.+',
         'org.apache.logging.log4j:log4j-core:2.+',
         'org.apache.tomcat.embed:tomcat-embed-core:8.+',
+        'org.aspectj:aspectjweaver:1.8.+',
+        'org.assertj:assertj-core:latest.release',
         'org.awaitility:awaitility:latest.release',
         'org.eclipse.jetty:jetty-client:9.+',
         'org.eclipse.jetty:jetty-server:9.+',
         'org.ehcache:ehcache:latest.release',
-        'org.glassfish.jersey.core:jersey-server:2.+',
-        'org.glassfish.jersey.inject:jersey-hk2:2.+',
-        'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+',
         'org.hdrhistogram:HdrHistogram:latest.release',
         'org.hibernate:hibernate-entitymanager:5.+',
         'org.hsqldb:hsqldb:2.5.+', // 2.6.0 requires JDK 11.
         'org.jooq:jooq:3.14.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
+        'org.junit.jupiter:junit-jupiter:5.7.+',
+        'org.junit.platform:junit-platform-launcher:1.7.+',
+        'org.junit.vintage:junit-vintage-engine:5.7.+',
         'org.latencyutils:LatencyUtils:latest.release',
+        'org.mockito:mockito-core:latest.release',
+        'org.mockito:mockito-inline:latest.release',
         'org.mongodb:mongodb-driver-sync:latest.release',
         'org.slf4j:slf4j-api:1.7.+',
         'org.springframework:spring-context:latest.release',
@@ -70,57 +75,20 @@ def VERSIONS = [
         'software.amazon.awssdk:cloudwatch:latest.release'
 ]
 
-def COMMON_VERSIONS = [
-        'org.aspectj:aspectjweaver:1.8.+',
-        'org.assertj:assertj-core:latest.release',
-        'junit:junit:4.12',
-        'org.junit.jupiter:junit-jupiter:5.7.+',
-        'org.junit.platform:junit-platform-launcher:1.7.+',
-        'org.junit.vintage:junit-vintage-engine:5.7.+',
-        'org.mockito:mockito-core:latest.release',
-        'org.mockito:mockito-inline:latest.release',
-]
-
 subprojects {
-  if (it.name != 'micrometer-jersey3') {
-    plugins.withId('java-library') {
-      dependencies {
-        constraints {
-          // Direct dependencies
-          COMMON_VERSIONS.each { version ->
-            // java-library plugin has three root configurations, so we apply constraints too all of
-            // them so they all can use the managed versions.
-            api version
-            compileOnly version
-            runtimeOnly version
-          }
-          // Direct dependencies
-          VERSIONS.each { version ->
-            // java-library plugin has three root configurations, so we apply constraints too all of
-            // them so they all can use the managed versions.
-            api version
-            compileOnly version
-            runtimeOnly version
-          }
-        }
-        implementation platform('io.projectreactor:reactor-bom:2020.0.10')
-      }
-    }
-  } else {
-    plugins.withId('java-library') {
-      dependencies {
-        constraints {
-          // Direct dependencies
-          COMMON_VERSIONS.each { version ->
-            // java-library plugin has three root configurations, so we apply constraints too all of
-            // them so they all can use the managed versions.
-            api version
-            compileOnly version
-            runtimeOnly version
-          }
+  plugins.withId('java-library') {
+    dependencies {
+      constraints {
+        // Direct dependencies
+        VERSIONS.each {version->
+          // java-library plugin has three root configurations, so we apply constraints too all of
+          // them so they all can use the managed versions.
+          api version
+          compileOnly version
+          runtimeOnly version
         }
       }
+      implementation platform('io.projectreactor:reactor-bom:2020.0.10')
     }
   }
-
 }

--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     api project(':micrometer-core')
 
-    compileOnly 'org.glassfish.jersey.core:jersey-server'
-    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2'
+    compileOnly 'org.glassfish.jersey.core:jersey-server:2.+'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:2.+'
 
-    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory'
+    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.+'
 
     // required by jdk 9
     testRuntimeOnly 'javax.xml.bind:jaxb-api'

--- a/micrometer-jersey3/build.gradle
+++ b/micrometer-jersey3/build.gradle
@@ -1,0 +1,18 @@
+dependencies {
+    api project(':micrometer-core')
+
+    compileOnly 'org.glassfish.jersey.core:jersey-server:3.+'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:3.+'
+
+    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:3.+'
+
+    // required by jdk 9
+    testRuntimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:3.+'
+
+    testImplementation 'org.assertj:assertj-core'
+
+    // See https://github.com/eclipse-ee4j/jersey/issues/3662
+    testImplementation 'junit:junit'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.mockito:mockito-core'
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/AnnotationFinder.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/AnnotationFinder.java
@@ -1,0 +1,44 @@
+/**
+ *  * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+
+public interface AnnotationFinder {
+    AnnotationFinder DEFAULT = new AnnotationFinder() {
+    };
+
+    /**
+     * The default implementation performs a simple search for a declared annotation matching the search type.
+     * Spring provides a more sophisticated annotation search utility that matches on meta-annotations as well.
+     *
+     * @param annotatedElement The element to search.
+     * @param annotationType   The annotation type class.
+     * @param <A>              Annotation type to search for.
+     * @return A matching annotation.
+     */
+    @SuppressWarnings("unchecked")
+    default <A extends Annotation> A findAnnotation(AnnotatedElement annotatedElement, Class<A> annotationType) {
+        Annotation[] anns = annotatedElement.getDeclaredAnnotations();
+        for (Annotation ann : anns) {
+            if (ann.annotationType() == annotationType) {
+                return (A) ann;
+            }
+        }
+        return null;
+    }
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/DefaultJerseyTagsProvider.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/DefaultJerseyTagsProvider.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.instrument.Tags;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+
+import io.micrometer.core.instrument.Tag;
+
+/**
+ * Default implementation for {@link JerseyTagsProvider}.
+ * 
+ * @author Michael Weirauch
+ * @author Johnny Lim
+ */
+public final class DefaultJerseyTagsProvider implements JerseyTagsProvider {
+
+    @Override
+    public Iterable<Tag> httpRequestTags(RequestEvent event) {
+        ContainerResponse response = event.getContainerResponse();
+        return Tags.of(JerseyTags.method(event.getContainerRequest()), JerseyTags.uri(event),
+                JerseyTags.exception(event), JerseyTags.status(response), JerseyTags.outcome(response));
+    }
+
+    @Override
+    public Iterable<Tag> httpLongRequestTags(RequestEvent event) {
+        return Tags.of(JerseyTags.method(event.getContainerRequest()), JerseyTags.uri(event));
+    }
+
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/JerseyTags.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/JerseyTags.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.http.Outcome;
+import io.micrometer.core.instrument.util.StringUtils;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.uri.UriTemplate;
+
+/**
+ * Factory methods for {@link Tag Tags} associated with a request-response exchange that
+ * is handled by Jersey 2.
+ *
+ * @author Michael Weirauch
+ * @author Johnny Lim
+ * @since 1.1.0
+ */
+public final class JerseyTags {
+
+    private static final Tag URI_NOT_FOUND = Tag.of("uri", "NOT_FOUND");
+
+    private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
+
+    private static final Tag URI_ROOT = Tag.of("uri", "root");
+
+    private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
+
+    private static final Tag STATUS_SERVER_ERROR = Tag.of("status", String.valueOf(Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+
+    private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
+
+    private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
+
+    private static final Pattern MULTIPLE_SLASH_PATTERN = Pattern.compile("//+");
+
+    private JerseyTags() {
+    }
+
+    /**
+     * Creates a {@code method} tag based on the {@link ContainerRequest#getMethod()
+     * method} of the given {@code request}.
+     * @param request the container request
+     * @return the method tag whose value is a capitalized method (e.g. GET).
+     */
+    public static Tag method(ContainerRequest request) {
+        return (request != null) ? Tag.of("method", request.getMethod()) : METHOD_UNKNOWN;
+    }
+
+    /**
+     * Creates a {@code status} tag based on the status of the given {@code response}.
+     * @param response the container response
+     * @return the status tag derived from the status of the response
+     */
+    public static Tag status(ContainerResponse response) {
+        /* In case there is no response we are dealing with an unmapped exception. */
+        return (response != null)
+                ? Tag.of("status", Integer.toString(response.getStatus()))
+                : STATUS_SERVER_ERROR;
+    }
+
+    /**
+     * Creates a {@code uri} tag based on the URI of the given {@code event}. Uses the
+     * {@link ExtendedUriInfo#getMatchedTemplates()} if
+     * available. {@code REDIRECTION} for 3xx responses, {@code NOT_FOUND} for 404 responses.
+     * @param event the request event
+     * @return the uri tag derived from the request event
+     */
+    public static Tag uri(RequestEvent event) {
+        ContainerResponse response = event.getContainerResponse();
+        if (response != null) {
+            int status = response.getStatus();
+            if (isRedirection(status)) {
+                return URI_REDIRECTION;
+            }
+            if (status == 404) {
+                return URI_NOT_FOUND;
+            }
+        }
+        String matchingPattern = getMatchingPattern(event);
+        if (matchingPattern.equals("/")) {
+            return URI_ROOT;
+        }
+        return Tag.of("uri", matchingPattern);
+    }
+
+    private static boolean isRedirection(int status) {
+        return Response.Status.Family.familyOf(status) == Response.Status.Family.REDIRECTION;
+    }
+
+    private static String getMatchingPattern(RequestEvent event) {
+        ExtendedUriInfo uriInfo = event.getUriInfo();
+        List<UriTemplate> templates = uriInfo.getMatchedTemplates();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(uriInfo.getBaseUri().getPath());
+        for (int i = templates.size() - 1; i >= 0; i--) {
+            sb.append(templates.get(i).getTemplate());
+        }
+        String multipleSlashCleaned = MULTIPLE_SLASH_PATTERN.matcher(sb.toString()).replaceAll("/");
+        if (multipleSlashCleaned.equals("/")) {
+            return multipleSlashCleaned;
+        }
+        return TRAILING_SLASH_PATTERN.matcher(multipleSlashCleaned).replaceAll("");
+    }
+
+    /**
+     * Creates a {@code exception} tag based on the {@link Class#getSimpleName() simple
+     * name} of the class of the given {@code exception}.
+     * @param event the request event
+     * @return the exception tag derived from the exception
+     */
+    public static Tag exception(RequestEvent event) {
+        Throwable exception = event.getException();
+        if (exception == null) {
+            return EXCEPTION_NONE;
+        }
+        ContainerResponse response = event.getContainerResponse();
+        if (response != null) {
+            int status = response.getStatus();
+            if (status == 404 || isRedirection(status)) {
+                return EXCEPTION_NONE;
+            }
+        }
+        if (exception.getCause() != null) {
+            exception = exception.getCause();
+        }
+        String simpleName = exception.getClass().getSimpleName();
+        return Tag.of("exception", StringUtils.isNotEmpty(simpleName) ? simpleName
+                : exception.getClass().getName());
+    }
+
+    /**
+     * Creates an {@code outcome} tag based on the status of the given {@code response}.
+     * @param response the container response
+     * @return the outcome tag derived from the status of the response
+     */
+    public static Tag outcome(ContainerResponse response) {
+        if (response != null) {
+            return Outcome.forStatus(response.getStatus()).asTag();
+        }
+        /* In case there is no response we are dealing with an unmapped exception. */
+        return Outcome.SERVER_ERROR.asTag();
+    }
+
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/JerseyTagsProvider.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/JerseyTagsProvider.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+
+import io.micrometer.core.instrument.Tag;
+
+/**
+ * Provides {@link Tag Tags} for Jersey request metrics.
+ * 
+ * @author Michael Weirauch
+ */
+public interface JerseyTagsProvider {
+
+    /**
+     * Provides tags to be associated with metrics for the given {@code event}.
+     *
+     * @param event
+     *            the request event
+     * @return tags to associate with metrics recorded for the request
+     */
+    Iterable<Tag> httpRequestTags(RequestEvent event);
+
+    /**
+     * Provides tags to be associated with the
+     * {@link io.micrometer.core.instrument.LongTaskTimer} which instruments the
+     * given long-running {@code event}.
+     *
+     * @param event
+     *            the request event
+     * @return tags to associate with metrics recorded for the request
+     */
+    Iterable<Tag> httpLongRequestTags(RequestEvent event);
+
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/MetricsApplicationEventListener.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/MetricsApplicationEventListener.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.glassfish.jersey.server.monitoring.ApplicationEvent;
+import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The Micrometer {@link ApplicationEventListener} which registers
+ * {@link RequestEventListener} for instrumenting Jersey server requests.
+ *
+ * @author Michael Weirauch
+ */
+public class MetricsApplicationEventListener implements ApplicationEventListener {
+
+    private final MeterRegistry meterRegistry;
+    private final JerseyTagsProvider tagsProvider;
+    private final String metricName;
+    private final AnnotationFinder annotationFinder;
+    private final boolean autoTimeRequests;
+
+    public MetricsApplicationEventListener(MeterRegistry registry, JerseyTagsProvider tagsProvider, String metricName,
+                                           boolean autoTimeRequests) {
+        this(registry, tagsProvider, metricName, autoTimeRequests, AnnotationFinder.DEFAULT);
+    }
+
+    public MetricsApplicationEventListener(MeterRegistry registry, JerseyTagsProvider tagsProvider,
+                                           String metricName, boolean autoTimeRequests,
+                                           AnnotationFinder annotationFinder) {
+        this.meterRegistry = requireNonNull(registry);
+        this.tagsProvider = requireNonNull(tagsProvider);
+        this.metricName = requireNonNull(metricName);
+        this.annotationFinder = requireNonNull(annotationFinder);
+        this.autoTimeRequests = autoTimeRequests;
+    }
+
+    @Override
+    public void onEvent(ApplicationEvent event) {
+    }
+
+    @Override
+    public RequestEventListener onRequest(RequestEvent requestEvent) {
+        return new MetricsRequestEventListener(meterRegistry, tagsProvider, metricName, autoTimeRequests, annotationFinder);
+    }
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/MetricsRequestEventListener.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/MetricsRequestEventListener.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.model.ResourceMethod;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEventListener;
+
+import jakarta.ws.rs.NotFoundException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * {@link RequestEventListener} recording timings for Jersey server requests.
+ *
+ * @author Michael Weirauch
+ * @author Jon Schneider
+ */
+public class MetricsRequestEventListener implements RequestEventListener {
+
+    private final Map<ContainerRequest, Timer.Sample> shortTaskSample = Collections
+        .synchronizedMap(new IdentityHashMap<>());
+
+    private final Map<ContainerRequest, Collection<LongTaskTimer.Sample>> longTaskSamples = Collections
+        .synchronizedMap(new IdentityHashMap<>());
+
+    private final Map<ContainerRequest, Set<Timed>> timedAnnotationsOnRequest = Collections
+        .synchronizedMap(new IdentityHashMap<>());
+
+    private final MeterRegistry registry;
+    private final JerseyTagsProvider tagsProvider;
+    private boolean autoTimeRequests;
+    private final TimedFinder timedFinder;
+    private final String metricName;
+
+    public MetricsRequestEventListener(MeterRegistry registry, JerseyTagsProvider tagsProvider,
+                                       String metricName, boolean autoTimeRequests, AnnotationFinder annotationFinder) {
+        this.registry = requireNonNull(registry);
+        this.tagsProvider = requireNonNull(tagsProvider);
+        this.metricName = requireNonNull(metricName);
+        this.autoTimeRequests = autoTimeRequests;
+        this.timedFinder = new TimedFinder(annotationFinder);
+    }
+
+    @Override
+    public void onEvent(RequestEvent event) {
+        ContainerRequest containerRequest = event.getContainerRequest();
+        Set<Timed> timedAnnotations;
+
+        switch (event.getType()) {
+            case ON_EXCEPTION:
+                if (!(event.getException() instanceof NotFoundException)) {
+                    break;
+                }
+            case REQUEST_MATCHED:
+                timedAnnotations = annotations(event);
+
+                timedAnnotationsOnRequest.put(containerRequest, timedAnnotations);
+                shortTaskSample.put(containerRequest, Timer.start(registry));
+
+                List<LongTaskTimer.Sample> longTaskSamples = longTaskTimers(timedAnnotations, event).stream().map(LongTaskTimer::start).collect(Collectors.toList());
+                if (!longTaskSamples.isEmpty()) {
+                    this.longTaskSamples.put(containerRequest, longTaskSamples);
+                }
+                break;
+            case FINISHED:
+                timedAnnotations = timedAnnotationsOnRequest.remove(containerRequest);
+                Timer.Sample shortSample = shortTaskSample.remove(containerRequest);
+
+                if (shortSample != null) {
+                    for (Timer timer : shortTimers(timedAnnotations, event)) {
+                        shortSample.stop(timer);
+                    }
+                }
+
+                Collection<LongTaskTimer.Sample> longSamples = this.longTaskSamples.remove(containerRequest);
+                if (longSamples != null) {
+                    for (LongTaskTimer.Sample longSample : longSamples) {
+                        longSample.stop();
+                    }
+                }
+                break;
+        }
+    }
+
+    private Set<Timer> shortTimers(Set<Timed> timed, RequestEvent event) {
+        /*
+         * Given we didn't find any matching resource method, 404s will be only
+         * recorded when auto-time-requests is enabled. On par with WebMVC
+         * instrumentation.
+         */
+        if ((timed == null || timed.isEmpty()) && autoTimeRequests) {
+            return Collections.singleton(registry.timer(metricName, tagsProvider.httpRequestTags(event)));
+        }
+
+        if (timed == null) {
+            return Collections.emptySet();
+        }
+
+        return timed.stream()
+            .map(t -> Timer.builder(t, metricName).tags(tagsProvider.httpRequestTags(event)).register(registry))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<LongTaskTimer> longTaskTimers(Set<Timed> timed, RequestEvent event) {
+        return timed.stream()
+            .filter(Timed::longTask)
+            .map(LongTaskTimer::builder)
+            .map(b -> b.tags(tagsProvider.httpLongRequestTags(event)).register(registry))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Timed> annotations(RequestEvent event) {
+        final Set<Timed> timed = new HashSet<>();
+
+        final ResourceMethod matchingResourceMethod = event.getUriInfo().getMatchedResourceMethod();
+        if (matchingResourceMethod != null) {
+            // collect on method level
+            timed.addAll(timedFinder.findTimedAnnotations(matchingResourceMethod.getInvocable().getHandlingMethod()));
+
+            // fallback on class level
+            if (timed.isEmpty()) {
+                timed.addAll(timedFinder.findTimedAnnotations(matchingResourceMethod.getInvocable().getHandlingMethod()
+                    .getDeclaringClass()));
+            }
+        }
+        return timed;
+    }
+}

--- a/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/TimedFinder.java
+++ b/micrometer-jersey3/src/main/java/io/micrometer/jersey3/server/TimedFinder.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.annotation.TimedSet;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class TimedFinder {
+    private final AnnotationFinder annotationFinder;
+
+    TimedFinder(AnnotationFinder annotationFinder) {
+        this.annotationFinder = annotationFinder;
+    }
+
+    Set<Timed> findTimedAnnotations(AnnotatedElement element) {
+        Timed t = annotationFinder.findAnnotation(element, Timed.class);
+        if (t != null)
+            return Collections.singleton(t);
+
+        TimedSet ts = annotationFinder.findAnnotation(element, TimedSet.class);
+        if (ts != null) {
+            return Arrays.stream(ts.value()).collect(Collectors.toSet());
+        }
+
+        return Collections.emptySet();
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/DefaultJerseyTagsProviderTest.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/DefaultJerseyTagsProviderTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.jersey3.server.DefaultJerseyTagsProvider;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.glassfish.jersey.server.ContainerResponse;
+import org.glassfish.jersey.server.ExtendedUriInfo;
+import org.glassfish.jersey.server.internal.monitoring.RequestEventImpl;
+import org.glassfish.jersey.server.internal.monitoring.RequestEventImpl.Builder;
+import org.glassfish.jersey.server.monitoring.RequestEvent;
+import org.glassfish.jersey.server.monitoring.RequestEvent.Type;
+import org.glassfish.jersey.uri.UriTemplate;
+import org.junit.Test;
+
+import jakarta.ws.rs.NotAcceptableException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.StreamSupport.stream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultJerseyTagsProvider}.
+ *
+ * @author Michael Weirauch
+ * @author Johnny Lim
+ */
+public class DefaultJerseyTagsProviderTest {
+
+    private final DefaultJerseyTagsProvider tagsProvider = new DefaultJerseyTagsProvider();
+
+    @Test
+    public void testRootPath() {
+        assertThat(tagsProvider.httpRequestTags(event(200, null, "/", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("root", 200, null, "SUCCESS"));
+    }
+
+    @Test
+    public void templatedPathsAreReturned() {
+        assertThat(tagsProvider.httpRequestTags(event(200, null, "/", "/", "/hello/{name}")))
+            .containsExactlyInAnyOrder(tagsFrom("/hello/{name}", 200, null, "SUCCESS"));
+    }
+
+    @Test
+    public void applicationPathIsPresent() {
+        assertThat(tagsProvider.httpRequestTags(event(200, null, "/app", "/", "/hello")))
+            .containsExactlyInAnyOrder(tagsFrom("/app/hello", 200, null, "SUCCESS"));
+    }
+
+    @Test
+    public void notFoundsAreShunted() {
+        assertThat(tagsProvider.httpRequestTags(event(404, null, "/app", "/", "/not-found")))
+            .containsExactlyInAnyOrder(tagsFrom("NOT_FOUND", 404, null, "CLIENT_ERROR"));
+    }
+
+    @Test
+    public void redirectsAreShunted() {
+        assertThat(tagsProvider.httpRequestTags(event(301, null, "/app", "/", "/redirect301")))
+            .containsExactlyInAnyOrder(tagsFrom("REDIRECTION", 301, null, "REDIRECTION"));
+        assertThat(tagsProvider.httpRequestTags(event(302, null, "/app", "/", "/redirect302")))
+            .containsExactlyInAnyOrder(tagsFrom("REDIRECTION", 302, null, "REDIRECTION"));
+        assertThat(tagsProvider.httpRequestTags(event(399, null, "/app", "/", "/redirect399")))
+            .containsExactlyInAnyOrder(tagsFrom("REDIRECTION", 399, null, "REDIRECTION"));
+    }
+
+    @Test
+    @SuppressWarnings("serial")
+    public void exceptionsAreMappedCorrectly() {
+        assertThat(tagsProvider.httpRequestTags(
+            event(500, new IllegalArgumentException(), "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("/app", 500, "IllegalArgumentException", "SERVER_ERROR"));
+        assertThat(tagsProvider.httpRequestTags(event(500,
+            new IllegalArgumentException(new NullPointerException()), "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("/app", 500, "NullPointerException", "SERVER_ERROR"));
+        assertThat(tagsProvider.httpRequestTags(
+            event(406, new NotAcceptableException(), "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("/app", 406, "NotAcceptableException", "CLIENT_ERROR"));
+        assertThat(tagsProvider.httpRequestTags(
+            event(500, new Exception("anonymous") { }, "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(tagsFrom("/app", 500, "io.micrometer.jersey3.server.DefaultJerseyTagsProviderTest$1", "SERVER_ERROR"));
+    }
+
+    @Test
+    public void longRequestTags() {
+        assertThat(tagsProvider.httpLongRequestTags(event(0, null, "/app", (String[]) null)))
+            .containsExactlyInAnyOrder(Tag.of("method", "GET"), Tag.of("uri", "/app"));
+    }
+
+    private static RequestEvent event(Integer status, Exception exception, String baseUri, String... uriTemplateStrings) {
+        Builder builder = new RequestEventImpl.Builder();
+
+        ContainerRequest containerRequest = mock(ContainerRequest.class);
+        when(containerRequest.getMethod()).thenReturn("GET");
+        builder.setContainerRequest(containerRequest);
+
+        ContainerResponse containerResponse = mock(ContainerResponse.class);
+        when(containerResponse.getStatus()).thenReturn(status);
+        builder.setContainerResponse(containerResponse);
+
+        builder.setException(exception, null);
+
+        ExtendedUriInfo extendedUriInfo = mock(ExtendedUriInfo.class);
+        when(extendedUriInfo.getBaseUri()).thenReturn(
+            URI.create("http://localhost:8080" + (baseUri == null ? "/" : baseUri)));
+        List<UriTemplate> uriTemplates = uriTemplateStrings == null ? Collections.emptyList()
+            : Arrays.stream(uriTemplateStrings).map(uri -> new UriTemplate(uri))
+            .collect(Collectors.toList());
+        // UriTemplate are returned in reverse order
+        Collections.reverse(uriTemplates);
+        when(extendedUriInfo.getMatchedTemplates()).thenReturn(uriTemplates);
+        builder.setExtendedUriInfo(extendedUriInfo);
+
+        return builder.build(Type.FINISHED);
+    }
+
+    private static Tag[] tagsFrom(String uri, int status, String exception, String outcome) {
+        Iterable<Tag> expectedTags = Tags.of(
+            "method", "GET",
+            "uri", uri,
+            "status", String.valueOf(status),
+            "exception", exception == null ? "None" : exception,
+            "outcome", outcome
+        );
+
+        return stream(expectedTags.spliterator(), false)
+            .toArray(Tag[]::new);
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/MetricsRequestEventListenerTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.jersey3.server.mapper.ResourceGoneExceptionMapper;
+import io.micrometer.jersey3.server.resources.TestResource;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MetricsApplicationEventListener}.
+ *
+ * @author Michael Weirauch
+ * @author Johnny Lim
+ */
+public class MetricsRequestEventListenerTest extends JerseyTest {
+
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private static final String METRIC_NAME = "http.server.requests";
+
+    private MeterRegistry registry;
+
+    @Override
+    protected Application configure() {
+        registry = new SimpleMeterRegistry();
+
+        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
+            registry, new DefaultJerseyTagsProvider(), METRIC_NAME, true);
+
+        final ResourceConfig config = new ResourceConfig();
+        config.register(listener);
+        config.register(TestResource.class);
+        config.register(ResourceGoneExceptionMapper.class);
+
+        return config;
+    }
+
+    @Test
+    public void resourcesAreTimed() {
+        target("/").request().get();
+        target("hello").request().get();
+        target("hello/").request().get();
+        target("hello/peter").request().get();
+        target("sub-resource/sub-hello/peter").request().get();
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("root", "200", "SUCCESS", null)).timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/hello", "200", "SUCCESS", null)).timer().count())
+            .isEqualTo(2);
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/hello/{name}", "200", "SUCCESS", null)).timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/sub-resource/sub-hello/{name}", "200", "SUCCESS", null)).timer().count())
+            .isEqualTo(1);
+
+        // assert we are not auto-timing long task @Timed
+        assertThat(registry.getMeters()).hasSize(4);
+    }
+
+    @Test
+    public void notFoundIsAccumulatedUnderSameUri() {
+        try {
+            target("not-found").request().get();
+        } catch (NotFoundException ignored) {
+        }
+        try {
+            target("throws-not-found-exception").request().get();
+        } catch (NotFoundException ignored) {
+        }
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("NOT_FOUND", "404", "CLIENT_ERROR", null)).timer().count())
+            .isEqualTo(2);
+    }
+
+    @Test
+    public void redirectsAreAccumulatedUnderSameUri() {
+        target("redirect/302").request().get();
+        target("redirect/307").request().get();
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("REDIRECTION", "302", "REDIRECTION", null)).timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("REDIRECTION", "307", "REDIRECTION", null)).timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void exceptionsAreMappedCorrectly() {
+        try {
+            target("throws-exception").request().get();
+        } catch (Exception ignored) {
+        }
+        try {
+            target("throws-webapplication-exception").request().get();
+        } catch (Exception ignored) {
+        }
+        try {
+            target("throws-mappable-exception").request().get();
+        } catch (Exception ignored) {
+        }
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/throws-exception", "500", "SERVER_ERROR", "IllegalArgumentException"))
+            .timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME).tags(
+            tagsFrom("/throws-webapplication-exception", "401", "CLIENT_ERROR", "NotAuthorizedException"))
+            .timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME).tags(
+            tagsFrom("/throws-mappable-exception", "410", "CLIENT_ERROR", "ResourceGoneException"))
+            .timer().count())
+            .isEqualTo(1);
+    }
+
+    private static Iterable<Tag> tagsFrom(String uri, String status, String outcome, String exception) {
+        return Tags.of("method", "GET", "uri", uri, "status", status, "outcome", outcome,
+                "exception", exception == null ? "None" : exception);
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/MetricsRequestEventListenerTimedTest.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/MetricsRequestEventListenerTimedTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.jersey3.server.resources.TimedOnClassResource;
+import io.micrometer.jersey3.server.resources.TimedResource;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Michael Weirauch
+ */
+public class MetricsRequestEventListenerTimedTest extends JerseyTest {
+
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private static final String METRIC_NAME = "http.server.requests";
+
+    private MeterRegistry registry;
+
+    private CountDownLatch longTaskRequestStartedLatch;
+
+    private CountDownLatch longTaskRequestReleaseLatch;
+
+    @Override
+    protected Application configure() {
+        registry = new SimpleMeterRegistry();
+        longTaskRequestStartedLatch = new CountDownLatch(1);
+        longTaskRequestReleaseLatch = new CountDownLatch(1);
+
+        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
+            registry, new DefaultJerseyTagsProvider(), METRIC_NAME, false);
+
+        final ResourceConfig config = new ResourceConfig();
+        config.register(listener);
+        config.register(
+            new TimedResource(longTaskRequestStartedLatch, longTaskRequestReleaseLatch));
+        config.register(TimedOnClassResource.class);
+
+        return config;
+    }
+
+    @Test
+    public void resourcesAndNotFoundsAreNotAutoTimed() {
+        target("not-timed").request().get();
+        target("not-found").request().get();
+
+        assertThat(registry.find(METRIC_NAME)
+            .tags(tagsFrom("/not-timed", 200)).timer()).isNull();
+
+        assertThat(registry.find(METRIC_NAME)
+            .tags(tagsFrom("NOT_FOUND", 404)).timer()).isNull();
+    }
+
+    @Test
+    public void resourcesWithAnnotationAreTimed() {
+        target("timed").request().get();
+        target("multi-timed").request().get();
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/timed", 200)).timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get("multi1")
+            .tags(tagsFrom("/multi-timed", 200)).timer().count())
+            .isEqualTo(1);
+
+        assertThat(registry.get("multi2")
+            .tags(tagsFrom("/multi-timed", 200)).timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void longTaskTimerSupported() throws InterruptedException, ExecutionException {
+        final Future<Response> future = target("long-timed").request().async().get();
+
+        /*
+         * Wait until the request has arrived at the server side. (Async client
+         * processing might be slower in triggering the request resulting in the
+         * assertions below to fail. Thread.sleep() is not an option, so resort
+         * to CountDownLatch.)
+         */
+        longTaskRequestStartedLatch.await();
+
+        // the request is not timed, yet
+        assertThat(registry.find(METRIC_NAME).tags(tagsFrom("/timed", 200)).timer())
+            .isNull();
+
+        // the long running task is timed
+        assertThat(registry.get("long.task.in.request")
+            .tags(Tags.of("method", "GET", "uri", "/long-timed"))
+            .longTaskTimer().activeTasks())
+            .isEqualTo(1);
+
+        // finish the long running request
+        longTaskRequestReleaseLatch.countDown();
+        future.get();
+
+        // the request is timed after the long running request completed
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("/long-timed", 200))
+            .timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void unnamedLongTaskTimerIsNotSupported() {
+        assertThatExceptionOfType(ProcessingException.class)
+            .isThrownBy(() -> target("long-timed-unnamed").request().get())
+            .withCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void classLevelAnnotationIsInherited() {
+        target("/class/inherited").request().get();
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(Tags.concat(tagsFrom("/class/inherited", 200),
+                Tags.of("on", "class")))
+            .timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    public void methodLevelAnnotationOverridesClassLevel() {
+        target("/class/on-method").request().get();
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(Tags.concat(tagsFrom("/class/on-method", 200),
+                Tags.of("on", "method")))
+            .timer().count())
+            .isEqualTo(1);
+
+        // class level annotation is not picked up
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    private static Iterable<Tag> tagsFrom(String uri, int status) {
+        return Tags.of("method", "GET", "uri", uri, "status", String.valueOf(status), "exception", "None");
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/exception/ResourceGoneException.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/exception/ResourceGoneException.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server.exception;
+
+public class ResourceGoneException extends RuntimeException {
+
+    public ResourceGoneException() {
+        super();
+    }
+
+    public ResourceGoneException(String message) {
+        super(message);
+    }
+
+    public ResourceGoneException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/mapper/ResourceGoneExceptionMapper.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/mapper/ResourceGoneExceptionMapper.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server.mapper;
+
+import io.micrometer.jersey3.server.exception.ResourceGoneException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.ExceptionMapper;
+
+public class ResourceGoneExceptionMapper implements ExceptionMapper<ResourceGoneException> {
+
+    @Override
+    public Response toResponse(ResourceGoneException exception) {
+        return Response.status(Status.GONE).build();
+    }
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TestResource.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TestResource.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server.resources;
+
+import java.net.URI;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.RedirectionException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import io.micrometer.jersey3.server.exception.ResourceGoneException;
+
+/**
+ * @author Michael Weirauch
+ */
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class TestResource {
+
+    @Produces(MediaType.TEXT_PLAIN)
+    public static class SubResource {
+
+        @GET
+        @Path("sub-hello/{name}")
+        public String hello(@PathParam("name") String name) {
+            return "hello " + name;
+        }
+
+    }
+
+    @GET
+    public String index() {
+        return "index";
+    }
+
+    @GET
+    @Path("hello")
+    public String hello() {
+        return "hello";
+    }
+
+    @GET
+    @Path("hello/{name}")
+    public String hello(@PathParam("name") String name) {
+        return "hello " + name;
+    }
+
+    @GET
+    @Path("throws-not-found-exception")
+    public String throwsNotFoundException() {
+        throw new NotFoundException();
+    }
+
+    @GET
+    @Path("throws-exception")
+    public String throwsException() {
+        throw new IllegalArgumentException();
+    }
+
+    @GET
+    @Path("throws-webapplication-exception")
+    public String throwsWebApplicationException() {
+        throw new NotAuthorizedException("notauth", Response.status(Status.UNAUTHORIZED).build());
+    }
+
+    @GET
+    @Path("throws-mappable-exception")
+    public String throwsMappableException() {
+        throw new ResourceGoneException("Resource has been permanently removed.");
+    }
+
+    @GET
+    @Path("redirect/{status}")
+    public Response redirect(@PathParam("status") int status) {
+        if (status == 307) {
+            throw new RedirectionException(status, URI.create("hello"));
+        }
+        return Response.status(status).header("Location", "/hello").build();
+    }
+
+    @Path("/sub-resource")
+    public SubResource subResource() {
+        return new SubResource();
+    }
+
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TimedOnClassResource.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TimedOnClassResource.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server.resources;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.micrometer.core.annotation.Timed;
+
+/**
+ * @author Michael Weirauch
+ */
+@Path("/class")
+@Produces(MediaType.TEXT_PLAIN)
+@Timed(extraTags = { "on", "class" })
+public class TimedOnClassResource {
+
+    @GET
+    @Path("inherited")
+    public String inherited() {
+        return "inherited";
+    }
+
+    @GET
+    @Path("on-method")
+    @Timed(extraTags = { "on", "method" })
+    public String onMethod() {
+        return "on-method";
+    }
+
+}

--- a/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TimedResource.java
+++ b/micrometer-jersey3/src/test/java/io/micrometer/jersey3/server/resources/TimedResource.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jersey3.server.resources;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import io.micrometer.core.annotation.Timed;
+
+/**
+ * @author Michael Weirauch
+ */
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class TimedResource {
+
+    private final CountDownLatch longTaskRequestStartedLatch;
+
+    private final CountDownLatch longTaskRequestReleaseLatch;
+
+    public TimedResource(CountDownLatch longTaskRequestStartedLatch,
+            CountDownLatch longTaskRequestReleaseLatch) {
+        this.longTaskRequestStartedLatch = requireNonNull(longTaskRequestStartedLatch);
+        this.longTaskRequestReleaseLatch = requireNonNull(longTaskRequestReleaseLatch);
+    }
+
+    @GET
+    @Path("not-timed")
+    public String notTimed() {
+        return "not-timed";
+    }
+
+    @GET
+    @Path("timed")
+    @Timed
+    public String timed() {
+        return "timed";
+    }
+
+    @GET
+    @Path("multi-timed")
+    @Timed("multi1")
+    @Timed("multi2")
+    public String multiTimed() {
+        return "multi-timed";
+    }
+
+    /*
+     * Async server side processing (AsyncResponse) is not supported in the
+     * in-memory test container.
+     */
+    @GET
+    @Path("long-timed")
+    @Timed
+    @Timed(value = "long.task.in.request", longTask = true)
+    public String longTimed() {
+        longTaskRequestStartedLatch.countDown();
+        try {
+            longTaskRequestReleaseLatch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return "long-timed";
+    }
+
+    @GET
+    @Path("long-timed-unnamed")
+    @Timed
+    @Timed(longTask = true)
+    public String longTimedUnnamed() {
+        return "long-timed-unnamed";
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ gradleEnterprise {
 
 include 'micrometer-core'
 include 'micrometer-jersey2'
+include 'micrometer-jersey3'
 
 ['core', 'boot2', 'boot2-reactive', 'spring-integration', 'hazelcast', 'hazelcast3', 'javalin'].each { sample ->
     include "micrometer-samples-$sample"


### PR DESCRIPTION
Basically copy pasted files from jersey2, changed javax.ws.rs.* to jakarta.ws.rs*
And some voodoo for the dependencies as jersey2 and jersey3 have different incompatible deps. 

Resolves #2748 