### PR TITLE
Add resettable DistributionSummary and Timer for Dynatrace registry

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -128,6 +128,20 @@ public interface DynatraceConfig extends StepRegistryConfig {
         return getBoolean(this, "enrichWithDynatraceMetadata").orElse(true);
     }
 
+    /**
+     * Return whether to fall back to the built-in micrometer instruments for Timer and DistributionSummary.
+     *
+     * @return {@code true} if the resetting Dynatrace instruments should be used, and false if the registry should
+     * fall back to the built-in Micrometer instruments.
+     * @since 1.9.0
+     */
+    default boolean useDynatraceSummaryInstruments() {
+        if (apiVersion() == V1) {
+            return false;
+        }
+        return getBoolean(this, "useDynatraceSummaryInstruments").orElse(true);
+    }
+
     @Override
     default Validated<?> validate() {
         return checkAll(this,

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -58,8 +58,9 @@ import static io.micrometer.core.instrument.config.MeterFilterReply.NEUTRAL;
 public class DynatraceMeterRegistry extends StepMeterRegistry {
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("dynatrace-metrics-publisher");
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceMeterRegistry.class);
-    private final DynatraceApiVersion apiVersion;
 
+    private final DynatraceApiVersion apiVersion;
+    private final boolean useDynatraceSummaryInstruments;
     private final AbstractDynatraceExporter exporter;
 
     @SuppressWarnings("deprecation")
@@ -71,6 +72,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
         super(config, clock);
 
         apiVersion = config.apiVersion();
+        useDynatraceSummaryInstruments = config.useDynatraceSummaryInstruments();
 
         if (apiVersion == DynatraceApiVersion.V2) {
             logger.info("Exporting to Dynatrace metrics API v2");
@@ -101,7 +103,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
-        if (apiVersion == DynatraceApiVersion.V2) {
+        if (apiVersion == DynatraceApiVersion.V2 && useDynatraceSummaryInstruments) {
             return new DynatraceDistributionSummary(id, clock, distributionStatisticConfig, scale);
         }
         return super.newDistributionSummary(id, distributionStatisticConfig, scale);
@@ -109,7 +111,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
-        if (apiVersion == DynatraceApiVersion.V2) {
+        if (apiVersion == DynatraceApiVersion.V2 && useDynatraceSummaryInstruments) {
             return new DynatraceTimer(id, clock, distributionStatisticConfig, pauseDetector, exporter.getBaseTimeUnit());
         }
         return super.newTimer(id, distributionStatisticConfig, pauseDetector);

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -109,7 +109,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
         if (apiVersion == DynatraceApiVersion.V2) {
-            return new DynatraceTimer(id, clock, distributionStatisticConfig, exporter.getBaseTimeUnit());
+            return new DynatraceTimer(id, clock, distributionStatisticConfig, pauseDetector, exporter.getBaseTimeUnit());
         }
         return super.newTimer(id, distributionStatisticConfig, pauseDetector);
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -101,7 +101,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
         if (apiVersion == DynatraceApiVersion.V2) {
-            return new DynatraceDistributionSummary(id, scale);
+            return new DynatraceDistributionSummary(id, distributionStatisticConfig, scale);
         }
         return super.newDistributionSummary(id, distributionStatisticConfig, scale);
     }
@@ -109,7 +109,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     @Override
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
         if (apiVersion == DynatraceApiVersion.V2) {
-            return new DynatraceTimer(id, clock, exporter.getBaseTimeUnit());
+            return new DynatraceTimer(id, clock, distributionStatisticConfig, exporter.getBaseTimeUnit());
         }
         return super.newTimer(id, distributionStatisticConfig, pauseDetector);
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -101,7 +101,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
         if (apiVersion == DynatraceApiVersion.V2) {
-            return new DynatraceDistributionSummary(id, distributionStatisticConfig, scale);
+            return new DynatraceDistributionSummary(id, clock, distributionStatisticConfig, scale);
         }
         return super.newDistributionSummary(id, distributionStatisticConfig, scale);
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -101,7 +101,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
     @Override
     protected DistributionSummary newDistributionSummary(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
         if (apiVersion == DynatraceApiVersion.V2) {
-            return new DynatraceDistributionSummary(id);
+            return new DynatraceDistributionSummary(id, scale);
         }
         return super.newDistributionSummary(id, distributionStatisticConfig, scale);
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Resettable {@link DistributionSummary} implementation for Dynatrace exporters.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+public final class DynatraceDistributionSummary extends AbstractMeter implements DistributionSummary, DynatraceSummarySnapshotSupport {
+    private final DynatraceSummary summary = new DynatraceSummary();
+    private static final Logger LOGGER = LoggerFactory.getLogger(DynatraceDistributionSummary.class.getName());
+
+    public DynatraceDistributionSummary(Id id) {
+        super(id);
+    }
+
+    @Override
+    public void record(double amount) {
+        summary.recordNonNegative(amount);
+    }
+
+    @Override
+    public long count() {
+        return summary.getCount();
+    }
+
+    @Override
+    public double totalAmount() {
+        return summary.getTotal();
+    }
+
+    @Override
+    public double max() {
+        return summary.getMax();
+    }
+
+    public double min() {
+        return summary.getMin();
+    }
+
+    @Override
+    public boolean hasValues() {
+        return count() > 0;
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot() {
+        return new DynatraceSummarySnapshot(min(), max(), totalAmount(), count());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit timeUnit) {
+        LOGGER.debug("Called takeSummarySnapshot with a TimeUnit on a DistributionSummary. Ignoring TimeUnit.");
+        return takeSummarySnapshot();
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
+        DynatraceSummarySnapshot snapshot = takeSummarySnapshot();
+        summary.reset();
+        return snapshot;
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
+        LOGGER.debug("Called takeSummarySnapshot with a TimeUnit on a DistributionSummary. Ignoring TimeUnit.");
+        return takeSummarySnapshotAndReset();
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        LOGGER.warn("Called takeSnapshot on a Dynatrace Distribution Summary, no percentiles will be exported.");
+        DynatraceSummarySnapshot dtSnapshot = takeSummarySnapshot();
+        return HistogramSnapshot.empty(dtSnapshot.getCount(), dtSnapshot.getTotal(), dtSnapshot.getMax());
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -17,6 +17,7 @@ package io.micrometer.dynatrace.types;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +35,11 @@ public final class DynatraceDistributionSummary extends AbstractMeter implements
     private static final Logger LOGGER = LoggerFactory.getLogger(DynatraceDistributionSummary.class.getName());
     private final double scale;
 
-    public DynatraceDistributionSummary(Id id, double scale) {
+    public DynatraceDistributionSummary(Id id, DistributionStatisticConfig distributionStatisticConfig, double scale) {
         super(id);
+        if (distributionStatisticConfig != DistributionStatisticConfig.NONE) {
+            LOGGER.warn("Distribution statistic config is currently ignored.");
+        }
         this.scale = scale;
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -32,14 +32,16 @@ import java.util.concurrent.TimeUnit;
 public final class DynatraceDistributionSummary extends AbstractMeter implements DistributionSummary, DynatraceSummarySnapshotSupport {
     private final DynatraceSummary summary = new DynatraceSummary();
     private static final Logger LOGGER = LoggerFactory.getLogger(DynatraceDistributionSummary.class.getName());
+    private final double scale;
 
-    public DynatraceDistributionSummary(Id id) {
+    public DynatraceDistributionSummary(Id id, double scale) {
         super(id);
+        this.scale = scale;
     }
 
     @Override
     public void record(double amount) {
-        summary.recordNonNegative(amount);
+        summary.recordNonNegative(amount * scale);
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+/**
+ * Internal class for resettable summary statistics
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+final class DynatraceSummary {
+    private long count = 0;
+    private double total = 0d;
+    private double min = 0d;
+    private double max = 0d;
+
+    synchronized void recordNonNegative(double amount) {
+        if (amount < 0) {
+            return;
+        }
+        if (count == 0) {
+            min = amount;
+            max = amount;
+        } else {
+            min = Math.min(min, amount);
+            max = Math.max(max, amount);
+        }
+        count++;
+        total += amount;
+    }
+
+    public synchronized long getCount() {
+        return count;
+    }
+
+    public synchronized double getTotal() {
+        return total;
+    }
+
+    public synchronized double getMin() {
+        return min;
+    }
+
+    public synchronized double getMax() {
+        return max;
+    }
+
+    synchronized void reset() {
+        min = 0d;
+        max = 0d;
+        total = 0d;
+        count = 0;
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import javax.annotation.concurrent.Immutable;
+
+
+/**
+ * Snapshot of a Dynatrace summary object.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+@Immutable
+public final class DynatraceSummarySnapshot {
+    private final double min;
+    private final double max;
+    private final double total;
+    private final long count;
+
+    DynatraceSummarySnapshot(double min, double max, double total, long count) {
+        this.min = min;
+        this.max = max;
+        this.total = total;
+        this.count = count;
+    }
+
+    public double getMin() {
+        return min;
+    }
+
+    public double getMax() {
+        return max;
+    }
+
+    public double getTotal() {
+        return total;
+    }
+
+    public long getCount() {
+        return count;
+    }
+}
+

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshotSupport.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshotSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interface for retrieving a {@link DynatraceSummarySnapshot}.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+public interface DynatraceSummarySnapshotSupport {
+    boolean hasValues();
+
+    DynatraceSummarySnapshot takeSummarySnapshot();
+
+    DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit);
+
+    DynatraceSummarySnapshot takeSummarySnapshotAndReset();
+
+    DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit);
+}

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -18,7 +18,10 @@ package io.micrometer.dynatrace.types;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -31,12 +34,16 @@ import java.util.function.Supplier;
  * @since 1.9.0
  */
 public final class DynatraceTimer extends AbstractMeter implements Timer, DynatraceSummarySnapshotSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DynatraceTimer.class.getName());
     private final DynatraceSummary summary = new DynatraceSummary();
     private final Clock clock;
     private final TimeUnit baseTimeUnit;
 
-    public DynatraceTimer(Id id, Clock clock, TimeUnit baseTimeUnit) {
+    public DynatraceTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, TimeUnit baseTimeUnit) {
         super(id);
+        if (distributionStatisticConfig != DistributionStatisticConfig.NONE) {
+            LOGGER.warn("Distribution statistic config is currently ignored.");
+        }
         this.clock = clock;
         this.baseTimeUnit = baseTimeUnit;
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.AbstractMeter;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Resettable {@link Timer} implementation for Dynatrace exporters.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+public final class DynatraceTimer extends AbstractMeter implements Timer, DynatraceSummarySnapshotSupport {
+    private final DynatraceSummary summary = new DynatraceSummary();
+    private final Clock clock;
+    private final TimeUnit baseTimeUnit;
+
+    public DynatraceTimer(Id id, Clock clock, TimeUnit baseTimeUnit) {
+        super(id);
+        this.clock = clock;
+        this.baseTimeUnit = baseTimeUnit;
+    }
+
+    @Override
+    public boolean hasValues() {
+        return count() > 0;
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot() {
+        return takeSummarySnapshot(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
+        return new DynatraceSummarySnapshot(min(unit), max(unit), totalTime(unit), count());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
+        return takeSummarySnapshotAndReset(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
+        DynatraceSummarySnapshot snapshot = takeSummarySnapshot(unit);
+        summary.reset();
+        return snapshot;
+    }
+
+    // from AbstractTimer
+    @Override
+    public <T> T recordCallable(Callable<T> f) throws Exception {
+        final long s = clock.monotonicTime();
+        try {
+            return f.call();
+        } finally {
+            final long e = clock.monotonicTime();
+            record(e - s, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    // from AbstractTimer
+    @Override
+    public <T> T record(Supplier<T> f) {
+        final long s = clock.monotonicTime();
+        try {
+            return f.get();
+        } finally {
+            final long e = clock.monotonicTime();
+            record(e - s, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    // from AbstractTimer
+    @Override
+    public void record(Runnable f) {
+        final long s = clock.monotonicTime();
+        try {
+            f.run();
+        } finally {
+            final long e = clock.monotonicTime();
+            record(e - s, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    @Override
+    public void record(long amount, TimeUnit unit) {
+        // store everything in baseTimeUnit
+        long inBaseUnit = baseTimeUnit().convert(amount, unit);
+        summary.recordNonNegative(inBaseUnit);
+    }
+
+    @Override
+    public long count() {
+        return summary.getCount();
+    }
+
+    @Override
+    public double totalTime(TimeUnit unit) {
+        return unit.convert((long) summary.getTotal(), baseTimeUnit());
+    }
+
+    @Override
+    public double max(TimeUnit unit) {
+        return unit.convert((long) summary.getMax(), baseTimeUnit());
+    }
+
+    @Override
+    public TimeUnit baseTimeUnit() {
+        return baseTimeUnit;
+    }
+
+    public double min(TimeUnit unit) {
+        return unit.convert((long) summary.getMin(), baseTimeUnit());
+    }
+
+    @Override
+    public HistogramSnapshot takeSnapshot() {
+        DynatraceSummarySnapshot dtSnapshot = takeSummarySnapshot();
+        return HistogramSnapshot.empty(dtSnapshot.getCount(), dtSnapshot.getTotal(), dtSnapshot.getMax());
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link DynatraceDistributionSummary}.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+class DynatraceDistributionSummaryTest {
+    private static final Offset<Double> OFFSET = Offset.offset(0.0001);
+    private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc", Meter.Type.DISTRIBUTION_SUMMARY);
+
+    @Test
+    void testHasValues() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        assertThat(ds.hasValues()).isFalse();
+        ds.record(3.14);
+        assertThat(ds.hasValues()).isTrue();
+
+        // reset, hasValues should be initially false
+        ds.takeSummarySnapshotAndReset();
+        assertThat(ds.hasValues()).isFalse();
+
+        // add invalid value, hasValues stays false
+        ds.record(-1.234);
+        assertThat(ds.hasValues()).isFalse();
+    }
+
+    @Test
+    void testDynatraceDistributionSummary() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds, 3.14, 4.76, 7.9, 2);
+    }
+
+    @Test
+    void testRecordNegativeIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(-1.234);
+        ds.record(4.76);
+        ds.record(-6.789);
+
+        assertMinMaxSumCount(ds, 3.14, 4.76, 7.9, 2);
+    }
+
+    @Test
+    void testMinMaxAreOverwritten() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+        ds.record(0.123);
+        ds.record(8.93);
+
+        assertMinMaxSumCount(ds, 0.123, 8.93, 16.953, 4);
+    }
+
+
+    @Test
+    void testGetSnapshotNoReset() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds.takeSummarySnapshot(), 3.14, 4.76, 7.9, 2);
+        // run twice to make sure its not reset in between
+        assertMinMaxSumCount(ds.takeSummarySnapshot(), 3.14, 4.76, 7.9, 2);
+    }
+
+    @Test
+    void testGetSnapshotNoResetWithTimeUnitIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds.takeSummarySnapshot(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
+        // run twice to make sure its not reset in between
+        assertMinMaxSumCount(ds.takeSummarySnapshot(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
+    }
+
+
+    @Test
+    void testGetSnapshotAndReset() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(), 3.14, 4.76, 7.9, 2);
+        // run twice to make sure its not reset in between
+        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(), 0d, 0d, 0d, 0);
+    }
+
+    @Test
+    void testGetSnapshotAndResetWithTimeUnitIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
+        // run twice to make sure its not reset in between
+        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(TimeUnit.MINUTES), 0d, 0d, 0d, 0);
+    }
+
+    private void assertMinMaxSumCount(DynatraceDistributionSummary ds, double expMin, double expMax, double expTotal, long expCount) {
+        assertThat(ds.min()).isCloseTo(expMin, OFFSET);
+        assertThat(ds.max()).isCloseTo(expMax, OFFSET);
+        assertThat(ds.totalAmount()).isCloseTo(expTotal, OFFSET);
+        assertThat(ds.count()).isEqualTo(expCount);
+    }
+
+    private void assertMinMaxSumCount(DynatraceSummarySnapshot snapshot, double expMin, double expMax, double expTotal, long expCount) {
+        assertThat(snapshot.getMin()).isCloseTo(expMin, OFFSET);
+        assertThat(snapshot.getMax()).isCloseTo(expMax, OFFSET);
+        assertThat(snapshot.getTotal()).isCloseTo(expTotal, OFFSET);
+        assertThat(snapshot.getCount()).isEqualTo(expCount);
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -15,7 +15,9 @@
  */
 package io.micrometer.dynatrace.types;
 
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import org.assertj.core.data.Offset;
@@ -35,10 +37,11 @@ class DynatraceDistributionSummaryTest {
     private static final Offset<Double> OFFSET = Offset.offset(0.0001);
     private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc", Meter.Type.DISTRIBUTION_SUMMARY);
     private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
+    private static final Clock CLOCK = new MockClock();
 
     @Test
     void testHasValues() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         assertThat(ds.hasValues()).isFalse();
         ds.record(3.14);
         assertThat(ds.hasValues()).isTrue();
@@ -54,7 +57,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testDynatraceDistributionSummary() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -64,7 +67,7 @@ class DynatraceDistributionSummaryTest {
     @Test
     void testDynatraceDistributionSummaryScaled() {
         double scale = 1.5;
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, scale);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, scale);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -73,7 +76,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testRecordNegativeIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(-1.234);
         ds.record(4.76);
@@ -84,7 +87,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testMinMaxAreOverwritten() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
         ds.record(0.123);
@@ -96,7 +99,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -107,7 +110,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -119,7 +122,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -130,7 +133,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -17,6 +17,7 @@ package io.micrometer.dynatrace.types;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
@@ -33,10 +34,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class DynatraceDistributionSummaryTest {
     private static final Offset<Double> OFFSET = Offset.offset(0.0001);
     private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc", Meter.Type.DISTRIBUTION_SUMMARY);
+    private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
 
     @Test
     void testHasValues() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         assertThat(ds.hasValues()).isFalse();
         ds.record(3.14);
         assertThat(ds.hasValues()).isTrue();
@@ -52,7 +54,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testDynatraceDistributionSummary() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -62,7 +64,7 @@ class DynatraceDistributionSummaryTest {
     @Test
     void testDynatraceDistributionSummaryScaled() {
         double scale = 1.5;
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, scale);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, scale);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -71,7 +73,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testRecordNegativeIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(-1.234);
         ds.record(4.76);
@@ -82,7 +84,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testMinMaxAreOverwritten() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
         ds.record(0.123);
@@ -94,7 +96,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -105,7 +107,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -117,7 +119,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -128,7 +130,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -36,7 +36,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testHasValues() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         assertThat(ds.hasValues()).isFalse();
         ds.record(3.14);
         assertThat(ds.hasValues()).isTrue();
@@ -52,7 +52,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testDynatraceDistributionSummary() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -60,8 +60,18 @@ class DynatraceDistributionSummaryTest {
     }
 
     @Test
+    void testDynatraceDistributionSummaryScaled() {
+        double scale = 1.5;
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, scale);
+        ds.record(3.14);
+        ds.record(4.76);
+
+        assertMinMaxSumCount(ds, 3.14 * scale, 4.76 * scale, 7.9 * scale, 2);
+    }
+
+    @Test
     void testRecordNegativeIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(-1.234);
         ds.record(4.76);
@@ -72,7 +82,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testMinMaxAreOverwritten() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
         ds.record(0.123);
@@ -84,7 +94,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -95,7 +105,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotNoResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -107,7 +117,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndReset() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
 
@@ -118,7 +128,7 @@ class DynatraceDistributionSummaryTest {
 
     @Test
     void testGetSnapshotAndResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID);
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, 1);
         ds.record(3.14);
         ds.record(4.76);
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceSummaryTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+
+/**
+ * Tests for {@link DynatraceSummary}.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+class DynatraceSummaryTest {
+    private static final Offset<Double> OFFSET = Offset.offset(0.0001);
+
+    @Test
+    void testRecordValues() {
+        DynatraceSummary summary = new DynatraceSummary();
+        summary.recordNonNegative(3.14);
+        summary.recordNonNegative(4.76);
+
+        assertMinMaxSumCount(summary, 3.14, 4.76, 7.9, 2);
+    }
+
+    @Test
+    void testRecordNegativeIgnored() {
+        DynatraceSummary summary = new DynatraceSummary();
+        summary.recordNonNegative(3.14);
+        summary.recordNonNegative(-1.234);
+        summary.recordNonNegative(4.76);
+        summary.recordNonNegative(-6.789);
+
+        assertMinMaxSumCount(summary, 3.14, 4.76, 7.9, 2);
+    }
+
+    @Test
+    void testReset() {
+        DynatraceSummary summary = new DynatraceSummary();
+        summary.recordNonNegative(3.14);
+        summary.recordNonNegative(4.76);
+
+        assertMinMaxSumCount(summary, 3.14, 4.76, 7.9, 2);
+        summary.reset();
+        assertMinMaxSumCount(summary, 0d, 0d, 0d, 0);
+    }
+
+    @Test
+    void testMinMaxAreOverwritten() {
+        DynatraceSummary summary = new DynatraceSummary();
+        summary.recordNonNegative(3.14);
+        summary.recordNonNegative(4.76);
+        summary.recordNonNegative(0.123);
+        summary.recordNonNegative(8.93);
+
+        assertMinMaxSumCount(summary, 0.123, 8.93, 16.953, 4);
+    }
+
+
+    private void assertMinMaxSumCount(DynatraceSummary summary, Double expMin, Double expMax, Double expTotal, long expCount) {
+        assertThat(summary.getMin()).isCloseTo(expMin, OFFSET);
+        assertThat(summary.getMax()).isCloseTo(expMax, OFFSET);
+        assertThat(summary.getCount()).isEqualTo(expCount);
+        assertThat(summary.getTotal()).isCloseTo(expTotal, OFFSET);
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link DynatraceTimer}.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.0
+ */
+class DynatraceTimerTest {
+    private static final Offset<Double> OFFSET = Offset.offset(0.0001);
+    private static final Clock CLOCK = new MockClock();
+    private static final TimeUnit BASE_TIME_UNIT = TimeUnit.MILLISECONDS;
+    private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc", Meter.Type.TIMER);
+
+    @Test
+    void testHasValues() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        assertThat(timer.hasValues()).isFalse();
+        timer.record(Duration.ofMillis(314));
+        assertThat(timer.hasValues()).isTrue();
+        timer.record(Duration.ofMillis(476));
+        assertThat(timer.hasValues()).isTrue();
+
+        // checks that the recorded values are returned in the TimeUnit used to set up the instrument
+        assertMinMaxSumCount(timer, 314, 476, 790, 2);
+        assertThat(timer.hasValues()).isTrue();
+        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(), 314, 476, 790, 2);
+        assertThat(timer.hasValues()).isFalse();
+
+        timer.record(-100, TimeUnit.MILLISECONDS);
+        assertThat(timer.hasValues()).isFalse();
+    }
+
+    @Test
+    void testNegativeValuesIgnored() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        timer.record(-100, TimeUnit.MILLISECONDS);
+        timer.record(Duration.ofMillis(-100));
+        assertMinMaxSumCount(timer, 0, 0, 0, 0);
+    }
+
+    @Test
+    void testMinMaxAreOverwritten() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        timer.record(Duration.ofMillis(314));
+        timer.record(Duration.ofMillis(476));
+        assertMinMaxSumCount(timer, 314, 476, 790, 2);
+        timer.record(Duration.ofMillis(123));
+        timer.record(Duration.ofMillis(579));
+        assertMinMaxSumCount(timer, 123, 579, 1492, 4);
+    }
+
+    @Test
+    void testGetSnapshotAndReset() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        timer.record(Duration.ofMillis(314));
+        timer.record(Duration.ofMillis(476));
+
+        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(BASE_TIME_UNIT), 314, 476, 790, 2);
+        // check that the timer was indeed reset
+        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 0d, 0d, 0d, 0);
+    }
+
+    @Test
+    void testGetSnapshotAndResetWithNoTimeUnit() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        // record in a time unit that is not the base time unit
+        timer.record(Duration.ofSeconds(1));
+        timer.record(Duration.ofSeconds(2));
+
+        // checks that the recorded values are returned in the TimeUnit used to set up the instrument
+        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(), 1000, 2000, 3000, 2);
+        // check that the timer was indeed reset
+        assertMinMaxSumCount(timer.takeSummarySnapshot(), 0d, 0d, 0d, 0);
+    }
+
+    @Test
+    void testGetSnapshot() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        timer.record(Duration.ofMillis(314));
+        timer.record(Duration.ofMillis(476));
+
+        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 314, 476, 790, 2);
+        // check that the timer was not reset
+        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 314, 476, 790, 2);
+    }
+
+    @Test
+    void testGetSnapshotWithNoTimeUnit() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        // record in a time unit that is not the base time unit
+        timer.record(Duration.ofSeconds(1));
+        timer.record(Duration.ofSeconds(2));
+
+        // checks that the recorded values are returned in the TimeUnit used to set up the instrument
+        assertMinMaxSumCount(timer.takeSummarySnapshot(), 1000, 2000, 3000, 2);
+        // check that the timer was not reset
+        assertMinMaxSumCount(timer.takeSummarySnapshot(), 1000, 2000, 3000, 2);
+    }
+
+    @Test
+    void testDifferentTimeUnits() {
+        // set up the timer to record in Nanoseconds
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, TimeUnit.NANOSECONDS);
+        Duration oneSecond = Duration.ofSeconds(1);
+        timer.record(oneSecond);
+        assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isCloseTo(1_000_000_000, OFFSET);
+        // when requesting the time in a different unit, it is converted to that unit before being returned
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isCloseTo(1d, OFFSET);
+        assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isCloseTo(1000, OFFSET);
+    }
+
+    @Test
+    void testUseAllRecordInterfaces() {
+        MockClock clock = new MockClock();
+        DynatraceTimer timer = new DynatraceTimer(ID, clock, BASE_TIME_UNIT);
+
+        // Runnable
+        timer.record(() -> {
+            // Simulate the passing of time by using the MockClock interface
+            clock.add(Duration.ofMillis(100));
+        });
+
+        // Supplier
+        timer.record(() -> {
+            clock.add(Duration.ofMillis(200));
+            return 0;
+        });
+
+        // Duration
+        timer.record(Duration.ofMillis(300));
+
+        // Amount & Unit
+        timer.record(400, TimeUnit.MILLISECONDS);
+
+        assertMinMaxSumCount(timer.takeSummarySnapshot(), 100, 400, 1000, 4);
+    }
+
+    private static void assertMinMaxSumCount(DynatraceTimer timer, double expMin, double expMax, double expTotal, long expCount) {
+        assertThat(timer.min(BASE_TIME_UNIT)).isCloseTo(expMin, OFFSET);
+        assertThat(timer.max(BASE_TIME_UNIT)).isCloseTo(expMax, OFFSET);
+        assertThat(timer.totalTime(BASE_TIME_UNIT)).isCloseTo(expTotal, OFFSET);
+        assertThat(timer.count()).isEqualTo(expCount);
+    }
+
+    private void assertMinMaxSumCount(DynatraceSummarySnapshot snapshot, double expMin, double expMax, double expTotal, long expCount) {
+        assertThat(snapshot.getMin()).isCloseTo(expMin, OFFSET);
+        assertThat(snapshot.getMax()).isCloseTo(expMax, OFFSET);
+        assertThat(snapshot.getTotal()).isCloseTo(expTotal, OFFSET);
+        assertThat(snapshot.getCount()).isEqualTo(expCount);
+    }
+}

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
@@ -38,10 +39,11 @@ class DynatraceTimerTest {
     private static final Clock CLOCK = new MockClock();
     private static final TimeUnit BASE_TIME_UNIT = TimeUnit.MILLISECONDS;
     private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc", Meter.Type.TIMER);
+    private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
 
     @Test
     void testHasValues() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         assertThat(timer.hasValues()).isFalse();
         timer.record(Duration.ofMillis(314));
         assertThat(timer.hasValues()).isTrue();
@@ -60,7 +62,7 @@ class DynatraceTimerTest {
 
     @Test
     void testNegativeValuesIgnored() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         timer.record(-100, TimeUnit.MILLISECONDS);
         timer.record(Duration.ofMillis(-100));
         assertMinMaxSumCount(timer, 0, 0, 0, 0);
@@ -68,7 +70,7 @@ class DynatraceTimerTest {
 
     @Test
     void testMinMaxAreOverwritten() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         timer.record(Duration.ofMillis(314));
         timer.record(Duration.ofMillis(476));
         assertMinMaxSumCount(timer, 314, 476, 790, 2);
@@ -79,7 +81,7 @@ class DynatraceTimerTest {
 
     @Test
     void testGetSnapshotAndReset() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         timer.record(Duration.ofMillis(314));
         timer.record(Duration.ofMillis(476));
 
@@ -90,7 +92,7 @@ class DynatraceTimerTest {
 
     @Test
     void testGetSnapshotAndResetWithNoTimeUnit() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         // record in a time unit that is not the base time unit
         timer.record(Duration.ofSeconds(1));
         timer.record(Duration.ofSeconds(2));
@@ -103,7 +105,7 @@ class DynatraceTimerTest {
 
     @Test
     void testGetSnapshot() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         timer.record(Duration.ofMillis(314));
         timer.record(Duration.ofMillis(476));
 
@@ -114,7 +116,7 @@ class DynatraceTimerTest {
 
     @Test
     void testGetSnapshotWithNoTimeUnit() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
         // record in a time unit that is not the base time unit
         timer.record(Duration.ofSeconds(1));
         timer.record(Duration.ofSeconds(2));
@@ -128,7 +130,7 @@ class DynatraceTimerTest {
     @Test
     void testDifferentTimeUnits() {
         // set up the timer to record in Nanoseconds
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, TimeUnit.NANOSECONDS);
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, TimeUnit.NANOSECONDS);
         Duration oneSecond = Duration.ofSeconds(1);
         timer.record(oneSecond);
         assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isCloseTo(1_000_000_000, OFFSET);
@@ -140,7 +142,7 @@ class DynatraceTimerTest {
     @Test
     void testUseAllRecordInterfaces() {
         MockClock clock = new MockClock();
-        DynatraceTimer timer = new DynatraceTimer(ID, clock, BASE_TIME_UNIT);
+        DynatraceTimer timer = new DynatraceTimer(ID, clock, DISTRIBUTION_STATISTIC_CONFIG, BASE_TIME_UNIT);
 
         // Runnable
         timer.record(() -> {

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -227,7 +227,7 @@ class DynatraceExporterV2Test {
 
         List<String> lines = exporter.toTimerLine(timer).collect(Collectors.toList());
         assertThat(lines).hasSize(1);
-        assertThat(lines.get(0)).isEqualTo("my.timer,dt.metrics.source=micrometer gauge,min=0.0,max=60.0,sum=90.0,count=3 " + clock.wallTime());
+        assertThat(lines.get(0)).isEqualTo("my.timer,dt.metrics.source=micrometer gauge,min=10.0,max=60.0,sum=90.0,count=3 " + clock.wallTime());
     }
 
     @Test
@@ -341,7 +341,7 @@ class DynatraceExporterV2Test {
 
         List<String> lines = exporter.toDistributionSummaryLine(summary).collect(Collectors.toList());
         assertThat(lines).hasSize(1);
-        assertThat(lines.get(0)).isEqualTo("my.summary,dt.metrics.source=micrometer gauge,min=0.0,max=5.4,sum=10.9,count=4 " + clock.wallTime());
+        assertThat(lines.get(0)).isEqualTo("my.summary,dt.metrics.source=micrometer gauge,min=0.1,max=5.4,sum=10.9,count=4 " + clock.wallTime());
     }
 
     @Test


### PR DESCRIPTION
related to #3007 

This PR introduces resettable `Timer` and `DistributionSummary` instruments to be used in the Dynatrace v2 exporter to ensure no max-buffering from previous export intervals ends up in the exported lines. These types also add support for tracking the minimum since the last export.