### PR TITLE
Allow file-based configuration for Dynatrace v2 exporter

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.dynatrace;
 
+import com.dynatrace.file.util.DynatraceFileBasedConfigurationProvider;
 import com.dynatrace.metric.util.DynatraceMetricApiConstants;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
@@ -46,7 +47,13 @@ public interface DynatraceConfig extends StepRegistryConfig {
         if (apiVersion() == V1) {
             return secret.required().get();
         }
-        return secret.orElse("");
+
+        return secret.orElse(
+                // Local OneAgent does not require a token.
+                uri().equals(DynatraceMetricApiConstants.getDefaultOneAgentEndpoint()) ?
+                        "" :
+                        DynatraceFileBasedConfigurationProvider.getInstance().getMetricIngestToken()
+        );
     }
 
     default String uri() {
@@ -54,7 +61,10 @@ public interface DynatraceConfig extends StepRegistryConfig {
         if (apiVersion() == V1) {
             return uri.required().get();
         }
-        return uri.orElse(DynatraceMetricApiConstants.getDefaultOneAgentEndpoint());
+
+        return uri.orElse(
+                DynatraceFileBasedConfigurationProvider.getInstance().getMetricIngestEndpoint()
+        );
     }
 
     default String deviceId() {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -56,16 +56,12 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source", "micrometer");
 
-    private final String endpoint;
-    private final boolean ignoreToken;
     private final MetricBuilderFactory metricBuilderFactory;
 
     public DynatraceExporterV2(DynatraceConfig config, Clock clock, HttpSender httpClient) {
         super(config, clock, httpClient);
-        this.endpoint = config.uri();
-        showErrorIfEndpointIsInvalid(endpoint);
-        ignoreToken = shouldIgnoreToken(config);
-        logger.info("Exporting to endpoint {}", this.endpoint);
+
+        logger.info("Exporting to endpoint {}", config.uri());
 
         MetricBuilderFactory.MetricBuilderFactoryBuilder factoryBuilder = MetricBuilderFactory.builder()
                 .withPrefix(config.metricKeyPrefix())
@@ -78,12 +74,14 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         metricBuilderFactory = factoryBuilder.build();
     }
 
-    private void showErrorIfEndpointIsInvalid(String uri) {
+    private boolean endpointIsInvalid(String uri) {
         try {
+            //noinspection ResultOfMethodCallIgnored
             URI.create(uri).toURL();
         } catch (IllegalArgumentException | MalformedURLException ex) {
-            logger.error("Invalid URI provided, exporting will fail: {}", uri);
+            return true;
         }
+        return false;
     }
 
     private boolean shouldIgnoreToken(DynatraceConfig config) {
@@ -254,12 +252,19 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     private void send(List<String> metricLines) {
+        String endpoint = config.uri();
+        if (endpointIsInvalid(endpoint)) {
+            logger.warn("Endpoint invalid. Skipping export... ({})", endpoint);
+            return;
+        }
         try {
+            logger.debug("Sending {} lines to {}", metricLines.size(), endpoint);
+
             String body = String.join("\n", metricLines);
             logger.debug("Sending lines:\n{}", body);
 
             HttpSender.Request.Builder requestBuilder = httpClient.post(endpoint);
-            if (!ignoreToken) {
+            if (!shouldIgnoreToken(config)) {
                 requestBuilder.withHeader("Authorization", "Api-Token " + config.apiToken());
             }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/com/dynatrace/file/util/FileBasedConfigurationTestHelper.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/com/dynatrace/file/util/FileBasedConfigurationTestHelper.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dynatrace.file.util;
+
+public class FileBasedConfigurationTestHelper {
+    // This allows overwriting the file location of the file-based configuration for testing.
+    public static void forceOverwriteConfig(String filename) {
+        DynatraceFileBasedConfigurationProvider.getInstance().forceOverwriteConfig(filename);
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -16,8 +16,11 @@
 
 package io.micrometer.dynatrace.v2;
 
+import com.dynatrace.file.util.FileBasedConfigurationTestHelper;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.ipc.http.HttpSender;
+import io.micrometer.core.lang.Nullable;
 import io.micrometer.core.util.internal.logging.LogEvent;
 import io.micrometer.core.util.internal.logging.MockLogger;
 import io.micrometer.core.util.internal.logging.MockLoggerFactory;
@@ -29,28 +32,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.MockClock.clock;
 import static io.micrometer.core.util.internal.logging.InternalLogLevel.ERROR;
-import static java.lang.Double.NaN;
-import static java.lang.Double.POSITIVE_INFINITY;
-import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.*;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link DynatraceExporterV2}.
@@ -464,6 +463,99 @@ class DynatraceExporterV2Test {
         exporter.export(Collections.singletonList(gauge));
 
         assertThat(LOGGER.getLogEvents()).contains(new LogEvent(ERROR, "Failed metric ingestion: Error Code=500, Response Body=simulated", null));
+    }
+
+    @Test
+    void endpointPickedUpBetweenExportsAndChangedPropertiesFile() throws Throwable {
+        String randomUuid = UUID.randomUUID().toString();
+        final Path tempFile = Files.createTempFile(randomUuid, ".properties");
+
+        FileBasedConfigurationTestHelper.forceOverwriteConfig(tempFile.toString());
+
+        DynatraceConfig config = new DynatraceConfig() {
+            // if nothing is set for uri and token, read from the file watcher
+            @Override
+            public DynatraceApiVersion apiVersion() {
+                return DynatraceApiVersion.V2;
+            }
+
+            @Nullable
+            @Override
+            public String get(String key) {
+                return null;
+            }
+        };
+
+        // set up mocks
+        HttpSender httpSender = mock(HttpSender.class);
+        MockClock clock = new MockClock();
+        DynatraceExporterV2 exporter = new DynatraceExporterV2(config, clock, httpSender);
+        DynatraceMeterRegistry meterRegistry = DynatraceMeterRegistry.builder(config).httpClient(httpSender).clock(clock).build();
+
+        when(httpSender.post(anyString())).thenCallRealMethod();
+        when(httpSender.newRequest(anyString())).thenCallRealMethod();
+        when(httpSender.send(any())).thenReturn(new HttpSender.Response(202, "{\n" +
+                "  \"linesOk\": 1,\n" +
+                "  \"linesInvalid\": 0,\n" +
+                "  \"error\": null,\n" +
+                "  \"warnings\": null\n" +
+                "}"));
+
+        // fill the file with content
+        final String baseUri = "https://your-dynatrace-ingest-url/api/v2/metrics/ingest/";
+        final String firstUri = baseUri + "first";
+        final String secondUri = baseUri + "second";
+
+        Files.write(tempFile,
+                ("DT_METRICS_INGEST_URL = " + firstUri + "\n" +
+                        "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.FIRST").getBytes());
+
+        // sleep for a short time so that the change can be picked up by the watcher
+        // This is only required in scenarios where writing and reading the file happens in very rapid succession
+        // (e.g. if both are done in one thread, as is the case in these tests).
+        Thread.sleep(10);
+
+        Counter counter = meterRegistry.counter("test.counter");
+        counter.increment(10);
+        clock.add(config.step());
+        exporter.export(Collections.singletonList(counter));
+
+        ArgumentCaptor<HttpSender.Request> firstRequestCaptor = ArgumentCaptor.forClass(HttpSender.Request.class);
+        verify(httpSender, times(1)).send(firstRequestCaptor.capture());
+        HttpSender.Request firstRequest = firstRequestCaptor.getValue();
+
+        assertThat(firstRequest.getUrl().toString()).isEqualTo(firstUri);
+        assertThat(firstRequest.getRequestHeaders()).containsOnly(
+                entry("Content-Type", "text/plain"),
+                entry("User-Agent", "micrometer"),
+                entry("Authorization", "Api-Token YOUR.DYNATRACE.TOKEN.FIRST")
+        );
+        String firstReqBody = new String(firstRequest.getEntity(), StandardCharsets.UTF_8);
+        assertThat(firstReqBody).isEqualTo("test.counter,dt.metrics.source=micrometer count,delta=10.0");
+
+        counter.increment(30);
+        clock.add(config.step());
+
+        // overwrite the file content to use the second uri
+        Files.write(tempFile,
+                ("DT_METRICS_INGEST_URL = " + secondUri + "\n" +
+                        "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.SECOND").getBytes());
+
+        Thread.sleep(10);
+        exporter.export(Collections.singletonList(counter));
+
+        ArgumentCaptor<HttpSender.Request> secondRequestCaptor = ArgumentCaptor.forClass(HttpSender.Request.class);
+        verify(httpSender, times(2)).send(secondRequestCaptor.capture());
+        HttpSender.Request secondRequest = secondRequestCaptor.getValue();
+
+        assertThat(secondRequest.getUrl().toString()).isEqualTo(secondUri);
+        assertThat(secondRequest.getRequestHeaders()).containsOnly(
+                entry("Content-Type", "text/plain"),
+                entry("User-Agent", "micrometer"),
+                entry("Authorization", "Api-Token YOUR.DYNATRACE.TOKEN.SECOND")
+        );
+        String secondReqBody = new String(secondRequest.getEntity(), StandardCharsets.UTF_8);
+        assertThat(secondReqBody).isEqualTo("test.counter,dt.metrics.source=micrometer count,delta=30.0");
     }
 
     private DynatraceExporterV2 createExporter(HttpSender httpClient) {


### PR DESCRIPTION
This PR introduces support for file-based configuration using the `DynatraceFileBasedConfigurationProvider`. It also makes sure changes in the file-based configuration are picked up, without having to restart the app to change configuration. 

This change adds another layer to the auto-configuration that is already available: Instead of falling back to the local OneAgent directly, the the file at `/var/lib/dynatrace/enrichment/endpoint/endpoint.properties` will be checked for configuration. The file will typically be provided by the [Dynatrace Operator](https://github.com/Dynatrace/dynatrace-operator) but can also just be added manually if you'd like to test it locally. I will follow up with a PR updating the documentation in `micrometer-docs` to describe the changes.