### PR TITLE
Prevent race conditions in cache metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/EhCache2Metrics.java
@@ -138,7 +138,8 @@ public class EhCache2Metrics extends CacheMeterBinder<Ehcache> {
 
     @Nullable
     private StatisticsGateway getStats() {
-        return getCache() != null ? getCache().getStatistics() : null;
+        Ehcache cache = getCache();
+        return cache != null ? cache.getStatistics() : null;
     }
 
     private void missMetrics(MeterRegistry registry) {


### PR DESCRIPTION
This PR changes to try to prevent possible race conditions in cache metrics as it seems that it might throw an NPE.

See gh-2643