### PR TITLE
Use managed version for hazelcast in micrometer-samples-hazelcast

### DIFF
--- a/samples/micrometer-samples-hazelcast/build.gradle
+++ b/samples/micrometer-samples-hazelcast/build.gradle
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     implementation project(':micrometer-core')
-    implementation 'com.hazelcast:hazelcast:4.+'
+    implementation 'com.hazelcast:hazelcast'
     implementation 'ch.qos.logback:logback-classic'
 }


### PR DESCRIPTION
This PR changes to use the managed version for `com.hazelcast:hazelcast` in the `micrometer-samples-hazelcast` sample project.