### PR TITLE
Change package name of Observation TCK

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKit.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKit.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKit.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKitTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKitTests.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 
-class NullContextObservationHandlerCompatibilityKitTests extends NullContextObservationHandlerCompatibilityKit {
+class AnyContextObservationHandlerCompatibilityKitTests extends AnyContextObservationHandlerCompatibilityKit {
 
     @Override
     public ObservationHandler<Observation.Context> handler() {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKitTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKitTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKitTests.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 
-class AnyContextObservationHandlerCompatibilityKitTests extends AnyContextObservationHandlerCompatibilityKit {
+class NullContextObservationHandlerCompatibilityKitTests extends NullContextObservationHandlerCompatibilityKit {
 
     @Override
     public ObservationHandler<Observation.Context> handler() {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 
-import static io.micrometer.core.tck.ObservationContextAssert.assertThat;
+import static io.micrometer.observation.tck.ObservationContextAssert.assertThat;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryAssertTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKitTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.ObservationRegistry;
 

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.tck;
+package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 
-import static io.micrometer.core.tck.TestObservationRegistryAssert.assertThat;
+import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 


### PR DESCRIPTION
Observation TCK should be in the io.micrometer.observation.tck package instead of io.micrometer.core.tck.
micrometer-test already has the io.micrometer.core.tck package so this change also resolves potential issues with the module system on Java 9 and above.