### PR TITLE
Add method to SimpleMeterRegistry for outputting all meters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
@@ -171,8 +171,7 @@ public class SimpleMeterRegistry extends MeterRegistry {
      * @return text representation of the meters in the registry
      */
     @Incubating(since = "2022-01-06")
-    @Override
-    public String toString() {
+    public String getMetersAsString() {
         return this.getMeters().stream()
                 .sorted(Comparator.comparing(meter -> meter.getId().getName()))
                 .map(this::toString)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
@@ -16,13 +16,18 @@
 package io.micrometer.core.instrument.simple;
 
 import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
@@ -31,8 +36,12 @@ import io.micrometer.core.instrument.step.StepFunctionTimer;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -55,7 +64,7 @@ class SimpleMeterRegistryTest {
         summary.record(1);
 
         Timer timer = Timer.builder("my.timer").serviceLevelObjectives(Duration.ofMillis(1)).register(registry);
-        timer.record(1, TimeUnit.MILLISECONDS);
+        timer.record(1, MILLISECONDS);
 
         Gauge summaryHist1 = registry.get("my.summary.histogram").tags("le", "1").gauge();
         Gauge summaryHist2 = registry.get("my.summary.histogram").tags("le", "2").gauge();
@@ -102,6 +111,85 @@ class SimpleMeterRegistryTest {
         Meter.Id id = new Meter.Id("some.timer", Tags.empty(), null, null, Meter.Type.COUNTER);
         FunctionCounter functionCounter = registry.newFunctionCounter(id, null, (o) -> 0d);
         assertThat(functionCounter).isInstanceOf(StepFunctionCounter.class);
+    }
+
+    @Test
+    void stringRepresentationOfMetersShouldBeOk() {
+        MockClock clock = new MockClock();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+
+        AtomicInteger temperature = new AtomicInteger(24);
+        Gauge.builder("temperature", () -> temperature)
+                .baseUnit("celsius")
+                .register(registry);
+
+        Counter correctAnswers = Counter.builder("answers")
+                .tag("correct", "true")
+                .register(registry);
+        correctAnswers.increment();
+        correctAnswers.increment();
+
+        Counter incorrectAnswers = Counter.builder("answers")
+                .tag("correct", "false")
+                .register(registry);
+        incorrectAnswers.increment();
+
+        Timer latency = Timer.builder("latency")
+                .tag("service", "test")
+                .tag("method", "GET")
+                .tag("uri", "/api/people")
+                .register(registry);
+
+        DistributionSummary requestSize = DistributionSummary.builder("request.size")
+                .baseUnit("bytes")
+                .register(registry);
+
+        for (int i = 0; i < 10; i++) {
+            latency.record(Duration.ofMillis(20 + i * 2));
+            requestSize.record(100 + i * 10);
+        }
+
+        LongTaskTimer handler = LongTaskTimer.builder("handler").register(registry);
+        LongTaskTimer.Sample sample = handler.start();
+        clock.add(Duration.ofSeconds(3));
+
+        AtomicLong processingTime = new AtomicLong(300);
+        TimeGauge.builder("processing.time", () -> processingTime, MILLISECONDS).register(registry);
+
+        AtomicInteger cacheMisses = new AtomicInteger(42);
+        FunctionCounter.builder("cache.miss", cacheMisses, AtomicInteger::doubleValue).register(registry);
+
+        AtomicLong cacheLatency = new AtomicLong(100);
+        FunctionTimer.builder("cache.latency", cacheLatency, obj -> 5, AtomicLong::doubleValue, MILLISECONDS).register(registry);
+
+        Meter.builder(
+                "custom.meter",
+                Meter.Type.OTHER,
+                Arrays.asList(
+                        new Measurement(() -> 42d, Statistic.VALUE),
+                        new Measurement(() -> 21d, Statistic.UNKNOWN)
+                )
+        ).register(registry);
+
+        assertThat(registry.toString()).isEqualTo(""
+                + "answers.count(COUNTER)[correct='true'] 2.0\n"
+                + "answers.count(COUNTER)[correct='false'] 1.0\n"
+                + "cache.latency.count.seconds(TIMER)[] 5.0\n"
+                + "cache.latency.total_time.seconds(TIMER)[] 0.1\n"
+                + "cache.miss.count(COUNTER)[] 42.0\n"
+                + "custom.meter.value(OTHER)[] 42.0\n"
+                + "custom.meter.unknown(OTHER)[] 21.0\n"
+                + "handler.active_tasks.seconds(LONG_TASK_TIMER)[] 1.0\n"
+                + "handler.duration.seconds(LONG_TASK_TIMER)[] 3.0E9\n" // this should be 3.0 but there is a bug in LongTaskTimer (fixing later)
+                + "latency.count.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 10.0\n"
+                + "latency.total_time.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.29\n"
+                + "latency.max.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.038\n"
+                + "processing.time.value.seconds(GAUGE)[] 0.3\n"
+                + "request.size.count.bytes(DISTRIBUTION_SUMMARY)[] 10.0\n"
+                + "request.size.total.bytes(DISTRIBUTION_SUMMARY)[] 1450.0\n"
+                + "request.size.max.bytes(DISTRIBUTION_SUMMARY)[] 190.0\n"
+                + "temperature.value.celsius(GAUGE)[] 24.0");
+        sample.stop();
     }
 
     private SimpleMeterRegistry createRegistry(CountingMode mode) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
@@ -171,7 +171,7 @@ class SimpleMeterRegistryTest {
                 )
         ).register(registry);
 
-        assertThat(registry.toString()).isEqualTo(""
+        assertThat(registry.getMetersAsString()).isEqualTo(""
                 + "answers.count(COUNTER)[correct='true'] 2.0\n"
                 + "answers.count(COUNTER)[correct='false'] 1.0\n"
                 + "cache.latency.count.seconds(TIMER)[] 5.0\n"

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
@@ -180,7 +180,7 @@ class SimpleMeterRegistryTest {
                 + "custom.meter.value(OTHER)[] 42.0\n"
                 + "custom.meter.unknown(OTHER)[] 21.0\n"
                 + "handler.active_tasks.seconds(LONG_TASK_TIMER)[] 1.0\n"
-                + "handler.duration.seconds(LONG_TASK_TIMER)[] 3.0E9\n" // this should be 3.0 but there is a bug in LongTaskTimer (fixing later)
+                + "handler.duration.seconds(LONG_TASK_TIMER)[] 3.0\n"
                 + "latency.count.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 10.0\n"
                 + "latency.total_time.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.29\n"
                 + "latency.max.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.038\n"


### PR DESCRIPTION
You can see the output in the test, it should look like this:
```
answers.count(COUNTER)[correct='true'] 2.0
answers.count(COUNTER)[correct='false'] 1.0
cache.latency.count.seconds(TIMER)[] 5.0
cache.latency.total_time.seconds(TIMER)[] 0.1
cache.miss.count(COUNTER)[] 42.0
custom.meter.value(OTHER)[] 42.0
custom.meter.unknown(OTHER)[] 21.0
handler.active_tasks.seconds(LONG_TASK_TIMER)[] 1.0
handler.duration.seconds(LONG_TASK_TIMER)[] 3.0
latency.count.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 10.0
latency.total_time.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.29
latency.max.seconds(TIMER)[method='GET', service='test', uri='/api/people'] 0.038
processing.time.value.seconds(GAUGE)[] 0.3
request.size.count.bytes(DISTRIBUTION_SUMMARY)[] 10.0
request.size.total.bytes(DISTRIBUTION_SUMMARY)[] 1450.0
request.size.max.bytes(DISTRIBUTION_SUMMARY)[] 190.0
temperature.value.celsius(GAUGE)[] 24.0
```