### PR TITLE
Use 2020.0.+ for io.projectreactor:reactor-bom

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -92,7 +92,7 @@ subprojects {
           runtimeOnly version
         }
       }
-      implementation platform('io.projectreactor:reactor-bom:2020.0.10')
+      implementation platform('io.projectreactor:reactor-bom:2020.0.+')
     }
   }
 }


### PR DESCRIPTION
It has been pinned for some reason in #2732, but it seems okay now as follows:

```
> Task :micrometer-core:dependencyInsight
io.projectreactor:reactor-bom:2020.0.10
   variant "platform-compile" [
      org.netflix.internal.statusScheme = integration,milestone,release (not requested)
      org.gradle.status                 = release (not requested)
      org.gradle.usage                  = java-api
      org.gradle.category               = platform

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling    = external
         org.gradle.jvm.environment        = standard-jvm
         org.gradle.libraryelements        = classes
         org.gradle.jvm.version            = 8
   ]

io.projectreactor:reactor-bom:2020.0.+ -> 2020.0.10
\--- compileClasspath
```