### PR TITLE
Add javax.annotation.Nullable to IllegalImportCheck

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -5,7 +5,7 @@
 <suppressions>
 	<suppress files="io[\\/]micrometer[\\/]core[\\/]instrument[\\/]binder[\\/]logging[\\/].+" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]core[\\/]util[\\/]internal[\\/]logging[\\/].+" checks="IllegalImport" />
-	<suppress files="implementations[\\/].+" checks="IllegalImport" />
+	<suppress files="implementations[\\/].+" id="SLF4JIllegalImportCheck" />
 	<suppress files="samples[\\/].+" checks="IllegalImport" />
 	<suppress files="LogbackMetricsAutoConfiguration" checks="IllegalImport" />
 	<suppress files="io[\\/]micrometer[\\/]jersey2[\\/]server[\\/].+" checks="SpringJUnit5" />

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -18,8 +18,14 @@
 
         <!-- Imports -->
         <module name="IllegalImportCheck" >
-            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.slf4j.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*"/>
-            <property name="illegalClasses" value="org\.assertj\.core\.api\.Java6Assertions\..*"/>
+            <property name="id" value="GeneralIllegalImportCheck"/>
+            <property name="illegalPkgs" value="com.google.common.(?!cache).*,org.apache.commons.text.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*"/>
+            <property name="illegalClasses" value="org\.assertj\.core\.api\.Java6Assertions\..*,javax.annotation.Nullable"/>
+            <property name="regexp" value="true"/>
+        </module>
+        <module name="IllegalImportCheck" >
+            <property name="id" value="SLF4JIllegalImportCheck"/>
+            <property name="illegalPkgs" value="org.slf4j.*"/>
             <property name="regexp" value="true"/>
         </module>
         <module name="UnusedImports">


### PR DESCRIPTION
This PR adds `javax.annotation.Nullable` to the Checkstyle `IllegalImportCheck` module.

This PR also splits the `IllegalImportCheck` module into `GeneralIllegalImportCheck` and `SLF4JIllegalImportCheck` as the suppression on `implementations` should be limited to the SLF4J only.

See gh-2779