### PR TITLE
Fix WavefrontMeterRegistryTest.configureDefaultSenderWithCustomConfig()

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryTest.java
+++ b/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontMeterRegistryTest.java
@@ -172,8 +172,9 @@ class WavefrontMeterRegistryTest {
         WavefrontClient sender = builder.build();
         assertThat(builder).hasFieldOrPropertyWithValue("flushInterval", 15_000L);
         assertThat(builder).hasFieldOrPropertyWithValue("flushIntervalTimeUnit", TimeUnit.MILLISECONDS);
-        assertThat(sender).extracting("reportingService").hasFieldOrPropertyWithValue("uri", URI.create("https://example.com"));
-        assertThat(sender).extracting("reportingService").hasFieldOrPropertyWithValue("token", "apiToken");
+        assertThat(sender).extracting("metricsReportingService")
+                .hasFieldOrPropertyWithValue("uri", URI.create("https://example.com"))
+                .hasFieldOrPropertyWithValue("token", "apiToken");
         assertThat(sender).hasFieldOrPropertyWithValue("batchSize", 20);
     }
 


### PR DESCRIPTION
It fails as follows:

```
WavefrontMeterRegistryTest > configureDefaultSenderWithCustomConfig() FAILED
    org.assertj.core.util.introspection.IntrospectionError: 
    Can't find any field or property with name 'reportingService'.
    Error when introspecting properties was :
    - No getter for property 'reportingService' in com.wavefront.sdk.common.clients.WavefrontClient 
    Error when introspecting fields was :
    - Unable to obtain the value of the field <'reportingService'> from <com.wavefront.sdk.common.clients.WavefrontClient@7afb1741>
        at app//org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:88)
        at app//org.assertj.core.util.introspection.PropertyOrFieldSupport.getValueOf(PropertyOrFieldSupport.java:60)
        at app//org.assertj.core.extractor.ByNameSingleExtractor.apply(ByNameSingleExtractor.java:29)
        at app//org.assertj.core.api.AbstractAssert.extracting(AbstractAssert.java:1059)
        at app//org.assertj.core.api.AbstractObjectAssert.extracting(AbstractObjectAssert.java:834)
        at app//io.micrometer.wavefront.WavefrontMeterRegistryTest.configureDefaultSenderWithCustomConfig(WavefrontMeterRegistryTest.java:175)

        Caused by:
        org.assertj.core.util.introspection.IntrospectionError: Unable to obtain the value of the field <'reportingService'> from <com.wavefront.sdk.common.clients.WavefrontClient@7afb1741>
            at app//org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:248)
            at app//org.assertj.core.util.introspection.FieldSupport.fieldValue(FieldSupport.java:202)
            at app//org.assertj.core.util.introspection.PropertyOrFieldSupport.getSimpleValue(PropertyOrFieldSupport.java:70)
            ... 5 more

            Caused by:
            java.lang.IllegalArgumentException: Cannot locate field reportingService on class com.wavefront.sdk.common.clients.WavefrontClient
                at org.assertj.core.util.Preconditions.checkArgument(Preconditions.java:129)
                at org.assertj.core.util.introspection.FieldUtils.readField(FieldUtils.java:144)
                at org.assertj.core.util.introspection.FieldSupport.readSimpleField(FieldSupport.java:208)
                ... 7 more
```

`reportingService` seems to be split into `metricsReportingService` and `tracesReportingService` in the recent Wavefront library as follows:

```
  private final ReportingService metricsReportingService;
  private final ReportingService tracesReportingService;
```
