### PR TITLE
`jvm.gc.live.data.size` and `max` not updating for optavgpause/optthruput collectors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -195,7 +195,10 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void countPoolSizeDelta(Map<String, MemoryUsage> before, Map<String, MemoryUsage> after, Counter counter,
-            AtomicLong previousPoolSize, String poolName) {
+            AtomicLong previousPoolSize, @Nullable String poolName) {
+        if (poolName == null) {
+            return;
+        }
         final long beforeBytes = before.get(poolName).getUsed();
         final long afterBytes = after.get(poolName).getUsed();
         final long delta = beforeBytes - previousPoolSize.get();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
@@ -75,7 +75,8 @@ class JvmGcMetricsTest {
         if (!binder.isGenerationalGc) {
             return;
         }
-        assertThat(registry.find("jvm.gc.memory.promoted").counter().count()).isPositive();
+        // cannot guarantee an object was promoted, so cannot check for positive count
+        assertThat(registry.find("jvm.gc.memory.promoted").counter()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
With the OpenJ9 non-generational collectors `optavgpause` and `optthruput`, a NPE was happening in the notification listener which caused some code in it to not be executed. Namely, setting the live and max data size was being effectively skipped for these collectors.

Now we check for `null` and only the allocated bytes counter is skipped when no allocation pool name is set.