### PR TITLE
Use Testcontainers for MongoDB integration tests

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -25,7 +25,6 @@ def VERSIONS = [
         'com.squareup.okhttp3:okhttp:latest.release',
         'com.tngtech.archunit:archunit-junit5:latest.release',
         'com.wavefront:wavefront-sdk-java:latest.release',
-        'de.flapdoodle.embed:de.flapdoodle.embed.mongo:latest.release',
         'io.dropwizard.metrics:metrics-core:4.+',
         'io.dropwizard.metrics:metrics-graphite:4.+',
         'io.dropwizard.metrics:metrics-jmx:4.+',
@@ -74,6 +73,7 @@ def VERSIONS = [
         'org.testcontainers:junit-jupiter:latest.release',
         'org.testcontainers:kafka:latest.release',
         'org.testcontainers:postgresql:latest.release',
+        'org.testcontainers:mongodb:latest.release',
         'org.testcontainers:testcontainers:latest.release',
         'ru.lanwen.wiremock:wiremock-junit5:latest.release',
         'software.amazon.awssdk:cloudwatch:latest.release'

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -89,8 +89,6 @@ dependencies {
     testImplementation 'ru.lanwen.wiremock:wiremock-junit5'
     testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
 
-    testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
-
     // Log4j2 Async dependency
     testImplementation 'com.lmax:disruptor:3.4.+'
 
@@ -102,6 +100,8 @@ dependencies {
     // Postgres Binder IT dependencies
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.postgresql:postgresql'
+
+    testImplementation 'org.testcontainers:mongodb'
 }
 
 task shenandoahTest(type: Test) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/AbstractMongoDbTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/AbstractMongoDbTest.java
@@ -15,51 +15,33 @@
  */
 package io.micrometer.core.instrument.binder.mongodb;
 
-import de.flapdoodle.embed.mongo.MongodExecutable;
-import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.MongodConfig;
-import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.runtime.Network;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-
-import java.io.IOException;
-
-import static de.flapdoodle.embed.mongo.MongodStarter.getDefaultInstance;
+import org.junit.jupiter.api.Tag;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
 
 /**
- * Base class for testing MongoDB client based on embedded MongoDB.
+ * Base class for testing MongoDB client based on Testcontainers.
  *
  * @author Christophe Bornet
+ * @author Johnny Lim
  */
+@Testcontainers
+@Tag("docker")
 abstract class AbstractMongoDbTest {
 
-    static final String HOST = "localhost";
+    @Container
+    private final MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"));
 
+    String host;
     int port;
 
-    private MongodExecutable mongodExecutable;
-
     @BeforeEach
-    void startEmbeddedMongoDb() throws IOException {
-        MongodStarter starter = getDefaultInstance();
-
-        port = Network.freeServerPort(Network.getLocalHost());
-
-        MongodConfig mongodConfig = MongodConfig.builder()
-                .version(Version.Main.PRODUCTION)
-                .net(new Net(HOST, port, Network.localhostIsIPv6()))
-                .build();
-        mongodExecutable = starter.prepare(mongodConfig);
-        mongodExecutable.start();
-    }
-
-    @AfterEach
-    void stopEmbeddedMongoDb() {
-        if (mongodExecutable != null) {
-            mongodExecutable.stop();
-        }
+    void setUp() {
+        host = mongoDBContainer.getHost();
+        port = mongoDBContainer.getFirstMappedPort();
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
@@ -61,7 +61,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         MongoClientSettings settings = MongoClientSettings.builder()
                 .addCommandListener(new MongoMetricsCommandListener(registry))
                 .applyToClusterSettings(builder -> builder
-                        .hosts(singletonList(new ServerAddress(HOST, port)))
+                        .hosts(singletonList(new ServerAddress(host, port)))
                         .addClusterListener(new ClusterListener() {
                             @Override
                             public void clusterOpening(ClusterOpeningEvent event) {
@@ -79,7 +79,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
-                "server.address", String.format("%s:%s", HOST, port),
+                "server.address", String.format("%s:%s", host, port),
                 "command", "insert",
                 "collection", "testCol",
                 "status", "SUCCESS"
@@ -95,7 +95,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
-                "server.address", String.format("%s:%s", HOST, port),
+                "server.address", String.format("%s:%s", host, port),
                 "command", "dropIndexes",
                 "collection", "testCol",
                 "status", "FAILED"
@@ -114,7 +114,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         MongoClientSettings settings = MongoClientSettings.builder()
                 .addCommandListener(new MongoMetricsCommandListener(registry, tagsProvider))
                 .applyToClusterSettings(builder -> builder
-                        .hosts(singletonList(new ServerAddress(HOST, port)))
+                        .hosts(singletonList(new ServerAddress(host, port)))
                         .addClusterListener(new ClusterListener() {
                             @Override
                             public void clusterOpening(ClusterOpeningEvent event) {
@@ -128,7 +128,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
                     .insertOne(new Document("testDoc", new Date()));
             Tags tags = Tags.of(
                     "cluster.id", clusterId.get(),
-                    "server.address", String.format("%s:%s", HOST, port),
+                    "server.address", String.format("%s:%s", host, port),
                     "command", "insert",
                     "collection", "testCol",
                     "status", "SUCCESS",
@@ -149,7 +149,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         MongoClientSettings settings = MongoClientSettings.builder()
                 .addCommandListener(new MongoMetricsCommandListener(registry, tagsProvider))
                 .applyToClusterSettings(builder -> builder
-                        .hosts(singletonList(new ServerAddress(HOST, port)))
+                        .hosts(singletonList(new ServerAddress(host, port)))
                         .addClusterListener(new ClusterListener() {
                             @Override
                             public void clusterOpening(ClusterOpeningEvent event) {
@@ -163,7 +163,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
                     .dropIndex("nonExistentIndex");
             Tags tags = Tags.of(
                     "cluster.id", clusterId.get(),
-                    "server.address", String.format("%s:%s", HOST, port),
+                    "server.address", String.format("%s:%s", host, port),
                     "command", "dropIndexes",
                     "collection", "testCol",
                     "status", "FAILED",

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
@@ -55,7 +55,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
                         .addConnectionPoolListener(new MongoMetricsConnectionPoolListener(registry))
                 )
                 .applyToClusterSettings(builder -> builder
-                        .hosts(singletonList(new ServerAddress(HOST, port)))
+                        .hosts(singletonList(new ServerAddress(host, port)))
                         .addClusterListener(new ClusterListener() {
                             @Override
                             public void clusterOpening(ClusterOpeningEvent event) {
@@ -70,7 +70,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
-                "server.address", String.format("%s:%s", HOST, port)
+                "server.address", String.format("%s:%s", host, port)
         );
 
         assertThat(registry.get("mongodb.driver.pool.size").tags(tags).gauge().value()).isEqualTo(2);
@@ -100,7 +100,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
                         .addConnectionPoolListener(connectionPoolListener)
                 )
                 .applyToClusterSettings(builder -> builder
-                        .hosts(singletonList(new ServerAddress(HOST, port)))
+                        .hosts(singletonList(new ServerAddress(host, port)))
                         .addClusterListener(new ClusterListener() {
                             @Override
                             public void clusterOpening(ClusterOpeningEvent event) {
@@ -115,7 +115,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
 
         Tags tags = Tags.of(
                 "cluster.id", clusterId.get(),
-                "server.address", String.format("%s:%s", HOST, port),
+                "server.address", String.format("%s:%s", host, port),
                 "my.custom.connection.pool.identifier", "custom"
         );
 
@@ -132,7 +132,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
 
     @Issue("#2384")
     void whenConnectionCheckedInAfterPoolClose_thenNoExceptionThrown() {
-        ServerId serverId = new ServerId(new ClusterId(), new ServerAddress(HOST, port));
+        ServerId serverId = new ServerId(new ClusterId(), new ServerAddress(host, port));
         ConnectionId connectionId = new ConnectionId(serverId);
         MongoMetricsConnectionPoolListener listener = new MongoMetricsConnectionPoolListener(registry);
         listener.connectionPoolCreated(new ConnectionPoolCreatedEvent(serverId, ConnectionPoolSettings.builder().build()));


### PR DESCRIPTION
This PR changes to use Testcontainers for MongoDB integration tests.