### PR TITLE
Send dogstatsd DISTRIBUTION for Timer when percentileHistogram enabled

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -61,12 +61,25 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
     }
 
     @Override
+    public String timing(double timeMs) {
+        if (percentileHistogram) {
+            return distributionLine(timeMs);
+        } else {
+            return super.timing(timeMs);
+        }
+    }
+
+    @Override
     public String histogram(double amount) {
         if (percentileHistogram) {
-            return line(DoubleFormat.decimalOrNan(amount), null, TYPE_DISTRIBUTION);
+            return distributionLine(amount);
         } else {
             return super.histogram(amount);
         }
+    }
+
+    private String distributionLine(double amount) {
+        return line(DoubleFormat.decimalOrNan(amount), null, TYPE_DISTRIBUTION);
     }
 
     @Override

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -371,7 +371,7 @@ class StatsdMeterRegistryTest {
     }
 
     @Test
-    void supportsDatadogDistributions() {
+    void summarySentAsDatadogDistribution_whenPercentileHistogramEnabled() {
         final Sinks.Many<String> lines = sink();
         registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.DATADOG))
                 .clock(clock)
@@ -381,6 +381,20 @@ class StatsdMeterRegistryTest {
         StepVerifier.create(lines.asFlux())
                 .then(() -> DistributionSummary.builder("my.summary").publishPercentileHistogram(true).register(registry).record(1))
                 .expectNext("my.summary:1|d")
+                .verifyComplete();
+    }
+
+    @Test
+    void timerSentAsDatadogDistribution_whenPercentileHistogramEnabled() {
+        final Sinks.Many<String> lines = sink();
+        registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.DATADOG))
+                .clock(clock)
+                .lineSink(toLineSink(lines))
+                .build();
+
+        StepVerifier.create(lines.asFlux())
+                .then(() -> Timer.builder("my.timer").publishPercentileHistogram(true).register(registry).record(2, TimeUnit.SECONDS))
+                .expectNext("my.timer:2000|d")
                 .verifyComplete();
     }
 


### PR DESCRIPTION
We added support for this for `DistributionSummary` with gh-2745. We can add similar support for Timers. Unfortunately the millisecond unit info gets lost this way, but the metric is treated as a distribution with more percentiles available in Datadog. Unit info metadata can be edited in the Datadog UI.

Related to #1056