### PR TITLE
Fix log formatting anchors in DynatraceExporterV2

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -175,7 +175,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private Stream<String> toSummaryLine(Meter meter, HistogramSnapshot histogramSnapshot, TimeUnit timeUnit) {
         long count = histogramSnapshot.count();
         if (count < 1) {
-            logger.debug("Summary with 0 count dropped: %s", meter.getId().getName());
+            logger.debug("Summary with 0 count dropped: {}", meter.getId().getName());
             return Stream.empty();
         }
         double total = (timeUnit != null) ? histogramSnapshot.total(timeUnit) : histogramSnapshot.total();
@@ -224,7 +224,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     Stream<String> toFunctionTimerLine(FunctionTimer meter) {
         long count = (long) meter.count();
         if (count < 1) {
-            logger.debug("Timer with 0 count dropped: %s", meter.getId().getName());
+            logger.debug("Timer with 0 count dropped: {}", meter.getId().getName());
             return Stream.empty();
         }
         double total = meter.totalTime(getBaseTimeUnit());

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -242,8 +242,7 @@ class DynatraceExporterV2Test {
 
         clock.add(config.step());
         // Before the update to drop zero count lines, this would contain 1 line (with count=0), which is not desired.
-        List<String> zeroCountLines = exporter.toTimerLine(timer).collect(Collectors.toList());
-        assertThat(zeroCountLines).isEmpty();
+        assertThat(exporter.toTimerLine(timer)).isEmpty();
     }
 
     @Test
@@ -357,8 +356,7 @@ class DynatraceExporterV2Test {
 
         clock.add(config.step());
         // Before the update to drop zero count lines, this would contain 1 line (with count=0), which is not desired.
-        List<String> zeroCountLines = exporter.toDistributionSummaryLine(summary).collect(Collectors.toList());
-        assertThat(zeroCountLines).isEmpty();
+        assertThat(exporter.toDistributionSummaryLine(summary)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
This PR fixes log formatting anchors in `DynatraceExporterV2`.

This PR also polishes `DynatraceExporterV2Test` a bit along the way.