### PR TITLE
Add missing package-info.java files

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -9,6 +9,10 @@
 	<suppress checks="IllegalImport" files="test[\\/]java[\\/]io[\\/]micrometer[\\/]core[\\/]instrument[\\/]binder[\\/]jersey[\\/]server.+" />
 	<suppress checks="IllegalImport" files="test[\\/]java[\\/]io[\\/]micrometer[\\/]jersey.+" />
 
+	<suppress checks="JavadocPackageCheck" files="benchmarks[\\/].+" />
+	<suppress checks="JavadocPackageCheck" files="samples[\\/].+" />
+	<suppress checks="JavadocPackageCheck" files="[\\/]src[\\/]test[\\/].*" />
+
 	<suppress id="SLF4JIllegalImportCheck" files="implementations[\\/].+" />
 
 	<suppress id="sysout" files="ClearCustomMetricDescriptors.java"/>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -8,6 +8,8 @@
         <property name="lineSeparator" value="lf"/>
     </module>
 
+    <module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck"/>
+
     <!-- TreeWalker Checks -->
     <module name="TreeWalker">
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/package-info.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Dynatrace v1 metrics API export.
+ */
+package io.micrometer.dynatrace.v1;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/package-info.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Dynatrace v2 metrics API export.
+ */
+package io.micrometer.dynatrace.v2;

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/package-info.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Predefined {@link io.micrometer.health.ServiceLevelObjective ServiceLevelObjective
+ * classes}.
+ */
+package io.micrometer.health.objectives;

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/util/package-info.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/util/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for Stackdriver.
+ */
+package io.micrometer.stackdriver.util;

--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Core annotations.
+ */
+package io.micrometer.core.annotation;

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * AOP-based metrics support.
+ */
+package io.micrometer.core.aop;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Apache Commons Pool 2.x.
+ */
+package io.micrometer.core.instrument.binder.commonspool2;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for databases.
+ */
+package io.micrometer.core.instrument.binder.db;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Apache HttpComponents.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Hystrix.
+ */
+package io.micrometer.core.instrument.binder.hystrix;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Jersey.
+ */
+package io.micrometer.core.instrument.binder.jersey.server;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Jetty.
+ */
+package io.micrometer.core.instrument.binder.jetty;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jpa/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for JPA.
+ */
+package io.micrometer.core.instrument.binder.jpa;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for JVM.
+ */
+package io.micrometer.core.instrument.binder.jvm;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Apache Kafka.
+ */
+package io.micrometer.core.instrument.binder.kafka;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for logging frameworks.
+ */
+package io.micrometer.core.instrument.binder.logging;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for MongoDB.
+ */
+package io.micrometer.core.instrument.binder.mongodb;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for OkHttp 3.
+ */
+package io.micrometer.core.instrument.binder.okhttp3;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders.
+ */
+package io.micrometer.core.instrument.binder;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for an operating system.
+ */
+package io.micrometer.core.instrument.binder.system;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Apache Tomcat.
+ */
+package io.micrometer.core.instrument.binder.tomcat;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for meter registry configuration validation.
+ */
+package io.micrometer.core.instrument.config.validate;

--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for HTTP communication.
+ */
+package io.micrometer.core.ipc.http;

--- a/micrometer-core/src/main/java/io/micrometer/core/lang/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/lang/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Common annotations with language-level semantics.
+ */
+package io.micrometer.core.lang;

--- a/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/package-info.java
+++ b/micrometer-jersey2/src/main/java/io/micrometer/jersey2/server/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Jersey.
+ */
+package io.micrometer.jersey2.server;

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/binder/cache/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testing cache meter binders.
+ */
+package io.micrometer.core.instrument.binder.cache;

--- a/micrometer-test/src/main/java/io/micrometer/core/ipc/http/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/ipc/http/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testing {@link io.micrometer.core.ipc.http.HttpSender HttpSender classes}.
+ */
+package io.micrometer.core.ipc.http;

--- a/micrometer-test/src/main/java/io/micrometer/core/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testing.
+ */
+package io.micrometer.core;

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TCK for {@link io.micrometer.core.instrument.MeterRegistry MeterRegistry classes}.
+ */
+package io.micrometer.core.tck;

--- a/micrometer-test/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/util/internal/logging/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testing internal logging.
+ */
+package io.micrometer.core.util.internal.logging;


### PR DESCRIPTION
This PR adds missing `package-info.java` files.

This PR also configures `JavadocPackageCheck` Checkstyle module.