### PR TITLE
Add jersey-server as transitive dependency, remove jersey-hk2

### DIFF
--- a/micrometer-jersey2/build.gradle
+++ b/micrometer-jersey2/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     api project(':micrometer-core')
 
-    compileOnly 'org.glassfish.jersey.core:jersey-server'
-    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2'
+    api 'org.glassfish.jersey.core:jersey-server'
+    testRuntimeOnly 'org.glassfish.jersey.inject:jersey-hk2'
 
     testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory'
 


### PR DESCRIPTION
Previously the jersey-server dependency was not transitive to consumers of micrometer-jersey2, but it is a required dependency. jersey-hk2 is a runtime dependency not directly used by micrometer-jersey2 code, so it is removed from being a transitive dependency.

See https://github.com/micrometer-metrics/micrometer/pull/2766#issuecomment-911443188