### PR TITLE
Clean up Javadoc warnings and errors

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -167,7 +167,7 @@ public interface ElasticConfig extends StepRegistryConfig {
     /**
      * Base64-encoded credentials string. From a generated API key, concatenate in UTF-8 format
      * the unique {@code id}, a colon ({@code :}), and the {@code api_key} in the following format:
-     * <p><pre>{@code <id>:<api_key>}</pre></p>
+     * <pre>{@code <id>:<api_key>}</pre>
      * The above should be the input for Base64 encoding, and the output is the credentials
      * returned by this method.
      * If configured, ApiKey type authentication is used instead of username/password authentication.

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
@@ -70,7 +70,7 @@ public interface StackdriverConfig extends StepRegistryConfig {
      * of backwards compatibility.
      * For example, when this is {@code false}, counter metrics are published as the GAUGE MetricKind.
      * When this is {@code true}, counter metrics are published as the CUMULATIVE MetricKind.
-     * <p></p>
+     * <p>
      * If you have published metrics to Stackdriver before, switching this flag will cause metrics
      * publishing to fail until you delete the old MetricDescriptor with the previous MetricKind so that
      * it can be recreated with the new MetricKind next time that metric is published.

--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
@@ -167,7 +167,7 @@ public interface HttpSender {
             /**
              * Configures the {@code Authentication} HTTP header with the given type and credentials.
              * The format will be:
-             * <p><pre>{@code Authorization: <type> <credentials>}</pre></p>
+             * <pre>{@code Authorization: <type> <credentials>}</pre>
              * No encoding will be performed on the {@code credentials}, so if the authentication scheme
              * expects {@code credentials} to be encoded, encode them before passing them to this method.
              *

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java
@@ -32,9 +32,9 @@ public abstract class CacheMeterBinderCompatibilityKit<C> {
     protected C cache;
 
     /**
-     * The return value will be assigned to {@link this#cache}.
+     * The return value will be assigned to {@link #cache}.
      * @return cache to use for tests
-     * @see this#bindToRegistry()
+     * @see #bindToRegistry()
      */
     public abstract C createCache();
 


### PR DESCRIPTION
This PR cleans up the following Javadoc warnings and errors:

```
> Task :micrometer-registry-atlas:compileJava
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java:161: warning: [deprecation] register(Meter) in AbstractRegistry has been deprecated
        registry.register(gauge);
                ^
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java:204: warning: [deprecation] register(Meter) in AbstractRegistry has been deprecated
        registry.register(spectatorMeter);
                ^
2 warnings

> Task :micrometer-registry-elastic:javadoc
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java:170: warning: empty <p> tag
     * <p><pre>{@code <id>:<api_key>}</pre></p>
       ^
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java:170: error: unexpected end tag: </p>
     * <p><pre>{@code <id>:<api_key>}</pre></p>
                                           ^
1 error
1 warning

> Task :micrometer-registry-stackdriver:javadoc
/Users/user/IdeaProjects/micrometer/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java:73: warning: empty <p> tag
     * <p></p>
          ^
1 warning

> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java:170: warning: empty <p> tag
             * <p><pre>{@code Authorization: <type> <credentials>}</pre></p>
               ^
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java:170: error: unexpected end tag: </p>
             * <p><pre>{@code Authorization: <type> <credentials>}</pre></p>
                                                                        ^

> Task :micrometer-test:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java:35: error: unexpected text
     * The return value will be assigned to {@link this#cache}.
                                            ^
/Users/user/IdeaProjects/micrometer/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/CacheMeterBinderCompatibilityKit.java:37: error: unexpected text
     * @see this#bindToRegistry()
       ^
2 errors
```