### PR TITLE
Use Collections.emptyMap()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static java.util.Collections.EMPTY_MAP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class KafkaMetricsTest {
@@ -532,9 +531,8 @@ class KafkaMetricsTest {
         kafkaMetrics.checkAndBindMetrics(registry);
     }
 
-    @SuppressWarnings("unchecked")
     private MetricName createMetricName(String name) {
-        return createMetricName(name, EMPTY_MAP);
+        return createMetricName(name, Collections.emptyMap());
     }
 
     private MetricName createMetricName(String name, String... keyValues) {


### PR DESCRIPTION
This PR changes to use `Collections.emptyMap()` instead of `Collections.EMPTY_MAP` to drop unchecked suppression.