### PR TITLE
Suppress "warning: no comment" in javadoc task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,7 @@ subprojects {
                         'implSpec:a:Implementation Requirements:',
                         'implNote:a:Implementation Note:'
                     )
+                    options.addBooleanOption('Xdoclint:all,-missing', true)
                 }
             }
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  * Cache<String, String> cache = Caffeine.newBuilder().recordStats().build();
  * CaffeineCacheMetrics.monitor(registry, cache, "mycache", "region", "test");
  * }</pre>
- * <p>
  *
  * @author Clint Checketts
  * @see CaffeineStatsCounter


### PR DESCRIPTION
This PR suppresses "warning: no comment" warnings in `javadoc` task as there are too many warnings to fix at once with JDK 17.

This PR also fixes the following Javadoc warning along the way:

> Task :micrometer-core:javadoc
/Users/user/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java:35: warning: empty \<p> tag
 \* \<p>
   ^
1 warning

Ideally, it would be better to fix them all gradually or at once at some point.