### PR TITLE
Prevent CompositeMeter allocating on each record

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -25,10 +25,9 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter implements CompositeMeter {
-    private AtomicBoolean childrenGuard = new AtomicBoolean();
+    private final AtomicBoolean childrenGuard = new AtomicBoolean();
     private Map<MeterRegistry, T> children = Collections.emptyMap();
 
     @Nullable
@@ -43,8 +42,8 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
     @Nullable
     abstract T registerNewMeter(MeterRegistry registry);
 
-    final void forEachChild(Consumer<T> task) {
-        children.values().forEach(task);
+    final Iterable<T> getChildren() {
+        return children.values();
     }
 
     T firstChild() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCounter.java
@@ -28,7 +28,9 @@ class CompositeCounter extends AbstractCompositeMeter<Counter> implements Counte
 
     @Override
     public void increment(double amount) {
-        forEachChild(c -> c.increment(amount));
+        for (Counter c : getChildren()) {
+            c.increment(amount);
+        }
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeDistributionSummary.java
@@ -35,7 +35,9 @@ class CompositeDistributionSummary extends AbstractCompositeMeter<DistributionSu
 
     @Override
     public void record(double amount) {
-        forEachChild(ds -> ds.record(amount));
+        for (DistributionSummary ds : getChildren()) {
+            ds.record(amount);
+        }
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeLongTaskTimer.java
@@ -38,7 +38,9 @@ class CompositeLongTaskTimer extends AbstractCompositeMeter<LongTaskTimer> imple
     @Override
     public Sample start() {
         List<Sample> samples = new ArrayList<>();
-        forEachChild(ltt -> samples.add(ltt.start()));
+        for (LongTaskTimer ltt : getChildren()) {
+            samples.add(ltt.start());
+        }
         return new CompositeSample(samples);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimer.java
@@ -42,12 +42,16 @@ class CompositeTimer extends AbstractCompositeMeter<Timer> implements Timer {
 
     @Override
     public void record(long amount, TimeUnit unit) {
-        forEachChild(ds -> ds.record(amount, unit));
+        for (Timer ds : getChildren()) {
+            ds.record(amount, unit);
+        }
     }
 
     @Override
     public void record(Duration duration) {
-        forEachChild(ds -> ds.record(duration));
+        for (Timer ds : getChildren()) {
+            ds.record(duration);
+        }
     }
 
     @Override


### PR DESCRIPTION
The way forEachChild was written mean each lambda has to close over the
argument which results in an allocation for each call. Instead we
slightly rewrite the forEachChild api to allow passing through the data
to each call so that the lambdas do not need to capture the argument.