### PR TITLE
Avoid classloading LatencyUtils when not configured

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
+import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.lang.Nullable;
 import org.LatencyUtils.IntervalEstimator;
@@ -101,6 +102,9 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     }
 
     private void initPauseDetector(PauseDetector pauseDetectorType) {
+        if (pauseDetectorType instanceof NoPauseDetector) {
+            return;
+        }
         pauseDetector = pauseDetectorCache.computeIfAbsent(pauseDetectorType, detector -> {
             if (detector instanceof ClockDriftPauseDetector) {
                 ClockDriftPauseDetector clockDriftPauseDetector = (ClockDriftPauseDetector) detector;

--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -10,7 +10,11 @@ repositories {
 }
 
 dependencies {
-    implementation project(":micrometer-core")
+    implementation(project(":micrometer-core")) {
+        // see gh-1599; pause detection and percentiles are not configured so these dependencies can be excluded
+        exclude module: 'LatencyUtils'
+        exclude module: 'HdrHistogram'
+    }
     ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'health', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'humio', 'appoptics', 'stackdriver'].each { sys ->
         implementation project(":micrometer-registry-$sys")
     }


### PR DESCRIPTION
The default MeterRegistry configuration uses a NoPauseDetector, which does not need to use any LatencyUtils classes. This change avoids classloading LatencyUtils classes, which makes it possible for end users to exclude the LatencyUtils dependency and not have any issues at runtime.

Without this change, when excluding the LatencyUtils dependency from your application classpath, the following exception is thrown when registering a Timer.

```
java.lang.NoClassDefFoundError: org/LatencyUtils/PauseDetector
	at io.micrometer.core.instrument.AbstractTimer.initPauseDetector(AbstractTimer.java:104) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.AbstractTimer.<init>(AbstractTimer.java:84) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.prometheus.PrometheusTimer.<init>(PrometheusTimer.java:57) ~[micrometer-registry-prometheus-1.9.1.jar:1.9.1]
	at io.micrometer.prometheus.PrometheusMeterRegistry.newTimer(PrometheusMeterRegistry.java:320) ~[micrometer-registry-prometheus-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.MeterRegistry.lambda$timer$2(MeterRegistry.java:318) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.MeterRegistry.getOrCreateMeter(MeterRegistry.java:618) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.MeterRegistry.registerMeterIfNecessary(MeterRegistry.java:570) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.MeterRegistry.timer(MeterRegistry.java:316) ~[micrometer-core-1.9.1.jar:1.9.1]
	at io.micrometer.core.instrument.Timer$Builder.register(Timer.java:399) ~[micrometer-core-1.9.1.jar:1.9.1]
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.getTimer(WebMvcMetricsFilter.java:161) ~[spring-boot-actuator-2.7.1.jar:2.7.1]
```

Closes #1599 