### PR TITLE
Use MeterEquivalence in AbstractMeter

### DIFF
--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorCounter.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorCounter.java
@@ -18,7 +18,6 @@ package io.micrometer.atlas;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 
 public class SpectatorCounter extends AbstractMeter implements Counter {
     private com.netflix.spectator.api.Counter counter;
@@ -36,16 +35,5 @@ public class SpectatorCounter extends AbstractMeter implements Counter {
     @Override
     public double count() {
         return counter.count();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorDistributionSummary.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorDistributionSummary.java
@@ -20,8 +20,6 @@ import com.netflix.spectator.api.Statistic;
 import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
-import io.micrometer.core.instrument.util.MeterEquivalence;
-import io.micrometer.core.lang.Nullable;
 
 import static java.util.stream.StreamSupport.stream;
 
@@ -67,16 +65,5 @@ public class SpectatorDistributionSummary extends AbstractDistributionSummary {
         }
 
         return Double.NaN;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorGauge.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorGauge.java
@@ -17,7 +17,6 @@ package io.micrometer.atlas;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 
 public class SpectatorGauge extends AbstractMeter implements Gauge {
     private com.netflix.spectator.api.Gauge gauge;
@@ -30,16 +29,5 @@ public class SpectatorGauge extends AbstractMeter implements Gauge {
     @Override
     public double value() {
         return gauge.value();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorLongTaskTimer.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorLongTaskTimer.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.util.concurrent.TimeUnit;
@@ -47,17 +46,6 @@ public class SpectatorLongTaskTimer extends DefaultLongTaskTimer implements Long
     @Override
     public int activeTasks() {
         return timer.activeTasks();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     class SpectatorSample extends Sample {

--- a/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBDistributionSummary.java
+++ b/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBDistributionSummary.java
@@ -18,7 +18,6 @@ package io.micrometer.opentsdb;
 import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.*;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
 
 import java.time.Duration;
@@ -94,17 +93,6 @@ public class OpenTSDBDistributionSummary extends AbstractDistributionSummary {
     @Override
     public double max() {
         return max.poll();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     /**

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
@@ -18,7 +18,6 @@ package io.micrometer.prometheus;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 
 import java.util.concurrent.atomic.DoubleAdder;
 
@@ -38,16 +37,5 @@ public class PrometheusCounter extends AbstractMeter implements Counter {
     @Override
     public double count() {
         return count.doubleValue();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
@@ -18,7 +18,6 @@ package io.micrometer.prometheus;
 import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.*;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
 
 import java.time.Duration;
@@ -95,17 +94,6 @@ public class PrometheusDistributionSummary extends AbstractDistributionSummary {
 
     public HistogramFlavor histogramFlavor() {
         return histogramFlavor;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     /**

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
@@ -17,7 +17,6 @@ package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import reactor.core.publisher.FluxSink;
 
 import java.util.concurrent.atomic.DoubleAdder;
@@ -48,17 +47,6 @@ public class StatsdCounter extends AbstractMeter implements Counter {
     @Override
     public double count() {
         return count.doubleValue();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     void shutdown() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
@@ -20,8 +20,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.TimeWindowMax;
-import io.micrometer.core.instrument.util.MeterEquivalence;
-import io.micrometer.core.lang.Nullable;
 import reactor.core.publisher.FluxSink;
 
 import java.util.concurrent.atomic.DoubleAdder;
@@ -70,17 +68,6 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
     @Override
     public double max() {
         return max.poll();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     void shutdown() {

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
@@ -17,7 +17,6 @@ package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
 import reactor.core.publisher.FluxSink;
 
@@ -55,17 +54,6 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
         if (Double.isFinite(val) && (alwaysPublish || lastValue.getAndSet(val) != val)) {
             sink.next(lineBuilder.gauge(val));
         }
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -16,8 +16,6 @@
 package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.distribution.*;
-import io.micrometer.core.instrument.util.MeterEquivalence;
-import io.micrometer.core.lang.Nullable;
 
 public abstract class AbstractDistributionSummary extends AbstractMeter implements DistributionSummary {
     protected final Histogram histogram;
@@ -55,16 +53,5 @@ public abstract class AbstractDistributionSummary extends AbstractMeter implemen
     @Override
     public HistogramSnapshot takeSnapshot() {
         return histogram.takeSnapshot(count(), totalAmount(), max());
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractMeter.java
@@ -15,6 +15,15 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.instrument.util.MeterEquivalence;
+import io.micrometer.core.lang.Nullable;
+
+/**
+ * Base class for {@link Meter} implementations.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
 public abstract class AbstractMeter implements Meter {
     private final Meter.Id id;
 
@@ -25,5 +34,16 @@ public abstract class AbstractMeter implements Meter {
     @Override
     public Id getId() {
         return id;
+    }
+
+    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
+    @Override
+    public boolean equals(@Nullable Object o) {
+        return MeterEquivalence.equals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
 import org.LatencyUtils.IntervalEstimator;
 import org.LatencyUtils.SimplePauseDetector;
@@ -186,17 +185,6 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     @Override
     public TimeUnit baseTimeUnit() {
         return baseTimeUnit;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardCounter.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument.dropwizard;
 import com.codahale.metrics.Meter;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 
 /**
  * @author Jon Schneider
@@ -39,16 +38,5 @@ public class DropwizardCounter extends AbstractMeter implements Counter {
     @Override
     public double count() {
         return impl.getCount();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardDistributionSummary.java
@@ -19,8 +19,6 @@ import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.TimeWindowMax;
-import io.micrometer.core.instrument.util.MeterEquivalence;
-import io.micrometer.core.lang.Nullable;
 
 import java.util.concurrent.atomic.DoubleAdder;
 
@@ -61,16 +59,5 @@ public class DropwizardDistributionSummary extends AbstractDistributionSummary {
     @Override
     public double max() {
         return max.poll();
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(@Nullable Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardGauge.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument.dropwizard;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 
 /**
  * @author Jon Schneider
@@ -35,16 +34,5 @@ public class DropwizardGauge extends AbstractMeter implements Gauge {
     public double value() {
         Double value = impl.getValue();
         return value == null ? Double.NaN : value;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument.internal;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.lang.Nullable;
 import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 
@@ -58,16 +57,5 @@ public class DefaultGauge<T> extends AbstractMeter implements Gauge {
             }
         }
         return Double.NaN;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
-import io.micrometer.core.instrument.util.MeterEquivalence;
 import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.util.*;
@@ -116,17 +115,6 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
     @Override
     public TimeUnit baseTimeUnit() {
         return baseTimeUnit;
-    }
-
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
-    @Override
-    public boolean equals(Object o) {
-        return MeterEquivalence.equals(this, o);
-    }
-
-    @Override
-    public int hashCode() {
-        return MeterEquivalence.hashCode(this);
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/internal/DefaultMeterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/internal/DefaultMeterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.internal;
+
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.Tags;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DefaultMeter}.
+ *
+ * @author Johnny Lim
+ */
+class DefaultMeterTest {
+
+    @Test
+    void equalsAndHashCode() {
+        Meter.Type type = Meter.Type.COUNTER;
+        Meter.Id id = new Meter.Id("my.meter", Tags.empty(), null, null, type);
+        Iterable<Measurement> measurements = Collections.singletonList(new Measurement(() -> 1d, Statistic.COUNT));
+        DefaultMeter meter1 = new DefaultMeter(id, type, measurements);
+        DefaultMeter meter2 = new DefaultMeter(id, type, measurements);
+        assertThat(meter1).isEqualTo(meter2);
+        assertThat(meter1).hasSameHashCodeAs(meter2);
+    }
+
+}


### PR DESCRIPTION
This PR changes to use `MeterEquivalence` in `AbstractMeter` as I couldn't find any reason why it can't be used there. There might be some historical reason or something that I missed.