### PR TITLE
TimedAspect `timedClass` missing `shouldSkip` predicate check

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -157,6 +157,10 @@ public class TimedAspect {
     @Around("@within(io.micrometer.core.annotation.Timed)")
     @Nullable
     public Object timedClass(ProceedingJoinPoint pjp) throws Throwable {
+        if (shouldSkip.test(pjp)) {
+            return pjp.proceed();
+        }
+
         Method method = ((MethodSignature) pjp.getSignature()).getMethod();
         Class<?> declaringClass = method.getDeclaringClass();
         Timed timed = declaringClass.getAnnotation(Timed.class);

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -261,6 +261,20 @@ class TimedAspectTest {
     }
 
     @Test
+    void timeClassWithSkipPredicate() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new TimedClass());
+        pf.addAspect(new TimedAspect(registry, (Predicate<ProceedingJoinPoint>) pjp -> true));
+
+        TimedClass service = pf.getProxy();
+
+        service.call();
+
+        assertThat(registry.find("call").timer()).isNull();
+    }
+
+    @Test
     void timeClassFailure() {
         MeterRegistry failingRegistry = new FailingMeterRegistry();
 


### PR DESCRIPTION
Related to https://github.com/micrometer-metrics/micrometer/issues/3190, the part with missing shouldSkip check