### PR TITLE
Added Global Tags Provider

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/Observation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/Observation.java
@@ -761,6 +761,16 @@ public interface Observation {
     }
 
     /**
+     * A provider of tags that will be set on the {@link ObservationRegistry}.
+     *
+     * @author Marcin Grzejszczak
+     * @since 2.0.0
+     */
+    interface GlobalTagsProvider<T extends Context> extends TagsProvider<T> {
+
+    }
+
+    /**
      * A functional interface like {@link Runnable} but it can throw exceptions.
      */
     @FunctionalInterface

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationRegistry.java
@@ -65,7 +65,7 @@ public interface ObservationRegistry {
 
         private final List<ObservationPredicate> observationPredicates = new CopyOnWriteArrayList<>();
 
-        private final List<Observation.TagsProvider<?>> tagsProviders = new CopyOnWriteArrayList<>();
+        private final List<Observation.GlobalTagsProvider<?>> tagsProviders = new CopyOnWriteArrayList<>();
 
         /**
          * Register a handler for the {@link Observation observations}.
@@ -96,7 +96,7 @@ public interface ObservationRegistry {
          * @param tagsProvider tags provider to add to the current configuration
          * @return This configuration instance
          */
-        public ObservationConfig tagsProvider(Observation.TagsProvider<?> tagsProvider) {
+        public ObservationConfig tagsProvider(Observation.GlobalTagsProvider<?> tagsProvider) {
             this.tagsProviders.add(tagsProvider);
             return this;
         }
@@ -117,7 +117,7 @@ public interface ObservationRegistry {
             return observationHandlers;
         }
 
-        Collection<Observation.TagsProvider<?>> getTagsProviders() {
+        Collection<Observation.GlobalTagsProvider<?>> getTagsProviders() {
             return tagsProviders;
         }
     }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
@@ -442,7 +442,7 @@ public abstract class ObservationRegistryCompatibilityKit {
         final String uuid = UUID.randomUUID().toString();
     }
 
-    static class TestTagsProvider implements Observation.TagsProvider<TestContext> {
+    static class TestTagsProvider implements Observation.GlobalTagsProvider<TestContext> {
         private final String id;
 
         public TestTagsProvider(String id) {
@@ -469,7 +469,7 @@ public abstract class ObservationRegistryCompatibilityKit {
         }
     }
 
-    static class UnsupportedTagsProvider implements Observation.TagsProvider<Observation.Context> {
+    static class UnsupportedTagsProvider implements Observation.GlobalTagsProvider<Observation.Context> {
         private final String id;
 
         public UnsupportedTagsProvider(String id) {

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -59,7 +59,7 @@ public class ObservationHandlerSample {
         private final UUID uuid = UUID.randomUUID();
     }
 
-    static class CustomTagsProvider implements Observation.TagsProvider<CustomContext> {
+    static class CustomTagsProvider implements Observation.GlobalTagsProvider<CustomContext> {
         @Override
         public Tags getLowCardinalityTags(CustomContext context) {
             return Tags.of("className", context.getClass().getSimpleName());


### PR DESCRIPTION
by providing a marker interface we are differentiating between the TagsProvider that should be applied on the observation and a GlobalTagsProvider that should be applied to all observations