### PR TITLE
NOOP Observation should be created when no handlers are registered

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
@@ -299,6 +299,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void runnableShouldBeScoped() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("myObservation", registry);
         Runnable runnable = () -> assertThat(registry.getCurrentObservation()).isSameAs(observation);
         observation.scoped(runnable);
@@ -307,6 +308,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void errorShouldBeReportedOnFailingScopedRunnable() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation.Context context = new Observation.Context();
         Observation observation = Observation.start("myObservation", context, registry);
         RuntimeException error = new RuntimeException("simulated");
@@ -321,6 +323,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void supplierShouldBeScoped() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("myObservation", registry);
         Supplier<String> supplier = () -> {
             assertThat(registry.getCurrentObservation()).isSameAs(observation);
@@ -333,6 +336,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void errorShouldBeReportedOnFailingScopedSupplier() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation.Context context = new Observation.Context();
         Observation observation = Observation.start("myObservation", context, registry);
         RuntimeException error = new RuntimeException("simulated");
@@ -347,6 +351,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void runnableShouldBeParentScoped() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation parent = Observation.start("myObservation", registry);
         Runnable runnable = () -> assertThat(registry.getCurrentObservation()).isSameAs(parent);
         Observation.tryScoped(parent, runnable);
@@ -362,6 +367,7 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     @Test
     void supplierShouldBeParentScoped() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation parent = Observation.start("myObservation", registry);
         Supplier<String> supplier = () -> {
             assertThat(registry.getCurrentObservation()).isSameAs(parent);

--- a/micrometer-observation-test/src/test/java/io/micrometer/core/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/core/tck/ObservationContextAssertTests.java
@@ -143,6 +143,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_low_cardinality_tag_exists() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityTag("foo", "bar");
 
@@ -160,6 +161,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_high_cardinality_tag_exists() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityTag("foo", "bar");
 
@@ -182,6 +184,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_high_cardinality_tag_present() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityTag("foo", "bar");
 
@@ -196,6 +199,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_low_cardinality_tag_present() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityTag("foo", "bar");
 
@@ -205,6 +209,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_any_tags_exist() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityTag("foo", "bar");
 
@@ -223,6 +228,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_tags_present() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityTag("foo", "bar");
 

--- a/micrometer-observation-test/src/test/java/io/micrometer/core/tck/ObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/core/tck/ObservationRegistryAssertTests.java
@@ -31,6 +31,7 @@ class ObservationRegistryAssertTests {
 
     @Test
     void assertionErrorThrownWhenRemainingObservationFound() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("hello", registry);
 
         try (Observation.Scope ws = observation.openScope()) {
@@ -55,6 +56,7 @@ class ObservationRegistryAssertTests {
 
     @Test
     void noAssertionErrorThrownWhenCurrentObservationPresent() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("hello", registry);
 
         try (Observation.Scope ws = observation.openScope()) {
@@ -65,6 +67,7 @@ class ObservationRegistryAssertTests {
 
     @Test
     void assertionErrorThrownWhenRemainingObservationNotSameAs() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.createNotStarted("foo", this.registry);
 
         assertThatThrownBy(() -> this.registryAssert.hasRemainingCurrentObservationSameAs(observation))
@@ -74,6 +77,7 @@ class ObservationRegistryAssertTests {
 
     @Test
     void noAssertionErrorThrownWhenCurrentObservationSameAs() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("hello", registry);
 
         try (Observation.Scope ws = observation.openScope()) {
@@ -84,6 +88,7 @@ class ObservationRegistryAssertTests {
 
     @Test
     void assertionErrorThrownWhenRemainingObservationSameAs() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.createNotStarted("foo", this.registry);
 
         try (Observation.Scope ws = observation.openScope()) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -106,7 +106,7 @@ public interface Observation {
      * @return created but not started observation
      */
     static Observation createNotStarted(String name, @Nullable Context context, @Nullable ObservationRegistry registry) {
-        if (registry == null || !registry.observationConfig().isObservationEnabled(name, context)) {
+        if (registry == null || !registry.observationConfig().isObservationEnabled(name, context) || registry.observationConfig().getObservationHandlers().isEmpty()) {
             return NoopObservation.INSTANCE;
         }
         return new SimpleObservation(name, registry, context == null ? new Context() : context);

--- a/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
@@ -19,12 +19,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CurrentObservationTest {
     private final ObservationRegistry registry = ObservationRegistry.create();
+
+    @BeforeEach
+    void setup() {
+        registry.observationConfig().observationHandler(context -> true);
+    }
 
     @Test
     void nestedSamples_parentChildThreadsInstrumented() throws ExecutionException, InterruptedException {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -32,6 +32,7 @@ class ObservationRegistryTest {
 
     @Test
     void openingScopeShouldSetSampleAsCurrent() {
+        registry.observationConfig().observationHandler(c -> true);
         Observation sample = Observation.start("test.timer", registry);
         Observation.Scope scope = sample.openScope();
 
@@ -76,6 +77,7 @@ class ObservationRegistryTest {
     @Test
     void observationShouldNotBeNoOpWhenNonNullRegistry() {
         ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(c -> true);
         assertThat(Observation.start("test.timer", registry)).isInstanceOf(SimpleObservation.class);
         assertThat(Observation.start("test.timer", new Observation.Context(), registry)).isInstanceOf(SimpleObservation.class);
         assertThat(Observation.createNotStarted("test.timer", registry)).isInstanceOf(SimpleObservation.class);

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Observation}.
+ *
+ * @author Jonatan Ivanov
+ * @author Tommy Ludwig
+ * @author Marcin Grzejszczak
+ */
+class ObservationTests {
+    @Test
+    void notHavingAnyHandlersShouldResultInNoOpObservation() {
+        ObservationRegistry registry = ObservationRegistry.create();
+
+        Observation observation = Observation.createNotStarted("foo", registry);
+
+        assertThat(observation).isSameAs(Observation.NOOP);
+    }
+
+    @Test
+    void notHavingARegistryShouldResultInNoOpObservation() {
+        Observation observation = Observation.createNotStarted("foo", null);
+
+        assertThat(observation).isSameAs(Observation.NOOP);
+    }
+
+    @Test
+    void notMatchingObservationPredicateShouldResultInNoOpObservation() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        registry.observationConfig().observationPredicate((s, context) -> false);
+
+        Observation observation = Observation.createNotStarted("foo", registry);
+
+        assertThat(observation).isSameAs(Observation.NOOP);
+    }
+
+    @Test
+    void matchingPredicateAndHandlerShouldResultInNoOpObservation() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        registry.observationConfig().observationPredicate((s, context) -> true);
+
+        Observation observation = Observation.createNotStarted("foo", registry);
+
+        assertThat(observation).isNotSameAs(Observation.NOOP);
+    }
+
+}

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -18,6 +18,7 @@ package io.micrometer.observation.contextpropagation;
 import io.micrometer.contextpropagation.ContextContainer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -25,6 +26,11 @@ import static org.assertj.core.api.BDDAssertions.then;
 class ObservationThreadLocalAccessorTests {
 
     ObservationRegistry observationRegistry = ObservationRegistry.create();
+
+    @BeforeEach
+    void setup() {
+        observationRegistry.observationConfig().observationHandler(context -> true);
+    }
 
     @Test
     void capturedThreadLocalValuesShouldBeCapturedRestoredAndCleared() {


### PR DESCRIPTION
this will influence tests - you'll always have to create at least one handler for your tests to actually do something more than noop

fixes #3105 