### PR TITLE
Support Jersey 3

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@
 	<suppress files="samples[\\/].+" checks="IllegalImport" />
 	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]jersey2[\\/]server[\\/].+" checks="SpringJUnit5" />
+	<suppress files="io[\\/]micrometer[\\/]samples[\\/]jersey3[\\/].+" checks="SpringJUnit5" />
 </suppressions>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -7,6 +7,7 @@
 	<suppress files="io[\\/]micrometer[\\/]core[\\/]util[\\/]internal[\\/]logging[\\/].+" checks="IllegalImport" />
 	<suppress files="implementations[\\/].+" checks="IllegalImport" />
 	<suppress files="samples[\\/].+" checks="IllegalImport" />
+	<suppress files="test[\\/]java[\\/]io[\\/]micrometer[\\/]jersey.+" checks="IllegalImport" />
 	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]jersey2[\\/]server[\\/].+" checks="SpringJUnit5" />
 	<suppress files="io[\\/]micrometer[\\/]samples[\\/]jersey3[\\/].+" checks="SpringJUnit5" />

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -18,7 +18,7 @@
 
         <!-- Imports -->
         <module name="IllegalImportCheck" >
-            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.slf4j.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*"/>
+            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.slf4j.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*,javax.ws.*"/>
             <property name="illegalClasses" value="org\.assertj\.core\.api\.Java6Assertions\..*"/>
             <property name="regexp" value="true"/>
         </module>

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/JerseyTags.java
@@ -18,9 +18,6 @@ package io.micrometer.jersey2.server;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.util.StringUtils;
@@ -48,7 +45,7 @@ public final class JerseyTags {
 
     private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
 
-    private static final Tag STATUS_SERVER_ERROR = Tag.of("status", String.valueOf(Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+    private static final Tag STATUS_SERVER_ERROR = Tag.of("status", "500");
 
     private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
 
@@ -107,7 +104,7 @@ public final class JerseyTags {
     }
 
     private static boolean isRedirection(int status) {
-        return Response.Status.Family.familyOf(status) == Response.Status.Family.REDIRECTION;
+        return 300 <= status && status < 400;
     }
 
     private static String getMatchingPattern(RequestEvent event) {

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
@@ -24,7 +24,6 @@ import org.glassfish.jersey.server.model.ResourceMethod;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
-import javax.ws.rs.NotFoundException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -69,7 +68,7 @@ public class MetricsRequestEventListener implements RequestEventListener {
 
         switch (event.getType()) {
             case ON_EXCEPTION:
-                if (!(event.getException() instanceof NotFoundException)) {
+                if (!isNotFoundException(event)) {
                     break;
                 }
             case REQUEST_MATCHED:
@@ -101,6 +100,16 @@ public class MetricsRequestEventListener implements RequestEventListener {
                 }
                 break;
         }
+    }
+
+    private boolean isNotFoundException(RequestEvent event) {
+        Throwable t = event.getException();
+        if (t == null) {
+            return false;
+        }
+        String className = t.getClass().getCanonicalName();
+        return className.equals("jakarta.ws.rs.NotFoundException")
+            || className.equals("javax.ws.rs.NotFoundException");
     }
 
     private Set<Timer> shortTimers(Set<Timed> timed, RequestEvent event) {

--- a/samples/micrometer-samples-jersey3/build.gradle
+++ b/samples/micrometer-samples-jersey3/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation project(":micrometer-core")
+    implementation(project(":micrometer-jersey2")) {
+        exclude group: 'org.glassfish.jersey.inject', module: 'jersey-hk2'
+    }
+
+    implementation 'org.glassfish.jersey.containers:jersey-container-jdk-http:3.+'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:3.+'
+
+    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http:3.+'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    // See https://github.com/eclipse-ee4j/jersey/issues/3662
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+    testImplementation 'org.assertj:assertj-core'
+}

--- a/samples/micrometer-samples-jersey3/build.gradle
+++ b/samples/micrometer-samples-jersey3/build.gradle
@@ -5,7 +5,8 @@ plugins {
 dependencies {
     implementation project(":micrometer-core")
     implementation(project(":micrometer-jersey2")) {
-        exclude group: 'org.glassfish.jersey.inject', module: 'jersey-hk2'
+        // exclude jersey 2 dependency
+        exclude group: 'org.glassfish.jersey.core', module: 'jersey-server'
     }
 
     implementation 'org.glassfish.jersey.containers:jersey-container-jdk-http:3.+'

--- a/samples/micrometer-samples-jersey3/src/main/java/io/micrometer/samples/jersey3/HelloWorldResource.java
+++ b/samples/micrometer-samples-jersey3/src/main/java/io/micrometer/samples/jersey3/HelloWorldResource.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.samples.jersey3;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+
+@Path("hello/{name}")
+public class HelloWorldResource {
+
+    @GET
+    @Produces("text/plain")
+    public String sayHi(@PathParam("name") String name) {
+        return "Hello, " + name;
+    }
+}

--- a/samples/micrometer-samples-jersey3/src/main/java/io/micrometer/samples/jersey3/Jersey3Main.java
+++ b/samples/micrometer-samples-jersey3/src/main/java/io/micrometer/samples/jersey3/Jersey3Main.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.samples.jersey3;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingMeterRegistry;
+import io.micrometer.core.instrument.logging.LoggingRegistryConfig;
+import io.micrometer.jersey2.server.DefaultJerseyTagsProvider;
+import io.micrometer.jersey2.server.MetricsApplicationEventListener;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.glassfish.jersey.server.ResourceConfig;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+
+public class Jersey3Main {
+
+    public static void main(String[] args) throws IOException {
+        MeterRegistry registry = new LoggingMeterRegistry(new LoggingRegistryConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public Duration step() {
+                return Duration.ofSeconds(10);
+            }
+        }, Clock.SYSTEM);
+        HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> server.stop(0)));
+        Application application = new ResourceConfig(HelloWorldResource.class).register(new MetricsApplicationEventListener(registry, new DefaultJerseyTagsProvider(), "http.server.requests", true));
+        server.createContext("/", RuntimeDelegate.getInstance().createEndpoint(application, HttpHandler.class));
+
+        server.start();
+    }
+}

--- a/samples/micrometer-samples-jersey3/src/test/java/io/micrometer/samples/jersey3/Jersey3Test.java
+++ b/samples/micrometer-samples-jersey3/src/test/java/io/micrometer/samples/jersey3/Jersey3Test.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.samples.jersey3;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.jersey2.server.DefaultJerseyTagsProvider;
+import io.micrometer.jersey2.server.MetricsApplicationEventListener;
+import jakarta.ws.rs.core.Application;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Jersey3Test extends JerseyTest {
+
+    static final String TIMER_METRIC_NAME = "http.server.requests";
+    MeterRegistry registry;
+
+    @Override
+    protected Application configure() {
+        registry = new SimpleMeterRegistry();
+        MetricsApplicationEventListener metricsListener = new MetricsApplicationEventListener(registry, new DefaultJerseyTagsProvider(), TIMER_METRIC_NAME, true);
+        return new ResourceConfig(HelloWorldResource.class)
+                .register(metricsListener);
+    }
+
+    @Test
+    public void helloResourceIsTimed() {
+        String response = target("hello/Jersey").request().get(String.class);
+        assertThat(response).isEqualTo("Hello, Jersey");
+        Timer timer = registry.get(TIMER_METRIC_NAME)
+                .tags("method", "GET", "uri", "/hello/{name}", "status", "200", "exception", "None", "outcome", "SUCCESS")
+                .timer();
+        assertThat(timer.count()).isEqualTo(1);
+        assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ gradleEnterprise {
 include 'micrometer-core'
 include 'micrometer-jersey2'
 
-['core', 'boot2', 'boot2-reactive', 'spring-integration', 'hazelcast', 'hazelcast3', 'javalin'].each { sample ->
+['core', 'boot2', 'boot2-reactive', 'spring-integration', 'hazelcast', 'hazelcast3', 'javalin', 'jersey3'].each { sample ->
     include "micrometer-samples-$sample"
     project(":micrometer-samples-$sample").projectDir = new File(rootProject.projectDir, "samples/micrometer-samples-$sample")
 }


### PR DESCRIPTION
Jersey 3 is using classes from the jakarta.* packages instead of
javax.*. The Jersey 2 code can be used with Jersey 3 if we don't import
these classes.

This commit avoids importing javax.* classes by inlining code, not
storing variables and checking for NotFoundException by it's class name.