### PR TITLE
Clean up unchecked compile warnings

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
     private LoadingCache<String, String> cache = Caffeine.newBuilder().build(key -> "");
-    private CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
+    private CaffeineCacheMetrics<String, String, Cache<String, String>> metrics = new CaffeineCacheMetrics<>(cache, "testCache", expectedTag);
 
     @Test
     void reportExpectedGeneralMetrics() {
@@ -74,7 +74,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
     void doNotReportMetricsForNonLoadingCache() {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         Cache<Object, Object> cache = Caffeine.newBuilder().build();
-        CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
+        CaffeineCacheMetrics<Object, Object, Cache<Object, Object>> metrics = new CaffeineCacheMetrics<>(cache, "testCache", expectedTag);
         metrics.bindTo(meterRegistry);
 
         assertThat(meterRegistry.find("cache.load.duration").timeGauge()).isNull();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheStats;
@@ -43,7 +44,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
             return "";
         }
     });
-    private GuavaCacheMetrics metrics = new GuavaCacheMetrics(cache, "testCache", expectedTag);
+    private GuavaCacheMetrics<String, String, Cache<String, String>> metrics = new GuavaCacheMetrics<>(cache, "testCache", expectedTag);
 
     @Test
     void reportExpectedMetrics() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -58,7 +58,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
     private CacheManager cacheManager = mock(CacheManager.class);
 
-    private JCacheMetrics metrics;
+    private JCacheMetrics<String, String, Cache<String, String>> metrics;
     private MBeanServer mbeanServer;
     private Long expectedAttributeValue = new Random().nextLong();
 
@@ -67,7 +67,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         when(cache.getCacheManager()).thenReturn(cacheManager);
         when(cache.getName()).thenReturn("testCache");
         when(cacheManager.getURI()).thenReturn(new URI("http://localhost"));
-        metrics = new JCacheMetrics(cache, expectedTag);
+        metrics = new JCacheMetrics<>(cache, expectedTag);
 
         // emulate MBean server with MBean used for statistic lookup
         mbeanServer = MBeanServerFactory.createMBeanServer();
@@ -148,7 +148,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
     void defaultValueWhenObjectNameNotInitialized() throws MalformedObjectNameException {
         // set cacheManager to null to emulate scenario when objectName not initialized
         when(cache.getCacheManager()).thenReturn(null);
-        metrics = new JCacheMetrics(cache, expectedTag);
+        metrics = new JCacheMetrics<>(cache, expectedTag);
 
         assertThat(metrics.hitCount()).isEqualTo(0L);
     }
@@ -157,7 +157,7 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
     void doNotReportMetricWhenObjectNameNotInitialized() throws MalformedObjectNameException {
         // set cacheManager to null to emulate scenario when objectName not initialized
         when(cache.getCacheManager()).thenReturn(null);
-        metrics = new JCacheMetrics(cache, expectedTag);
+        metrics = new JCacheMetrics<>(cache, expectedTag);
         MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindImplementationSpecificMetrics(registry);
 


### PR DESCRIPTION
There are the following warnings:

```
> Task :micrometer-core:compileTestJava
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java:41: warning: [unchecked] unchecked call to CaffeineCacheMetrics(C,String,Iterable<Tag>) as a member of the raw type CaffeineCacheMetrics
    private CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
                                           ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class CaffeineCacheMetrics
    K extends Object declared in class CaffeineCacheMetrics
    V extends Object declared in class CaffeineCacheMetrics
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java:77: warning: [unchecked] unchecked call to CaffeineCacheMetrics(C,String,Iterable<Tag>) as a member of the raw type CaffeineCacheMetrics
        CaffeineCacheMetrics metrics = new CaffeineCacheMetrics(cache, "testCache", expectedTag);
                                       ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class CaffeineCacheMetrics
    K extends Object declared in class CaffeineCacheMetrics
    V extends Object declared in class CaffeineCacheMetrics
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java:70: warning: [unchecked] unchecked call to JCacheMetrics(C,Iterable<Tag>) as a member of the raw type JCacheMetrics
        metrics = new JCacheMetrics(cache, expectedTag);
                  ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class JCacheMetrics
    K extends Object declared in class JCacheMetrics
    V extends Object declared in class JCacheMetrics
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java:151: warning: [unchecked] unchecked call to JCacheMetrics(C,Iterable<Tag>) as a member of the raw type JCacheMetrics
        metrics = new JCacheMetrics(cache, expectedTag);
                  ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class JCacheMetrics
    K extends Object declared in class JCacheMetrics
    V extends Object declared in class JCacheMetrics
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java:160: warning: [unchecked] unchecked call to JCacheMetrics(C,Iterable<Tag>) as a member of the raw type JCacheMetrics
        metrics = new JCacheMetrics(cache, expectedTag);
                  ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class JCacheMetrics
    K extends Object declared in class JCacheMetrics
    V extends Object declared in class JCacheMetrics
/Users/user/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java:46: warning: [unchecked] unchecked call to GuavaCacheMetrics(C,String,Iterable<Tag>) as a member of the raw type GuavaCacheMetrics
    private GuavaCacheMetrics metrics = new GuavaCacheMetrics(cache, "testCache", expectedTag);
                                        ^
  where C,K,V are type-variables:
    C extends Cache<K,V> declared in class GuavaCacheMetrics
    K extends Object declared in class GuavaCacheMetrics
    V extends Object declared in class GuavaCacheMetrics
6 warnings
```

See gh-2643