### PR TITLE
Upgrade Elasticsearch Docker image to 7.16.3 in integration tests

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch7IntegrationTest.java
@@ -25,7 +25,7 @@ class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
 
     @Override
     protected String getVersion() {
-        return "7.15.0";
+        return "7.16.3";
     }
 
 }


### PR DESCRIPTION
This PR upgrades Elasticsearch Docker image to 7.16.3 in integration tests.