### PR TITLE
Dynatrace registry: Truncate log output

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -317,7 +317,8 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         response.code(),
                         StringUtils.truncate(response.body(), LOG_RESPONSE_BODY_TRUNCATION_LIMIT)));
         } catch (Throwable throwable) {
-            logger.error("Failed metric ingestion: " + throwable.getMessage(), throwable);
+            logger.error("Failed metric ingestion: " + throwable);
+            logger.debug(throwable);
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -62,7 +62,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static final String LOG_RESPONSE_BODY_TRUNCATION_INDICATOR = " (truncated)";
 
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
-    private static final WarnThenDebugLogger warnThenDebugLoggerSend = new WarnThenDebugLogger(DynatraceExporterV2.class);
+    private static final WarnThenDebugLogger warnThenDebugLoggerSendStack = new WarnThenDebugLogger(DynatraceExporterV2.class);
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source", "micrometer");
 
     private final MetricBuilderFactory metricBuilderFactory;
@@ -320,7 +320,8 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         response.code(),
                         StringUtils.truncate(response.body(), LOG_RESPONSE_BODY_TRUNCATION_LIMIT, LOG_RESPONSE_BODY_TRUNCATION_INDICATOR)));
         } catch (Throwable throwable) {
-            warnThenDebugLoggerSend.log("Failed metric ingestion", throwable);
+            logger.warn("Failed metric ingestion: " + throwable);
+            warnThenDebugLoggerSendStack.log("Stack trace for previous 'Failed metric ingestion' warning log: ", throwable);
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -25,6 +25,7 @@ import io.micrometer.core.instrument.util.StringUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.util.internal.logging.InternalLogger;
 import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.core.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.dynatrace.AbstractDynatraceExporter;
 import io.micrometer.dynatrace.DynatraceConfig;
 import io.micrometer.dynatrace.types.DynatraceSummarySnapshot;
@@ -61,6 +62,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static final String LOG_RESPONSE_BODY_TRUNCATION_INDICATOR = " (truncated)";
 
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
+    private static final WarnThenDebugLogger warnThenDebugLoggerSend = new WarnThenDebugLogger(DynatraceExporterV2.class);
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source", "micrometer");
 
     private final MetricBuilderFactory metricBuilderFactory;
@@ -318,8 +320,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         response.code(),
                         StringUtils.truncate(response.body(), LOG_RESPONSE_BODY_TRUNCATION_LIMIT, LOG_RESPONSE_BODY_TRUNCATION_INDICATOR)));
         } catch (Throwable throwable) {
-            logger.error("Failed metric ingestion: " + throwable);
-            logger.debug(throwable);
+            warnThenDebugLoggerSend.log("Failed metric ingestion", throwable);
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringUtils.java
@@ -89,6 +89,25 @@ public final class StringUtils {
         return string;
     }
 
+    /**
+     * Truncate the String to the max length and append string to indicate if truncation was applied
+     *
+     * @param string String to truncate
+     * @param maxLength max length, which includes the length required for {@code truncationIndicator}
+     * @param truncationIndicator A string that is appended if {@code string} is truncated
+     * @return truncated String
+     */
+    public static String truncate(String string, int maxLength, String truncationIndicator) {
+        if (truncationIndicator.length() >= maxLength) {
+            throw new IllegalArgumentException("maxLength must be greater than length of truncationIndicator");
+        }
+        final int remainingLength = maxLength - truncationIndicator.length();
+        if (string.length() > remainingLength) {
+            return string.substring(0, remainingLength) + truncationIndicator;
+        }
+        return string;
+    }
+
     private StringUtils() {
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/StringUtils.java
@@ -101,8 +101,8 @@ public final class StringUtils {
         if (truncationIndicator.length() >= maxLength) {
             throw new IllegalArgumentException("maxLength must be greater than length of truncationIndicator");
         }
-        final int remainingLength = maxLength - truncationIndicator.length();
-        if (string.length() > remainingLength) {
+        if (string.length() > maxLength) {
+            final int remainingLength = maxLength - truncationIndicator.length();
             return string.substring(0, remainingLength) + truncationIndicator;
         }
         return string;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringUtilsTest.java
@@ -48,6 +48,11 @@ class StringUtilsTest {
     }
 
     @Test
+    void truncateWithIndicatorWhenSameAsMaxLengthShouldReturnItself() {
+        assertThat(StringUtils.truncate("1234567", 7, "...")).isEqualTo("1234567");
+    }
+
+    @Test
     void truncateWithIndicatorWhenLessThanMaxLengthShouldReturnItself() {
         assertThat(StringUtils.truncate("123", 7, "...")).isEqualTo("123");
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/StringUtilsTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.util;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link StringUtils}.
@@ -34,6 +35,31 @@ class StringUtilsTest {
     @Test
     void truncateWhenLessThanMaxLengthShouldReturnItself() {
         assertThat(StringUtils.truncate("123", 5)).isEqualTo("123");
+    }
+
+    @Test
+    void truncateWithIndicatorWhenGreaterThanMaxLengthShouldTruncate() {
+        assertThat(StringUtils.truncate("1234567890", 7, "...")).isEqualTo("1234...");
+    }
+
+    @Test
+    void truncateWithEmptyIndicatorWhenGreaterThanMaxLengthShouldTruncate() {
+        assertThat(StringUtils.truncate("1234567890", 7, "")).isEqualTo("1234567");
+    }
+
+    @Test
+    void truncateWithIndicatorWhenLessThanMaxLengthShouldReturnItself() {
+        assertThat(StringUtils.truncate("123", 7, "...")).isEqualTo("123");
+    }
+
+    @Test
+    void truncateWithIndicatorThrowsOnInvalidLength1() {
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.truncate("12345", 7, "[abbreviated]"));
+    }
+
+    @Test
+    void truncateWithIndicatorThrowsOnInvalidLength2() {
+        assertThrows(IllegalArgumentException.class, () -> StringUtils.truncate("1234567890", 7, "[abbreviated]"));
     }
 
     @Test


### PR DESCRIPTION
Sometimes the response body can be quite large so we should truncate it for logging.

Also logging stack traces from errors during HTTP requests only on debug level should be sufficient.