### PR TITLE
Add Javadoc `@since` tag to StatsD changes

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -506,6 +506,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
          *                            to a StatsD line generator that knows how to write counts, gauges
          *                            timers, and histograms in the proprietary format.
          * @return This builder.
+         * @since 1.8.0
          */
         public Builder lineBuilder(BiFunction<Meter.Id, DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction) {
             this.lineBuilderFunction = lineBuilderFunction;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/DatadogStatsdLineBuilder.java
@@ -53,6 +53,14 @@ public class DatadogStatsdLineBuilder extends FlavorStatsdLineBuilder {
         this(id, config, null);
     }
 
+    /**
+     * Create a {@code DatadogStatsdLineBuilder} instance.
+     *
+     * @param id meter ID
+     * @param config meter registry configuration
+     * @param distributionStatisticConfig distribution statistic configuration
+     * @since 1.8.0
+     */
     public DatadogStatsdLineBuilder(Meter.Id id, MeterRegistry.Config config, @Nullable DistributionStatisticConfig distributionStatisticConfig) {
         super(id, config);
 


### PR DESCRIPTION
This PR adds Javadoc `@since` tag to the recent StatsD changes.

See gh-1056
See gh-2798