### PR TITLE
Request and response size for Jersey

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTest.java
@@ -88,7 +88,38 @@ class MetricsRequestEventListenerTest extends JerseyTest {
             .isEqualTo(1);
 
         // assert we are not auto-timing long task @Timed
-        assertThat(registry.getMeters()).hasSize(4);
+        assertThat(registry.getMeters()).hasSize(12);
+    }
+
+    @Test
+    void resourcesSizeAreRecorded() {
+        target("/").request().get();
+        target("hello").request().get();
+        target("hello/").request().get();
+        target("hello/peter").request().get();
+        target("sub-resource/sub-hello/peter").request().get();
+
+        assertThat(registry.get(METRIC_NAME + ".request.size")
+                .tags(tagsFrom("root", "200", "SUCCESS", null)).summary().count())
+                .isEqualTo(0);
+
+        assertThat(registry.get(METRIC_NAME + ".response.size")
+                .tags(tagsFrom("root", "200", "SUCCESS", null)).summary().count())
+                .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME + ".response.size")
+                .tags(tagsFrom("/hello", "200", "SUCCESS", null)).summary().count())
+                .isEqualTo(2);
+
+        assertThat(registry.get(METRIC_NAME + ".response.size")
+                .tags(tagsFrom("/hello/{name}", "200", "SUCCESS", null)).summary().count())
+                .isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME + ".response.size")
+                .tags(tagsFrom("/sub-resource/sub-hello/{name}", "200", "SUCCESS", null)).summary().count())
+                .isEqualTo(1);
+
+        assertThat(registry.getMeters()).hasSize(12);
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTimedTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTimedTest.java
@@ -160,7 +160,7 @@ class MetricsRequestEventListenerTimedTest extends JerseyTest {
         future.get();
 
         // no meters registered except the one checked above
-        assertThat(registry.getMeters().size()).isOne();
+        assertThat(registry.getMeters().size()).isEqualTo(3);
     }
 
     @Test
@@ -192,7 +192,7 @@ class MetricsRequestEventListenerTimedTest extends JerseyTest {
             .isEqualTo(1);
 
         // class level annotation is not picked up
-        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters()).hasSize(3);
     }
 
     private static Iterable<Tag> tagsFrom(String uri, int status) {


### PR DESCRIPTION
Emit request and response size if available, under the `http.server.request.size` and `http.server.response.size` metrics (the prefix is configurable like the other http metrics).

Fix: #880 