### PR TITLE
Config for OTLP Resource attributes

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -18,6 +18,9 @@ package io.micrometer.registry.otlp;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.push.PushRegistryConfig;
 
+import java.util.Collections;
+import java.util.Map;
+
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkAll;
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.checkRequired;
 import static io.micrometer.core.instrument.config.validate.PropertyValidator.getUrlString;
@@ -46,6 +49,18 @@ public interface OtlpConfig extends PushRegistryConfig {
      */
     default String url() {
         return getUrlString(this, "url").orElse("http://localhost:4318/v1/metrics");
+    }
+
+    /**
+     * Attributes to set on the Resource that will be used for all metrics published. This
+     * should include a {@code service.name} attribute that identifies your service.
+     * @return map of key value pairs to use as resource attributes
+     * @see <a href=
+     * "https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service">OpenTelemetry
+     * Resource Semantic Conventions</a>
+     */
+    default Map<String, String> resourceAttributes() {
+        return Collections.emptyMap();
     }
 
     @Override

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -54,10 +54,11 @@ public interface OtlpConfig extends PushRegistryConfig {
 
     /**
      * Attributes to set on the Resource that will be used for all metrics published. This
-     * should include a {@code service.name} attribute that identifies your service. By
-     * default, resource attributes will load using the {@link #get(String)} method,
+     * should include a {@code service.name} attribute that identifies your service.
+     * <p>
+     * By default, resource attributes will load using the {@link #get(String)} method,
      * extracting key values from a comma-separated list in the format
-     * {@code  key1=value1,key2=value2}. Resource attributes will be loaded from the
+     * {@code key1=value1,key2=value2}. Resource attributes will be loaded from the
      * {@code OTEL_RESOURCE_ATTRIBUTES} environment variable and the service name from the
      * {@code OTEL_SERVICE_NAME} environment variable if they are set and
      * {@link #get(String)} does not return a value.

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.registry.otlp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtlpConfigTest {
+
+    @Test
+    void resourceAttributesInputParsing() {
+        OtlpConfig config = k -> "key1=value1,";
+        assertThat(config.resourceAttributes()).containsEntry("key1", "value1").hasSize(1);
+        config = k -> "k=v,a";
+        assertThat(config.resourceAttributes()).containsEntry("k", "v").hasSize(1);
+        config = k -> "k=v,a==";
+        assertThat(config.resourceAttributes()).containsEntry("k", "v").containsEntry("a", "=").hasSize(2);
+        config = k -> " k = v, a= b ";
+        assertThat(config.resourceAttributes()).containsEntry("k", "v").containsEntry("a", "b").hasSize(2);
+    }
+
+}

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import java.lang.management.CompilationMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -464,6 +466,31 @@ class OtlpMeterRegistryTest {
                 + "unit: \"milliseconds\"\n" + "histogram {\n" + "  data_points {\n"
                 + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 240001000000\n" + "    sum: 0.0\n"
                 + "  }\n" + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
+    }
+
+    // If the value was not specified, SDKs MUST fallback to 'unknown_service'
+    @Test
+    void unknownServiceByDefault() {
+        assertThat(registry.getResourceAttributes())
+                .contains(OtlpMeterRegistry.createKeyValue("service.name", "unknown_service"));
+    }
+
+    @Test
+    void setServiceName() {
+        registry = new OtlpMeterRegistry(new OtlpConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public Map<String, String> resourceAttributes() {
+                return Collections.singletonMap("service.name", "myService");
+            }
+        }, Clock.SYSTEM);
+
+        assertThat(registry.getResourceAttributes())
+                .contains(OtlpMeterRegistry.createKeyValue("service.name", "myService"));
     }
 
 }

--- a/implementations/micrometer-registry-otlp/src/test/resources/otlp-config.properties
+++ b/implementations/micrometer-registry-otlp/src/test/resources/otlp-config.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2022 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+otlp.resourceAttributes=key1=value1,key2=value2


### PR DESCRIPTION
Adds a config method for attributes that are set on the [Resource](https://opentelemetry.io/docs/reference/specification/resource/sdk/) shared by all metrics published from the OtlpMeterRegistry. Of note, this allows configuring the `service.name` to [identify your service](https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/#service), but is generic enough to allow configuration of arbitrary attributes.

The use cases for this largely overlaps with how we expect Micrometer common tags are used, and it is a shame I could not come up with a way to better connect these now. There is precedent for this approach in e.g. the StackdriverMeterRegistry. But it potentially creates inconsistency or duplicated work when using multiple registries.
For example, if you want to include metadata (tags) about the deployment environment and service name, you would typically [configure common tags](https://micrometer.io/docs/concepts#_common_tags):
```
meterRegistry.commonTags("env", "prod", "service", "checkout");
```
This approach works with this OTLP registry as well, but the common tags are applied as attributes to all metrics data points, instead of the resource. What difference this may have in a metrics backend is not clear.

I called out `service.name` before because it is defined in the Resource semantic conventions, and so it may be given special treatment. But by using the OTLP-specific configuration of resource attributes, these tags will not be configured on other registries if a composite registry were being used, even though it is highly likely the types of attributes set on a resource should be common tags in other registries. Taking the above example, you want the info about environment and service name available in your metrics backend regardless of which registry you are using.

This supports either setting the key-value list in a specified environment variable or through the standard config's `get` method. See https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/#general-sdk-configuration

Resolves gh-3146