### PR TITLE
Make DynatraceExporterV2.logger non-static

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -62,12 +62,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private static final Pattern IS_NULL_ERROR_RESPONSE = Pattern.compile("\"error\":\\s?null");
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
-
     private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(DynatraceExporterV2.class);
 
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source",
             "micrometer");
+
+    // This should be non-static for MockLoggerFactory.injectLogger() in tests.
+    private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
 
     private final MetricBuilderFactory metricBuilderFactory;
 


### PR DESCRIPTION
`DynatraceExporterV2Test.failOnSendShouldHaveProperLogging()` could fail as follows:

```
> Task :micrometer-registry-dynatrace:test

DynatraceExporterV2Test > failOnSendShouldHaveProperLogging() FAILED
    java.lang.AssertionError: 
    Expecting ArrayList:
      []
    to contain:
      [LogEvent{level=ERROR, message='Failed metric ingestion: Error Code=500, Response Body=simulated', cause=null}]
    but could not find the following element(s):
      [LogEvent{level=ERROR, message='Failed metric ingestion: Error Code=500, Response Body=simulated', cause=null}]
        at io.micrometer.dynatrace.v2.DynatraceExporterV2Test.failOnSendShouldHaveProperLogging(DynatraceExporterV2Test.java:514)
```

This is because `MockLoggerFactory.injectLogger()` doesn't work when a target logger is a static field and has been initialized already. This happens on the 1.9.x or later branch as de70a010 has changed `DynatraceExporterV2.logger` to a static field.

It could be reproduced with the following command:

```
./gradlew :micrometer-registry-dynatrace:clean :micrometer-registry-dynatrace:test --tests io.micrometer.dynatrace.DynatraceMeterRegistryTest.shouldSendProperRequest --tests io.micrometer.dynatrace.v2.DynatraceExporterV2Test.failOnSendShouldHaveProperLogging --no-build-cache
```
