### PR TITLE
Introduce HttpTagsProvider with default implementation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -287,7 +287,8 @@ public interface Timer extends Meter, HistogramSupport {
         }
 
         /**
-         * Records the duration of the operation.
+         * Records the duration of the operation and adds tags to the {@link Timer.Builder} based on the
+         * {@link HandlerContext} for this {@link Sample}.
          *
          * @param timer The timer to record the sample to.
          * @return The total duration of the sample in nanoseconds

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/DefaultHttpTagsProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.http;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.transport.http.HttpRequest;
+import io.micrometer.core.instrument.transport.http.HttpResponse;
+
+/**
+ * Default implementation of {@link HttpTagsProvider} that can be extended for customization.
+ *
+ * @since 2.0.0
+ */
+public class DefaultHttpTagsProvider implements HttpTagsProvider {
+    @Override
+    public Tags getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
+        return Tags.of(HttpTags.method(request), HttpTags.uri(request), HttpTags.status(response),
+                HttpTags.outcome(response), HttpTags.exception(exception));
+    }
+
+    @Override
+    public Tags getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
+        return Tags.empty();
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpTags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpTags.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.http;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.transport.http.HttpRequest;
+import io.micrometer.core.instrument.transport.http.HttpResponse;
+import io.micrometer.core.instrument.util.StringUtils;
+
+/**
+ * Utility class providing convenience methods to generate tags for HTTP metrics based on
+ * the {@link HttpRequest} and {@link HttpResponse} abstraction.
+ *
+ * @author Jon Schneider
+ * @since 2.0.0
+ */
+public class HttpTags {
+    private static final Tag EXCEPTION_NONE = Tag.of("exception", "None");
+
+    private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+
+    private static final Tag METHOD_UNKNOWN = Tag.of("method", "UNKNOWN");
+
+    private static final Tag OUTCOME_UNKNOWN = Tag.of("outcome", "UNKNOWN");
+
+    private static final Tag URI_UNKNOWN = Tag.of("uri", "UNKNOWN");
+
+    private HttpTags() {
+    }
+
+    /**
+     * Creates a {@code method} tag based on the {@link HttpRequest#method()
+     * method} of the given {@code request}.
+     * @param request the request
+     * @return the method tag whose value is a capitalized method (e.g. GET).
+     */
+    public static Tag method(HttpRequest request) {
+        return (request != null) ? Tag.of("method", request.method()) : METHOD_UNKNOWN;
+    }
+
+    /**
+     * Creates a {@code status} tag based on the status of the given {@code response}.
+     * @param response the HTTP response
+     * @return the status tag derived from the status of the response
+     */
+    public static Tag status(HttpResponse response) {
+        return (response != null) ? Tag.of("status", Integer.toString(response.statusCode())) : STATUS_UNKNOWN;
+    }
+
+    /**
+     * Creates a {@code exception} tag based on the {@link Class#getSimpleName() simple
+     * name} of the class of the given {@code exception}.
+     * @param exception the exception, may be {@code null}
+     * @return the exception tag derived from the exception
+     */
+    public static Tag exception(Throwable exception) {
+        if (exception != null) {
+            String simpleName = exception.getClass().getSimpleName();
+            return Tag.of("exception", StringUtils.isNotBlank(simpleName) ? simpleName : exception.getClass().getName());
+        }
+        return EXCEPTION_NONE;
+    }
+
+    /**
+     * Creates an {@code outcome} tag based on the status of the given {@code response}.
+     * @param response the HTTP response
+     * @return the outcome tag derived from the status of the response
+     */
+    public static Tag outcome(HttpResponse response) {
+        return (response != null) ? Outcome.forStatus(response.statusCode()).asTag() : OUTCOME_UNKNOWN;
+    }
+
+    public static Tag uri(HttpRequest request) {
+        String uri = request.route();
+        return uri == null ? URI_UNKNOWN : Tag.of("uri", uri);
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpTagsProvider.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 VMware, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.http;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.transport.http.HttpRequest;
+import io.micrometer.core.instrument.transport.http.HttpResponse;
+
+/**
+ * Provides tags for HTTP-related metrics.
+ *
+ * @see HttpTags
+ */
+public interface HttpTagsProvider {
+
+    /**
+     * Default implementation.
+     */
+    HttpTagsProvider DEFAULT = new DefaultHttpTagsProvider();
+
+    /**
+     * Provide tags known to be low-cardinality, generally appropriate for use with metrics.
+     * These tags should not overlap with the tags provided by {@link #getHighCardinalityTags(HttpRequest, HttpResponse, Throwable)}.
+     *
+     * @param request http request
+     * @param response http response
+     * @param exception exception thrown during operation, or null
+     * @return set of tags based on the given parameters
+     */
+    Tags getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
+
+    /**
+     * Provide tags known to be high-cardinality, which generally are not appropriate for use with metrics.
+     * These tags should not overlap with the tags provided by {@link #getLowCardinalityTags(HttpRequest, HttpResponse, Throwable)}.
+     *
+     * @param request http request
+     * @param response http response
+     * @param exception exception thrown during operation, or null
+     * @return set of tags based on the given parameters
+     */
+    Tags getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpClientHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpClientHandlerContext.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.tracing.context;
 
+import io.micrometer.core.instrument.binder.http.HttpTagsProvider;
 import io.micrometer.core.instrument.transport.http.HttpClientRequest;
 import io.micrometer.core.instrument.transport.http.HttpClientResponse;
 import io.micrometer.core.lang.NonNull;
@@ -39,6 +40,12 @@ public class HttpClientHandlerContext extends HttpHandlerContext<HttpClientReque
      * @param request http client request
      */
     public HttpClientHandlerContext(HttpClientRequest request) {
+        super();
+        this.request = request;
+    }
+
+    public HttpClientHandlerContext(HttpClientRequest request, HttpTagsProvider tagsProvider) {
+        super(tagsProvider);
         this.request = request;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpHandlerContext.java
@@ -15,7 +15,9 @@
  */
 package io.micrometer.core.instrument.tracing.context;
 
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.http.HttpTagsProvider;
 import io.micrometer.core.instrument.transport.http.HttpRequest;
 import io.micrometer.core.instrument.transport.http.HttpResponse;
 import io.micrometer.core.lang.NonNull;
@@ -30,6 +32,16 @@ import io.micrometer.core.lang.Nullable;
  * @param <RES> response type
  */
 public abstract class HttpHandlerContext<REQ extends HttpRequest, RES extends HttpResponse> extends Timer.HandlerContext {
+
+    private final HttpTagsProvider tagsProvider;
+
+    public HttpHandlerContext() {
+        this(HttpTagsProvider.DEFAULT);
+    }
+
+    public HttpHandlerContext(HttpTagsProvider tagsProvider) {
+        this.tagsProvider = tagsProvider;
+    }
 
     /**
      * Returns the HTTP request.
@@ -56,4 +68,9 @@ public abstract class HttpHandlerContext<REQ extends HttpRequest, RES extends Ht
      */
     abstract HttpHandlerContext<REQ, RES> setResponse(@Nullable RES response);
 
+    @NonNull
+    @Override
+    public Tags getLowCardinalityTags() {
+        return this.tagsProvider.getLowCardinalityTags(getRequest(), getResponse(), null);
+    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/tracing/context/HttpServerHandlerContext.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.tracing.context;
 
+import io.micrometer.core.instrument.binder.http.HttpTagsProvider;
 import io.micrometer.core.lang.NonNull;
 import io.micrometer.core.instrument.transport.http.HttpServerRequest;
 import io.micrometer.core.instrument.transport.http.HttpServerResponse;
@@ -37,6 +38,12 @@ public class HttpServerHandlerContext extends HttpHandlerContext<HttpServerReque
      * @param request http server request
      */
     public HttpServerHandlerContext(HttpServerRequest request) {
+        super();
+        this.request = request;
+    }
+
+    public HttpServerHandlerContext(HttpServerRequest request, HttpTagsProvider tagsProvider) {
+        super(tagsProvider);
         this.request = request;
     }
 


### PR DESCRIPTION
This allows us to provide a consistent default set of HTTP tags derived from the abstract request/response API that instrumentation will wrap using their concrete HTTP request/response objects.
It also allows end users (not instrumentors) to provide their own implementation if they want a different set of tags without rewriting the instrumentation provided.

TODO:
- [ ] Tests
- [ ] Replace existing instrumentation in micrometer that could use this.

It's unfortunate it shares the name and purpose of the `TagsProvider` interface but does not extend it because it has parameters specific to it. Perhaps this is something to consider evolving in a more clear way later on.

Example usage of this in instrumentation is like the following. Pass an `HttpTagsProvider` instance to the `HttpHandlerContext` being used with your `Timer.start` calls. For convenience, a constructor without `HttpTagsProvider` is available that will use the default implementation.

```java
HttpClientRequest wrappedRequest = new SpringHttpClientRequest(request);
HttpClientHandlerContext handlerContext = new HttpClientHandlerContext(wrappedRequest, this.tagsProvider);
Timer.Sample sample = Timer.start(this.meterRegistry, handlerContext);

// do an HTTP operation

HttpClientResponse wrappedResponse = new SpringHttpClientResponse(response, wrappedRequest);
handlerContext.setResponse(wrappedResponse);
sample.stop(getTimeBuilder(wrappedRequest, wrappedResponse, null)); // a caught exception can be passed here instead of null
```