### PR TITLE
Declare HdrHistogram as a runtime dependency

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -8,8 +8,7 @@ dependencies {
     api project(":micrometer-commons")
     api project(":micrometer-observation")
 
-    // TODO(anuraaga): HdrHistogram is exposed in the micrometer API but probably shouldn't be
-    api 'org.hdrhistogram:HdrHistogram'
+    implementation 'org.hdrhistogram:HdrHistogram'
     implementation('org.latencyutils:LatencyUtils') {
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
     }


### PR DESCRIPTION
HdrHistogram is not exposed in the API. It is an implementation detail of client-side percentiles. The scope of the dependency can be changed accordingly.

This was found while working on #1599.