### PR TITLE
Include aarch_64 netty dns resolver for Apple silicon macs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -96,6 +96,7 @@ subprojects {
         }
       }
       implementation platform('io.projectreactor:reactor-bom:2020.0.+')
+	  implementation platform('io.netty:netty-bom:4.1.+')
     }
   }
 }

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -10,17 +10,17 @@ dependencies {
         // We do not use HTTP modules; exclude to avoid false positive CVE reports
         exclude module: 'netty-codec-http'
     }
-	// We need make sure netty dns resolution works on all macs
-	implementation 'io.netty:netty-resolver-dns-native-macos:+:osx-x86_64'
-	implementation 'io.netty:netty-resolver-dns-native-macos:+:osx-aarch_64'
+    // We need make sure netty dns resolution works on all macs
+    implementation(group: 'io.netty', name: 'netty-resolver-dns-native-macos', classifier: 'osx-x86_64')
+    implementation(group: 'io.netty', name: 'netty-resolver-dns-native-macos', classifier: 'osx-aarch_64')
 
     testImplementation project(':micrometer-test')
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'ch.qos.logback:logback-classic'
     testImplementation 'org.awaitility:awaitility'
     // for running tests with UDS on OSX
-    testImplementation 'io.netty:netty-transport-native-kqueue:+:osx-x86_64'
-    testImplementation 'io.netty:netty-transport-native-kqueue:+:osx-aarch_64'
+    testImplementation(group: 'io.netty', name: 'netty-transport-native-kqueue', classifier: 'osx-x86_64')
+    testImplementation(group: 'io.netty', name: 'netty-transport-native-kqueue', classifier: 'osx-aarch_64')
 }
 
 nebulaPublishVerification {

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -10,6 +10,9 @@ dependencies {
         // We do not use HTTP modules; exclude to avoid false positive CVE reports
         exclude module: 'netty-codec-http'
     }
+	// We need make sure netty dns resolution works on all macs
+	implementation 'io.netty:netty-resolver-dns-native-macos:+:osx-x86_64'
+	implementation 'io.netty:netty-resolver-dns-native-macos:+:osx-aarch_64'
 
     testImplementation project(':micrometer-test')
     testImplementation 'io.projectreactor:reactor-test'
@@ -53,7 +56,7 @@ publishing {
                 asNode()
                     .dependencies
                     .dependency
-                    .findAll { ['reactor-core', 'reactor-netty-core'].contains(it.artifactId.text()) }
+                    .findAll { ['reactor-core', 'reactor-netty-core', 'netty-resolver-dns-native-macos'].contains(it.artifactId.text()) }
                     .each { it.parent().remove(it) }
             }
         }


### PR DESCRIPTION
Fix for #3066 

It looks like the `x86_64` classifier was already included in the shaded jar, this PR just makes sure that we also include the `aarch64` classifier in the jar too so that we don't get the errors described in #3066 

I verified the native lib is included in the shaded jar, and that it's *not* included in the generated pom as expected. 

This appears to resolve the issues I was seeing on my computer.