### PR TITLE
Use consistent casing for no-op

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -82,20 +82,20 @@ final class NoopObservation implements Observation {
 
     @Override
     public Scope openScope() {
-        return NoOpScope.INSTANCE;
+        return NoopScope.INSTANCE;
     }
 
     /**
      * Scope that does nothing.
      */
-    static final class NoOpScope implements Scope {
+    static final class NoopScope implements Scope {
 
         /**
-         * Instance of {@link NoOpScope}.
+         * Instance of {@link NoopScope}.
          */
-        public static final Scope INSTANCE = new NoOpScope();
+        public static final Scope INSTANCE = new NoopScope();
 
-        private NoOpScope() {
+        private NoopScope() {
 
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
@@ -43,7 +43,7 @@ final class NoopObservationRegistry implements ObservationRegistry {
 
     @Override
     public Observation.Scope getCurrentObservationScope() {
-        return NoopObservation.NoOpScope.INSTANCE;
+        return NoopObservation.NoopScope.INSTANCE;
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -162,7 +162,7 @@ public interface Observation {
      * Checks whether this {@link Observation} is no-op.
      * @return {@code true} when this is a no-op observation
      */
-    default boolean isNoOp() {
+    default boolean isNoop() {
         return this == NoopObservation.INSTANCE;
     }
 
@@ -388,7 +388,7 @@ public interface Observation {
         /**
          * No-op scope.
          */
-        Scope NOOP = NoopObservation.NoOpScope.INSTANCE;
+        Scope NOOP = NoopObservation.NoopScope.INSTANCE;
 
         /**
          * Current observation available within this scope.
@@ -403,8 +403,8 @@ public interface Observation {
          * Checks whether this {@link Scope} is no-op.
          * @return {@code true} when this is a no-op scope
          */
-        default boolean isNoOp() {
-            return this == NoopObservation.NoOpScope.INSTANCE;
+        default boolean isNoop() {
+            return this == NoopObservation.NoopScope.INSTANCE;
         }
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -83,7 +83,7 @@ public interface ObservationRegistry {
      * Checks whether this {@link ObservationRegistry} is no-op.
      * @return {@code true} when this is a no-op observation registry
      */
-    default boolean isNoOp() {
+    default boolean isNoop() {
         return this == NOOP;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
@@ -57,8 +57,8 @@ class SimpleObservationRegistry implements ObservationRegistry {
     }
 
     @Override
-    public boolean isNoOp() {
-        return ObservationRegistry.super.isNoOp();
+    public boolean isNoop() {
+        return ObservationRegistry.super.isNoop();
     }
 
 }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -58,7 +58,7 @@ class ObservationRegistryTest {
     }
 
     @Test
-    void observationShouldBeNoOpWhenPredicateApplicable() {
+    void observationShouldBeNoopWhenPredicateApplicable() {
         registry.observationConfig().observationPredicate((name, context) -> !name.equals("test.timer"));
 
         Observation sample = Observation.start("test.timer", registry);
@@ -67,7 +67,7 @@ class ObservationRegistryTest {
     }
 
     @Test
-    void observationShouldBeNoOpWhenNullRegistry() {
+    void observationShouldBeNoopWhenNullRegistry() {
         assertThat(Observation.start("test.timer", null)).isSameAs(NoopObservation.INSTANCE);
         assertThat(Observation.start("test.timer", new Observation.Context(), null)).isSameAs(NoopObservation.INSTANCE);
         assertThat(Observation.createNotStarted("test.timer", null)).isSameAs(NoopObservation.INSTANCE);
@@ -76,7 +76,7 @@ class ObservationRegistryTest {
     }
 
     @Test
-    void observationShouldNotBeNoOpWhenNonNullRegistry() {
+    void observationShouldNotBeNoopWhenNonNullRegistry() {
         ObservationRegistry registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(c -> true);
         assertThat(Observation.start("test.timer", registry)).isInstanceOf(SimpleObservation.class);

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ObservationTests {
 
     @Test
-    void notHavingAnyHandlersShouldResultInNoOpObservation() {
+    void notHavingAnyHandlersShouldResultInNoopObservation() {
         ObservationRegistry registry = ObservationRegistry.create();
 
         Observation observation = Observation.createNotStarted("foo", registry);
@@ -38,14 +38,14 @@ class ObservationTests {
     }
 
     @Test
-    void notHavingARegistryShouldResultInNoOpObservation() {
+    void notHavingARegistryShouldResultInNoopObservation() {
         Observation observation = Observation.createNotStarted("foo", null);
 
         assertThat(observation).isSameAs(Observation.NOOP);
     }
 
     @Test
-    void notMatchingObservationPredicateShouldResultInNoOpObservation() {
+    void notMatchingObservationPredicateShouldResultInNoopObservation() {
         ObservationRegistry registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(context -> true);
         registry.observationConfig().observationPredicate((s, context) -> false);
@@ -56,7 +56,7 @@ class ObservationTests {
     }
 
     @Test
-    void matchingPredicateAndHandlerShouldNotResultInNoOpObservation() {
+    void matchingPredicateAndHandlerShouldNotResultInNoopObservation() {
         ObservationRegistry registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(context -> true);
         registry.observationConfig().observationPredicate((s, context) -> true);


### PR DESCRIPTION
This PR changes to use consistent casing for "no-op".