### PR TITLE
Deprecate remaining Jersey classes

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/TimedFinder.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/TimedFinder.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Deprecated
 class TimedFinder {
     private final AnnotationFinder annotationFinder;
 

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
  * @author Michael Weirauch
  * @author Johnny Lim
  */
+@Deprecated
 class DefaultJerseyTagsProviderTest {
 
     private final DefaultJerseyTagsProvider tagsProvider = new DefaultJerseyTagsProvider();

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Michael Weirauch
  * @author Johnny Lim
  */
+@Deprecated
 class MetricsRequestEventListenerTest extends JerseyTest {
 
     static {

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTimedTest.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTimedTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Michael Weirauch
  */
+@Deprecated
 class MetricsRequestEventListenerTimedTest extends JerseyTest {
 
     static {


### PR DESCRIPTION
This PR deprecates the remaining Jersey classes that cause deprecated warnings as follows:

```
> Task :micrometer-jersey2:compileJava
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/TimedFinder.java:28: warning: [deprecation] AnnotationFinder in io.micrometer.jersey2.server has been deprecated
    private final AnnotationFinder annotationFinder;
                  ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/TimedFinder.java:30: warning: [deprecation] AnnotationFinder in io.micrometer.jersey2.server has been deprecated
    TimedFinder(AnnotationFinder annotationFinder) {
                ^
2 warnings

...

> Task :micrometer-jersey2:compileTestJava
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java:55: warning: [deprecation] MetricsApplicationEventListener in io.micrometer.jersey2.server has been deprecated
        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
              ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java:55: warning: [deprecation] MetricsApplicationEventListener in io.micrometer.jersey2.server has been deprecated
        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
                                                             ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTest.java:56: warning: [deprecation] DefaultJerseyTagsProvider in io.micrometer.jersey2.server has been deprecated
            registry, new DefaultJerseyTagsProvider(), METRIC_NAME, true);
                          ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java:50: warning: [deprecation] DefaultJerseyTagsProvider in io.micrometer.jersey2.server has been deprecated
    private final DefaultJerseyTagsProvider tagsProvider = new DefaultJerseyTagsProvider();
                  ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/DefaultJerseyTagsProviderTest.java:50: warning: [deprecation] DefaultJerseyTagsProvider in io.micrometer.jersey2.server has been deprecated
    private final DefaultJerseyTagsProvider tagsProvider = new DefaultJerseyTagsProvider();
                                                               ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTimedTest.java:63: warning: [deprecation] MetricsApplicationEventListener in io.micrometer.jersey2.server has been deprecated
        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
              ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTimedTest.java:63: warning: [deprecation] MetricsApplicationEventListener in io.micrometer.jersey2.server has been deprecated
        final MetricsApplicationEventListener listener = new MetricsApplicationEventListener(
                                                             ^
/Users/user/IdeaProjects/micrometer/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/MetricsRequestEventListenerTimedTest.java:64: warning: [deprecation] DefaultJerseyTagsProvider in io.micrometer.jersey2.server has been deprecated
            registry, new DefaultJerseyTagsProvider(), METRIC_NAME, false);
                          ^
8 warnings
```