### PR TITLE
Polishing HandlerContext-related classes

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -340,6 +340,9 @@ public interface Timer extends Meter, HistogramSupport {
         }
     }
 
+    /**
+     * Nestable bounding for {@link Timer timed} operations that capture and pass along already opened scopes.
+     */
     class Scope implements Closeable {
         private final ThreadLocal<Sample> threadLocal;
         private final Sample currentSample;
@@ -363,10 +366,14 @@ public interface Timer extends Meter, HistogramSupport {
         }
     }
 
+    /**
+     * Context for {@link Sample} instances used by {@link TimerRecordingHandler} to pass arbitrary objects between
+     * handler methods. Usage is similar to the JDK {@link Map} API.
+     */
     @SuppressWarnings("unchecked")
     class HandlerContext implements TagsProvider {
         private final Map<Class<?>, Object> map = new HashMap<>();
-        
+
         public <T> HandlerContext put(Class<T> clazz, T object) {
             this.map.put(clazz, object);
             return this;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -51,10 +51,10 @@ public interface Timer extends Meter, HistogramSupport {
      * @return A timing sample with start time recorded.
      */
     static Sample start(MeterRegistry registry) {
-        return start(registry, null);
+        return start(registry, new HandlerContext());
     }
 
-    static Sample start(MeterRegistry registry, @Nullable HandlerContext handlerContext) {
+    static Sample start(MeterRegistry registry, HandlerContext handlerContext) {
         return new Sample(registry, handlerContext);
     }
 
@@ -263,10 +263,10 @@ public interface Timer extends Meter, HistogramSupport {
         private final HandlerContext handlerContext;
         private final MeterRegistry registry;
 
-        Sample(MeterRegistry registry, @Nullable HandlerContext ctx) {
+        Sample(MeterRegistry registry, HandlerContext ctx) {
             this.clock = registry.config().clock();
             this.startTime = clock.monotonicTime();
-            this.handlerContext = ctx == null ? new HandlerContext() : ctx;
+            this.handlerContext = ctx;
             this.handlers = registry.config().getTimerRecordingHandlers().stream()
                     .filter(handler -> handler.supportsContext(this.handlerContext))
                     .collect(Collectors.toList());

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpClientHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpClientHandlerContext.java
@@ -20,7 +20,8 @@ import io.micrometer.core.instrument.transport.http.HttpClientResponse;
 import io.micrometer.core.lang.NonNull;
 
 /**
- * An IntervalEvent that represents an HTTP client event.
+ * {@link io.micrometer.core.instrument.Timer.HandlerContext HandlerContext}
+ * for an HTTP client request/response.
  *
  * @author Jonatan Ivanov
  * @author Marcin Grzejszczak

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
@@ -16,10 +16,10 @@
 package io.micrometer.core.instrument.tracing.context;
 
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.transport.http.HttpRequest;
+import io.micrometer.core.instrument.transport.http.HttpResponse;
 import io.micrometer.core.lang.NonNull;
 import io.micrometer.core.lang.Nullable;
-import io.micrometer.core.instrument.transport.http.Request;
-import io.micrometer.core.instrument.transport.http.Response;
 
 /**
  * {@link io.micrometer.core.instrument.Timer.HandlerContext HandlerContext} for an HTTP exchange.
@@ -29,7 +29,7 @@ import io.micrometer.core.instrument.transport.http.Response;
  * @param <REQ> request type
  * @param <RES> response type
  */
-public abstract class HttpHandlerContext<REQ extends Request, RES extends Response> extends Timer.HandlerContext {
+public abstract class HttpHandlerContext<REQ extends HttpRequest, RES extends HttpResponse> extends Timer.HandlerContext {
 
     /**
      * Returns the HTTP request.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
@@ -22,7 +22,7 @@ import io.micrometer.core.instrument.transport.http.Request;
 import io.micrometer.core.instrument.transport.http.Response;
 
 /**
- * An IntervalEvent that represents an HTTP event.
+ * {@link io.micrometer.core.instrument.Timer.HandlerContext HandlerContext} for an HTTP exchange.
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0
@@ -48,10 +48,10 @@ public abstract class HttpHandlerContext<REQ extends Request, RES extends Respon
     abstract RES getResponse();
 
     /**
-     * Sets the given HTTP response on the event. Might be {@code null} when an
-     * exception occurred and there's no response.
+     * Sets the given HTTP response for this context. Might be {@code null} when an
+     * exception occurred and there is no response.
      *
-     * @param response a HTTP response
+     * @param response HTTP response
      * @return this
      */
     abstract HttpHandlerContext<REQ, RES> setResponse(RES response);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
@@ -54,6 +54,6 @@ public abstract class HttpHandlerContext<REQ extends Request, RES extends Respon
      * @param response HTTP response
      * @return this
      */
-    abstract HttpHandlerContext<REQ, RES> setResponse(RES response);
+    abstract HttpHandlerContext<REQ, RES> setResponse(@Nullable RES response);
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
@@ -20,7 +20,7 @@ import io.micrometer.core.instrument.transport.http.HttpServerRequest;
 import io.micrometer.core.instrument.transport.http.HttpServerResponse;
 
 /**
- * An IntervalEvent that represents an HTTP server event.
+ * {@link io.micrometer.core.instrument.Timer.HandlerContext HandlerContext} for an HTTP server request/response.
  *
  * @author Marcin Grzejszczak
  * @since 2.0.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
@@ -31,8 +31,6 @@ public class HttpServerHandlerContext extends HttpHandlerContext<HttpServerReque
 
     private HttpServerResponse response;
 
-    private Object handler;
-
     /**
      * Creates a new {@link HttpServerHandlerContext}.
      *
@@ -46,17 +44,6 @@ public class HttpServerHandlerContext extends HttpHandlerContext<HttpServerReque
     @Override
     public HttpServerRequest getRequest() {
         return this.request;
-    }
-
-    /**
-     * Sets a request handler.
-     *
-     * @param handler handler for this request
-     * @return this
-     */
-    public HttpServerHandlerContext setHandler(Object handler) {
-        this.handler = handler;
-        return this;
     }
 
     @Override


### PR DESCRIPTION
Polishes some of the new code added in 2.0 with JavaDocs, nullability, and removing unused code.

While we usually use squash commit, I think this would be better as a rebase to retain the individual commits, as I tried to make them into logical changes to keep the git history as clean as possible for future reference.