### PR TITLE
MetricType prefix config for StackdriverMeterRegistry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,6 +339,8 @@ subprojects {
                     txtOutputFile = file("${project.buildDir}/reports/japi.txt")
                     ignoreMissingClasses = true
                     includeSynthetic = true
+                    // TODO remove methodExcludes when gh-3181 is resolved
+                    methodExcludes = ['io.micrometer.stackdriver.StackdriverConfig#metricTypePrefix()']
                     onlyIf { compatibleVersion != 'SKIP' }
                 }
 

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
@@ -84,6 +84,16 @@ public interface StackdriverConfig extends StepRegistryConfig {
     }
 
     /**
+     * Available prefixes defined in
+     * <a href= "https://cloud.google.com/monitoring/custom-metrics#identifier">Google
+     * Cloud documentation</a>
+     * @return a prefix for MetricType
+     */
+    default String metricTypePrefix() {
+        return getString(this, "metricTypePrefix").orElse("custom.googleapis.com/");
+    }
+
+    /**
      * Return {@link CredentialsProvider} to use.
      * @return {@code CredentialsProvider} to use
      * @since 1.4.0

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMeterRegistry.java
@@ -426,7 +426,7 @@ public class StackdriverMeterRegistry extends StepMeterRegistry {
         }
 
         private String metricType(Meter.Id id, @Nullable String statistic) {
-            StringBuilder metricType = new StringBuilder("custom.googleapis.com/").append(getConventionName(id));
+            StringBuilder metricType = new StringBuilder(config.metricTypePrefix()).append(getConventionName(id));
             if (statistic != null) {
                 metricType.append('/').append(statistic);
             }

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/MetricTypePrefixTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/MetricTypePrefixTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.stackdriver;
 
 import com.google.monitoring.v3.TimeSeries;

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/MetricTypePrefixTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/MetricTypePrefixTest.java
@@ -1,0 +1,43 @@
+package io.micrometer.stackdriver;
+
+import com.google.monitoring.v3.TimeSeries;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MockClock;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricTypePrefixTest {
+
+    private final Map<String, String> config = new HashMap<>(
+            Collections.singletonMap("stackdriver.projectId", "projectId"));
+
+    private final StackdriverMeterRegistry meterRegistry = new StackdriverMeterRegistry(config::get, new MockClock());
+
+    @Test
+    void metricTypePrefixWhenNotConfigured() {
+        StackdriverMeterRegistry.Batch batch = meterRegistry.new Batch();
+        List<TimeSeries> timeSeries = meterRegistry
+                .createCounter(batch, Counter.builder("counter").register(meterRegistry)).collect(Collectors.toList());
+        assertThat(timeSeries).hasSize(1);
+        assertThat(timeSeries.get(0).getMetric().getType()).isEqualTo("custom.googleapis.com/counter");
+    }
+
+    @Test
+    void metricTypePrefixWhenConfigured() {
+        config.put("stackdriver.metricTypePrefix", "external.googleapis.com/user/");
+
+        StackdriverMeterRegistry.Batch batch = meterRegistry.new Batch();
+        List<TimeSeries> timeSeries = meterRegistry
+                .createCounter(batch, Counter.builder("counter").register(meterRegistry)).collect(Collectors.toList());
+        assertThat(timeSeries).hasSize(1);
+        assertThat(timeSeries.get(0).getMetric().getType()).isEqualTo("external.googleapis.com/user/counter");
+    }
+
+}


### PR DESCRIPTION
Add support for different prefixes in StackdriverMeterRegistry.
Related to #3171