### PR TITLE
Use static import for Assertions.assertThat

### DIFF
--- a/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
@@ -16,11 +16,12 @@
 package io.micrometer.observation;
 
 import io.micrometer.observation.ObservationHandler.AllMatchingCompositeObservationHandler;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AllMatchingCompositeObservationHandlerTests {
 
@@ -35,8 +36,8 @@ class AllMatchingCompositeObservationHandlerTests {
 
         allMatchingHandler.onStart(null);
 
-        Assertions.assertThat(this.matchingHandler.started).isTrue();
-        Assertions.assertThat(this.matchingHandler2.started).isTrue();
+        assertThat(this.matchingHandler.started).isTrue();
+        assertThat(this.matchingHandler2.started).isTrue();
     }
 
     @Test
@@ -46,8 +47,8 @@ class AllMatchingCompositeObservationHandlerTests {
 
         allMatchingHandler.onStop(null);
 
-        Assertions.assertThat(this.matchingHandler.stopped).isTrue();
-        Assertions.assertThat(this.matchingHandler2.stopped).isTrue();
+        assertThat(this.matchingHandler.stopped).isTrue();
+        assertThat(this.matchingHandler2.stopped).isTrue();
     }
 
     @Test
@@ -57,8 +58,8 @@ class AllMatchingCompositeObservationHandlerTests {
 
         allMatchingHandler.onError(null);
 
-        Assertions.assertThat(this.matchingHandler.errored).isTrue();
-        Assertions.assertThat(this.matchingHandler2.errored).isTrue();
+        assertThat(this.matchingHandler.errored).isTrue();
+        assertThat(this.matchingHandler2.errored).isTrue();
     }
 
     @Test
@@ -68,8 +69,8 @@ class AllMatchingCompositeObservationHandlerTests {
 
         allMatchingHandler.onScopeOpened(null);
 
-        Assertions.assertThat(this.matchingHandler.scopeOpened).isTrue();
-        Assertions.assertThat(this.matchingHandler2.scopeOpened).isTrue();
+        assertThat(this.matchingHandler.scopeOpened).isTrue();
+        assertThat(this.matchingHandler2.scopeOpened).isTrue();
     }
 
     @Test
@@ -79,15 +80,15 @@ class AllMatchingCompositeObservationHandlerTests {
 
         allMatchingHandler.onScopeClosed(null);
 
-        Assertions.assertThat(this.matchingHandler.scopeClosed).isTrue();
-        Assertions.assertThat(this.matchingHandler2.scopeClosed).isTrue();
+        assertThat(this.matchingHandler.scopeClosed).isTrue();
+        assertThat(this.matchingHandler2.scopeClosed).isTrue();
     }
 
     @Test
     void should_support_the_context_if_any_handler_supports_it() {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
-        Assertions.assertThat(allMatchingHandler.supportsContext(new Observation.Context())).isTrue();
+        assertThat(allMatchingHandler.supportsContext(new Observation.Context())).isTrue();
     }
 
     @Test
@@ -99,7 +100,7 @@ class AllMatchingCompositeObservationHandlerTests {
         handlers.add(this.matchingHandler2);
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 handlers);
-        Assertions.assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
+        assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
     }
 
     @Test
@@ -109,7 +110,7 @@ class AllMatchingCompositeObservationHandlerTests {
         handlers.add(new NotMatchingHandler());
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 handlers);
-        Assertions.assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
+        assertThat(allMatchingHandler.getHandlers()).isEqualTo(handlers);
     }
 
     static class MatchingHandler implements ObservationHandler<Observation.Context> {


### PR DESCRIPTION
This PR changes to use `static` `import` for `Assertions.assertThat()`.