### PR TITLE
Get Timed annotation from proxy target when failed

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -163,6 +163,9 @@ public class TimedAspect {
 
         Method method = ((MethodSignature) pjp.getSignature()).getMethod();
         Class<?> declaringClass = method.getDeclaringClass();
+        if (!declaringClass.isAnnotationPresent(Timed.class)) {
+            declaringClass = pjp.getTarget().getClass();
+        }
         Timed timed = declaringClass.getAnnotation(Timed.class);
 
         return perform(pjp, timed, method);

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -275,6 +275,21 @@ class TimedAspectTest {
     }
 
     @Test
+    void timeClassImplementingInterface() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new TimedImpl());
+        pf.addAspect(new TimedAspect(registry));
+
+        TimedInterface service = pf.getProxy();
+
+        service.call();
+
+        assertThat(registry.get("call").tag("class", "io.micrometer.core.aop.TimedAspectTest$TimedInterface")
+                .tag("method", "call").tag("extra", "tag").timer().count()).isEqualTo(1);
+    }
+
+    @Test
     void timeClassFailure() {
         MeterRegistry failingRegistry = new FailingMeterRegistry();
 
@@ -378,6 +393,21 @@ class TimedAspectTest {
     static class TimedClass {
 
         void call() {
+        }
+
+    }
+
+    interface TimedInterface {
+
+        void call();
+
+    }
+
+    @Timed(value = "call", extraTags = { "extra", "tag" })
+    static class TimedImpl implements TimedInterface {
+
+        @Override
+        public void call() {
         }
 
     }


### PR DESCRIPTION
Partially resolves https://github.com/micrometer-metrics/micrometer/issues/3190, the part with having an NPE when using interfaces