### PR TITLE
Use Javadoc code instead of Markdown backticks

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFlavor.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFlavor.java
@@ -29,7 +29,7 @@ public enum StatsdFlavor {
     /**
      * https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/
      * <p>
-     * For gauges to work as expected, you should set `delete_gauges = false` in your input options as documented here:
+     * For gauges to work as expected, you should set {@code delete_gauges = false} in your input options as documented here:
      * https://github.com/influxdata/telegraf/tree/master/plugins/inputs/statsd
      */
     TELEGRAF,


### PR DESCRIPTION
This PR changes to use Javadoc `@code` instead of Markdown backticks.