### PR TITLE
Further improvement of observation convention

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
@@ -84,8 +84,7 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         Iterable<Tag> unknownRequestTags = context.getUnknownRequestTags();
         boolean includeHostTag = context.isIncludeHostTag();
         // TODO: Tags to key values and back - maybe we can improve this?
-        KeyValues keyValues = KeyValues.of("method", requestAvailable ? request.method() : TAG_VALUE_UNKNOWN, "uri",
-                getUriTag(urlMapper, state, request), "status", getStatusMessage(state.response, state.exception))
+        KeyValues keyValues = KeyValues.of(OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.METHOD.of(requestAvailable ? request.method() : TAG_VALUE_UNKNOWN), OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.URI.of(getUriTag(urlMapper, state, request)), OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.STATUS.of(getStatusMessage(state.response, state.exception)))
                 .and(tagsToKeyValues(stream(extraTags.spliterator(), false)))
                 .and(stream(contextSpecificTags.spliterator(), false)
                         .map(contextTag -> contextTag.apply(request, state.response))
@@ -93,8 +92,8 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
                 .and(getRequestTags(request, tagsToKeyValues(stream(unknownRequestTags.spliterator(), false))))
                 .and(generateTagsForRoute(request));
         if (includeHostTag) {
-            keyValues = KeyValues.of(keyValues).and("host",
-                    requestAvailable ? request.url().host() : TAG_VALUE_UNKNOWN);
+            keyValues = KeyValues.of(keyValues).and(OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.HOST.of(
+                    requestAvailable ? request.url().host() : TAG_VALUE_UNKNOWN));
         }
         return keyValues;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
@@ -84,7 +84,12 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         Iterable<Tag> unknownRequestTags = context.getUnknownRequestTags();
         boolean includeHostTag = context.isIncludeHostTag();
         // TODO: Tags to key values and back - maybe we can improve this?
-        KeyValues keyValues = KeyValues.of(OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.METHOD.of(requestAvailable ? request.method() : TAG_VALUE_UNKNOWN), OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.URI.of(getUriTag(urlMapper, state, request)), OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.STATUS.of(getStatusMessage(state.response, state.exception)))
+        KeyValues keyValues = KeyValues.of(
+                OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.METHOD
+                        .of(requestAvailable ? request.method() : TAG_VALUE_UNKNOWN),
+                OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.URI.of(getUriTag(urlMapper, state, request)),
+                OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.STATUS
+                        .of(getStatusMessage(state.response, state.exception)))
                 .and(tagsToKeyValues(stream(extraTags.spliterator(), false)))
                 .and(stream(contextSpecificTags.spliterator(), false)
                         .map(contextTag -> contextTag.apply(request, state.response))
@@ -92,8 +97,8 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
                 .and(getRequestTags(request, tagsToKeyValues(stream(unknownRequestTags.spliterator(), false))))
                 .and(generateTagsForRoute(request));
         if (includeHostTag) {
-            keyValues = KeyValues.of(keyValues).and(OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.HOST.of(
-                    requestAvailable ? request.url().host() : TAG_VALUE_UNKNOWN));
+            keyValues = KeyValues.of(keyValues).and(OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.HOST
+                    .of(requestAvailable ? request.url().host() : TAG_VALUE_UNKNOWN));
         }
         return keyValues;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpDocumentedObservation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpDocumentedObservation.java
@@ -16,10 +16,7 @@
 package io.micrometer.core.instrument.binder.okhttp3;
 
 import io.micrometer.common.docs.KeyName;
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.docs.DocumentedObservation;
 
 /**
@@ -35,8 +32,8 @@ public enum OkHttpDocumentedObservation implements DocumentedObservation {
      */
     DEFAULT {
         @Override
-        public String getName() {
-            return "%s";
+        public Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+            return DefaultOkHttpObservationConvention.class;
         }
 
         @Override
@@ -44,33 +41,6 @@ public enum OkHttpDocumentedObservation implements DocumentedObservation {
             return OkHttpLegacyLowCardinalityTags.values();
         }
     };
-
-    /**
-     * Creates an {@link OkHttpDocumentedObservation} depending on the configuration.
-     * @param registry observation registry
-     * @param okHttpContext the ok http context
-     * @param requestsMetricName name of the observation
-     * @param customConvention custom convention. If {@code null}, the
-     * {@link DefaultOkHttpObservationConvention} will be used.
-     * @return a new {@link OkHttpDocumentedObservation}
-     */
-    @SuppressWarnings("unchecked")
-    static Observation of(@NonNull ObservationRegistry registry, @NonNull OkHttpContext okHttpContext,
-            @NonNull String requestsMetricName,
-            @Nullable Observation.ObservationConvention<OkHttpContext> customConvention) {
-        Observation.ObservationConvention<OkHttpContext> convention = null;
-        if (registry.isNoop()) {
-            return Observation.NOOP;
-        }
-        else if (customConvention != null) {
-            convention = customConvention;
-        }
-        else {
-            convention = registry.observationConfig().getObservationConvention(okHttpContext,
-                    new DefaultOkHttpObservationConvention(requestsMetricName));
-        }
-        return Observation.createNotStarted(convention, okHttpContext, registry);
-    }
 
     enum OkHttpLegacyLowCardinalityTags implements KeyName {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -88,6 +88,8 @@ public class OkHttpMetricsEventListener extends EventListener {
 
     private final LegacyOkHttpMetricsEventListener legacyListener;
 
+    private final DefaultOkHttpObservationConvention defaultConvention;
+
     protected OkHttpMetricsEventListener(MeterRegistry registry, String requestsMetricName,
             Function<Request, String> urlMapper, Iterable<Tag> extraTags,
             Iterable<BiFunction<Request, Response, Tag>> contextSpecificTags) {
@@ -117,6 +119,7 @@ public class OkHttpMetricsEventListener extends EventListener {
         this.unknownRequestTags = unknownRequestTags;
         this.legacyListener = new LegacyOkHttpMetricsEventListener(registry, requestsMetricName, urlMapper, extraTags,
                 contextSpecificTags, unknownRequestTags, includeHostTag);
+        this.defaultConvention = new DefaultOkHttpObservationConvention(requestsMetricName);
     }
 
     public static Builder builder(MeterRegistry registry, String name) {
@@ -173,7 +176,7 @@ public class OkHttpMetricsEventListener extends EventListener {
             });
         }
         Observation observation = OkHttpDocumentedObservation.DEFAULT.start(this.observationRegistry, okHttpContext,
-                this.observationConvention, new DefaultOkHttpObservationConvention(requestsMetricName));
+                this.observationConvention, this.defaultConvention);
         callState.setContext(okHttpContext);
         callState.setObservation(observation);
         this.callState.put(call, callState);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -172,8 +172,7 @@ public class OkHttpMetricsEventListener extends EventListener {
                 }
             });
         }
-        Observation observation = OkHttpDocumentedObservation
-                .of(this.observationRegistry, okHttpContext, requestsMetricName, this.observationConvention).start();
+        Observation observation = Observation.start(this.observationRegistry, okHttpContext, this.observationConvention, new DefaultOkHttpObservationConvention(requestsMetricName));
         callState.setContext(okHttpContext);
         callState.setObservation(observation);
         this.callState.put(call, callState);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -172,7 +172,8 @@ public class OkHttpMetricsEventListener extends EventListener {
                 }
             });
         }
-        Observation observation = Observation.start(this.observationRegistry, okHttpContext, this.observationConvention, new DefaultOkHttpObservationConvention(requestsMetricName));
+        Observation observation = OkHttpDocumentedObservation.DEFAULT.start(this.observationRegistry, okHttpContext,
+                this.observationConvention, new DefaultOkHttpObservationConvention(requestsMetricName));
         callState.setContext(okHttpContext);
         callState.setObservation(observation);
         this.callState.put(call, callState);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -100,7 +100,8 @@ public interface Observation {
      */
     static Observation createNotStarted(String name, @Nullable Context context,
             @Nullable ObservationRegistry registry) {
-        if (registry == null || registry.isNoop() || !registry.observationConfig().isObservationEnabled(name, context)) {
+        if (registry == null || registry.isNoop()
+                || !registry.observationConfig().isObservationEnabled(name, context)) {
             return NoopObservation.INSTANCE;
         }
         return new SimpleObservation(name, registry, context == null ? new Context() : context);
@@ -115,14 +116,18 @@ public interface Observation {
      * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
      * was found.
      * @param <T> type of context
-     * @param customConvention custom convention. If {@code null}, the default one will be picked
-     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
+     * @param customConvention custom convention. If {@code null}, the default one will be
+     * picked
+     * @param defaultConvention default convention when no custom convention was passed,
+     * nor a configured one was found
      * @param context the observation context
      * @param registry observation registry
      * @return created but not started observation
      */
-    static <T extends Observation.Context> Observation createNotStarted(@Nullable Observation.ObservationConvention<T> customConvention,
-            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context, @NonNull ObservationRegistry registry) {
+    static <T extends Observation.Context> Observation createNotStarted(
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context,
+            @NonNull ObservationRegistry registry) {
         Observation.ObservationConvention<T> convention;
         if (customConvention != null) {
             convention = customConvention;
@@ -173,8 +178,10 @@ public interface Observation {
      * nor a configured one was found
      * @return started observation
      */
-    static <T extends Observation.Context> Observation start(@Nullable Observation.ObservationConvention<T> customConvention,
-            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context, @NonNull ObservationRegistry registry) {
+    static <T extends Observation.Context> Observation start(
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context,
+            @NonNull ObservationRegistry registry) {
         return createNotStarted(customConvention, defaultConvention, context, registry).start();
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -108,6 +108,32 @@ public interface Observation {
     }
 
     /**
+     * Creates but <b>does not start</b> an {@link Observation}. Remember to call
+     * {@link Observation#start()} when you want the measurements to start. When no
+     * registry is passed or observation is not applicable will return a no-op
+     * observation. Allows to set a custom {@link ObservationConvention} and requires
+     * to provide a default one if a neither a custom nor a pre-configured one (via {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)}) was found.
+     * @param <T> type of context
+     * @param registry observation registry
+     * @param context the observation context
+     * @param customConvention custom convention. If {@code null}, the default one will be picked
+     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
+     * @return created but not started observation
+     */
+    static <T extends Observation.Context> Observation createNotStarted(@NonNull ObservationRegistry registry, @NonNull T context,
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention) {
+        Observation.ObservationConvention<T> convention;
+        if (customConvention != null) {
+            convention = customConvention;
+        }
+        else {
+            convention = registry.observationConfig().getObservationConvention(context, defaultConvention);
+        }
+        return Observation.createNotStarted(convention, context, registry);
+    }
+
+    /**
      * Creates and starts an {@link Observation}. When no registry is passed or
      * observation is not applicable will return a no-op observation.
      * @param observationConvention observation convention
@@ -129,6 +155,24 @@ public interface Observation {
     static Observation start(ObservationConvention<?> observationConvention, @Nullable Context context,
             @Nullable ObservationRegistry registry) {
         return createNotStarted(observationConvention, context, registry).start();
+    }
+
+    /**
+     * Creates and starts an {@link Observation}. When no
+     * registry is passed or observation is not applicable will return a no-op
+     * observation. Allows to set a custom {@link ObservationConvention} and requires
+     * to provide a default one if a neither a custom nor a pre-configured one (via {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)}) was found.
+     * @param <T> type of context
+     * @param registry observation registry
+     * @param context the observation context
+     * @param customConvention custom convention. If {@code null}, the default one will be picked
+     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
+     * @return started observation
+     */
+    static <T extends Observation.Context> Observation start(@NonNull ObservationRegistry registry, @NonNull T context,
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention) {
+       return createNotStarted(registry, context, customConvention, defaultConvention).start();
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -100,8 +100,7 @@ public interface Observation {
      */
     static Observation createNotStarted(String name, @Nullable Context context,
             @Nullable ObservationRegistry registry) {
-        if (registry == null || registry.isNoop() || !registry.observationConfig().isObservationEnabled(name, context)
-                || registry.observationConfig().getObservationHandlers().isEmpty()) {
+        if (registry == null || registry.isNoop() || !registry.observationConfig().isObservationEnabled(name, context)) {
             return NoopObservation.INSTANCE;
         }
         return new SimpleObservation(name, registry, context == null ? new Context() : context);
@@ -116,17 +115,14 @@ public interface Observation {
      * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
      * was found.
      * @param <T> type of context
-     * @param registry observation registry
+     * @param customConvention custom convention. If {@code null}, the default one will be picked
+     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
      * @param context the observation context
-     * @param customConvention custom convention. If {@code null}, the default one will be
-     * picked
-     * @param defaultConvention default convention when no custom convention was passed,
-     * nor a configured one was found
+     * @param registry observation registry
      * @return created but not started observation
      */
-    static <T extends Observation.Context> Observation createNotStarted(@NonNull ObservationRegistry registry,
-            @NonNull T context, @Nullable Observation.ObservationConvention<T> customConvention,
-            @NonNull Observation.ObservationConvention<T> defaultConvention) {
+    static <T extends Observation.Context> Observation createNotStarted(@Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context, @NonNull ObservationRegistry registry) {
         Observation.ObservationConvention<T> convention;
         if (customConvention != null) {
             convention = customConvention;
@@ -177,10 +173,9 @@ public interface Observation {
      * nor a configured one was found
      * @return started observation
      */
-    static <T extends Observation.Context> Observation start(@NonNull ObservationRegistry registry, @NonNull T context,
-            @Nullable Observation.ObservationConvention<T> customConvention,
-            @NonNull Observation.ObservationConvention<T> defaultConvention) {
-        return createNotStarted(registry, context, customConvention, defaultConvention).start();
+    static <T extends Observation.Context> Observation start(@Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention, @NonNull T context, @NonNull ObservationRegistry registry) {
+        return createNotStarted(customConvention, defaultConvention, context, registry).start();
     }
 
     /**
@@ -211,7 +206,6 @@ public interface Observation {
             @Nullable ObservationRegistry registry) {
         if (registry == null || registry.isNoop()
                 || !registry.observationConfig().isObservationEnabled(observationConvention.getName(), context)
-                || registry.observationConfig().getObservationHandlers().isEmpty()
                 || observationConvention == NoopObservationConvention.INSTANCE) {
             return NoopObservation.INSTANCE;
         }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -111,17 +111,21 @@ public interface Observation {
      * Creates but <b>does not start</b> an {@link Observation}. Remember to call
      * {@link Observation#start()} when you want the measurements to start. When no
      * registry is passed or observation is not applicable will return a no-op
-     * observation. Allows to set a custom {@link ObservationConvention} and requires
-     * to provide a default one if a neither a custom nor a pre-configured one (via {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)}) was found.
+     * observation. Allows to set a custom {@link ObservationConvention} and requires to
+     * provide a default one if a neither a custom nor a pre-configured one (via
+     * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
+     * was found.
      * @param <T> type of context
      * @param registry observation registry
      * @param context the observation context
-     * @param customConvention custom convention. If {@code null}, the default one will be picked
-     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
+     * @param customConvention custom convention. If {@code null}, the default one will be
+     * picked
+     * @param defaultConvention default convention when no custom convention was passed,
+     * nor a configured one was found
      * @return created but not started observation
      */
-    static <T extends Observation.Context> Observation createNotStarted(@NonNull ObservationRegistry registry, @NonNull T context,
-            @Nullable Observation.ObservationConvention<T> customConvention,
+    static <T extends Observation.Context> Observation createNotStarted(@NonNull ObservationRegistry registry,
+            @NonNull T context, @Nullable Observation.ObservationConvention<T> customConvention,
             @NonNull Observation.ObservationConvention<T> defaultConvention) {
         Observation.ObservationConvention<T> convention;
         if (customConvention != null) {
@@ -158,21 +162,25 @@ public interface Observation {
     }
 
     /**
-     * Creates and starts an {@link Observation}. When no
-     * registry is passed or observation is not applicable will return a no-op
-     * observation. Allows to set a custom {@link ObservationConvention} and requires
-     * to provide a default one if a neither a custom nor a pre-configured one (via {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)}) was found.
+     * Creates and starts an {@link Observation}. When no registry is passed or
+     * observation is not applicable will return a no-op observation. Allows to set a
+     * custom {@link ObservationConvention} and requires to provide a default one if a
+     * neither a custom nor a pre-configured one (via
+     * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
+     * was found.
      * @param <T> type of context
      * @param registry observation registry
      * @param context the observation context
-     * @param customConvention custom convention. If {@code null}, the default one will be picked
-     * @param defaultConvention default convention when no custom convention was passed, nor a configured one was found
+     * @param customConvention custom convention. If {@code null}, the default one will be
+     * picked
+     * @param defaultConvention default convention when no custom convention was passed,
+     * nor a configured one was found
      * @return started observation
      */
     static <T extends Observation.Context> Observation start(@NonNull ObservationRegistry registry, @NonNull T context,
             @Nullable Observation.ObservationConvention<T> customConvention,
             @NonNull Observation.ObservationConvention<T> defaultConvention) {
-       return createNotStarted(registry, context, customConvention, defaultConvention).start();
+        return createNotStarted(registry, context, customConvention, defaultConvention).start();
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -148,8 +148,8 @@ public interface ObservationRegistry {
         }
 
         /**
-         * Register a {@link Observation.ObservationConvention}.
-         * @param observationConvention observation convention
+         * Register {@link Observation.ObservationConvention observation conventions}.
+         * @param observationConvention observation conventions
          * @return This configuration instance
          */
         public ObservationConfig observationConvention(Observation.ObservationConvention<?>... observationConvention) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
@@ -58,7 +58,7 @@ class SimpleObservationRegistry implements ObservationRegistry {
 
     @Override
     public boolean isNoop() {
-        return ObservationRegistry.super.isNoop();
+        return ObservationRegistry.super.isNoop() || observationConfig().getObservationHandlers().isEmpty();
     }
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
@@ -56,8 +56,8 @@ public interface DocumentedObservation {
     KeyName[] EMPTY = new KeyName[0];
 
     /**
-     * Default technical name (e.g metric name). You can set the name either by this method or
-     * {@link #getDefaultConvention()}. You can't use both.
+     * Default technical name (e.g metric name). You can set the name either by this
+     * method or {@link #getDefaultConvention()}. You can't use both.
      * @return name
      */
     default String getName() {
@@ -65,8 +65,8 @@ public interface DocumentedObservation {
     }
 
     /**
-     *  Default naming convention (sets a technical name and key values). You can set the name either by this method or
-     * {@link #getName()} ()}. You can't use both.
+     * Default naming convention (sets a technical name and key values). You can set the
+     * name either by this method or {@link #getName()} ()}. You can't use both.
      * @return default naming convention
      */
     default Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
@@ -126,21 +126,35 @@ public interface DocumentedObservation {
     }
 
     /**
-     * Creates an {@link Observation} for the given {@link Observation.ObservationConvention}. You need to manually start it.
+     * Creates an {@link Observation} for the given
+     * {@link Observation.ObservationConvention}. You need to manually start it.
      * @param registry observation registry
      * @param context observation context
-     * @param customConvention convention that (if not {@code null}) will override any pre-configured conventions
-     * @param defaultConvention default convention that will be picked if there was neither custom convention nor a pre-configured one via {@link ObservationRegistry.ObservationConfig#observationConvention(Observation.ObservationConvention[])}
+     * @param customConvention convention that (if not {@code null}) will override any
+     * pre-configured conventions
+     * @param defaultConvention default convention that will be picked if there was
+     * neither custom convention nor a pre-configured one via
+     * {@link ObservationRegistry.ObservationConfig#observationConvention(Observation.ObservationConvention[])}
      * @return observation
      */
-    default <T extends Observation.Context> Observation observation(ObservationRegistry registry, T context, @Nullable Observation.ObservationConvention<T> customConvention, @NonNull Observation.ObservationConvention<T> defaultConvention) {
+    default <T extends Observation.Context> Observation observation(ObservationRegistry registry, T context,
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention) {
         if (getDefaultConvention() == null) {
-            throw new IllegalStateException("You've decided to use convention based naming yet this observation [" + getClass() + "] has not defined any default convention");
+            throw new IllegalStateException("You've decided to use convention based naming yet this observation ["
+                    + getClass() + "] has not defined any default convention");
         }
-        else if (!getDefaultConvention().isAssignableFrom(Objects.requireNonNull(defaultConvention, "You have not provided a default convention in the Observation factory method").getClass())) {
-            throw new IllegalArgumentException("Observation [" + getClass() + "] defined default convention to be of type [" + getDefaultConvention() + "] but you have provided an incompatible one of type [" + defaultConvention.getClass() + "]");
+        else if (!getDefaultConvention()
+                .isAssignableFrom(Objects
+                        .requireNonNull(defaultConvention,
+                                "You have not provided a default convention in the Observation factory method")
+                        .getClass())) {
+            throw new IllegalArgumentException("Observation [" + getClass()
+                    + "] defined default convention to be of type [" + getDefaultConvention()
+                    + "] but you have provided an incompatible one of type [" + defaultConvention.getClass() + "]");
         }
-        return Observation.createNotStarted(registry, context, customConvention, defaultConvention).contextualName(getContextualName());
+        return Observation.createNotStarted(registry, context, customConvention, defaultConvention)
+                .contextualName(getContextualName());
     }
 
     /**
@@ -160,6 +174,23 @@ public interface DocumentedObservation {
      */
     default Observation start(ObservationRegistry registry, Observation.Context context) {
         return observation(registry, context).start();
+    }
+
+    /**
+     * Creates and starts an {@link Observation}.
+     * @param registry observation registry
+     * @param context observation context
+     * @param customConvention convention that (if not {@code null}) will override any
+     * pre-configured conventions
+     * @param defaultConvention default convention that will be picked if there was
+     * neither custom convention nor a pre-configured one via
+     * {@link ObservationRegistry.ObservationConfig#observationConvention(Observation.ObservationConvention[])}
+     * @return observation
+     */
+    default <T extends Observation.Context> Observation start(ObservationRegistry registry, T context,
+            @Nullable Observation.ObservationConvention<T> customConvention,
+            @NonNull Observation.ObservationConvention<T> defaultConvention) {
+        return observation(registry, context, customConvention, defaultConvention).start();
     }
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
@@ -153,7 +153,7 @@ public interface DocumentedObservation {
                     + "] defined default convention to be of type [" + getDefaultConvention()
                     + "] but you have provided an incompatible one of type [" + defaultConvention.getClass() + "]");
         }
-        return Observation.createNotStarted(registry, context, customConvention, defaultConvention)
+        return Observation.createNotStarted(customConvention, defaultConvention, context, registry)
                 .contextualName(getContextualName());
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
@@ -29,27 +29,28 @@ class DocumentedObservationTests {
     void iseShouldBeThrownWhenDocumentedObservationHasNotOverriddenDefaultConvention() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(registry, new Observation.Context(), null, null))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("You've decided to use convention based naming yet this observation");
+        thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(registry,
+                new Observation.Context(), null, null)).isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("You've decided to use convention based naming yet this observation");
     }
 
     @Test
     void npeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionWasNotPassedToTheFactoryMethod() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null, null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("You have not provided a default convention in the Observation factory method");
+        thenThrownBy(
+                () -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null, null))
+                        .isInstanceOf(NullPointerException.class).hasMessageContaining(
+                                "You have not provided a default convention in the Observation factory method");
     }
 
     @Test
     void iaeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionIsNotOfProperType() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null, new SecondObservationConvention()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("but you have provided an incompatible one of type");
+        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null,
+                new SecondObservationConvention())).isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("but you have provided an incompatible one of type");
     }
 
     @Test
@@ -57,7 +58,8 @@ class DocumentedObservationTests {
         ObservationRegistry registry = observationRegistry();
         Observation.Context context = new Observation.Context();
 
-        TestConventionObservation.OVERRIDDEN.observation(registry, context, null, new ThirdObservationConvention()).start().stop();
+        TestConventionObservation.OVERRIDDEN.observation(registry, context, null, new ThirdObservationConvention())
+                .start().stop();
 
         then(context.getName()).isEqualTo("three");
         then(context.getContextualName()).isEqualTo("contextual");
@@ -72,6 +74,7 @@ class DocumentedObservationTests {
     }
 
     enum TestConventionObservation implements DocumentedObservation {
+
         NOT_OVERRIDDEN_METHODS {
 
         },
@@ -87,6 +90,7 @@ class DocumentedObservationTests {
                 return FirstObservationConvention.class;
             }
         }
+
     }
 
     static class FirstObservationConvention implements Observation.ObservationConvention<Observation.Context> {
@@ -100,6 +104,7 @@ class DocumentedObservationTests {
         public boolean supportsContext(Observation.Context context) {
             return true;
         }
+
     }
 
     static class SecondObservationConvention implements Observation.ObservationConvention<Observation.Context> {
@@ -113,6 +118,7 @@ class DocumentedObservationTests {
         public boolean supportsContext(Observation.Context context) {
             return true;
         }
+
     }
 
     static class ThirdObservationConvention extends FirstObservationConvention {
@@ -136,5 +142,7 @@ class DocumentedObservationTests {
         public boolean supportsContext(Observation.Context context) {
             return true;
         }
+
     }
+
 }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation.docs;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+
+class DocumentedObservationTests {
+
+    @Test
+    void iseShouldBeThrownWhenDocumentedObservationHasNotOverriddenDefaultConvention() {
+        ObservationRegistry registry = observationRegistry();
+
+        thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(registry, new Observation.Context(), null, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("You've decided to use convention based naming yet this observation");
+    }
+
+    @Test
+    void npeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionWasNotPassedToTheFactoryMethod() {
+        ObservationRegistry registry = observationRegistry();
+
+        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("You have not provided a default convention in the Observation factory method");
+    }
+
+    @Test
+    void iaeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionIsNotOfProperType() {
+        ObservationRegistry registry = observationRegistry();
+
+        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(registry, new Observation.Context(), null, new SecondObservationConvention()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("but you have provided an incompatible one of type");
+    }
+
+    @Test
+    void observationShouldBeCreatedWhenObservationConventionIsOfProperType() {
+        ObservationRegistry registry = observationRegistry();
+        Observation.Context context = new Observation.Context();
+
+        TestConventionObservation.OVERRIDDEN.observation(registry, context, null, new ThirdObservationConvention()).start().stop();
+
+        then(context.getName()).isEqualTo("three");
+        then(context.getContextualName()).isEqualTo("contextual");
+        then(context.getLowCardinalityKeyValues()).isEqualTo(KeyValues.of("low key", "low value"));
+        then(context.getHighCardinalityKeyValues()).isEqualTo(KeyValues.of("high key", "high value"));
+    }
+
+    private ObservationRegistry observationRegistry() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        return registry;
+    }
+
+    enum TestConventionObservation implements DocumentedObservation {
+        NOT_OVERRIDDEN_METHODS {
+
+        },
+
+        OVERRIDDEN {
+            @Override
+            public String getContextualName() {
+                return "contextual";
+            }
+
+            @Override
+            public Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+                return FirstObservationConvention.class;
+            }
+        }
+    }
+
+    static class FirstObservationConvention implements Observation.ObservationConvention<Observation.Context> {
+
+        @Override
+        public String getName() {
+            return "one";
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
+
+    static class SecondObservationConvention implements Observation.ObservationConvention<Observation.Context> {
+
+        @Override
+        public String getName() {
+            return "two";
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
+
+    static class ThirdObservationConvention extends FirstObservationConvention {
+
+        @Override
+        public String getName() {
+            return "three";
+        }
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("low key", "low value");
+        }
+
+        @Override
+        public KeyValues getHighCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("high key", "high value");
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Makes `DocumentedObservation` require either `getName()` or `getDefaultConvention()` methods to be provided in order to resolve the final name for an observation. 