### PR TITLE
Fix generic parameters for composite observations

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -18,6 +18,7 @@ package io.micrometer.observation;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -100,7 +101,7 @@ public interface ObservationHandler<T extends Observation.Context> {
          * @param handlers the handlers that are registered under the composite
          */
         @SafeVarargs
-        public FirstMatchingCompositeObservationHandler(ObservationHandler<Observation.Context>... handlers) {
+        public FirstMatchingCompositeObservationHandler(ObservationHandler<? extends Observation.Context>... handlers) {
             this(Arrays.asList(handlers));
         }
 
@@ -108,8 +109,11 @@ public interface ObservationHandler<T extends Observation.Context> {
          * Creates a new instance of {@code FirstMatchingCompositeObservationHandler}.
          * @param handlers the handlers that are registered under the composite
          */
-        public FirstMatchingCompositeObservationHandler(List<ObservationHandler<Observation.Context>> handlers) {
-            this.handlers = handlers;
+        @SuppressWarnings("unchecked")
+        public FirstMatchingCompositeObservationHandler(
+                List<? extends ObservationHandler<? extends Observation.Context>> handlers) {
+            this.handlers = handlers.stream().map(handler -> (ObservationHandler<Observation.Context>) handler)
+                    .collect(Collectors.toList());
         }
 
         @Override
@@ -166,7 +170,7 @@ public interface ObservationHandler<T extends Observation.Context> {
          * @param handlers the handlers that are registered under the composite
          */
         @SafeVarargs
-        public AllMatchingCompositeObservationHandler(ObservationHandler<Observation.Context>... handlers) {
+        public AllMatchingCompositeObservationHandler(ObservationHandler<? extends Observation.Context>... handlers) {
             this(Arrays.asList(handlers));
         }
 
@@ -174,8 +178,11 @@ public interface ObservationHandler<T extends Observation.Context> {
          * Creates a new instance of {@code AllMatchingCompositeObservationHandler}.
          * @param handlers the handlers that are registered under the composite
          */
-        public AllMatchingCompositeObservationHandler(List<ObservationHandler<Observation.Context>> handlers) {
-            this.handlers = handlers;
+        @SuppressWarnings("unchecked")
+        public AllMatchingCompositeObservationHandler(
+                List<? extends ObservationHandler<? extends Observation.Context>> handlers) {
+            this.handlers = handlers.stream().map(handler -> (ObservationHandler<Observation.Context>) handler)
+                    .collect(Collectors.toList());
         }
 
         @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
@@ -19,7 +19,7 @@ import io.micrometer.observation.ObservationHandler.AllMatchingCompositeObservat
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 class AllMatchingCompositeObservationHandlerTests {
@@ -91,12 +91,25 @@ class AllMatchingCompositeObservationHandlerTests {
     }
 
     @Test
-    void should_return_handlers() {
-        List<ObservationHandler<Observation.Context>> handlers = Arrays.asList(new NotMatchingHandler(),
-                this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
+    void should_return_observation_handlers() {
+        List<ObservationHandler<? extends Observation.Context>> handlers = new ArrayList<>();
+        handlers.add(new NotMatchingHandler());
+        handlers.add(this.matchingHandler);
+        handlers.add(new NotMatchingHandler());
+        handlers.add(this.matchingHandler2);
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 handlers);
-        Assertions.assertThat(allMatchingHandler.getHandlers()).isSameAs(handlers);
+        Assertions.assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
+    }
+
+    @Test
+    void should_return_custom_handlers() {
+        List<NotMatchingHandler> handlers = new ArrayList<>();
+        handlers.add(new NotMatchingHandler());
+        handlers.add(new NotMatchingHandler());
+        AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
+                handlers);
+        Assertions.assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
     }
 
     static class MatchingHandler implements ObservationHandler<Observation.Context> {
@@ -143,25 +156,25 @@ class AllMatchingCompositeObservationHandlerTests {
 
     }
 
-    static class NotMatchingHandler implements ObservationHandler<Observation.Context> {
+    static class NotMatchingHandler implements ObservationHandler<CustomContext> {
 
         @Override
-        public void onStart(Observation.Context context) {
+        public void onStart(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onError(Observation.Context context) {
+        public void onError(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onScopeOpened(Observation.Context context) {
+        public void onScopeOpened(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onStop(Observation.Context context) {
+        public void onStop(CustomContext context) {
             throwAssertionError();
         }
 
@@ -173,6 +186,10 @@ class AllMatchingCompositeObservationHandlerTests {
         private void throwAssertionError() {
             throw new AssertionError("Not matching handler must not be called");
         }
+
+    }
+
+    static class CustomContext extends Observation.Context {
 
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
@@ -18,7 +18,7 @@ package io.micrometer.observation;
 import io.micrometer.observation.ObservationHandler.FirstMatchingCompositeObservationHandler;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,12 +85,24 @@ class FirstMatchingCompositeObservationHandlerTests {
     }
 
     @Test
-    void should_return_handlers() {
-        List<ObservationHandler<Observation.Context>> handlers = Arrays.asList(new NotMatchingHandler(),
-                this.matchingHandler, new NotMatchingHandler());
+    void should_return_observation_handlers() {
+        List<ObservationHandler<? extends Observation.Context>> handlers = new ArrayList<>();
+        handlers.add(new NotMatchingHandler());
+        handlers.add(this.matchingHandler);
+        handlers.add(new NotMatchingHandler());
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 handlers);
-        assertThat(firstMatchingHandler.getHandlers()).isSameAs(handlers);
+        assertThat(firstMatchingHandler.getHandlers()).isEqualTo(handlers);
+    }
+
+    @Test
+    void should_return_custom_handlers() {
+        List<NotMatchingHandler> handlers = new ArrayList<>();
+        handlers.add(new NotMatchingHandler());
+        handlers.add(new NotMatchingHandler());
+        FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
+                handlers);
+        assertThat(firstMatchingHandler.getHandlers()).isEqualTo(handlers);
     }
 
     static class MatchingHandler implements ObservationHandler<Observation.Context> {
@@ -137,25 +149,25 @@ class FirstMatchingCompositeObservationHandlerTests {
 
     }
 
-    static class NotMatchingHandler implements ObservationHandler<Observation.Context> {
+    static class NotMatchingHandler implements ObservationHandler<CustomContext> {
 
         @Override
-        public void onStart(Observation.Context context) {
+        public void onStart(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onError(Observation.Context context) {
+        public void onError(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onScopeOpened(Observation.Context context) {
+        public void onScopeOpened(CustomContext context) {
             throwAssertionError();
         }
 
         @Override
-        public void onStop(Observation.Context context) {
+        public void onStop(CustomContext context) {
             throwAssertionError();
         }
 
@@ -167,6 +179,10 @@ class FirstMatchingCompositeObservationHandlerTests {
         private void throwAssertionError() {
             throw new AssertionError("Not matching handler must not be called");
         }
+
+    }
+
+    static class CustomContext extends Observation.Context {
 
     }
 


### PR DESCRIPTION
Using concrete prevents users to use a custom context (extending `Observation.Context`).
Also, the ctor that accepts a `List` can't accept a `List` of custom `ObservationHandler`s.
This PR makes both flexible and adds a test as well. Downside: we need to tricks in the ctor.