### PR TITLE
1.10.x KeyValue & KeyValues

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/LogbackMetricsSuppressingFluxSink.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/LogbackMetricsSuppressingFluxSink.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import reactor.core.Disposable;
 import reactor.core.publisher.FluxSink;
 import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 /**
  * This is an internal class only for use within Micrometer.
@@ -53,6 +54,11 @@ public class LogbackMetricsSuppressingFluxSink implements FluxSink<String> {
     @Override
     public Context currentContext() {
         return delegate.currentContext();
+    }
+
+    @Override
+    public ContextView contextView() {
+        return delegate.contextView();
     }
 
     @Override

--- a/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
@@ -22,16 +22,16 @@ import io.micrometer.common.lang.Nullable;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Immutable {@link Tag}.
+ * Immutable {@link KeyValue}.
  *
  * @author Jon Schneider
  * @since 2.0.0
  */
-class ImmutableTag implements Tag {
+class ImmutableKeyValue implements KeyValue {
     private final String key;
     private final String value;
 
-    ImmutableTag(String key, String value) {
+    ImmutableKeyValue(String key, String value) {
         requireNonNull(key);
         requireNonNull(value);
         this.key = key;
@@ -52,7 +52,7 @@ class ImmutableTag implements Tag {
     public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Tag that = (Tag) o;
+        KeyValue that = (KeyValue) o;
         return Objects.equals(key, that.getKey()) &&
             Objects.equals(value, that.getValue());
     }

--- a/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
  * Immutable {@link KeyValue}.
  *
  * @author Jon Schneider
- * @since 2.0.0
+ * @since 1.10.0
  */
 class ImmutableKeyValue implements KeyValue {
     private final String key;

--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
@@ -21,17 +21,17 @@ package io.micrometer.common;
  * @author Jon Schneider
  * @since 2.0.0
  */
-public interface Tag extends Comparable<Tag> {
+public interface KeyValue extends Comparable<KeyValue> {
     String getKey();
 
     String getValue();
 
-    static Tag of(String key, String value) {
-        return new ImmutableTag(key, value);
+    static KeyValue of(String key, String value) {
+        return new ImmutableKeyValue(key, value);
     }
 
     @Override
-    default int compareTo(Tag o) {
+    default int compareTo(KeyValue o) {
         return getKey().compareTo(o.getKey());
     }
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
@@ -19,7 +19,7 @@ package io.micrometer.common;
  * Key/value pair representing a dimension of a meter used to classify and drill into measurements.
  *
  * @author Jon Schneider
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface KeyValue extends Comparable<KeyValue> {
     String getKey();

--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
@@ -34,7 +34,7 @@ import static java.util.stream.Collectors.joining;
  * @author Maciej Walkowiak
  * @author Phillip Webb
  * @author Johnny Lim
- * @since 2.0.0
+ * @since 1.10.0
  */
 public final class KeyValues implements Iterable<KeyValue> {
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/docs/TagKey.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/docs/TagKey.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
  * Represents a tag key.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface TagKey {
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/docs/TagKey.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/docs/TagKey.java
@@ -17,8 +17,6 @@ package io.micrometer.common.docs;
 
 import java.util.Arrays;
 
-import io.micrometer.common.Tag;
-
 
 /**
  * Represents a tag key.
@@ -43,14 +41,4 @@ public interface TagKey {
      * @return tag key
      */
     String getKey();
-
-    /**
-     * Returns a tag for this {@code TagKey}.
-     *
-     * @param value value to append to this tag
-     * @return tag
-     */
-    default Tag of(String value) {
-        return Tag.of(getKey(), value);
-    }
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/docs/DocumentedMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/docs/DocumentedMeter.java
@@ -35,7 +35,7 @@ import io.micrometer.core.lang.Nullable;
  * </ul>
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface DocumentedMeter {
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/MeterObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/MeterObservationHandler.java
@@ -23,7 +23,7 @@ import io.micrometer.observation.ObservationHandler;
  *
  * @author Marcin Grzejszczak
  * @param <T> type of context
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface MeterObservationHandler<T extends Observation.Context> extends ObservationHandler<T> {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/TimerObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/TimerObservationHandler.java
@@ -27,7 +27,7 @@ import io.micrometer.observation.Observation;
  * Handler for {@link Timer.Sample}.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class TimerObservationHandler implements MeterObservationHandler<Observation.Context> {
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/AnyContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/AnyContextObservationHandlerCompatibilityKit.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * and implement the abstract methods.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public abstract class AnyContextObservationHandlerCompatibilityKit extends NullContextObservationHandlerCompatibilityKit {
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ConcreteContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ConcreteContextObservationHandlerCompatibilityKit.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * and implement the abstract methods.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public abstract class ConcreteContextObservationHandlerCompatibilityKit<T extends Observation.Context> {
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/NullContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/NullContextObservationHandlerCompatibilityKit.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * and implement the abstract methods.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public abstract class NullContextObservationHandlerCompatibilityKit {
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationContextAssert.java
@@ -21,8 +21,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.micrometer.observation.Observation;
-import io.micrometer.common.Tag;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractThrowableAssert;
 
@@ -136,7 +136,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
 
     public SELF hasNoTags() {
         isNotNull();
-        Tags tags = this.actual.getAllTags();
+        KeyValues tags = this.actual.getAllTags();
         if (tags.stream().findAny().isPresent()) {
             failWithMessage("Observation should have no tags but has <%s>", tags);
         }
@@ -145,7 +145,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
 
     public SELF hasAnyTags() {
         isNotNull();
-        Tags tags = this.actual.getAllTags();
+        KeyValues tags = this.actual.getAllTags();
         if (!tags.stream().findAny().isPresent()) {
             failWithMessage("Observation should have any tags but has none");
         }
@@ -153,11 +153,11 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     }
 
     private List<String> lowCardinalityTagKeys() {
-        return this.actual.getLowCardinalityTags().stream().map(Tag::getKey).collect(Collectors.toList());
+        return this.actual.getLowCardinalityTags().stream().map(KeyValue::getKey).collect(Collectors.toList());
     }
 
     private List<String> highCardinalityTagKeys() {
-        return this.actual.getHighCardinalityTags().stream().map(Tag::getKey).collect(Collectors.toList());
+        return this.actual.getHighCardinalityTags().stream().map(KeyValue::getKey).collect(Collectors.toList());
     }
 
     public SELF hasLowCardinalityTagWithKey(String key) {
@@ -189,7 +189,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     public SELF doesNotHaveLowCardinalityTag(String key, String value) {
         isNotNull();
         doesNotHaveLowCardinalityTagWithKey(key);
-        Optional<Tag> optional = this.actual.getLowCardinalityTags().stream().filter(tag -> tag.getKey().equals(key)).findFirst();
+        Optional<KeyValue> optional = this.actual.getLowCardinalityTags().stream().filter(tag -> tag.getKey().equals(key)).findFirst();
         if (!optional.isPresent()) {
             return (SELF) this;
         }
@@ -230,7 +230,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     public SELF doesNotHaveHighCardinalityTag(String key, String value) {
         isNotNull();
         doesNotHaveHighCardinalityTagWithKey(key);
-        Optional<Tag> optional = this.actual.getHighCardinalityTags().stream().filter(tag -> tag.getKey().equals(key)).findFirst();
+        Optional<KeyValue> optional = this.actual.getHighCardinalityTags().stream().filter(tag -> tag.getKey().equals(key)).findFirst();
         if (!optional.isPresent()) {
             return (SELF) this;
         }

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryAssert.java
@@ -26,7 +26,7 @@ import org.assertj.core.api.AbstractAssert;
  * or {@link ObservationRegistryAssert#then(ObservationRegistry)}.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 @SuppressWarnings("unchecked")
 public class ObservationRegistryAssert<SELF extends ObservationRegistryAssert<SELF, ACTUAL>, ACTUAL extends ObservationRegistry> extends AbstractAssert<SELF, ACTUAL> {

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/ObservationRegistryCompatibilityKit.java
@@ -24,8 +24,8 @@ import java.util.function.Supplier;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.common.Tag;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -401,9 +401,9 @@ public abstract class ObservationRegistryCompatibilityKit {
         Exception exception = new IOException("simulated");
         Observation observation = Observation.start("test.observation", testContext, registry)
                 .lowCardinalityTag("lcTag1", "1")
-                .lowCardinalityTag(Tag.of("lcTag2", "2"))
+                .lowCardinalityTag(KeyValue.of("lcTag2", "2"))
                 .highCardinalityTag("hcTag1", "3")
-                .highCardinalityTag(Tag.of("hcTag2", "4"))
+                .highCardinalityTag(KeyValue.of("hcTag2", "4"))
                 .tagsProvider(new TestTagsProvider("local"))
                 .tagsProvider(new UnsupportedTagsProvider("local"))
                 .contextualName("test.observation.42")
@@ -414,27 +414,27 @@ public abstract class ObservationRegistryCompatibilityKit {
             assertThat(context).isSameAs(testContext);
             assertThat(context.getName()).isEqualTo("test.observation");
             assertThat(context.getLowCardinalityTags()).containsExactlyInAnyOrder(
-                    Tag.of("lcTag1", "1"),
-                    Tag.of("lcTag2", "2"),
-                    Tag.of("local.context.class", "TestContext"),
-                    Tag.of("global.context.class", "TestContext")
+                    KeyValue.of("lcTag1", "1"),
+                    KeyValue.of("lcTag2", "2"),
+                    KeyValue.of("local.context.class", "TestContext"),
+                    KeyValue.of("global.context.class", "TestContext")
             );
             assertThat(context.getHighCardinalityTags()).containsExactlyInAnyOrder(
-                    Tag.of("hcTag1", "3"),
-                    Tag.of("hcTag2", "4"),
-                    Tag.of("local.uuid", testContext.uuid),
-                    Tag.of("global.uuid", testContext.uuid)
+                    KeyValue.of("hcTag1", "3"),
+                    KeyValue.of("hcTag2", "4"),
+                    KeyValue.of("local.uuid", testContext.uuid),
+                    KeyValue.of("global.uuid", testContext.uuid)
             );
 
             assertThat(context.getAllTags()).containsExactlyInAnyOrder(
-                    Tag.of("lcTag1", "1"),
-                    Tag.of("lcTag2", "2"),
-                    Tag.of("local.context.class", "TestContext"),
-                    Tag.of("global.context.class", "TestContext"),
-                    Tag.of("hcTag1", "3"),
-                    Tag.of("hcTag2", "4"),
-                    Tag.of("local.uuid", testContext.uuid),
-                    Tag.of("global.uuid", testContext.uuid)
+                    KeyValue.of("lcTag1", "1"),
+                    KeyValue.of("lcTag2", "2"),
+                    KeyValue.of("local.context.class", "TestContext"),
+                    KeyValue.of("global.context.class", "TestContext"),
+                    KeyValue.of("hcTag1", "3"),
+                    KeyValue.of("hcTag2", "4"),
+                    KeyValue.of("local.uuid", testContext.uuid),
+                    KeyValue.of("global.uuid", testContext.uuid)
             );
 
             assertThat((String) context.get("context.field")).isEqualTo("42");
@@ -464,13 +464,13 @@ public abstract class ObservationRegistryCompatibilityKit {
         }
 
         @Override
-        public Tags getLowCardinalityTags(TestContext context) {
-            return Tags.of(this.id + "." + "context.class", TestContext.class.getSimpleName());
+        public KeyValues getLowCardinalityTags(TestContext context) {
+            return KeyValues.of(this.id + "." + "context.class", TestContext.class.getSimpleName());
         }
 
         @Override
-        public Tags getHighCardinalityTags(TestContext context) {
-            return Tags.of(this.id + "." + "uuid", context.uuid);
+        public KeyValues getHighCardinalityTags(TestContext context) {
+            return KeyValues.of(this.id + "." + "uuid", context.uuid);
         }
 
         @Override
@@ -491,13 +491,13 @@ public abstract class ObservationRegistryCompatibilityKit {
         }
 
         @Override
-        public Tags getLowCardinalityTags(Observation.Context context) {
-            return Tags.of(this.id + "." + "unsupported.lc", "unsupported");
+        public KeyValues getLowCardinalityTags(Observation.Context context) {
+            return KeyValues.of(this.id + "." + "unsupported.lc", "unsupported");
         }
 
         @Override
-        public Tags getHighCardinalityTags(Observation.Context context) {
-            return Tags.of(this.id + "." + "unsupported.hc", "unsupported");
+        public KeyValues getHighCardinalityTags(Observation.Context context) {
+            return KeyValues.of(this.id + "." + "unsupported.hc", "unsupported");
         }
 
         @Override

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/TestObservationRegistry.java
@@ -30,7 +30,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 public final class TestObservationRegistry implements ObservationRegistry {
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/core/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/core/tck/TestObservationRegistryAssert.java
@@ -28,7 +28,7 @@ import io.micrometer.observation.Observation;
  * or {@link TestObservationRegistryAssert#then(TestObservationRegistry)}.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class TestObservationRegistryAssert extends ObservationRegistryAssert<TestObservationRegistryAssert, TestObservationRegistry> {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -25,7 +25,7 @@ import io.micrometer.common.KeyValue;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 final class NoopObservation implements Observation {
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -16,7 +16,7 @@
 package io.micrometer.observation;
 
 
-import io.micrometer.common.Tag;
+import io.micrometer.common.KeyValue;
 
 /**
  * No-op implementation of {@link Observation} so that we can disable the instrumentation logic.
@@ -42,7 +42,7 @@ final class NoopObservation implements Observation {
     }
 
     @Override
-    public Observation lowCardinalityTag(Tag tag) {
+    public Observation lowCardinalityTag(KeyValue tag) {
         return this;
     }
 
@@ -52,7 +52,7 @@ final class NoopObservation implements Observation {
     }
 
     @Override
-    public Observation highCardinalityTag(Tag tag) {
+    public Observation highCardinalityTag(KeyValue tag) {
         return this;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
@@ -26,7 +26,7 @@ import java.util.Collections;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 final class NoopObservationConfig extends ObservationRegistry.ObservationConfig {
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
@@ -23,7 +23,7 @@ package io.micrometer.observation;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 final class NoopObservationRegistry implements ObservationRegistry {
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -48,7 +48,7 @@ import io.micrometer.observation.lang.Nullable;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface Observation {
 
@@ -406,7 +406,7 @@ public interface Observation {
      * (e.g. tracing context) are put in scope (e.g. in a ThreadLocal).
      * When the scope is closed the resources will be removed from the scope.
      *
-     * @since 2.0.0
+     * @since 1.10.0
      */
     interface Scope extends AutoCloseable {
 
@@ -439,7 +439,7 @@ public interface Observation {
      * A mutable holder of data required by a {@link ObservationHandler}. When extended
      * you can provide your own, custom information to be processed by the handlers.
      *
-     * @since 2.0.0
+     * @since 1.10.0
      */
     @SuppressWarnings("unchecked")
     class Context {
@@ -692,7 +692,7 @@ public interface Observation {
      *
      * @param <T> {@link TagsProvider} type
      * @author Marcin Grzejszczak
-     * @since 2.0.0
+     * @since 1.10.0
      */
     interface TagsProviderAware<T extends TagsProvider<?>> {
         /**
@@ -707,7 +707,7 @@ public interface Observation {
      * A provider of tags.
      *
      * @author Marcin Grzejszczak
-     * @since 2.0.0
+     * @since 1.10.0
      */
     interface TagsProvider<T extends Context> {
 
@@ -805,7 +805,7 @@ public interface Observation {
      * A provider of tags that will be set on the {@link ObservationRegistry}.
      *
      * @author Marcin Grzejszczak
-     * @since 2.0.0
+     * @since 1.10.0
      */
     interface GlobalTagsProvider<T extends Context> extends TagsProvider<T> {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -29,8 +29,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.micrometer.common.Tag;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.lang.NonNull;
 import io.micrometer.observation.lang.Nullable;
 
@@ -130,7 +130,7 @@ public interface Observation {
      * @param tag tag
      * @return this
      */
-    Observation lowCardinalityTag(Tag tag);
+    Observation lowCardinalityTag(KeyValue tag);
 
     /**
      * Sets a low cardinality tag. Low cardinality means that this tag
@@ -142,7 +142,7 @@ public interface Observation {
      * @return this
      */
     default Observation lowCardinalityTag(String key, String value) {
-        return lowCardinalityTag(Tag.of(key, value));
+        return lowCardinalityTag(KeyValue.of(key, value));
     }
 
     /**
@@ -153,7 +153,7 @@ public interface Observation {
      * @param tag tag
      * @return this
      */
-    Observation highCardinalityTag(Tag tag);
+    Observation highCardinalityTag(KeyValue tag);
 
     /**
      * Sets a high cardinality tag. High cardinality means that this tag
@@ -165,7 +165,7 @@ public interface Observation {
      * @return this
      */
     default Observation highCardinalityTag(String key, String value) {
-        return highCardinalityTag(Tag.of(key, value));
+        return highCardinalityTag(KeyValue.of(key, value));
     }
 
     /**
@@ -452,9 +452,9 @@ public interface Observation {
         @Nullable
         private Throwable error;
 
-        private final Set<Tag> lowCardinalityTags = new LinkedHashSet<>();
+        private final Set<KeyValue> lowCardinalityTags = new LinkedHashSet<>();
 
-        private final Set<Tag> highCardinalityTags = new LinkedHashSet<>();
+        private final Set<KeyValue> highCardinalityTags = new LinkedHashSet<>();
 
         /**
          * The observation name.
@@ -616,7 +616,7 @@ public interface Observation {
          *
          * @param tag a tag
          */
-        void addLowCardinalityTag(Tag tag) {
+        void addLowCardinalityTag(KeyValue tag) {
             this.lowCardinalityTags.add(tag);
         }
 
@@ -626,7 +626,7 @@ public interface Observation {
          *
          * @param tag a tag
          */
-        void addHighCardinalityTag(Tag tag) {
+        void addHighCardinalityTag(KeyValue tag) {
             this.highCardinalityTags.add(tag);
         }
 
@@ -635,7 +635,7 @@ public interface Observation {
          *
          * @param tags collection of tags
          */
-        void addLowCardinalityTags(Tags tags) {
+        void addLowCardinalityTags(KeyValues tags) {
             tags.stream().forEach(this::addLowCardinalityTag);
         }
 
@@ -644,22 +644,22 @@ public interface Observation {
          *
          * @param tags collection of tags
          */
-        void addHighCardinalityTags(Tags tags) {
+        void addHighCardinalityTags(KeyValues tags) {
             tags.stream().forEach(this::addHighCardinalityTag);
         }
 
         @NonNull
-        public Tags getLowCardinalityTags() {
-            return Tags.of(this.lowCardinalityTags);
+        public KeyValues getLowCardinalityTags() {
+            return KeyValues.of(this.lowCardinalityTags);
         }
 
         @NonNull
-        public Tags getHighCardinalityTags() {
-            return Tags.of(this.highCardinalityTags);
+        public KeyValues getHighCardinalityTags() {
+            return KeyValues.of(this.highCardinalityTags);
         }
 
         @NonNull
-        public Tags getAllTags() {
+        public KeyValues getAllTags() {
             return this.getLowCardinalityTags().and(this.getHighCardinalityTags());
         }
 
@@ -673,7 +673,7 @@ public interface Observation {
                     ", map=" + toString(map);
         }
 
-        private String toString(Collection<Tag> tags) {
+        private String toString(Collection<KeyValue> tags) {
             return tags.stream()
                     .map(tag -> String.format("%s='%s'", tag.getKey(), tag.getValue()))
                     .collect(Collectors.joining(", ", "[", "]"));
@@ -721,8 +721,8 @@ public interface Observation {
          *
          * @return tags
          */
-        default Tags getLowCardinalityTags(T context) {
-            return Tags.empty();
+        default KeyValues getLowCardinalityTags(T context) {
+            return KeyValues.empty();
         }
 
         /**
@@ -730,8 +730,8 @@ public interface Observation {
          *
          * @return tags
          */
-        default Tags getHighCardinalityTags(T context) {
-            return Tags.empty();
+        default KeyValues getHighCardinalityTags(T context) {
+            return KeyValues.empty();
         }
 
         /**
@@ -767,11 +767,11 @@ public interface Observation {
             }
 
             @Override
-            public Tags getLowCardinalityTags(Context context) {
+            public KeyValues getLowCardinalityTags(Context context) {
                 return getProvidersForContext(context)
                         .map(tagsProvider -> tagsProvider.getLowCardinalityTags(context))
-                        .reduce(Tags::and)
-                        .orElse(Tags.empty());
+                        .reduce(KeyValues::and)
+                        .orElse(KeyValues.empty());
             }
 
             private Stream<TagsProvider> getProvidersForContext(Context context) {
@@ -779,11 +779,11 @@ public interface Observation {
             }
 
             @Override
-            public Tags getHighCardinalityTags(Context context) {
+            public KeyValues getHighCardinalityTags(Context context) {
                 return getProvidersForContext(context)
                         .map(tagsProvider -> tagsProvider.getHighCardinalityTags(context))
-                        .reduce(Tags::and)
-                        .orElse(Tags.empty());
+                        .reduce(KeyValues::and)
+                        .orElse(KeyValues.empty());
             }
 
             @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface ObservationHandler<T extends Observation.Context> {
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationPredicate.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationPredicate.java
@@ -24,7 +24,7 @@ import java.util.function.BiPredicate;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface ObservationPredicate extends BiPredicate<String, Observation.Context> {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -28,7 +28,7 @@ import io.micrometer.observation.lang.Nullable;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface ObservationRegistry {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationTextPublisher.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationTextPublisher.java
@@ -25,7 +25,7 @@ import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
  * An {@link ObservationHandler} that converts the context to text and Publishes it to the {@link Consumer} of your choice.
  *
  * @author Jonatan Ivanov
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class ObservationTextPublisher implements ObservationHandler<Observation.Context> {
     private final Consumer<String> consumer;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.stream.Collectors;
 
-import io.micrometer.common.Tag;
+import io.micrometer.common.KeyValue;
 import io.micrometer.observation.lang.Nullable;
 
 /**
@@ -59,13 +59,13 @@ class SimpleObservation implements Observation {
     }
 
     @Override
-    public Observation lowCardinalityTag(Tag tag) {
+    public Observation lowCardinalityTag(KeyValue tag) {
         this.context.addLowCardinalityTag(tag);
         return this;
     }
 
     @Override
-    public Observation highCardinalityTag(Tag tag) {
+    public Observation highCardinalityTag(KeyValue tag) {
         this.context.addHighCardinalityTag(tag);
         return this;
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -30,7 +30,7 @@ import io.micrometer.observation.lang.Nullable;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 class SimpleObservation implements Observation {
     private final ObservationRegistry registry;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.lang.Nullable;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  *
- * @since 2.0.0
+ * @since 1.10.0
  */
 class SimpleObservationRegistry implements ObservationRegistry {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
@@ -38,7 +38,7 @@ import io.micrometer.observation.ObservationRegistry;
  * </ul>
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface DocumentedObservation {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/Kind.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/Kind.java
@@ -19,7 +19,7 @@ package io.micrometer.observation.transport;
  * Represents side of communication.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public enum Kind {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpClientRequest.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpClientRequest.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.transport.Kind;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpClientRequest extends HttpRequest {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpClientResponse.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpClientResponse.java
@@ -26,7 +26,7 @@ import io.micrometer.observation.lang.Nullable;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpClientResponse extends HttpResponse {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpRequest.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpRequest.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.lang.Nullable;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpRequest extends Request {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpResponse.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpResponse.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.lang.Nullable;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpResponse extends Response {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpServerRequest.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpServerRequest.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.transport.Kind;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpServerRequest extends HttpRequest {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpServerResponse.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/HttpServerResponse.java
@@ -26,7 +26,7 @@ import io.micrometer.observation.lang.Nullable;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpServerResponse extends HttpResponse {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/Request.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/Request.java
@@ -26,7 +26,7 @@ import io.micrometer.observation.transport.Kind;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface Request {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/Response.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/Response.java
@@ -27,7 +27,7 @@ import io.micrometer.observation.lang.Nullable;
  *
  * @author OpenZipkin Brave Authors
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface Response {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpClientContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpClientContext.java
@@ -26,7 +26,7 @@ import io.micrometer.observation.lang.NonNull;
  *
  * @author Jonatan Ivanov
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class HttpClientContext extends HttpContext<HttpClientRequest, HttpClientResponse> {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpContext.java
@@ -16,7 +16,7 @@
 package io.micrometer.observation.transport.http.context;
 
 import io.micrometer.observation.Observation;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.transport.http.HttpRequest;
 import io.micrometer.observation.transport.http.HttpResponse;
 import io.micrometer.observation.transport.http.tags.HttpTagsProvider;
@@ -79,7 +79,7 @@ public abstract class HttpContext<REQ extends HttpRequest, RES extends HttpRespo
 
     @NonNull
     @Override
-    public Tags getLowCardinalityTags() {
+    public KeyValues getLowCardinalityTags() {
         return this.tagsProvider.getLowCardinalityTags(getRequest(), getResponse(), null);
     }
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpContext.java
@@ -27,7 +27,7 @@ import io.micrometer.observation.lang.Nullable;
  * {@link Observation.Context} for an HTTP exchange.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  * @param <REQ> request type
  * @param <RES> response type
  */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpServerContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/context/HttpServerContext.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.lang.NonNull;
  * {@link Observation.Context Context} for an HTTP server request/response.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class HttpServerContext extends HttpContext<HttpServerRequest, HttpServerResponse> {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/DefaultHttpTagsProvider.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/DefaultHttpTagsProvider.java
@@ -23,7 +23,7 @@ import io.micrometer.observation.transport.http.HttpResponse;
  * Default implementation of {@link HttpTagsProvider} that can be extended for customization.
  *
  * @author Tommy Ludwig
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class DefaultHttpTagsProvider implements HttpTagsProvider {
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/DefaultHttpTagsProvider.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/DefaultHttpTagsProvider.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport.http.tags;
 
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.transport.http.HttpRequest;
 import io.micrometer.observation.transport.http.HttpResponse;
 
@@ -27,13 +27,13 @@ import io.micrometer.observation.transport.http.HttpResponse;
  */
 public class DefaultHttpTagsProvider implements HttpTagsProvider {
     @Override
-    public Tags getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
-        return Tags.of(HttpTags.method(request), HttpTags.uri(request), HttpTags.status(response),
+    public KeyValues getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
+        return KeyValues.of(HttpTags.method(request), HttpTags.uri(request), HttpTags.status(response),
                 HttpTags.outcome(response), HttpTags.exception(exception));
     }
 
     @Override
-    public Tags getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
-        return Tags.empty();
+    public KeyValues getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception) {
+        return KeyValues.empty();
     }
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTags.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTags.java
@@ -25,7 +25,7 @@ import io.micrometer.common.util.StringUtils;
  * the {@link HttpRequest} and {@link HttpResponse} abstraction.
  *
  * @author Jon Schneider
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class HttpTags {
     private static final String METHOD = "method";

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTags.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTags.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport.http.tags;
 
-import io.micrometer.common.Tag;
+import io.micrometer.common.KeyValue;
 import io.micrometer.observation.transport.http.HttpRequest;
 import io.micrometer.observation.transport.http.HttpResponse;
 import io.micrometer.common.util.StringUtils;
@@ -35,13 +35,13 @@ public class HttpTags {
 
     private static final String UNKNOWN = "UNKNOWN";
 
-    private static final Tag EXCEPTION_NONE = Tag.of(EXCEPTION, "None");
+    private static final KeyValue EXCEPTION_NONE = KeyValue.of(EXCEPTION, "None");
 
-    private static final Tag STATUS_UNKNOWN = Tag.of(STATUS, UNKNOWN);
+    private static final KeyValue STATUS_UNKNOWN = KeyValue.of(STATUS, UNKNOWN);
 
-    private static final Tag METHOD_UNKNOWN = Tag.of(METHOD, UNKNOWN);
+    private static final KeyValue METHOD_UNKNOWN = KeyValue.of(METHOD, UNKNOWN);
 
-    private static final Tag URI_UNKNOWN = Tag.of(URI, UNKNOWN);
+    private static final KeyValue URI_UNKNOWN = KeyValue.of(URI, UNKNOWN);
 
     private HttpTags() {
     }
@@ -52,8 +52,8 @@ public class HttpTags {
      * @param request the request
      * @return the method tag whose value is a capitalized method (e.g. GET).
      */
-    public static Tag method(HttpRequest request) {
-        return (request != null) ? Tag.of(METHOD, request.method()) : METHOD_UNKNOWN;
+    public static KeyValue method(HttpRequest request) {
+        return (request != null) ? KeyValue.of(METHOD, request.method()) : METHOD_UNKNOWN;
     }
 
     /**
@@ -61,8 +61,8 @@ public class HttpTags {
      * @param response the HTTP response
      * @return the status tag derived from the status of the response
      */
-    public static Tag status(HttpResponse response) {
-        return (response != null) ? Tag.of(STATUS, Integer.toString(response.statusCode())) : STATUS_UNKNOWN;
+    public static KeyValue status(HttpResponse response) {
+        return (response != null) ? KeyValue.of(STATUS, Integer.toString(response.statusCode())) : STATUS_UNKNOWN;
     }
 
     /**
@@ -71,10 +71,10 @@ public class HttpTags {
      * @param exception the exception, may be {@code null}
      * @return the exception tag derived from the exception
      */
-    public static Tag exception(Throwable exception) {
+    public static KeyValue exception(Throwable exception) {
         if (exception != null) {
             String simpleName = exception.getClass().getSimpleName();
-            return Tag.of(EXCEPTION, StringUtils.isNotBlank(simpleName) ? simpleName : exception.getClass().getName());
+            return KeyValue.of(EXCEPTION, StringUtils.isNotBlank(simpleName) ? simpleName : exception.getClass().getName());
         }
         return EXCEPTION_NONE;
     }
@@ -84,12 +84,12 @@ public class HttpTags {
      * @param response the HTTP response
      * @return the outcome tag derived from the status of the response
      */
-    public static Tag outcome(HttpResponse response) {
+    public static KeyValue outcome(HttpResponse response) {
         return ((response != null) ? Outcome.forStatus(response.statusCode()) : Outcome.UNKNOWN).asTag();
     }
 
-    public static Tag uri(HttpRequest request) {
+    public static KeyValue uri(HttpRequest request) {
         String uri = request.route();
-        return uri == null ? URI_UNKNOWN : Tag.of(URI, uri);
+        return uri == null ? URI_UNKNOWN : KeyValue.of(URI, uri);
     }
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTagsProvider.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTagsProvider.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport.http.tags;
 
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.transport.http.HttpRequest;
 import io.micrometer.observation.transport.http.HttpResponse;
 
@@ -42,7 +42,7 @@ public interface HttpTagsProvider {
      * @param exception exception thrown during operation, or null
      * @return set of tags based on the given parameters
      */
-    Tags getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
+    KeyValues getLowCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
 
     /**
      * Provide tags known to be high-cardinality, which generally are not appropriate for use with metrics.
@@ -53,5 +53,5 @@ public interface HttpTagsProvider {
      * @param exception exception thrown during operation, or null
      * @return set of tags based on the given parameters
      */
-    Tags getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
+    KeyValues getHighCardinalityTags(HttpRequest request, HttpResponse response, Throwable exception);
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTagsProvider.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/HttpTagsProvider.java
@@ -24,7 +24,7 @@ import io.micrometer.observation.transport.http.HttpResponse;
  *
  * @see HttpTags
  * @author Tommy Ludwig
- * @since 2.0.0
+ * @since 1.10.0
  */
 public interface HttpTagsProvider {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/Outcome.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/http/tags/Outcome.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport.http.tags;
 
-import io.micrometer.common.Tag;
+import io.micrometer.common.KeyValue;
 
 /**
  * The outcome of an HTTP request.
@@ -55,18 +55,18 @@ public enum Outcome {
      */
     UNKNOWN;
 
-    private final Tag tag;
+    private final KeyValue tag;
 
     Outcome() {
-        this.tag = Tag.of("outcome", name());
+        this.tag = KeyValue.of("outcome", name());
     }
 
     /**
-     * Returns the {@code Outcome} as a {@link Tag} named {@code outcome}.
+     * Returns the {@code Outcome} as a {@link KeyValue} named {@code outcome}.
      *
      * @return the {@code outcome} {@code Tag}
      */
-    public Tag asTag() {
+    public KeyValue asTag() {
         return this.tag;
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTextPublisherTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTextPublisherTests.java
@@ -18,7 +18,7 @@ package io.micrometer.observation;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import io.micrometer.common.Tag;
+import io.micrometer.common.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,8 +89,8 @@ class ObservationTextPublisherTests {
                 .setName("testName")
                 .setContextualName("testContextualName")
                 .setError(new IOException("simulated"));
-        context.addLowCardinalityTag(Tag.of("lcTag", "foo"));
-        context.addHighCardinalityTag(Tag.of("hcTag", "bar"));
+        context.addLowCardinalityTag(KeyValue.of("lcTag", "foo"));
+        context.addHighCardinalityTag(KeyValue.of("hcTag", "bar"));
         context.put("contextKey", "contextValue");
 
         return context;

--- a/micrometer-observation/src/test/java/io/micrometer/observation/TagsProviderTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/TagsProviderTest.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.Tag;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,8 +41,8 @@ class TagsProviderTest {
                 new MatchingTestTagsProvider(), new AnotherMatchingTestTagsProvider(), new NotMatchingTestTagsProvider()
         );
 
-        assertThat(tagsProvider.getLowCardinalityTags(new Observation.Context())).containsExactlyInAnyOrder(Tag.of("matching-low-1", ""), Tag.of("matching-low-2", ""));
-        assertThat(tagsProvider.getHighCardinalityTags(new Observation.Context())).containsExactlyInAnyOrder(Tag.of("matching-high-1", ""), Tag.of("matching-high-2", ""));
+        assertThat(tagsProvider.getLowCardinalityTags(new Observation.Context())).containsExactlyInAnyOrder(KeyValue.of("matching-low-1", ""), KeyValue.of("matching-low-2", ""));
+        assertThat(tagsProvider.getHighCardinalityTags(new Observation.Context())).containsExactlyInAnyOrder(KeyValue.of("matching-high-1", ""), KeyValue.of("matching-high-2", ""));
     }
 
     static class TestTagsProvider implements Observation.TagsProvider<Observation.Context> {
@@ -59,13 +59,13 @@ class TagsProviderTest {
         }
 
         @Override
-        public Tags getLowCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("matching-low-1", ""));
+        public KeyValues getLowCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("matching-low-1", ""));
         }
 
         @Override
-        public Tags getHighCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("matching-high-1", ""));
+        public KeyValues getHighCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("matching-high-1", ""));
         }
     }
 
@@ -77,13 +77,13 @@ class TagsProviderTest {
         }
 
         @Override
-        public Tags getLowCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("matching-low-2", ""));
+        public KeyValues getLowCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("matching-low-2", ""));
         }
 
         @Override
-        public Tags getHighCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("matching-high-2", ""));
+        public KeyValues getHighCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("matching-high-2", ""));
         }
     }
 
@@ -94,13 +94,13 @@ class TagsProviderTest {
         }
 
         @Override
-        public Tags getLowCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("not-matching-low", ""));
+        public KeyValues getLowCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("not-matching-low", ""));
         }
 
         @Override
-        public Tags getHighCardinalityTags(Observation.Context context) {
-            return Tags.of(Tag.of("not-matching-high", ""));
+        public KeyValues getHighCardinalityTags(Observation.Context context) {
+            return KeyValues.of(KeyValue.of("not-matching-high", ""));
         }
     }
 }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
@@ -187,7 +187,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if there is no meter registered under given name with given tags.
      */
-    public MeterRegistryAssert hasMeterWithNameAndTags(String meterName, io.micrometer.common.Tags tags) {
+    public MeterRegistryAssert hasMeterWithNameAndTags(String meterName, KeyValues tags) {
         return hasMeterWithNameAndTags(meterName, toMicrometerTags(tags));
     }
 
@@ -251,7 +251,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @return this
      * @throws AssertionError if there is a meter registered under given name with given tags.
      */
-    public MeterRegistryAssert doesNotHaveMeterWithNameAndTags(String meterName, io.micrometer.common.Tags tags) {
+    public MeterRegistryAssert doesNotHaveMeterWithNameAndTags(String meterName, KeyValues tags) {
         return doesNotHaveMeterWithNameAndTags(meterName, toMicrometerTags(tags));
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
@@ -18,6 +18,7 @@ package io.micrometer.core.tck;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -199,11 +200,11 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @throws AssertionError if the actual value is {@code null}.
      * @throws AssertionError if there is no timer registered under given name with given tags.
      */
-    public MeterRegistryAssert hasTimerWithNameAndTags(String timerName, io.micrometer.common.Tags tags) {
+    public MeterRegistryAssert hasTimerWithNameAndTags(String timerName, KeyValues tags) {
         return hasTimerWithNameAndTags(timerName, toMicrometerTags(tags));
     }
 
-    private Tags toMicrometerTags(io.micrometer.common.Tags tags) {
+    private Tags toMicrometerTags(KeyValues tags) {
         Tag[] array = tags.stream().map(tag -> Tag.of(tag.getKey(), tag.getValue())).toArray(Tag[]::new);
         return Tags.of(array);
     }
@@ -262,7 +263,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @return this
      * @throws AssertionError if there is a timer registered under given name with given tags.
      */
-    public MeterRegistryAssert doesNotHaveTimerWithNameAndTags(String timerName, io.micrometer.common.Tags tags) {
+    public MeterRegistryAssert doesNotHaveTimerWithNameAndTags(String timerName, KeyValues tags) {
         return doesNotHaveTimerWithNameAndTags(timerName, toMicrometerTags(tags));
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
@@ -33,7 +33,7 @@ import org.assertj.core.api.AbstractAssert;
  * or {@link MeterRegistryAssert#then(MeterRegistry)}.
  *
  * @author Marcin Grzejszczak
- * @since 2.0.0
+ * @since 1.10.0
  */
 public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, MeterRegistry> {
 

--- a/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.tck;
 
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -109,7 +111,7 @@ class MeterRegistryAssertTests {
     void assertionErrorThrownWhenTimerPresentWithCommonTagValue() {
         Timer.start(this.simpleMeterRegistry).stop(Timer.builder("matching-metric-name").tag("matching-tag", "matching-value").register(this.simpleMeterRegistry));
 
-        assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveTimerWithNameAndTags("matching-metric-name", io.micrometer.common.Tags.of("matching-tag", "matching-value")))
+        assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveTimerWithNameAndTags("matching-metric-name", KeyValues.of("matching-tag", "matching-value")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected no timer with name <matching-metric-name> and tags <[tag(matching-tag=matching-value)]> but found one");
     }
@@ -148,7 +150,7 @@ class MeterRegistryAssertTests {
     void noAssertionErrorThrownWhenTimerWithCommonTagPresent() {
         Timer.start(this.simpleMeterRegistry).stop(Timer.builder("matching-metric-name").tag("matching-tag", "matching-value").register(this.simpleMeterRegistry));
 
-        assertThatCode(() -> meterRegistryAssert.hasTimerWithNameAndTags("matching-metric-name", io.micrometer.common.Tags.of("matching-tag", "matching-value")))
+        assertThatCode(() -> meterRegistryAssert.hasTimerWithNameAndTags("matching-metric-name", KeyValues.of("matching-tag", "matching-value")))
             .doesNotThrowAnyException();
     }
 
@@ -166,7 +168,7 @@ class MeterRegistryAssertTests {
 
     @Test
     void noAssertionErrorThrownWhenTimerWithCommonTagsMissing() {
-        assertThatCode(() -> meterRegistryAssert.doesNotHaveTimerWithNameAndTags("foo", io.micrometer.common.Tags.of(io.micrometer.common.Tag.of("bar", "baz"))))
+        assertThatCode(() -> meterRegistryAssert.doesNotHaveTimerWithNameAndTags("foo", KeyValues.of(KeyValue.of("bar", "baz"))))
                 .doesNotThrowAnyException();
     }
 

--- a/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
@@ -248,7 +248,7 @@ class MeterRegistryAssertTests {
     void assertionErrorThrownWhenMeterPresentWithCommonTagValue() {
         Timer.start(this.simpleMeterRegistry).stop(Timer.builder("matching-metric-name").tag("matching-tag", "matching-value").register(this.simpleMeterRegistry));
 
-        assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveMeterWithNameAndTags("matching-metric-name", io.micrometer.common.Tags.of("matching-tag", "matching-value")))
+        assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveMeterWithNameAndTags("matching-metric-name", KeyValues.of("matching-tag", "matching-value")))
                 .isInstanceOf(AssertionError.class)
                 .hasMessageContaining("Expected no meter with name <matching-metric-name> and tags <[tag(matching-tag=matching-value)]> but found one");
     }
@@ -281,7 +281,7 @@ class MeterRegistryAssertTests {
     void noAssertionErrorThrownWhenMeterWithCommonTagPresent() {
         Timer.start(this.simpleMeterRegistry).stop(Timer.builder("matching-metric-name").tag("matching-tag", "matching-value").register(this.simpleMeterRegistry));
 
-        assertThatCode(() -> meterRegistryAssert.hasMeterWithNameAndTags("matching-metric-name", io.micrometer.common.Tags.of("matching-tag", "matching-value")))
+        assertThatCode(() -> meterRegistryAssert.hasMeterWithNameAndTags("matching-metric-name", KeyValues.of("matching-tag", "matching-value")))
                 .doesNotThrowAnyException();
     }
 
@@ -299,7 +299,7 @@ class MeterRegistryAssertTests {
 
     @Test
     void noAssertionErrorThrownWhenMeterWithCommonTagsMissing() {
-        assertThatCode(() -> meterRegistryAssert.doesNotHaveMeterWithNameAndTags("foo", io.micrometer.common.Tags.of(io.micrometer.common.Tag.of("bar", "baz"))))
+        assertThatCode(() -> meterRegistryAssert.doesNotHaveMeterWithNameAndTags("foo", KeyValues.of(KeyValue.of("bar", "baz"))))
                 .doesNotThrowAnyException();
     }
 

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -25,7 +25,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
-import io.micrometer.common.Tags;
+import io.micrometer.common.KeyValues;
 
 public class ObservationHandlerSample {
     private static final SimpleMeterRegistry registry = new SimpleMeterRegistry();
@@ -66,13 +66,13 @@ public class ObservationHandlerSample {
 
     static class CustomTagsProvider implements Observation.GlobalTagsProvider<CustomContext> {
         @Override
-        public Tags getLowCardinalityTags(CustomContext context) {
-            return Tags.of("className", context.getClass().getSimpleName());
+        public KeyValues getLowCardinalityTags(CustomContext context) {
+            return KeyValues.of("className", context.getClass().getSimpleName());
         }
 
         @Override
-        public Tags getHighCardinalityTags(CustomContext context) {
-            return Tags.of("userId", context.uuid.toString());
+        public KeyValues getHighCardinalityTags(CustomContext context) {
+            return KeyValues.of("userId", context.uuid.toString());
         }
 
         @Override
@@ -83,13 +83,13 @@ public class ObservationHandlerSample {
 
     static class CustomLocalTagsProvider implements Observation.TagsProvider<CustomContext> {
         @Override
-        public Tags getLowCardinalityTags(CustomContext context) {
-            return Tags.of("localClassName", context.getClass().getSimpleName());
+        public KeyValues getLowCardinalityTags(CustomContext context) {
+            return KeyValues.of("localClassName", context.getClass().getSimpleName());
         }
 
         @Override
-        public Tags getHighCardinalityTags(CustomContext context) {
-            return Tags.of("localUserId", context.uuid.toString());
+        public KeyValues getHighCardinalityTags(CustomContext context) {
+            return KeyValues.of("localUserId", context.uuid.toString());
         }
 
         @Override


### PR DESCRIPTION
Trying to fix the Tag & Tags confusion

- we rename Tag & Tags into KeyValue and KeyValues - that way there will be no confusions between the current Tag(s) and the ones from the common module
- TagKey will have the "of" method removed - that way we will not be returning Tags from commons that can be then used by micrometer's core code

Modified since from 2.0.0 to 1.10.0

[related PR](https://github.com/micrometer-metrics/micrometer/pull/3120)