### PR TITLE
Deprecate `ReactorNettySender`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/ReactorNettySender.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/ReactorNettySender.java
@@ -25,7 +25,9 @@ import reactor.util.function.Tuple2;
  *
  * @author Jon Schneider
  * @since 1.1.0
+ * @deprecated use a different {@link HttpSender} implementation or report your use case for this to the Micrometer project maintainers
  */
+@Deprecated
 public class ReactorNettySender implements HttpSender {
     private final HttpClient httpClient;
 

--- a/micrometer-core/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+@SuppressWarnings("deprecation")
 @ExtendWith(WiremockResolver.class)
 class ReactorNettySenderTests {
     HttpSender httpSender = new ReactorNettySender();


### PR DESCRIPTION
Having code in micrometer-core that depends on reactor-netty creates a dependency cycle between the two projects. In an effort to work towards eliminating that cycle, we are proactively deprecating the ReactorNettySender. If we receive feedback that users have use cases for it, we can consider moving it to the reactor-netty project or elsewhere. Lacking enough feedback, we will plan to remove this in the next feature release.

See gh-2802