### PR TITLE
StepMeterRegistry: wait for stepmeters to finalize on close

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -102,4 +102,15 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
                 .merge(DistributionStatisticConfig.DEFAULT);
     }
 
+    @Override
+    public void close() {
+        stop();
+        try {
+            Thread.sleep(config.step().toMillis());
+        } catch (final InterruptedException e) {
+            // ignore
+        } finally {
+            super.close();
+        }
+    }
 }


### PR DESCRIPTION
This is a minimal change required to fix #1882 .

Introduces:

- A test case to verify the metrics published on close are complete and not published twice (with background publishing thread).
- `close()` method override in `StepMeterRegistry` to wait for stepmeters to finalize values.

As a drawback, service shutdown might take longer than usual (up to step duration).