### PR TITLE
Change max heap size for Gradle daemon to 1 GB

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 


### PR DESCRIPTION
Running `./gradlew clean check --no-build-cache` locally gives the following failure:

```
➜  micrometer git:(main) ✗ ./gradlew clean check --no-build-cache
...
Expiring Daemon because JVM heap space is exhausted
Daemon will be stopped at the end of the build after running out of JVM memory
Expiring Daemon because JVM heap space is exhausted
Exception in thread "Daemon client event forwarder" java.lang.OutOfMemoryError: Java heap space

> Task :micrometer-registry-prometheus:compileTestJava
compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.13, {1}, {2}, {3}, {4}, {5}, {6}, {7}
java.lang.OutOfMemoryError: Java heap space


FAILURE: Build failed with an exception.

* What went wrong:
Gradle build daemon has been stopped: JVM garbage collector thrashing and after running out of JVM memory
...
```

Default max heap size for a Gradle daemon seems to be 512 MB as follows:

```
➜  ~ jps -lvm | grep "GradleDaemon"
11428 org.gradle.launcher.daemon.bootstrap.GradleDaemon 7.4.2 --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED -XX:MaxMetaspaceSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xms256m -Xmx512m -Dfile.encoding=UTF-8 -Duser.country=KR -Duser.language=en -Duser.variant
➜  ~
```

Changing it to 1 GB seems to resolve the failure.