### PR TITLE
Make descriptions static where they are not

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -71,7 +71,7 @@ public class JvmThreadMetrics implements MeterBinder {
             for (Thread.State state : Thread.State.values()) {
                 Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, state))
                         .tags(Tags.concat(tags, "state", getStateTagValue(state)))
-                        .description("The current number of threads having " + state + " state")
+                        .description("The current number of threads")
                         .baseUnit(BaseUnits.THREADS).register(registry);
             }
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -71,8 +71,7 @@ public class JvmThreadMetrics implements MeterBinder {
             for (Thread.State state : Thread.State.values()) {
                 Gauge.builder("jvm.threads.states", threadBean, (bean) -> getThreadStateCount(bean, state))
                         .tags(Tags.concat(tags, "state", getStateTagValue(state)))
-                        .description("The current number of threads")
-                        .baseUnit(BaseUnits.THREADS).register(registry);
+                        .description("The current number of threads").baseUnit(BaseUnits.THREADS).register(registry);
             }
         }
         catch (Error error) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -149,24 +149,19 @@ class MetricsTurboFilter extends TurboFilter {
 
     MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
         errorCounter = Counter.builder("logback.events").tags(tags).tags("level", "error")
-                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS).register(registry);
 
         warnCounter = Counter.builder("logback.events").tags(tags).tags("level", "warn")
-                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS).register(registry);
 
         infoCounter = Counter.builder("logback.events").tags(tags).tags("level", "info")
-                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS).register(registry);
 
         debugCounter = Counter.builder("logback.events").tags(tags).tags("level", "debug")
-                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS).register(registry);
 
         traceCounter = Counter.builder("logback.events").tags(tags).tags("level", "trace")
-                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS).register(registry);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -149,23 +149,23 @@ class MetricsTurboFilter extends TurboFilter {
 
     MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
         errorCounter = Counter.builder("logback.events").tags(tags).tags("level", "error")
-                .description("Number of error level events that made it to the logs").baseUnit(BaseUnits.EVENTS)
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
         warnCounter = Counter.builder("logback.events").tags(tags).tags("level", "warn")
-                .description("Number of warn level events that made it to the logs").baseUnit(BaseUnits.EVENTS)
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
         infoCounter = Counter.builder("logback.events").tags(tags).tags("level", "info")
-                .description("Number of info level events that made it to the logs").baseUnit(BaseUnits.EVENTS)
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
         debugCounter = Counter.builder("logback.events").tags(tags).tags("level", "debug")
-                .description("Number of debug level events that made it to the logs").baseUnit(BaseUnits.EVENTS)
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
         traceCounter = Counter.builder("logback.events").tags(tags).tags("level", "trace")
-                .description("Number of trace level events that made it to the logs").baseUnit(BaseUnits.EVENTS)
+                .description("Number of events that made it to the logs").baseUnit(BaseUnits.EVENTS)
                 .register(registry);
     }
 


### PR DESCRIPTION
Since the `description` of the `Meter`s can be different per `Meter`, we can run into weird situations when the description is dynamic/different for different `Meter.Id`s that share the same name but differ in tags for backends that does not support different description per time series.

**jvm.threads.states**
The description here (Prometheus group) is `The current number of threads having NEW state`.
This is somewhat misleading since we have time series for all of the states not just `NEW`.

```
# HELP jvm_threads_states_threads The current number of threads having NEW state
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threads{state="new",} 0.0
jvm_threads_states_threads{state="timed-waiting",} 3.0
jvm_threads_states_threads{state="blocked",} 0.0
jvm_threads_states_threads{state="waiting",} 12.0
jvm_threads_states_threads{state="terminated",} 0.0
jvm_threads_states_threads{state="runnable",} 7.0
```

**logback.events**
The description here (Prometheus group) is `Number of error level events that made it to the logs`.
This is somewhat misleading since we have time series for all of the levels not just `error`.

```
# HELP logback_events_total Number of error level events that made it to the logs
# TYPE logback_events_total counter
logback_events_total{level="info",} 6.0
logback_events_total{level="debug",} 0.0
logback_events_total{level="warn",} 0.0
logback_events_total{level="error",} 0.0
logback_events_total{level="trace",} 0.0
```