### PR TITLE
Add TagProvider to customize the tag names in Grpc metric interceptors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
@@ -209,7 +209,7 @@ public abstract class AbstractMetricCollectingInterceptor {
      * @param timerTemplate The template to create the instances from.
      * @return The newly created function that returns a timer for a given code.
      */
-    protected Function<Code, Timer> asTimerFunction(final MethodDescriptor<?,?> method, final Supplier<Timer.Builder> timerTemplate) {
+    protected Function<Code, Timer> asTimerFunction(final MethodDescriptor<?, ?> method, final Supplier<Timer.Builder> timerTemplate) {
         final Map<Code, Timer> cache = new EnumMap<>(Code.class);
         final Function<Code, Timer> creator = code -> timerTemplate.get()
                 .tags(this.grpcTagProvider.getTagsForResult(method, code))

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
@@ -5,7 +5,7 @@ import io.grpc.Status;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 
-public class DefaultGrpcTagProvider implements GrpcTagProvider{
+public class DefaultGrpcTagProvider implements GrpcTagProvider {
 
     /**
      * The metrics tag key that belongs to the called service name.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.micrometer.core.instrument.binder.grpc;
 
 import io.grpc.MethodDescriptor;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
@@ -1,0 +1,39 @@
+package io.micrometer.core.instrument.binder.grpc;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+public class DefaultGrpcTagProvider implements GrpcTagProvider{
+
+    /**
+     * The metrics tag key that belongs to the called service name.
+     */
+    private static final String TAG_SERVICE_NAME = "service";
+    /**
+     * The metrics tag key that belongs to the called method name.
+     */
+    private static final String TAG_METHOD_NAME = "method";
+    /**
+     * The metrics tag key that belongs to the type of the called method.
+     */
+    private static final String TAG_METHOD_TYPE = "methodType";
+    /**
+     * The metrics tag key that belongs to the result status code.
+     */
+    private static final String TAG_STATUS_CODE = "statusCode";
+
+    @Override
+    public Iterable<Tag> getBaseTags(MethodDescriptor<?, ?> method) {
+        return Tags.of(
+                 TAG_SERVICE_NAME, method.getServiceName(),
+                TAG_METHOD_NAME, method.getBareMethodName(),
+                TAG_METHOD_TYPE, method.getType().name());
+    }
+
+    @Override
+    public Iterable<Tag> getTagsForResult(MethodDescriptor<?, ?> method, Status.Code code) {
+        return Tags.of(TAG_STATUS_CODE, code.name());
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcTagProvider.java
@@ -27,9 +27,10 @@ public class DefaultGrpcTagProvider implements GrpcTagProvider{
     @Override
     public Iterable<Tag> getBaseTags(MethodDescriptor<?, ?> method) {
         return Tags.of(
-                 TAG_SERVICE_NAME, method.getServiceName(),
+                TAG_SERVICE_NAME, method.getServiceName(),
                 TAG_METHOD_NAME, method.getBareMethodName(),
-                TAG_METHOD_TYPE, method.getType().name());
+                TAG_METHOD_TYPE, method.getType().name()
+        );
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
@@ -1,0 +1,16 @@
+package io.micrometer.core.instrument.binder.grpc;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.micrometer.core.instrument.Tag;
+
+public interface GrpcTagProvider {
+    /**
+     * Provides tags to be associated with metrics for the given {@code mothod}
+     * @param method The method the tags will be created for.
+     * @return tags to associate with metrics for the request and response exchange
+     */
+    Iterable<Tag> getBaseTags(final MethodDescriptor<?, ?> method);
+    Iterable<Tag> getTagsForResult(final MethodDescriptor<?, ?> method, Status.Code code);
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.micrometer.core.instrument.binder.grpc;
 
 import io.grpc.MethodDescriptor;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcTagProvider.java
@@ -8,9 +8,16 @@ public interface GrpcTagProvider {
     /**
      * Provides tags to be associated with metrics for the given {@code mothod}
      * @param method The method the tags will be created for.
-     * @return tags to associate with metrics for the request and response exchange
+     * @return tags to associate with metrics for the method
      */
     Iterable<Tag> getBaseTags(final MethodDescriptor<?, ?> method);
+    /**
+     * Provides tags to be associated with the result of the given {@code method} and {@code code}.
+     * These will be applied in addition to the result of {@code getBaseTags}
+     * @param method The method the tags will be created for.
+     * @param code The status code of the result.
+     * @return tags to associate with metrics for the method's response
+     */
     Iterable<Tag> getTagsForResult(final MethodDescriptor<?, ?> method, Status.Code code);
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -123,7 +123,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     @Override
     protected Counter newRequestCounterFor(final MethodDescriptor<?, ?> method) {
         return this.counterCustomizer.apply(
-                this.prepareCounterFor(method,
+                prepareCounterFor(method,
                         METRIC_NAME_CLIENT_REQUESTS_SENT,
                         "The total number of requests sent"))
                 .register(this.registry);
@@ -132,7 +132,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     @Override
     protected Counter newResponseCounterFor(final MethodDescriptor<?, ?> method) {
         return this.counterCustomizer.apply(
-                        this.prepareCounterFor(method,
+                prepareCounterFor(method,
                         METRIC_NAME_CLIENT_RESPONSES_RECEIVED,
                         "The total number of responses received"))
                 .register(this.registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -91,7 +91,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     @Override
     protected Counter newRequestCounterFor(final MethodDescriptor<?, ?> method) {
         return this.counterCustomizer.apply(
-                prepareCounterFor(method,
+                this.prepareCounterFor(method,
                         METRIC_NAME_CLIENT_REQUESTS_SENT,
                         "The total number of requests sent"))
                 .register(this.registry);
@@ -100,7 +100,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     @Override
     protected Counter newResponseCounterFor(final MethodDescriptor<?, ?> method) {
         return this.counterCustomizer.apply(
-                prepareCounterFor(method,
+                        this.prepareCounterFor(method,
                         METRIC_NAME_CLIENT_RESPONSES_RECEIVED,
                         "The total number of responses received"))
                 .register(this.registry);
@@ -108,7 +108,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
 
     @Override
     protected Function<Code, Timer> newTimerFunction(final MethodDescriptor<?, ?> method) {
-        return asTimerFunction(() -> this.timerCustomizer.apply(
+        return asTimerFunction(method, () -> this.timerCustomizer.apply(
                 prepareTimerFor(method,
                         METRIC_NAME_CLIENT_PROCESSING_DURATION,
                         "The total time taken for the client to complete the call, including network delay")));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -88,6 +88,38 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
         super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
     }
 
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given {@link MeterRegistry}.
+     * Also uses the {@link GrpcTagProvider} to create tags
+     *
+     * @param registry The registry to use.
+     * @param grpcTagProvider The GrpcTagProvider to create tags for the method invocations.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry,
+            final GrpcTagProvider grpcTagProvider,
+            final Code... eagerInitializedCodes) {
+        super(registry, grpcTagProvider, eagerInitializedCodes);
+    }
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given {@link MeterRegistry} and uses the
+     * given customizers to configure the {@link Counter}s and {@link Timer}s.
+     * Also uses the {@link GrpcTagProvider} to create tags
+     *
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created timers.
+     * @param grpcTagProvider The GrpcTagProvider to create tags for the method invocations.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry,
+            final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer,
+            final GrpcTagProvider grpcTagProvider,
+            final Code... eagerInitializedCodes) {
+        super(registry, counterCustomizer, timerCustomizer, grpcTagProvider, eagerInitializedCodes);
+    }
+
     @Override
     protected Counter newRequestCounterFor(final MethodDescriptor<?, ?> method) {
         return this.counterCustomizer.apply(

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
@@ -93,6 +93,37 @@ public class MetricCollectingServerInterceptor extends AbstractMetricCollectingI
     }
 
     /**
+     * Creates a new gRPC server interceptor that will collect metrics into the given {@link MeterRegistry}
+     * Also uses the {@link GrpcTagProvider} to create tags
+     *
+     * @param registry The registry to use.
+     * @param grpcTagProvider The GrpcTagProvider to create tags for the method invocations.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingServerInterceptor(final MeterRegistry registry,
+            final GrpcTagProvider grpcTagProvider, final Code... eagerInitializedCodes) {
+        super(registry, grpcTagProvider, eagerInitializedCodes);
+    }
+
+    /**
+     * Creates a new gRPC server interceptor that will collect metrics into the given {@link MeterRegistry} and uses the
+     * given customizers to configure the {@link Counter}s and {@link Timer}s.
+     * Also uses the {@link GrpcTagProvider} to create tags
+     *
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created timers.
+     * @param grpcTagProvider The GrpcTagProvider to create tags for the method invocations.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingServerInterceptor(final MeterRegistry registry,
+            final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final GrpcTagProvider grpcTagProvider,
+            final Code... eagerInitializedCodes) {
+        super(registry, counterCustomizer, timerCustomizer, grpcTagProvider, eagerInitializedCodes);
+    }
+
+    /**
      * Pre-registers the all methods provided by the given service. This will initialize all default counters and timers
      * for those methods.
      *

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
@@ -134,7 +134,7 @@ public class MetricCollectingServerInterceptor extends AbstractMetricCollectingI
 
     @Override
     protected Function<Code, Timer> newTimerFunction(final MethodDescriptor<?, ?> method) {
-        return asTimerFunction(() -> this.timerCustomizer.apply(
+        return asTimerFunction(method, () -> this.timerCustomizer.apply(
                 prepareTimerFor(method,
                         METRIC_NAME_SERVER_PROCESSING_DURATION,
                         "The total time taken for the server to complete the call")));

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcMetricsTest.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2017 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.grpc;
+
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GrpcMetricsTest {
+    private SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+
+    @Test
+    void nonRenamedMetrics() throws Exception {
+
+        MetricCollectingClientInterceptor metricCollectingClientInterceptor = new MetricCollectingClientInterceptor(registry);
+        runARequest(metricCollectingClientInterceptor);
+
+        Tags expectedTags = Tags.of(
+                "method", "bare",
+                "methodType", "UNARY",
+                "service", "service"
+        );
+
+        assertThat( registry.get("grpc.client.responses.received").tags(expectedTags).counter().count()).isEqualTo(1.0);
+        assertThat( registry.get("grpc.client.requests.sent").tags(expectedTags).counter().count()).isEqualTo(1.0);
+        Timer clientTimer = registry.get("grpc.client.processing.duration").tags(expectedTags).timer();
+        assertThat(clientTimer.getId().getTag("statusCode")).isEqualTo("OK");
+        assertThat( clientTimer.count()).isEqualTo(1);
+    }
+    @Test
+    void renamedMetrics() throws Exception {
+
+        MetricCollectingClientInterceptor metricCollectingClientInterceptor = new MetricCollectingClientInterceptor(registry, new GrpcTagProvider() {
+            @Override
+            public Iterable<Tag> getBaseTags(MethodDescriptor<?, ?> method) {
+                return Tags.of(
+                        "tacoServiceName", method.getServiceName(),
+                        "tacoMethodName", method.getBareMethodName(),
+                        "tacoType", method.getType().name(),
+                        "tacos", "rock"
+                );
+            }
+            @Override
+            public Iterable<Tag> getTagsForResult(MethodDescriptor<?, ?> method, Status.Code code) {
+                return Tags.of("tacoStatus", code.name());
+            }
+        });
+        runARequest(metricCollectingClientInterceptor);
+
+        Tags unexpectedTags = Tags.of(
+                "method", "bare",
+                "methodType", "UNARY",
+                "service", "service"
+        );
+        assertThatThrownBy(() -> registry.get("grpc.client.responses.received").tags(unexpectedTags).counter()).isInstanceOf(MeterNotFoundException.class);
+
+        Tags expectedTags = Tags.of(
+                "tacoMethodName", "bare",
+                "tacoType", "UNARY",
+                "tacoServiceName", "service",
+                "tacos","rock"
+        );
+
+        assertThat( registry.get("grpc.client.responses.received").tags(expectedTags).counter().count()).isEqualTo(1.0);
+        assertThat( registry.get("grpc.client.requests.sent").tags(expectedTags).counter().count()).isEqualTo(1.0);
+        Timer clientTimer = registry.get("grpc.client.processing.duration").tags(expectedTags).timer();
+        assertThat(clientTimer.getId().getTag("tacoStatus")).isEqualTo("OK");
+        assertThat(clientTimer.getId().getTag("status")).isNull();
+        assertThat( clientTimer.count()).isEqualTo(1);
+    }
+
+    private void runARequest(MetricCollectingClientInterceptor metricCollectingClientInterceptor) {
+        MethodDescriptor mock = Mockito.mock(MethodDescriptor.class);
+        Mockito.when(mock.getServiceName()).thenReturn("service");
+        Mockito.when(mock.getBareMethodName()).thenReturn("bare");
+        Mockito.when(mock.getType()).thenReturn(MethodDescriptor.MethodType.UNARY);
+
+        AbstractMetricCollectingInterceptor.MetricSet metricSet = metricCollectingClientInterceptor.metricsFor(mock);
+        metricSet.getRequestCounter().increment();
+        metricSet.getResponseCounter().increment();
+        Consumer<Status.Code> codeConsumer = metricSet.newProcessingDurationTiming(registry);
+        codeConsumer.accept(Status.Code.OK);
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcMetricsTest.java
@@ -85,7 +85,7 @@ class GrpcMetricsTest {
                 "tacoMethodName", "bare",
                 "tacoType", "UNARY",
                 "tacoServiceName", "service",
-                "tacos","rock"
+                "tacos", "rock"
         );
 
         assertThat( registry.get("grpc.client.responses.received").tags(expectedTags).counter().count()).isEqualTo(1.0);


### PR DESCRIPTION
For https://github.com/micrometer-metrics/micrometer/issues/2805

I went with a simple tag provider. I left the existing tag customizers as is for now.