### PR TITLE
Ensure distribution can be configured per-metric

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -502,7 +502,8 @@ public class StatsdMeterRegistry extends MeterRegistry {
          * Used for completely customizing the StatsD line format. Intended for use by custom, proprietary
          * StatsD flavors.
          *
-         * @param lineBuilderFunction A mapping from a meter ID to a StatsD line generator that knows how to write counts, gauges
+         * @param lineBuilderFunction A mapping from a meter ID and a Distribution statistic configuration
+         *                            to a StatsD line generator that knows how to write counts, gauges
          *                            timers, and histograms in the proprietary format.
          * @return This builder.
          */
@@ -510,6 +511,24 @@ public class StatsdMeterRegistry extends MeterRegistry {
             this.lineBuilderFunction = lineBuilderFunction;
             return this;
         }
+
+
+        /**
+         * Used for completely customizing the StatsD line format. Intended for use by custom, proprietary
+         * StatsD flavors.
+         *
+         * @param lineBuilderFunction A mapping from a meter ID to a StatsD line generator that knows how to write counts, gauges
+         *                            timers, and histograms in the proprietary format.
+         *
+         * @return This builder.
+         * @deprecated Use {@link #lineBuilder(BiFunction)} instead since 1.8.0.
+         */
+        @Deprecated
+        public Builder lineBuilder(Function<Meter.Id, StatsdLineBuilder> lineBuilderFunction) {
+            this.lineBuilderFunction = (id, dsc) -> lineBuilderFunction.apply(id);
+            return this;
+        }
+
 
         public Builder nameMapper(HierarchicalNameMapper nameMapper) {
             this.nameMapper = nameMapper;

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -373,28 +373,38 @@ class StatsdMeterRegistryTest {
     @Test
     void summarySentAsDatadogDistribution_whenPercentileHistogramEnabled() {
         final Sinks.Many<String> lines = sink();
-        registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.DATADOG))
+        final StatsdConfig config = configWithFlavor(StatsdFlavor.DATADOG);
+        registry = StatsdMeterRegistry.builder(config)
                 .clock(clock)
-                .lineSink(toLineSink(lines))
+                .lineSink(toLineSink(lines, 2))
                 .build();
 
         StepVerifier.create(lines.asFlux())
-                .then(() -> DistributionSummary.builder("my.summary").publishPercentileHistogram(true).register(registry).record(1))
-                .expectNext("my.summary:1|d")
+                .then(() -> {
+                    Timer.builder("my.timer2").publishPercentileHistogram(false).register(registry).record(20, TimeUnit.SECONDS);
+                    Timer.builder("my.timer").publishPercentileHistogram(true).register(registry).record(2, TimeUnit.SECONDS);
+                })
+                .expectNext("my.timer2:20000|ms")
+                .expectNext("my.timer:2000|d")
                 .verifyComplete();
     }
 
     @Test
     void timerSentAsDatadogDistribution_whenPercentileHistogramEnabled() {
         final Sinks.Many<String> lines = sink();
-        registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.DATADOG))
+        final StatsdConfig config = configWithFlavor(StatsdFlavor.DATADOG);
+        registry = StatsdMeterRegistry.builder(config)
                 .clock(clock)
-                .lineSink(toLineSink(lines))
+                .lineSink(toLineSink(lines, 2))
                 .build();
 
         StepVerifier.create(lines.asFlux())
-                .then(() -> Timer.builder("my.timer").publishPercentileHistogram(true).register(registry).record(2, TimeUnit.SECONDS))
+                .then(() -> {
+                    Timer.builder("my.timer").publishPercentileHistogram(true).register(registry).record(2, TimeUnit.SECONDS);
+                    Timer.builder("my.timer2").publishPercentileHistogram(false).register(registry).record(20, TimeUnit.SECONDS);
+                })
                 .expectNext("my.timer:2000|d")
+                .expectNext("my.timer2:20000|ms")
                 .verifyComplete();
     }
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -381,11 +381,11 @@ class StatsdMeterRegistryTest {
 
         StepVerifier.create(lines.asFlux())
                 .then(() -> {
-                    Timer.builder("my.timer2").publishPercentileHistogram(false).register(registry).record(20, TimeUnit.SECONDS);
-                    Timer.builder("my.timer").publishPercentileHistogram(true).register(registry).record(2, TimeUnit.SECONDS);
+                    DistributionSummary.builder("my.summary2").publishPercentileHistogram(false).register(registry).record(20);
+                    DistributionSummary.builder("my.summary").publishPercentileHistogram(true).register(registry).record(2);
                 })
-                .expectNext("my.timer2:20000|ms")
-                .expectNext("my.timer:2000|d")
+                .expectNext("my.summary2:20|h")
+                .expectNext("my.summary:2|d")
                 .verifyComplete();
     }
 


### PR DESCRIPTION
Ensure emitting distributions can be configured per-metric, as reported by @hdv.

Fix #2798