### PR TITLE
Improve build cacheability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ subprojects {
                 metaInf {
                     [
                         'Build-Date',
+                        'Build-Date-UTC',
                         'Built-By',
                         'Built-OS',
                         'Build-Host',

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.8.1'
+    id 'com.gradle.enterprise' version '3.9'
     id 'io.spring.ge.conventions' version '0.0.9'
 }
 


### PR DESCRIPTION
- Ignore Build-Date-UTC as RuntimeNormalization to get cache hits on `micrometer-samples-hazelcast3:test` and `micrometer-samples-jersey3:test`
- Bump up Gradle Enterprise Plugin to 3.9