### PR TITLE
Update samples to use Spring Boot 2.6.0-M2

### DIFF
--- a/samples/micrometer-samples-boot2-reactive/build.gradle
+++ b/samples/micrometer-samples-boot2-reactive/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.0-M1'
+    id 'org.springframework.boot' version '2.6.0-M2'
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.0-M1'
+    id 'org.springframework.boot' version '2.6.0-M2'
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/samples/micrometer-samples-spring-integration/build.gradle
+++ b/samples/micrometer-samples-spring-integration/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.0-M1'
+    id 'org.springframework.boot' version '2.6.0-M2'
 }
 
 apply plugin: 'io.spring.dependency-management'


### PR DESCRIPTION
This PR updates samples to use Spring Boot 2.6.0-M2.