### PR TITLE
Deprecate ReactorNettySenderTest

### DIFF
--- a/micrometer-test/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.ipc.http;
 
+@Deprecated
 class ReactorNettySenderTest extends HttpSenderCompatibilityKit {
     @Override
     public HttpSender httpClient() {


### PR DESCRIPTION
This PR deprecates `ReactorNettySenderTest` as it causes the following warning:

```
> Task :micrometer-test:compileTestJava
/Users/user/IdeaProjects/micrometer/micrometer-test/src/test/java/io/micrometer/core/ipc/http/ReactorNettySenderTest.java:21: warning: [deprecation] ReactorNettySender in io.micrometer.core.ipc.http has been deprecated
        return new ReactorNettySender();
                   ^
1 warning
```