### PR TITLE
Update "system.cpu.usage" description to match the updated JVM behavior

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -102,7 +102,7 @@ public class ProcessorMetrics implements MeterBinder {
         if (systemCpuUsage != null) {
             Gauge.builder("system.cpu.usage", operatingSystemBean, x -> invoke(systemCpuUsage))
                 .tags(tags)
-                .description("The \"recent cpu usage\" for the whole system")
+                .description("The \"recent cpu usage\" of the system the application is running in")
                 .register(registry);
         }
 


### PR DESCRIPTION
Updated `system.cpu.usage` metric description to match the changed JVM behavior introduced by https://bugs.openjdk.java.net/browse/JDK-8265836.

The current metrics behavior:
* If application runs in a containerized environment with either quota or share applied (not the default 1024, refer to [this](https://github.com/openjdk/jdk8u/blob/master/jdk/src/linux/classes/jdk/internal/platform/cgroupv1/Metrics.java#L350)), it reports container level CPU utilization.
* In other environment, it reports system level CPU utilization.

Refer to https://github.com/micrometer-metrics/micrometer/issues/2944. cc @jonatan-ivanov 
