### PR TITLE
Use latest.release for JUnit dependencies

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,8 +62,8 @@ def VERSIONS = [
         'org.hsqldb:hsqldb:2.5.+', // 2.6.0 requires JDK 11.
         'org.jooq:jooq:3.14.+',
         'org.jsr107.ri:cache-ri-impl:1.0.0',
-        'org.junit.jupiter:junit-jupiter:5.8.+',
-        'org.junit.platform:junit-platform-launcher:1.8.+',
+        'org.junit.jupiter:junit-jupiter:latest.release',
+        'org.junit.platform:junit-platform-launcher:latest.release',
         'org.latencyutils:LatencyUtils:latest.release',
         'org.mockito:mockito-core:latest.release',
         'org.mockito:mockito-inline:latest.release',


### PR DESCRIPTION
This PR changes to use `latest.release` for JUnit dependencies.