### PR TITLE
Improve cacheability ignoring Java vendor and minor version in Nebula's generated manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,9 @@ subprojects {
                         'Change',
                         'Full-Change',
                         'Branch',
-                        'Module-Origin'
+                        'Module-Origin',
+                        'Created-By',
+                        'Build-Java-Version'
                     ].each {
                         ignoreAttribute it
                         ignoreProperty it


### PR DESCRIPTION
The _Manifest_ created by [Nebula plugins](https://github.com/nebula-plugins/gradle-info-plugin) has some properties depending on _Java vendor_ and _minor version_.

An example in _micrometer-test/build/manifest/micrometer-test.properties_:
```
Created-By=11.0.12+7 (Eclipse Foundation)
Build-Java-Version=11.0.12
```

This leads to cache misses when using a different _Java vendor / minor version_ than what was used for the build which fed the cache in the first place. 