### PR TITLE
Fix failure messages in MeterRegistryAssert

### DIFF
--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
@@ -315,7 +315,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
         isNotNull();
         Meter foundMeter = actual.find(meterName).tagKeys(tagKeys).meter();
         if (foundMeter != null) {
-            failWithMessage("Expected a meter with name <%s> and tag keys <%s> but found one", meterName, String.join(",", tagKeys));
+            failWithMessage("Expected no meter with name <%s> and tag keys <%s> but found one", meterName, String.join(",", tagKeys));
         }
         return this;
     }
@@ -332,7 +332,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
         isNotNull();
         Timer foundTimer = actual.find(timerName).tagKeys(tagKeys).timer();
         if (foundTimer != null) {
-            failWithMessage("Expected a timer with name <%s> and tag keys <%s> but found one", timerName, String.join(",", tagKeys));
+            failWithMessage("Expected no timer with name <%s> and tag keys <%s> but found one", timerName, String.join(",", tagKeys));
         }
         return this;
     }

--- a/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/tck/MeterRegistryAssertTests.java
@@ -95,7 +95,7 @@ class MeterRegistryAssertTests {
 
         assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveTimerWithNameAndTagKeys("matching-metric-name", "matching-tag"))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("Expected a timer with name <matching-metric-name> and tag keys <matching-tag> but found one");
+                .hasMessageContaining("Expected no timer with name <matching-metric-name> and tag keys <matching-tag> but found one");
     }
 
     @Test
@@ -232,7 +232,7 @@ class MeterRegistryAssertTests {
 
         assertThatThrownBy(() -> meterRegistryAssert.doesNotHaveMeterWithNameAndTagKeys("matching-metric-name", "matching-tag"))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("Expected a meter with name <matching-metric-name> and tag keys <matching-tag> but found one");
+                .hasMessageContaining("Expected no meter with name <matching-metric-name> and tag keys <matching-tag> but found one");
     }
 
     @Test


### PR DESCRIPTION
This PR fixes failure messages in `MeterRegistryAssert`.