### PR TITLE
Drop summary and timer lines with a count of 0 in the Dynatrace exporter

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -174,6 +174,10 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private Stream<String> toSummaryLine(Meter meter, HistogramSnapshot histogramSnapshot, TimeUnit timeUnit) {
         long count = histogramSnapshot.count();
+        if (count < 1) {
+            logger.debug("Summary with 0 count dropped: %s", meter.getId().getName());
+            return Stream.empty();
+        }
         double total = (timeUnit != null) ? histogramSnapshot.total(timeUnit) : histogramSnapshot.total();
         double max = (timeUnit != null) ? histogramSnapshot.max(timeUnit) : histogramSnapshot.max();
         double min = (count == 1) ? max : minFromHistogramSnapshot(histogramSnapshot, timeUnit);
@@ -218,9 +222,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toFunctionTimerLine(FunctionTimer meter) {
+        long count = (long) meter.count();
+        if (count < 1) {
+            logger.debug("Timer with 0 count dropped: %s", meter.getId().getName());
+            return Stream.empty();
+        }
         double total = meter.totalTime(getBaseTimeUnit());
         double average = meter.mean(getBaseTimeUnit());
-        long count = Double.valueOf(meter.count()).longValue();
 
         return createSummaryLine(meter, average, average, total, count);
     }


### PR DESCRIPTION
With this change, Dynatrace metrics lines (summaries and timers) with a count of 0 are dropped on the exporter side.