### PR TITLE
Correct tag names according to Micrometer's docs

### DIFF
--- a/micrometer-binders/src/main/java/io/micrometer/binder/grpc/AbstractMetricCollectingInterceptor.java
+++ b/micrometer-binders/src/main/java/io/micrometer/binder/grpc/AbstractMetricCollectingInterceptor.java
@@ -52,11 +52,11 @@ public abstract class AbstractMetricCollectingInterceptor {
     /**
      * The metrics tag key that belongs to the type of the called method.
      */
-    private static final String TAG_METHOD_TYPE = "methodType";
+    private static final String TAG_METHOD_TYPE = "method.type";
     /**
      * The metrics tag key that belongs to the result status code.
      */
-    private static final String TAG_STATUS_CODE = "statusCode";
+    private static final String TAG_STATUS_CODE = "status.code";
 
     /**
      * Creates a new counter builder for the given method. By default the base unit will be messages.


### PR DESCRIPTION
See. https://micrometer.io/docs/concepts#_tag_naming

With the current implementation and using official prometheus exporter,
we end up with label names `methodType` and `statusCode`. These labels
don't follow the snake_case naming convention that prometheus follows
for labels.
Using dot for word separator makes micrometer automatically convert
label names to snake case out of the box. 
See. https://github.com/micrometer-metrics/micrometer/blob/main/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusNamingConvention.java

This PR applies the same changes raised here: https://github.com/yidongnan/grpc-spring-boot-starter/pull/645