### PR TITLE
Add integration tests for Elasticsearch 8

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchApiKeyIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchApiKeyIntegrationTest.java
@@ -24,9 +24,12 @@ import java.time.Duration;
 import java.util.Base64;
 
 /**
- * Test Elasticsearch backend with API key authentication.
+ * Base class for testing Elasticsearch backend with API key authentication.
+ *
+ * @author Tommy Ludwig
+ * @author Johnny Lim
  */
-class ElasticsearchApiKeyIntegrationTest extends ElasticsearchMeterRegistryElasticsearch7IntegrationTest {
+abstract class AbstractElasticsearchApiKeyIntegrationTest extends AbstractElasticsearchMeterRegistryIntegrationTest {
 
     @Override
     protected ElasticConfig getConfig() {

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
@@ -40,6 +40,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("docker")
 abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
 
+    protected static final String VERSION_7 = "7.17.0";
+    protected static final String VERSION_8 = "8.0.0";
+
     protected static final String USER = "elastic";
     protected static final String PASSWORD = "changeme";
 

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/Elasticsearch7ApiKeyIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/Elasticsearch7ApiKeyIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 VMware, Inc.
+ * Copyright 2022 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,11 @@
 package io.micrometer.elastic;
 
 /**
- * Integration tests on {@link ElasticMeterRegistry} for Elasticsearch 7.
+ * Integration tests with API key authentication for Elasticsearch 7.
  *
  * @author Johnny Lim
  */
-class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
-        extends AbstractElasticsearchMeterRegistryIntegrationTest {
+class Elasticsearch7ApiKeyIntegrationTest extends AbstractElasticsearchApiKeyIntegrationTest {
 
     @Override
     protected String getVersion() {

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/Elasticsearch8ApiKeyIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/Elasticsearch8ApiKeyIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 VMware, Inc.
+ * Copyright 2022 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,15 @@
 package io.micrometer.elastic;
 
 /**
- * Integration tests on {@link ElasticMeterRegistry} for Elasticsearch 7.
+ * Integration tests with API key authentication for Elasticsearch 8.
  *
  * @author Johnny Lim
  */
-class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
-        extends AbstractElasticsearchMeterRegistryIntegrationTest {
+class Elasticsearch8ApiKeyIntegrationTest extends AbstractElasticsearchApiKeyIntegrationTest {
 
     @Override
     protected String getVersion() {
-        return VERSION_7;
+        return VERSION_8;
     }
 
 }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch8IntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticsearchMeterRegistryElasticsearch8IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 VMware, Inc.
+ * Copyright 2022 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 package io.micrometer.elastic;
 
 /**
- * Integration tests on {@link ElasticMeterRegistry} for Elasticsearch 7.
+ * Integration tests on {@link ElasticMeterRegistry} for Elasticsearch 8.
  *
  * @author Johnny Lim
  */
-class ElasticsearchMeterRegistryElasticsearch7IntegrationTest
+class ElasticsearchMeterRegistryElasticsearch8IntegrationTest
         extends AbstractElasticsearchMeterRegistryIntegrationTest {
 
     @Override
     protected String getVersion() {
-        return VERSION_7;
+        return VERSION_8;
     }
 
 }


### PR DESCRIPTION
This PR adds integration tests for Elasticsearch 8.

This PR also updates the existing integration tests to use Elasticsearch 7.17.0.