### PR TITLE
Adding support for Apache HttpClient 5

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -43,6 +43,7 @@ def VERSIONS = [
         'net.sf.ehcache:ehcache:latest.release',
         'org.apache.httpcomponents:httpasyncclient:latest.release',
         'org.apache.httpcomponents:httpclient:latest.release',
+        'org.apache.httpcomponents.client5:httpclient5:latest.release',
         'org.apache.kafka:kafka-clients:2.+',
         'org.apache.kafka:kafka-streams:2.+',
         'org.apache.logging.log4j:log4j-core:2.+',

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // apache httpcomponents monitoring
     optionalApi 'org.apache.httpcomponents:httpclient'
     optionalApi 'org.apache.httpcomponents:httpasyncclient'
+    optionalApi 'org.apache.httpcomponents.client5:httpclient5'
 
     // hystrix monitoring
     optionalApi 'com.netflix.hystrix:hystrix-core'

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultUriMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultUriMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import java.util.function.Function;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpRequest;
+
+
+/**
+ * Extracts the URI pattern from the predefined request header, {@value DefaultUriMapper#URI_PATTERN_HEADER} if available.
+ *
+ * @author Benjamin Hubert
+ * @since 1.9.0
+ */
+public class DefaultUriMapper implements Function<HttpRequest, String> {
+
+    /**
+     * Header name for URI pattern.
+     */
+    public static final String URI_PATTERN_HEADER = "URI_PATTERN";
+
+    @Override
+    public String apply(HttpRequest httpRequest) {
+        Header uriPattern = httpRequest.getLastHeader(URI_PATTERN_HEADER);
+        if (uriPattern != null && uriPattern.getValue() != null) {
+            return uriPattern.getValue();
+        }
+        return "UNKNOWN";
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/HttpContextUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/HttpContextUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.Tags;
+import org.apache.hc.client5.http.RouteInfo;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+class HttpContextUtils {
+    static Tags generateTagsForRoute(HttpContext context) {
+        String targetScheme = "UNKNOWN";
+        String targetHost = "UNKNOWN";
+        String targetPort = "UNKNOWN";
+        Object routeAttribute = context.getAttribute(HttpClientContext.HTTP_ROUTE);
+        if (routeAttribute instanceof RouteInfo) {
+            HttpHost host = ((RouteInfo) routeAttribute).getTargetHost();
+            targetScheme = host.getSchemeName();
+            targetHost = host.getHostName();
+            targetPort = String.valueOf(host.getPort());
+        }
+        return Tags.of(
+                "target.scheme", targetScheme,
+                "target.host", targetHost,
+                "target.port", targetPort
+        );
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import io.micrometer.core.annotation.Incubating;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.HttpResponseInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * Provides {@link HttpRequestInterceptor} and {@link HttpResponseInterceptor} for
+ * configuring with an {@link org.apache.hc.client5.http.async.HttpAsyncClient}. Usage example:
+ * <pre>{@code
+ *     MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
+ *             request -> request.getRequestLine().getUri(),
+ *             Tags.empty(),
+ *             true);
+ *
+ *     CloseableHttpAsyncClient httpAsyncClient = HttpAsyncClients.custom()
+ *             .addInterceptorFirst(interceptor.getRequestInterceptor())
+ *             .addInterceptorLast(interceptor.getResponseInterceptor())
+ *             .build();
+ * }</pre>
+ *
+ * @author Jon Schneider
+ * @since 1.9.0
+ */
+@Incubating(since = "1.9.0")
+public class MicrometerHttpClientInterceptor {
+    private static final String METER_NAME = "httpcomponents.httpclient.request";
+
+    private final Map<HttpContext, Timer.ResourceSample> timerByHttpContext = new ConcurrentHashMap<>();
+
+    private final HttpRequestInterceptor requestInterceptor;
+    private final HttpResponseInterceptor responseInterceptor;
+
+    /**
+     * Create a {@code MicrometerHttpClientInterceptor} instance.
+     *
+     * @param meterRegistry      meter registry to bind
+     * @param uriMapper          URI mapper to create {@code uri} tag
+     * @param extraTags          extra tags
+     * @param exportTagsForRoute whether to export tags for route
+     */
+    public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry,
+                                           Function<HttpRequest, String> uriMapper,
+                                           Iterable<Tag> extraTags,
+                                           boolean exportTagsForRoute) {
+        this.requestInterceptor = (request, entity, context) -> timerByHttpContext.put(context, Timer.resource(meterRegistry, METER_NAME)
+                .tags("method", request.getMethod(), "uri", uriMapper.apply(request)));
+
+        this.responseInterceptor = (response, entity, context) ->
+            timerByHttpContext.remove(context)
+                    .tag("status", Integer.toString(response.getCode()))
+                    .tags(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
+                    .tags(extraTags)
+                    .close();
+    }
+
+    /**
+     * Create a {@code MicrometerHttpClientInterceptor} instance with {@link DefaultUriMapper}.
+     *
+     * @param meterRegistry      meter registry to bind
+     * @param extraTags          extra tags
+     * @param exportTagsForRoute whether to export tags for route
+     */
+    public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry,
+                                           Iterable<Tag> extraTags,
+                                           boolean exportTagsForRoute) {
+        this(meterRegistry, new DefaultUriMapper(), extraTags, exportTagsForRoute);
+    }
+
+    public HttpRequestInterceptor getRequestInterceptor() {
+        return requestInterceptor;
+    }
+
+    public HttpResponseInterceptor getResponseInterceptor() {
+        return responseInterceptor;
+    }
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2019 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Function;
+
+import io.micrometer.core.annotation.Incubating;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ConnectionReuseStrategy;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.impl.Http1StreamListener;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.HttpClientConnection;
+import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.Timeout;
+
+
+/**
+ * This HttpRequestExecutor tracks the request duration of every request, that
+ * goes through an {@link HttpClient}. It must be
+ * registered as request executor when creating the HttpClient instance.
+ * For example:
+ *
+ * <pre>
+ *     HttpClientBuilder.create()
+ *         .setRequestExecutor(MicrometerHttpRequestExecutor
+ *                 .builder(meterRegistry)
+ *                 .build())
+ *         .build();
+ * </pre>
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @author Tommy Ludwig
+ * @since 1.9.0
+ */
+@Incubating(since = "1.9.0")
+public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
+
+    private static final String METER_NAME = "httpcomponents.httpclient.request";
+
+    private static final Tag STATUS_UNKNOWN = Tag.of("status", "UNKNOWN");
+    private static final Tag STATUS_CLIENT_ERROR = Tag.of("status", "CLIENT_ERROR");
+    private static final Tag STATUS_IO_ERROR = Tag.of("status", "IO_ERROR");
+
+    private final MeterRegistry registry;
+    private final Function<HttpRequest, String> uriMapper;
+    private final Iterable<Tag> extraTags;
+    private final boolean exportTagsForRoute;
+
+    /**
+     * Use {@link #builder(MeterRegistry)} to create an instance of this class.
+     */
+    private MicrometerHttpRequestExecutor(Timeout waitForContinue,
+                                          ConnectionReuseStrategy connReuseStrategy,
+                                          Http1StreamListener streamListener,
+                                          MeterRegistry registry,
+                                          Function<HttpRequest, String> uriMapper,
+                                          Iterable<Tag> extraTags,
+                                          boolean exportTagsForRoute) {
+        super(waitForContinue, connReuseStrategy, streamListener);
+        this.registry = Optional.ofNullable(registry).orElseThrow(() -> new IllegalArgumentException("registry is required but has been initialized with null"));
+        this.uriMapper = Optional.ofNullable(uriMapper).orElseThrow(() -> new IllegalArgumentException("uriMapper is required but has been initialized with null"));
+        this.extraTags = Optional.ofNullable(extraTags).orElse(Collections.emptyList());
+        this.exportTagsForRoute = exportTagsForRoute;
+    }
+
+    /**
+     * Use this method to create an instance of {@link MicrometerHttpRequestExecutor}.
+     *
+     * @param registry The registry to register the metrics to.
+     * @return An instance of the builder, which allows further configuration of
+     * the request executor.
+     */
+    public static Builder builder(MeterRegistry registry) {
+        return new Builder(registry);
+    }
+
+    @Override
+    public ClassicHttpResponse execute(
+            final ClassicHttpRequest request,
+            final HttpClientConnection conn,
+            final HttpResponseInformationCallback informationCallback,
+            final HttpContext context) throws IOException, HttpException {
+        Timer.Sample timerSample = Timer.start(registry);
+
+        Tag method = Tag.of("method", request.getMethod());
+        Tag uri = Tag.of("uri", uriMapper.apply(request));
+        Tag status = STATUS_UNKNOWN;
+
+        Tags routeTags = exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty();
+
+        try {
+            ClassicHttpResponse response = super.execute(request, conn, informationCallback, context);
+            status = response != null ? Tag.of("status", Integer.toString(response.getCode())) : STATUS_CLIENT_ERROR;
+            return response;
+        } catch (IOException | HttpException | RuntimeException e) {
+            status = STATUS_IO_ERROR;
+            throw e;
+        } finally {
+            Iterable<Tag> tags = Tags.of(extraTags)
+                    .and(routeTags)
+                    .and(uri, method, status);
+
+            timerSample.stop(Timer.builder(METER_NAME)
+                    .description("Duration of Apache HttpClient request execution")
+                    .tags(tags)
+                    .register(registry));
+        }
+    }
+
+    public static class Builder {
+        private final MeterRegistry registry;
+        private Timeout waitForContinue = HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE;
+        private ConnectionReuseStrategy connectionReuseStrategy;
+        private Http1StreamListener streamListener;
+        private Iterable<Tag> tags = Collections.emptyList();
+        private Function<HttpRequest, String> uriMapper = new DefaultUriMapper();
+        private boolean exportTagsForRoute = false;
+
+        Builder(MeterRegistry registry) {
+            this.registry = registry;
+        }
+
+        /**
+         * @param waitForContinue Overrides the wait for continue time for this
+         *                        request executor. See {@link HttpRequestExecutor}
+         *                        for details.
+         * @return This builder instance.
+         */
+        public Builder waitForContinue(Timeout waitForContinue) {
+            this.waitForContinue = waitForContinue;
+            return this;
+        }
+
+        public Builder connectionReuseStrategy(ConnectionReuseStrategy connectionReuseStrategy) {
+            this.connectionReuseStrategy = connectionReuseStrategy;
+            return this;
+        }
+
+        public Builder streamListener(Http1StreamListener streamListener) {
+            this.streamListener = streamListener;
+            return this;
+        }
+
+        /**
+         * @param tags Additional tags which should be exposed with every value.
+         * @return This builder instance.
+         */
+        public Builder tags(Iterable<Tag> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        /**
+         * Allows to register a mapping function for exposing request URIs. Be
+         * careful, exposing request URIs could result in a huge number of tag
+         * values, which could cause problems in your meter registry.
+         *
+         * By default, this feature is almost disabled. It only exposes values
+         * of the {@value DefaultUriMapper#URI_PATTERN_HEADER} HTTP header.
+         *
+         * @param uriMapper A mapper that allows mapping and exposing request
+         *                  paths.
+         * @return This builder instance.
+         * @see DefaultUriMapper
+         */
+        public Builder uriMapper(Function<HttpRequest, String> uriMapper) {
+            this.uriMapper = uriMapper;
+            return this;
+        }
+
+        /**
+         * Allows to expose the target scheme, host and port with every metric.
+         * Be careful with enabling this feature: If your client accesses a huge
+         * number of remote servers, this would result in a huge number of tag
+         * values, which could cause cardinality problems.
+         *
+         * By default, this feature is disabled.
+         *
+         * @param exportTagsForRoute Set this to true, if the metrics should be
+         *                           tagged with the target route.
+         * @return This builder instance.
+         */
+        public Builder exportTagsForRoute(boolean exportTagsForRoute) {
+            this.exportTagsForRoute = exportTagsForRoute;
+            return this;
+        }
+
+        /**
+         * @return Creates an instance of {@link MicrometerHttpRequestExecutor}
+         * with all the configured properties.
+         */
+        public MicrometerHttpRequestExecutor build() {
+            return new MicrometerHttpRequestExecutor(waitForContinue, connectionReuseStrategy, streamListener,
+                    registry, uriMapper, tags, exportTagsForRoute);
+        }
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.lang.NonNull;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
+import org.apache.hc.core5.pool.ConnPoolControl;
+
+/**
+ * Collects metrics from a {@link ConnPoolControl}, for example {@link PoolingHttpClientConnectionManager}
+ * for synchronous HTTP clients or {@link PoolingAsyncClientConnectionManager} for asynchronous HTTP clients.
+ * <p>
+ * It monitors the overall connection pool state.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @since 1.9.0
+ */
+public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
+
+    private final ConnPoolControl<HttpRoute> connPoolControl;
+    private final Iterable<Tag> tags;
+
+    /**
+     * Creates a metrics binder for the given pooling connection pool control.
+     *
+     * @param connPoolControl The connection pool control to monitor.
+     * @param name              Name of the connection pool control. Will be added as tag with the
+     *                          key "httpclient".
+     * @param tags              Tags to apply to all recorded metrics. Must be an even number
+     *                          of arguments representing key/value pairs of tags.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, String... tags) {
+        this(connPoolControl, name, Tags.of(tags));
+    }
+
+    /**
+     * Creates a metrics binder for the given connection pool control.
+     *
+     * @param connPoolControl The connection pool control to monitor.
+     * @param name            Name of the connection pool control. Will be added as tag with the key "httpclient".
+     * @param tags            Tags to apply to all recorded metrics.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name, Iterable<Tag> tags) {
+        this.connPoolControl = connPoolControl;
+        this.tags = Tags.concat(tags, "httpclient", name);
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        registerTotalMetrics(registry);
+    }
+
+    private void registerTotalMetrics(MeterRegistry registry) {
+        Gauge.builder("httpcomponents.httpclient.pool.total.max",
+                connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getMax())
+                .description("The configured maximum number of allowed persistent connections for all routes.")
+                .tags(tags)
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.connections",
+                connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getAvailable())
+                .description("The number of persistent and available connections for all routes.")
+                .tags(tags).tag("state", "available")
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.connections",
+                connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getLeased())
+                .description("The number of persistent and leased connections for all routes.")
+                .tags(tags).tag("state", "leased")
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.pending",
+                connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getPending())
+                .description("The number of connection requests being blocked awaiting a free connection for all routes.")
+                .tags(tags)
+                .register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.route.max.default",
+                connPoolControl,
+                ConnPoolControl::getDefaultMaxPerRoute)
+                .description("The configured default maximum number of allowed persistent connections per route.")
+                .tags(tags)
+                .register(registry);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import java.util.concurrent.Future;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MicrometerHttpClientInterceptor}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
+@ExtendWith(WiremockResolver.class)
+class MicrometerHttpClientInterceptorTest {
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    }
+
+    @Test
+    void asyncRequest(@WiremockResolver.Wiremock WireMockServer server) throws Exception {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpAsyncClient client = asyncClient();
+        client.start();
+        SimpleHttpRequest request = SimpleHttpRequest.create(HttpGet.METHOD_NAME, server.baseUrl());
+
+        Future<SimpleHttpResponse> future = client.execute(request, null);
+        HttpResponse response = future.get();
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(registry.get("httpcomponents.httpclient.request").timer().count()).isEqualTo(1);
+
+        client.close();
+    }
+
+    @Test
+    void uriIsReadFromHttpHeader(@WiremockResolver.Wiremock WireMockServer server) throws Exception {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry, Tags.empty(), true);
+        CloseableHttpAsyncClient client = asyncClient(interceptor);
+        client.start();
+        SimpleHttpRequest request = SimpleHttpRequest.create(HttpGet.METHOD_NAME, server.baseUrl());
+        request.addHeader(DefaultUriMapper.URI_PATTERN_HEADER, "/some/pattern");
+
+        Future<SimpleHttpResponse> future = client.execute(request, null);
+        HttpResponse response = future.get();
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(registry.get("httpcomponents.httpclient.request").tag("uri", "/some/pattern").tag("status", "200").timer().count())
+                .isEqualTo(1);
+
+        client.close();
+    }
+
+    private CloseableHttpAsyncClient asyncClient() {
+        MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
+                HttpRequest::getRequestUri,
+                Tags.empty(),
+                true);
+        return asyncClient(interceptor);
+    }
+
+    private CloseableHttpAsyncClient asyncClient(MicrometerHttpClientInterceptor interceptor) {
+        return HttpAsyncClients.custom()
+                .addRequestInterceptorFirst(interceptor.getRequestInterceptor())
+                .addResponseInterceptorLast(interceptor.getResponseInterceptor())
+                .build();
+    }
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link MicrometerHttpRequestExecutor}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+@ExtendWith(WiremockResolver.class)
+class MicrometerHttpRequestExecutorTest {
+
+    private static final String EXPECTED_METER_NAME = "httpcomponents.httpclient.request";
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    }
+
+    @Test
+    void timeSuccessful(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        client.execute(new HttpGet(server.baseUrl()));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void httpMethodIsTagged(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        client.execute(new HttpGet(server.baseUrl()));
+        client.execute(new HttpGet(server.baseUrl()));
+        client.execute(new HttpPost(server.baseUrl()));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "POST")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void httpStatusCodeIsTagged(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(urlEqualTo("/ok")).willReturn(aResponse().withStatus(200)));
+        server.stubFor(any(urlEqualTo("/notfound")).willReturn(aResponse().withStatus(404)));
+        server.stubFor(any(urlEqualTo("/error")).willReturn(aResponse().withStatus(500)));
+        HttpClient client = client(executor(false));
+        client.execute(new HttpGet(server.baseUrl() + "/ok"));
+        client.execute(new HttpGet(server.baseUrl() + "/ok"));
+        client.execute(new HttpGet(server.baseUrl() + "/notfound"));
+        client.execute(new HttpGet(server.baseUrl() + "/error"));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET", "status", "200")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET", "status", "404")
+                .timer().count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("method", "GET", "status", "500")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void uriIsUnknownByDefault(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        client.execute(new HttpGet(server.baseUrl()));
+        client.execute(new HttpGet(server.baseUrl() + "/someuri"));
+        client.execute(new HttpGet(server.baseUrl() + "/otheruri"));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "UNKNOWN")
+                .timer().count()).isEqualTo(3L);
+    }
+
+    @Test
+    void uriIsReadFromHttpHeader(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        HttpGet getWithHeader = new HttpGet(server.baseUrl());
+        getWithHeader.addHeader(DefaultUriMapper.URI_PATTERN_HEADER, "/some/pattern");
+        client.execute(getWithHeader);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/some/pattern")
+                .timer().count()).isEqualTo(1L);
+        assertThrows(MeterNotFoundException.class, () -> registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "UNKNOWN")
+                .timer());
+    }
+
+    @Test
+    void routeNotTaggedByDefault(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(false));
+        client.execute(new HttpGet(server.baseUrl()));
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME)
+                .timer().getId().getTags().stream()
+                .map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).doesNotContain("target.scheme", "target.host", "target.port");
+        assertThat(tagKeys).contains("status", "method");
+    }
+
+    @Test
+    void routeTaggedIfEnabled(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        HttpClient client = client(executor(true));
+        client.execute(new HttpGet(server.baseUrl()));
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME)
+                .timer().getId().getTags().stream()
+                .map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).contains("target.scheme", "target.host", "target.port");
+    }
+
+    @Test
+    void waitForContinueGetsPassedToSuper() {
+        io.micrometer.core.instrument.binder.httpcomponents.MicrometerHttpRequestExecutor requestExecutor = io.micrometer.core.instrument.binder.httpcomponents.MicrometerHttpRequestExecutor.builder(registry)
+                .waitForContinue(1000)
+                .build();
+        assertThat(requestExecutor).hasFieldOrPropertyWithValue("waitForContinue", 1000);
+    }
+
+    @Test
+    void uriMapperWorksAsExpected(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .uriMapper(HttpRequest::getRequestUri)
+                .build();
+        HttpClient client = client(executor);
+        client.execute(new HttpGet(server.baseUrl()));
+        client.execute(new HttpGet(server.baseUrl() + "/foo"));
+        client.execute(new HttpGet(server.baseUrl() + "/bar"));
+        client.execute(new HttpGet(server.baseUrl() + "/foo"));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/")
+                .timer().count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/foo")
+                .timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("uri", "/bar")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void additionalTagsAreExposed(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .tags(Tags.of("foo", "bar", "some.key", "value"))
+                .exportTagsForRoute(true)
+                .build();
+        HttpClient client = client(executor);
+        client.execute(new HttpGet(server.baseUrl()));
+        assertThat(registry.get(EXPECTED_METER_NAME)
+                .tags("foo", "bar", "some.key", "value", "target.host", "localhost")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void settingNullRegistryThrowsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MicrometerHttpRequestExecutor.builder(null)
+                        .build());
+    }
+
+    @Test
+    void overridingUriMapperWithNullThrowsException() {
+        assertThrows(IllegalArgumentException.class, () ->
+                MicrometerHttpRequestExecutor.builder(registry)
+                        .uriMapper(null)
+                        .build()
+        );
+    }
+
+    @Test
+    void overrideExtraTagsDoesNotThrowAnException(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .tags(null)
+                .build();
+        HttpClient client = client(executor);
+        client.execute(new HttpGet(server.baseUrl()));
+        assertThat(registry.get(EXPECTED_METER_NAME)).isNotNull();
+    }
+
+    private HttpClient client(HttpRequestExecutor executor) {
+        return HttpClientBuilder.create()
+                .setRequestExecutor(executor)
+                .build();
+    }
+
+    private HttpRequestExecutor executor(boolean exportRoutes) {
+        return MicrometerHttpRequestExecutor.builder(registry)
+                .exportTagsForRoute(exportRoutes)
+                .build();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.pool.PoolStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PoolingHttpClientConnectionManagerMetricsBinder}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+class PoolingHttpClientConnectionManagerMetricsBinderTest {
+
+    private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    private ConnPoolControl<HttpRoute> connPoolControl;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        connPoolControl = (ConnPoolControl<HttpRoute>) mock(ConnPoolControl.class);
+        new PoolingHttpClientConnectionManagerMetricsBinder(connPoolControl, "test").bindTo(registry);
+    }
+
+    @Test
+    void totalMax() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getMax()).thenReturn(13);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.max")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(13.0);
+    }
+
+    @Test
+    void totalAvailable() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getAvailable()).thenReturn(17);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+            .tags("httpclient", "test", "state", "available")
+            .gauge().value()).isEqualTo(17.0);
+    }
+
+    @Test
+    void totalLeased() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getLeased()).thenReturn(23);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+            .tags("httpclient", "test", "state", "leased")
+            .gauge().value()).isEqualTo(23.0);
+    }
+
+    @Test
+    void totalPending() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getPending()).thenReturn(37);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.pending")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(37.0);
+    }
+
+    @Test
+    void routeMaxDefault() {
+        when(connPoolControl.getDefaultMaxPerRoute()).thenReturn(7);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max.default")
+            .tags("httpclient", "test")
+            .gauge().value()).isEqualTo(7.0);
+    }
+
+}


### PR DESCRIPTION
Adding support for Apache HttpClient 5 by simply copying and adapting the old Apache HttpClient support.

The intention of this PR is merely to have something to discuss #2513 around.