### PR TITLE
Use `latest.release` for `io.opentelemetry.proto:opentelemetry-proto`

### DIFF
--- a/implementations/micrometer-registry-otlp/build.gradle
+++ b/implementations/micrometer-registry-otlp/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':micrometer-core')
 
     // some proto are marked alpha, hence the alpha version. metrics proto is what we use and it is marked stable
-    implementation 'io.opentelemetry.proto:opentelemetry-proto:0.16.0-alpha'
+    implementation 'io.opentelemetry.proto:opentelemetry-proto:latest.release'
 
     testImplementation project(':micrometer-test')
 }


### PR DESCRIPTION
This PR changes to use `latest.release` for `io.opentelemetry.proto:opentelemetry-proto`.