### PR TITLE
Fix duration conversion of LongTaskTimer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -195,7 +195,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
     default Iterable<Measurement> measure() {
         return Arrays.asList(
                 new Measurement(() -> (double) activeTasks(), Statistic.ACTIVE_TASKS),
-                new Measurement(() -> duration(TimeUnit.NANOSECONDS), Statistic.DURATION)
+                new Measurement(() -> duration(baseTimeUnit()), Statistic.DURATION)
         );
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/DefaultLongTaskTimerTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/DefaultLongTaskTimerTest.java
@@ -33,8 +33,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.core.instrument.MockClock.clock;
-import static io.micrometer.core.instrument.Statistic.ACTIVE_TASKS;
-import static io.micrometer.core.instrument.Statistic.DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultLongTaskTimerTest {
@@ -95,26 +93,5 @@ public class DefaultLongTaskTimerTest {
         while (index < countAtBuckets.length) {
             assertThat(countAtBuckets[index++].count()).isEqualTo(2);
         }
-    }
-
-    @Test
-    void measure() {
-        MockClock clock = new MockClock();
-        SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
-        LongTaskTimer ltt = LongTaskTimer.builder("test.ltt").register(registry);
-        LongTaskTimer.Sample sample = ltt.start();
-        clock.add(Duration.ofSeconds(3));
-
-        assertThat(ltt.measure()).satisfiesExactlyInAnyOrder(
-                measurement -> assertThat(measurement).satisfies(m -> {
-                    assertThat(m.getValue()).isEqualTo(1.0);
-                    assertThat(m.getStatistic()).isSameAs(ACTIVE_TASKS);
-                }),
-                measurement -> assertThat(measurement).satisfies(m -> {
-                    assertThat(m.getValue()).isEqualTo(3.0);
-                    assertThat(m.getStatistic()).isSameAs(DURATION);
-                })
-        );
-        sample.stop();
     }
 }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/DefaultLongTaskTimerTest.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/DefaultLongTaskTimerTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static io.micrometer.core.instrument.MockClock.clock;
+import static io.micrometer.core.instrument.Statistic.ACTIVE_TASKS;
+import static io.micrometer.core.instrument.Statistic.DURATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultLongTaskTimerTest {
@@ -93,5 +95,26 @@ public class DefaultLongTaskTimerTest {
         while (index < countAtBuckets.length) {
             assertThat(countAtBuckets[index++].count()).isEqualTo(2);
         }
+    }
+
+    @Test
+    void measure() {
+        MockClock clock = new MockClock();
+        SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+        LongTaskTimer ltt = LongTaskTimer.builder("test.ltt").register(registry);
+        LongTaskTimer.Sample sample = ltt.start();
+        clock.add(Duration.ofSeconds(3));
+
+        assertThat(ltt.measure()).satisfiesExactlyInAnyOrder(
+                measurement -> assertThat(measurement).satisfies(m -> {
+                    assertThat(m.getValue()).isEqualTo(1.0);
+                    assertThat(m.getStatistic()).isSameAs(ACTIVE_TASKS);
+                }),
+                measurement -> assertThat(measurement).satisfies(m -> {
+                    assertThat(m.getValue()).isEqualTo(3.0);
+                    assertThat(m.getStatistic()).isSameAs(DURATION);
+                })
+        );
+        sample.stop();
     }
 }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -391,7 +391,6 @@ public abstract class MeterRegistryCompatibilityKit {
                         assertThat(m.getStatistic()).isSameAs(DURATION);
                     })
             );
-            sample.stop();
 
             clock(registry).add(10, TimeUnit.NANOSECONDS);
             sample.stop();


### PR DESCRIPTION
If you call the measure method of LongTaskTimer and check the duration, it's always in nanoseconds instead of the baseUnit.
It seems the original intention was using the base unit: https://github.com/micrometer-metrics/micrometer/commit/70925b355a6f795f3f10477023fab0b2cdafa72f#diff-551e65260957b90931b406fcb647b39367c83d11aa8f07d3f388c667d60f8971R124
fixes gh-2947