### PR TITLE
Only make a LongTaskTimer with `@Timed(longTask=true)`

### DIFF
--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/MetricsRequestEventListener.java
@@ -118,8 +118,9 @@ public class MetricsRequestEventListener implements RequestEventListener {
         }
 
         return timed.stream()
-            .map(t -> Timer.builder(t, metricName).tags(tagsProvider.httpRequestTags(event)).register(registry))
-            .collect(Collectors.toSet());
+                .filter(annotation -> !annotation.longTask())
+                .map(t -> Timer.builder(t, metricName).tags(tagsProvider.httpRequestTags(event)).register(registry))
+                .collect(Collectors.toSet());
     }
 
     private Set<LongTaskTimer> longTaskTimers(Set<Timed> timed, RequestEvent event) {

--- a/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/resources/TimedResource.java
+++ b/micrometer-jersey2/src/test/java/io/micrometer/jersey2/server/resources/TimedResource.java
@@ -83,6 +83,19 @@ public class TimedResource {
     }
 
     @GET
+    @Path("just-long-timed")
+    @Timed(value = "long.task.in.request", longTask = true)
+    public String justLongTimed() {
+        longTaskRequestStartedLatch.countDown();
+        try {
+            longTaskRequestReleaseLatch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return "long-timed";
+    }
+
+    @GET
     @Path("long-timed-unnamed")
     @Timed
     @Timed(longTask = true)


### PR DESCRIPTION
Before both a `LongTaskTimer` and `Timer` were being made because the logic to make regular timers from the `@Timed` annotation did not filter out annotations where `longTask` was `true`.

Resolves gh-2861