### PR TITLE
Avoid auto-boxing in `Measurement#getValue`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Measurement.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Measurement.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 /**
@@ -22,15 +23,21 @@ import java.util.function.Supplier;
  *
  * @author Clint Checketts
  * @author Jon Schneider
+ * @author Philippe Marschall
  */
 public class Measurement {
 
-    private final Supplier<Double> f;
+    private final DoubleSupplier f;
 
     private final Statistic statistic;
 
-    public Measurement(Supplier<Double> valueFunction, Statistic statistic) {
+    public Measurement(DoubleSupplier valueFunction, Statistic statistic) {
         this.f = valueFunction;
+        this.statistic = statistic;
+    }
+
+    public Measurement(Supplier<Double> valueFunction, Statistic statistic) {
+        this.f = valueFunction::get;
         this.statistic = statistic;
     }
 
@@ -38,7 +45,7 @@ public class Measurement {
      * @return Value for the measurement.
      */
     public double getValue() {
-        return f.get();
+        return f.getAsDouble();
     }
 
     public Statistic getStatistic() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeasurement.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeasurement.java
@@ -20,7 +20,7 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Statistic;
 
 import java.util.concurrent.atomic.DoubleAdder;
-import java.util.function.Supplier;
+import java.util.function.DoubleSupplier;
 
 class StepMeasurement extends Measurement {
 
@@ -28,17 +28,14 @@ class StepMeasurement extends Measurement {
 
     private final DoubleAdder lastCount = new DoubleAdder();
 
-    private final Supplier<Double> f;
-
-    public StepMeasurement(Supplier<Double> f, Statistic statistic, Clock clock, long stepMillis) {
+    StepMeasurement(DoubleSupplier f, Statistic statistic, Clock clock, long stepMillis) {
         super(f, statistic);
-        this.f = f;
         this.value = new StepDouble(clock, stepMillis);
     }
 
     @Override
     public double getValue() {
-        double absoluteCount = f.get();
+        double absoluteCount = super.getValue();
         double inc = Math.max(0, absoluteCount - lastCount.sum());
         lastCount.add(inc);
         value.getCurrent().add(inc);


### PR DESCRIPTION
Use DoubleSupplier instead of Supplier<Double> where possible to avoid
boxing.