### PR TITLE
fixing name collision on PoolingHttpClientConnectionManagerMetricsBinder

### DIFF
--- a/micrometer-binders/src/main/java/io/micrometer/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-binders/src/main/java/io/micrometer/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -77,13 +77,13 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
                 .description("The configured maximum number of allowed persistent connections for all routes.")
                 .tags(tags)
                 .register(registry);
-        Gauge.builder("httpcomponents.httpclient.pool.total.connections",
+        Gauge.builder("httpcomponents.httpclient.pool.total.available",
                 connPoolControl,
                 (connPoolControl) -> connPoolControl.getTotalStats().getAvailable())
                 .description("The number of persistent and available connections for all routes.")
                 .tags(tags).tag("state", "available")
                 .register(registry);
-        Gauge.builder("httpcomponents.httpclient.pool.total.connections",
+        Gauge.builder("httpcomponents.httpclient.pool.total.leased",
                 connPoolControl,
                 (connPoolControl) -> connPoolControl.getTotalStats().getLeased())
                 .description("The number of persistent and leased connections for all routes.")

--- a/micrometer-binders/src/test/java/io/micrometer/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-binders/src/test/java/io/micrometer/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -63,7 +63,7 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getAvailable()).thenReturn(17);
         when(connPoolControl.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.available")
             .tags("httpclient", "test", "state", "available")
             .gauge().value()).isEqualTo(17.0);
     }
@@ -73,7 +73,7 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getLeased()).thenReturn(23);
         when(connPoolControl.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.leased")
             .tags("httpclient", "test", "state", "leased")
             .gauge().value()).isEqualTo(23.0);
     }


### PR DESCRIPTION
Hello, two metrics have same name on PoolingHttpClientConnectionManagerMetricsBinder