### PR TITLE
Upgrade to Elasticsearch 8.1.3 and 7.17.3 for integration tests

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
@@ -40,8 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("docker")
 abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
 
-    protected static final String VERSION_7 = "7.17.2";
-    protected static final String VERSION_8 = "8.1.2";
+    protected static final String VERSION_7 = "7.17.3";
+    protected static final String VERSION_8 = "8.1.3";
 
     protected static final String USER = "elastic";
     protected static final String PASSWORD = "changeme";


### PR DESCRIPTION
This PR upgrades to Elasticsearch 8.1.3 and 7.17.3 for integration tests.