### PR TITLE
Pin Jersey dependencies to 3.0.+ in its sample

### DIFF
--- a/samples/micrometer-samples-jersey3/build.gradle
+++ b/samples/micrometer-samples-jersey3/build.gradle
@@ -5,9 +5,9 @@ plugins {
 dependencies {
     implementation project(":micrometer-core")
 
-    implementation 'org.glassfish.jersey.containers:jersey-container-jdk-http:3.+'
-    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:3.+'
+    implementation 'org.glassfish.jersey.containers:jersey-container-jdk-http:3.0.+'
+    runtimeOnly 'org.glassfish.jersey.inject:jersey-hk2:3.0.+'
 
     testImplementation project(':micrometer-test')
-    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http:3.+'
+    testImplementation 'org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-jdk-http:3.0.+'
 }


### PR DESCRIPTION
`main` builds are broken now as follows:

```
> Task :micrometer-samples-jersey3:compileJava FAILED
/Users/user/IdeaProjects/micrometer/samples/micrometer-samples-jersey3/src/main/java/io/micrometer/samples/jersey3/HelloWorldResource.java:18: error: cannot access jakarta.ws.rs.GET
import jakarta.ws.rs.GET;
                    ^
  bad class file: /Users/user/.gradle/caches/modules-2/files-2.1/jakarta.ws.rs/jakarta.ws.rs-api/3.1.0/15ce10d249a38865b58fc39521f10f29ab0e3363/jakarta.ws.rs-api-3.1.0.jar(jakarta/ws/rs/GET.class)
    class file has wrong version 55.0, should be 52.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
```

`jakarta.ws.rs:jakarta.ws.rs-api:3.1.0` seems to require JDK 11, and it seems to be pulled by Jersey 3.1.0-M2 as follows:

```
➜  micrometer git:(main) ✗ ./gradlew :micrometer-samples-jersey3:dependencyInsight --dependency jakarta.ws.rs-api
...
> Task :micrometer-samples-jersey3:dependencyInsight
jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 8
   ]

jakarta.ws.rs:jakarta.ws.rs-api:3.1.0
+--- org.glassfish.jersey.containers:jersey-container-jdk-http:3.1.0-M2
|    \--- compileClasspath (requested org.glassfish.jersey.containers:jersey-container-jdk-http:3.+)
+--- org.glassfish.jersey.core:jersey-client:3.1.0-M2
|    \--- org.glassfish.jersey.core:jersey-server:3.1.0-M2
|         +--- project :micrometer-core (requested org.glassfish.jersey.core:jersey-server:2.+)
|         |    \--- compileClasspath
|         +--- org.glassfish.jersey.containers:jersey-container-jdk-http:3.1.0-M2 (*)
|         \--- project :micrometer-commons (requested org.glassfish.jersey.core:jersey-server:2.+)
|              \--- project :micrometer-core (*)
+--- org.glassfish.jersey.core:jersey-common:3.1.0-M2
|    +--- org.glassfish.jersey.containers:jersey-container-jdk-http:3.1.0-M2 (*)
|    +--- org.glassfish.jersey.core:jersey-server:3.1.0-M2 (*)
|    \--- org.glassfish.jersey.core:jersey-client:3.1.0-M2 (*)
\--- org.glassfish.jersey.core:jersey-server:3.1.0-M2 (*)

(*) - dependencies omitted (listed previously)

A web-based, searchable dependency report is available by adding the --scan option.

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed

A build scan was not published as you have not authenticated with server 'ge.micrometer.io'.
➜  micrometer git:(main) ✗
```

This PR pins Jersey dependencies to 3.0.+ in its sample to restore builds on JDK 8.