### PR TITLE
Dynatrace registry: Print ignored config warning only when necessary

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -129,6 +129,11 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
              */
             @Override
             public DistributionStatisticConfig configure(Meter.Id id, DistributionStatisticConfig config) {
+                if (useDynatraceSummaryInstruments && dynatraceInstrumentTypeExists(id)) {
+                    // do not add artificial 0 percentile when using Dynatrace instruments
+                    return config;
+                }
+
                 double[] percentiles;
 
                 double[] configPercentiles = config.getPercentiles();
@@ -166,6 +171,16 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                 return metersWithArtificialZeroPercentile.contains(id.getName()) && "0".equals(id.getTag("phi"));
             }
         });
+    }
+
+    private boolean dynatraceInstrumentTypeExists(Meter.Id id) {
+        switch (id.getType()) {
+            case DISTRIBUTION_SUMMARY:
+            case TIMER:
+                return true;
+            default:
+                return false;
+        }
     }
 
     public static class Builder {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -35,15 +35,17 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
     private static final Logger LOGGER = LoggerFactory.getLogger(DynatraceDistributionSummary.class);
     // Configuration that will set the Histogram in AbstractDistributionSummary to a NoopHistogram.
     private static final DistributionStatisticConfig NOOP_HISTOGRAM_CONFIG =
-            DistributionStatisticConfig.builder().percentilesHistogram(false).percentiles().build();
+            DistributionStatisticConfig.builder().percentilesHistogram(false).percentiles().serviceLevelObjectives().build();
 
     private final DynatraceSummary summary = new DynatraceSummary();
 
     public DynatraceDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, double scale) {
-        super(id, clock, NOOP_HISTOGRAM_CONFIG, scale, false);
+        // make sure the Histogram in AbstractDistributionSummary is always a NoopHistogram by disabling the respective config options
+        super(id, clock, distributionStatisticConfig.merge(NOOP_HISTOGRAM_CONFIG), scale, false);
 
-        if (distributionStatisticConfig != DistributionStatisticConfig.NONE) {
-            LOGGER.warn("Distribution statistic config is currently ignored.");
+        if (distributionStatisticConfig.isPublishingPercentiles() ||
+                distributionStatisticConfig.isPublishingHistogram()) {
+            LOGGER.warn("Histogram config on DistributionStatisticConfig is currently ignored. Collecting summary statistics.");
         }
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -37,16 +37,17 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
 
     // Configuration that will set the Histogram in AbstractTimer to a NoopHistogram.
     private static final DistributionStatisticConfig NOOP_HISTOGRAM_CONFIG =
-            DistributionStatisticConfig.builder().percentilesHistogram(false).percentiles().build();
+            DistributionStatisticConfig.builder().percentilesHistogram(false).percentiles().serviceLevelObjectives().build();
 
     private final DynatraceSummary summary = new DynatraceSummary();
 
     public DynatraceTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit) {
         // make sure the Histogram in AbstractTimer is always a NoopHistogram by disabling the respective config options
-        super(id, clock, NOOP_HISTOGRAM_CONFIG, pauseDetector, baseTimeUnit, false);
+        super(id, clock, distributionStatisticConfig.merge(NOOP_HISTOGRAM_CONFIG), pauseDetector, baseTimeUnit, false);
 
-        if (distributionStatisticConfig != DistributionStatisticConfig.NONE) {
-            LOGGER.warn("Distribution statistic config is currently ignored.");
+        if (distributionStatisticConfig.isPublishingPercentiles() ||
+                distributionStatisticConfig.isPublishingHistogram()) {
+            LOGGER.warn("Histogram config on DistributionStatisticConfig is currently ignored. Collecting summary statistics.");
         }
     }
 


### PR DESCRIPTION
When using the new Dynatrace instruments introduced in #3093, a warning is almost always printed that states that the DistributionStatisticConfig is ignored. This PR ensures that the warning is printed only if there is an explicit attempt to modify histogram boundaries.