### PR TITLE
Prometheus histogram exemplars

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusCounter.java
@@ -61,7 +61,7 @@ public class PrometheusCounter extends AbstractMeter implements Counter {
         return count.doubleValue();
     }
 
-    Exemplar exemplar() {
+    @Nullable Exemplar exemplar() {
         return exemplar.get();
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
@@ -19,22 +19,28 @@ import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.lang.Nullable;
+import io.prometheus.client.exemplars.Exemplar;
+import io.prometheus.client.exemplars.HistogramExemplarSampler;
 
-import java.time.Duration;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 
 public class PrometheusDistributionSummary extends AbstractDistributionSummary {
     private static final CountAtBucket[] EMPTY_HISTOGRAM = new CountAtBucket[0];
-    @Nullable
-    private final Histogram histogram;
+
     private final LongAdder count = new LongAdder();
     private final DoubleAdder amount = new DoubleAdder();
     private final TimeWindowMax max;
 
     private final HistogramFlavor histogramFlavor;
+    @Nullable private final Histogram histogram;
+    private boolean exemplarsEnabled = false;
 
     PrometheusDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, HistogramFlavor histogramFlavor) {
+        this(id, clock, distributionStatisticConfig, scale, histogramFlavor, null);
+    }
+
+    PrometheusDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale, HistogramFlavor histogramFlavor, @Nullable HistogramExemplarSampler exemplarSampler) {
         super(id, clock,
                 DistributionStatisticConfig.builder()
                         .percentilesHistogram(false)
@@ -49,21 +55,20 @@ public class PrometheusDistributionSummary extends AbstractDistributionSummary {
         if (distributionStatisticConfig.isPublishingHistogram()) {
             switch (histogramFlavor) {
                 case Prometheus:
-                    histogram = new TimeWindowFixedBoundaryHistogram(clock, DistributionStatisticConfig.builder()
-                            .expiry(Duration.ofDays(1825)) // effectively never roll over
-                            .bufferLength(1)
-                            .build()
-                            .merge(distributionStatisticConfig), true);
+                    PrometheusHistogram prometheusHistogram = new PrometheusHistogram(clock, distributionStatisticConfig, exemplarSampler);
+                    this.histogram = prometheusHistogram;
+                    this.exemplarsEnabled = prometheusHistogram.isExemplarsEnabled();
                     break;
                 case VictoriaMetrics:
-                    histogram = new FixedBoundaryVictoriaMetricsHistogram();
+                    this.histogram = new FixedBoundaryVictoriaMetricsHistogram();
                     break;
                 default:
-                    histogram = null;
+                    this.histogram = null;
                     break;
             }
-        } else {
-            histogram = null;
+        }
+        else {
+            this.histogram = null;
         }
     }
 
@@ -75,6 +80,15 @@ public class PrometheusDistributionSummary extends AbstractDistributionSummary {
 
         if (histogram != null)
             histogram.recordDouble(amount);
+    }
+
+    @Nullable Exemplar[] exemplars() {
+        if (exemplarsEnabled) {
+            return ((PrometheusHistogram) histogram).exemplars();
+        }
+        else {
+            return null;
+        }
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusDistributionSummary.java
@@ -17,6 +17,7 @@ package io.micrometer.prometheus;
 
 import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.lang.Nullable;
 import io.prometheus.client.exemplars.Exemplar;
@@ -25,6 +26,12 @@ import io.prometheus.client.exemplars.HistogramExemplarSampler;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 
+/**
+ * {@link DistributionSummary} for Prometheus.
+ *
+ * @author Jon Schneider
+ * @author Jonatan Ivanov
+ */
 public class PrometheusDistributionSummary extends AbstractDistributionSummary {
     private static final CountAtBucket[] EMPTY_HISTOGRAM = new CountAtBucket[0];
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusHistogram.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusHistogram.java
@@ -22,11 +22,17 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.Histogram;
 import io.micrometer.core.instrument.distribution.TimeWindowFixedBoundaryHistogram;
 import io.micrometer.core.lang.Nullable;
 import io.prometheus.client.exemplars.Exemplar;
 import io.prometheus.client.exemplars.HistogramExemplarSampler;
 
+/**
+ * Internal {@link Histogram} implementation for Prometheus that handles {@link Exemplar exemplars}.
+ *
+ * @author Jonatan Ivanov
+ */
 class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
     private final double[] buckets;
     private final AtomicReferenceArray<Exemplar> exemplars;

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusHistogram.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusHistogram.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.prometheus;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.TimeWindowFixedBoundaryHistogram;
+import io.micrometer.core.lang.Nullable;
+import io.prometheus.client.exemplars.Exemplar;
+import io.prometheus.client.exemplars.HistogramExemplarSampler;
+
+class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
+    private final double[] buckets;
+    private final AtomicReferenceArray<Exemplar> exemplars;
+    @Nullable private final HistogramExemplarSampler exemplarSampler;
+
+    PrometheusHistogram(Clock clock, DistributionStatisticConfig config, @Nullable HistogramExemplarSampler exemplarSampler) {
+        super(
+                clock,
+                DistributionStatisticConfig.builder()
+                        .expiry(Duration.ofDays(1825)) // effectively never roll over
+                        .bufferLength(1)
+                        .build()
+                        .merge(config),
+                true
+        );
+
+        this.exemplarSampler = exemplarSampler;
+        if (isExemplarsEnabled()) {
+            double[] originalBuckets = super.getBuckets();
+            if (originalBuckets[originalBuckets.length - 1] != Double.POSITIVE_INFINITY) {
+                this.buckets = Arrays.copyOf(originalBuckets, originalBuckets.length + 1);
+                this.buckets[buckets.length - 1] = Double.POSITIVE_INFINITY;
+            }
+            else {
+                this.buckets = originalBuckets;
+            }
+            this.exemplars = new AtomicReferenceArray<>(this.buckets.length);
+        }
+        else {
+            this.buckets = null;
+            this.exemplars = null;
+        }
+    }
+
+    boolean isExemplarsEnabled() {
+        return exemplarSampler != null;
+    }
+
+    @Override
+    public void recordDouble(double value) {
+        super.recordDouble(value);
+        if (isExemplarsEnabled()) {
+            updateExemplar(value);
+        }
+    }
+
+    @Override
+    public void recordLong(long value) {
+        super.recordLong(value);
+        if (isExemplarsEnabled()) {
+            updateExemplar(value);
+        }
+    }
+
+    private void updateExemplar(double value) {
+        int index = this.leastLessThanOrEqualTo(value);
+        index = (index == -1) ? exemplars.length() - 1 : index;
+        updateExemplar(value, index);
+    }
+
+    private void updateExemplar(double value, int index) {
+        double bucketFrom = (index == 0) ? Double.NEGATIVE_INFINITY : buckets[index - 1];
+        double bucketTo = buckets[index];
+        Exemplar prev;
+        Exemplar next;
+
+        do {
+            prev = exemplars.get(index);
+            next = exemplarSampler.sample(value, bucketFrom, bucketTo, prev);
+            if (next == null || next == prev) {
+                return;
+            }
+        }
+        while (!exemplars.compareAndSet(index, prev, next));
+    }
+
+    @Nullable Exemplar[] exemplars() {
+        if (isExemplarsEnabled()) {
+            Exemplar[] exemplarsArray = new Exemplar[this.exemplars.length()];
+            for (int i = 0; i < this.exemplars.length(); i++) {
+                exemplarsArray[i] = this.exemplars.get(i);
+            }
+
+            return exemplarsArray;
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * The least bucket that is less than or equal to a sample.
+     */
+    private int leastLessThanOrEqualTo(double key) {
+        double[] buckets = getBuckets();
+        int low = 0;
+        int high = buckets.length - 1;
+
+        while (low <= high) {
+            int mid = (low + high) >>> 1;
+            if (buckets[mid] < key)
+                low = mid + 1;
+            else if (buckets[mid] > key)
+                high = mid - 1;
+            else
+                return mid; // exact match
+        }
+
+        return low < buckets.length ? low : -1;
+    }
+}

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -56,6 +56,7 @@ import static java.util.stream.StreamSupport.stream;
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Jonatan Ivanov
  */
 public class PrometheusMeterRegistry extends MeterRegistry {
     private final PrometheusConfig prometheusConfig;

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
@@ -17,6 +17,7 @@ package io.micrometer.prometheus;
 
 import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
@@ -27,6 +28,12 @@ import io.prometheus.client.exemplars.HistogramExemplarSampler;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
+/**
+ * {@link Timer} for Prometheus.
+ *
+ * @author Jon Schneider
+ * @author Jonatan Ivanov
+ */
 public class PrometheusTimer extends AbstractTimer {
     private static final CountAtBucket[] EMPTY_HISTOGRAM = new CountAtBucket[0];
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -671,10 +671,10 @@ class PrometheusMeterRegistryTest {
         String scraped = registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
         assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"} 1.0");
         assertThat(scraped)
-                .contains("test_timer_seconds_bucket{le=\"0.1\"} 1.0 # {span_id=\"3\",trace_id=\"4\"} 1.5E7")
-                .contains("test_timer_seconds_bucket{le=\"0.2\"} 2.0 # {span_id=\"5\",trace_id=\"6\"} 1.5E8")
+                .contains("test_timer_seconds_bucket{le=\"0.1\"} 1.0 # {span_id=\"3\",trace_id=\"4\"} 0.015")
+                .contains("test_timer_seconds_bucket{le=\"0.2\"} 2.0 # {span_id=\"5\",trace_id=\"6\"} 0.15")
                 .contains("test_timer_seconds_bucket{le=\"0.3\"} 2.0\n")
-                .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3.0 # {span_id=\"7\",trace_id=\"8\"} 1.5E9");
+                .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3.0 # {span_id=\"7\",trace_id=\"8\"} 1.5");
         assertThat(scraped)
                 .contains("test_histogram_bucket{le=\"1.0\"} 1.0 # {span_id=\"9\",trace_id=\"10\"} 0.15")
                 .contains("test_histogram_bucket{le=\"16.0\"} 2.0 # {span_id=\"11\",trace_id=\"12\"} 15.0")

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.micrometer.core.instrument.MockClock.clock;
 import static java.util.Collections.emptyList;
@@ -646,23 +647,107 @@ class PrometheusMeterRegistryTest {
         Counter counter = Counter.builder("my.counter").register(registry);
         counter.increment();
 
-        assertThat(registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100))
-                .startsWith("# TYPE my_counter counter\n")
-                .contains("# HELP my_counter  \n")
-                .contains("my_counter_total 1.0 # {span_id=\"testSpanId\",trace_id=\"testTraceId\"} 1.0")
-                .endsWith("# EOF\n");
+        Timer timer = Timer.builder("test.timer")
+                .serviceLevelObjectives(Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(300))
+                .register(registry);
+        timer.record(Duration.ofMillis(15));
+        timer.record(Duration.ofMillis(150));
+        timer.record(Duration.ofMillis(1_500));
+
+        DistributionSummary histogram = DistributionSummary.builder("test.histogram")
+                .publishPercentileHistogram()
+                .register(registry);
+        histogram.record(0.15);
+        histogram.record(15);
+        histogram.record(5E18);
+
+        DistributionSummary slos = DistributionSummary.builder("test.slos")
+                .serviceLevelObjectives(100, 200, 300)
+                .register(registry);
+        slos.record(10);
+        slos.record(250);
+        slos.record(1_000);
+
+        String scraped = registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+        assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"} 1.0");
+        assertThat(scraped)
+                .contains("test_timer_seconds_bucket{le=\"0.1\"} 1.0 # {span_id=\"3\",trace_id=\"4\"} 1.5E7")
+                .contains("test_timer_seconds_bucket{le=\"0.2\"} 2.0 # {span_id=\"5\",trace_id=\"6\"} 1.5E8")
+                .contains("test_timer_seconds_bucket{le=\"0.3\"} 2.0\n")
+                .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3.0 # {span_id=\"7\",trace_id=\"8\"} 1.5E9");
+        assertThat(scraped)
+                .contains("test_histogram_bucket{le=\"1.0\"} 1.0 # {span_id=\"9\",trace_id=\"10\"} 0.15")
+                .contains("test_histogram_bucket{le=\"16.0\"} 2.0 # {span_id=\"11\",trace_id=\"12\"} 15.0")
+                .contains("test_histogram_bucket{le=\"+Inf\"} 3.0 # {span_id=\"13\",trace_id=\"14\"} 5.0E18");
+        assertThat(scraped)
+                .contains("test_slos_bucket{le=\"100.0\"} 1.0 # {span_id=\"15\",trace_id=\"16\"} 10.0")
+                .contains("test_slos_bucket{le=\"200.0\"} 1.0\n")
+                .contains("test_slos_bucket{le=\"300.0\"} 2.0 # {span_id=\"17\",trace_id=\"18\"} 250.0")
+                .contains("test_slos_bucket{le=\"+Inf\"} 3.0 # {span_id=\"19\",trace_id=\"20\"} 1000.0");
+        assertThat(scraped).endsWith("# EOF\n");
+    }
+
+    @Test
+    void noExemplarsIfNoSampler() {
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry, clock);
+
+        Counter counter = Counter.builder("my.counter").register(registry);
+        counter.increment();
+
+        Timer timer = Timer.builder("test.timer")
+                .serviceLevelObjectives(Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(300))
+                .register(registry);
+        timer.record(Duration.ofMillis(15));
+        timer.record(Duration.ofMillis(150));
+        timer.record(Duration.ofMillis(1_500));
+
+        DistributionSummary histogram = DistributionSummary.builder("test.histogram")
+                .publishPercentileHistogram()
+                .register(registry);
+        histogram.record(0.15);
+        histogram.record(15);
+        histogram.record(5E18);
+
+        DistributionSummary slos = DistributionSummary.builder("test.slos")
+                .serviceLevelObjectives(100, 200, 300)
+                .register(registry);
+        slos.record(10);
+        slos.record(250);
+        slos.record(1_000);
+
+        String scraped = registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
+        assertThat(scraped).contains("my_counter_total 1.0\n");
+        assertThat(scraped)
+                .contains("test_timer_seconds_bucket{le=\"0.1\"} 1.0\n")
+                .contains("test_timer_seconds_bucket{le=\"0.2\"} 2.0\n")
+                .contains("test_timer_seconds_bucket{le=\"0.3\"} 2.0\n")
+                .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3.0\n");
+        assertThat(scraped)
+                .contains("test_histogram_bucket{le=\"1.0\"} 1.0\n")
+                .contains("test_histogram_bucket{le=\"16.0\"} 2.0\n")
+                .contains("test_histogram_bucket{le=\"+Inf\"} 3.0\n");
+        assertThat(scraped)
+                .contains("test_slos_bucket{le=\"100.0\"} 1.0\n")
+                .contains("test_slos_bucket{le=\"200.0\"} 1.0\n")
+                .contains("test_slos_bucket{le=\"300.0\"} 2.0\n")
+                .contains("test_slos_bucket{le=\"+Inf\"} 3.0\n");
+        assertThat(scraped)
+                .doesNotContain("span_id")
+                .doesNotContain("trace_id");
+        assertThat(scraped).endsWith("# EOF\n");
     }
 
     static class TestSpanContextSupplier implements SpanContextSupplier {
+        private final AtomicLong count = new AtomicLong();
 
         @Override
         public String getTraceId() {
-            return "testTraceId";
+            return String.valueOf(count.incrementAndGet());
         }
 
         @Override
         public String getSpanId() {
-            return "testSpanId";
+            return String.valueOf(count.incrementAndGet());
         }
     }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
@@ -109,6 +109,10 @@ public class TimeWindowFixedBoundaryHistogram
         printStream.write('\n');
     }
 
+    protected double[] getBuckets() {
+        return this.buckets;
+    }
+
     class FixedBoundaryHistogram {
         /**
          * For recording efficiency, this is a normal histogram. We turn these values into

--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -19,6 +19,17 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-actuator') {
         exclude group: 'io.micrometer', module: 'micrometer-core'
     }
+
+    implementation platform('org.springframework.cloud:spring-cloud-dependencies:latest.release')
+    implementation('org.springframework.cloud:spring-cloud-starter-sleuth') {
+        // Zipkin can use Micrometer to record metrics
+        // TraceMetricsMicrometerConfiguration autoconfigures this
+        // So if Micrometer wants to depend on Sleuth's Tracer, we have a circular dependency
+        // I'm not sure why spring-cloud-starter-sleuth depends on zipkin-reporter-metrics-micrometer and not spring-cloud-sleuth-zipkin
+        exclude group: 'io.zipkin.reporter2', module: 'zipkin-reporter-metrics-micrometer'
+    }
+    implementation('org.springframework.cloud:spring-cloud-sleuth-zipkin')
+
 }
 
 bootJar {

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
@@ -51,7 +51,7 @@ public class PersonController {
     @Timed("person.requests")
     public Person person(@PathVariable String id) {
         String userType = "0".equals(id) ? "admin" : "regular";
-        Counter.builder("person")
+        Counter.builder("person.requests")
                 .tag("type", userType)
                 .register(registry)
                 .increment();

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
@@ -16,6 +16,7 @@
 package io.micrometer.boot2.samples.components;
 
 import io.micrometer.core.annotation.Timed;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +40,7 @@ public class PersonController {
     @Timed(percentiles = {0.5, 0.95, 0.999}, histogram = true)
     public List<String> allPeople() {
         try {
+            Counter.builder("allPeople").register(registry).increment();
             Thread.sleep(200);
         } catch (InterruptedException e) {
             e.printStackTrace();

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
@@ -40,7 +40,6 @@ public class PersonController {
     @Timed(percentiles = {0.5, 0.95, 0.999}, histogram = true)
     public List<String> allPeople() {
         try {
-            Counter.builder("allPeople").register(registry).increment();
             Thread.sleep(200);
         } catch (InterruptedException e) {
             e.printStackTrace();
@@ -51,6 +50,12 @@ public class PersonController {
     @GetMapping("/api/person/{id}")
     @Timed("person.requests")
     public Person person(@PathVariable String id) {
+        String userType = "0".equals(id) ? "admin" : "regular";
+        Counter.builder("person")
+                .tag("type", userType)
+                .register(registry)
+                .increment();
+
         return new Person(id, "jon", "schneider", "USA", "MO");
     }
 
@@ -87,8 +92,7 @@ public class PersonController {
             result.put("max", t.max(TimeUnit.MILLISECONDS));
             result.put("mean", t.mean(TimeUnit.MILLISECONDS));
         }
+
         return result;
-
-
     }
 }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ExemplarSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ExemplarSample.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.samples;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exemplars.DefaultExemplarSampler;
+import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
+
+import static io.prometheus.client.exporter.common.TextFormat.CONTENT_TYPE_OPENMETRICS_100;
+
+public class ExemplarSample {
+    private static final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(
+            PrometheusConfig.DEFAULT,
+            new CollectorRegistry(),
+            Clock.SYSTEM,
+            new DefaultExemplarSampler(new TestSpanContextSupplier())
+    );
+
+    public static void main(String[] args) throws InterruptedException {
+        Counter counter = registry.counter("test.counter");
+        counter.increment();
+
+        Timer timer = Timer.builder("test.timer")
+                .publishPercentileHistogram()
+                .serviceLevelObjectives(Duration.ofMillis(350))
+                .register(registry);
+        timer.record(Duration.ofMillis(100));
+        timer.record(Duration.ofSeconds(1));
+
+        DistributionSummary distributionSummary = DistributionSummary.builder("test.distribution")
+                .publishPercentileHistogram()
+                .register(registry);
+        distributionSummary.record(100);
+        distributionSummary.record(1000);
+        System.out.println(registry.scrape(CONTENT_TYPE_OPENMETRICS_100));
+    }
+
+    static class TestSpanContextSupplier implements SpanContextSupplier {
+        private final AtomicLong count = new AtomicLong();
+
+        @Override
+        public String getTraceId() {
+            return String.valueOf(count.incrementAndGet());
+        }
+
+        @Override
+        public String getSpanId() {
+            return String.valueOf(count.incrementAndGet());
+        }
+    }
+}

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
@@ -30,7 +30,7 @@ import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
 
 import static io.prometheus.client.exporter.common.TextFormat.CONTENT_TYPE_OPENMETRICS_100;
 
-public class ExemplarSample {
+public class PrometheusExemplarsSample {
     private static final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(
             PrometheusConfig.DEFAULT,
             new CollectorRegistry(),
@@ -44,16 +44,19 @@ public class ExemplarSample {
 
         Timer timer = Timer.builder("test.timer")
                 .publishPercentileHistogram()
-                .serviceLevelObjectives(Duration.ofMillis(350))
                 .register(registry);
+        timer.record(Duration.ofNanos(1_000 * 100));
+        timer.record(Duration.ofMillis(2));
         timer.record(Duration.ofMillis(100));
-        timer.record(Duration.ofSeconds(1));
+        timer.record(Duration.ofSeconds(60));
 
         DistributionSummary distributionSummary = DistributionSummary.builder("test.distribution")
                 .publishPercentileHistogram()
                 .register(registry);
-        distributionSummary.record(100);
-        distributionSummary.record(1000);
+        distributionSummary.record(0.15);
+        distributionSummary.record(15);
+        distributionSummary.record(5E18);
+
         System.out.println(registry.scrape(CONTENT_TYPE_OPENMETRICS_100));
     }
 


### PR DESCRIPTION
fixes #2812
closes #2672

# How to test/use this

There are various ways to try this, here's what you need to do and should see:
- You need to pass a `SpanContextSupplier` implementation to the `PrometheusMeterRegistry`
- You need to use a `Counter` or a `Timer` or a `DistributionSummary` (`publishPercentileHistogram` or `serviceLevelObjectives` must be enabled)
- You need to call `scrape` using the `openmetrics-text` format
- You should see something like this: `test_counter_total 1.0 # {span_id="1",trace_id="2"} 1.0 1647993571.375`  
The part after the `#` belongs to the Exemplar: spanId, traceID, captured value (incrementing the counter by 1), timestamp.

## Run `PrometheusExemplarsSample`

This sample does everything for you (using a "fake" `SpanContextSupplier` implementation), check the output and look for `trace_id` and `span_id`, e.g.:
```
test_counter_total 1.0 # {span_id="1",trace_id="2"} 1.0 1647993571.375
```
or
```
test_timer_seconds_bucket{le="0.001"} 1.0 # {span_id="3",trace_id="4"} 0.001 1647993571.398
```

## Check the added verifications to `PrometheusMeterRegistryTest`

The tests added in this PR are pretty similar to `PrometheusExemplarsSample` but you can also see what to expect in the verification steps. 

## Run `PrometheusSample`

This is a full-fledged example with a real Spring-Boot application using a real Distributed Tracing solution (Spring Cloud Sleuth).

After you start the app, you need to generate some traffic. If you record something using a `Counter` or a `Timer` or a `DistributionSummary` (`publishPercentileHistogram` or `serviceLevelObjectives` must be enabled), and that recording is in the scope of Sleuth, you should also see an Exemplar created to the involved time series.  
Since Spring Boot does this for you out of the box, you should see the exemplars if you hit any method of the controller in the sample, e.g.:
```
http :8080/api/people
```

Doing this should already record the Exemplar for you, you should see it if you scrape the Prometheus endpoint using the `openmetrics-text` format:
```
http :8080/actuator/prometheus 'Accept: application/openmetrics-text; version=1.0.0' | grep trace_id
```

## `PrometheusSample` with Prometheus, Grafana and Zipkin

You can see this in action using Prometheus, Grafana and Zipkin, here's how to do it:
1. Run `PrometheusSample`
2. Go to https://github.com/jonatan-ivanov/local-services and start Prometheus and Zipkin using its docker-compose files
(clone, cd into the prometheus/zipkin dirs, and `docker compose up`)
3. Hit the "person" endpoint (I prepared a `Counter` for you there): `http :8080/api/person/1`
4. Go to your local Prometheus instance ([link](http://localhost:9090/graph?g0.expr=person_requests_total&g0.tab=0&g0.stacked=0&g0.show_exemplars=1&g0.range_input=1h)), query `person_requests_total` and click "Show Exemplars":  
The Exemplar is a little diamond on your graph that shows you the traceId and the spanId if you hover over it
6. Go to your local Grafana instance and check the "Exemplars" dashboard ([link](http://localhost:3000/d/fTL0SuI7k/exemplars?orgId=1&refresh=5s)):  
The Exemplar is a little diamond on your graph that shows you the traceId and the spanId if you hover over it, also if you press the "Go to" button next to the traceId, it will open that particular Trace in Zipkin