### PR TITLE
MeterRegistry implements ObservationRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -25,10 +25,14 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.noop.*;
+import io.micrometer.core.instrument.observation.TimerObservationHandler;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.core.instrument.search.Search;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
 
 import java.time.Duration;
 import java.util.*;
@@ -61,7 +65,7 @@ import static java.util.Objects.requireNonNull;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  */
-public abstract class MeterRegistry {
+public abstract class MeterRegistry implements ObservationRegistry {
 
     protected final Clock clock;
 
@@ -95,6 +99,8 @@ public abstract class MeterRegistry {
 
     private final AtomicBoolean closed = new AtomicBoolean();
 
+    private final ObservationRegistry observationRegistry;
+
     private PauseDetector pauseDetector = new NoPauseDetector();
 
     @Nullable
@@ -111,8 +117,48 @@ public abstract class MeterRegistry {
     private NamingConvention namingConvention = NamingConvention.snakeCase;
 
     protected MeterRegistry(Clock clock) {
+        this(clock, ObservationRegistry.create());
+    }
+
+    protected MeterRegistry(Clock clock, ObservationRegistry observationRegistry) {
         requireNonNull(clock);
+        requireNonNull(observationRegistry);
         this.clock = clock;
+        this.observationRegistry = observationRegistry;
+    }
+
+    /**
+     * Adds a {@link TimerObservationHandler} to the list of {@link ObservationHandler}.
+     * @return this
+     */
+    public MeterRegistry withTimerObservationHandler() {
+        this.observationRegistry.observationConfig().observationHandler(new TimerObservationHandler(this));
+        return this;
+    }
+
+    @Override
+    public Observation getCurrentObservation() {
+        return this.observationRegistry.getCurrentObservation();
+    }
+
+    @Override
+    public Observation.Scope getCurrentObservationScope() {
+        return this.observationRegistry.getCurrentObservationScope();
+    }
+
+    @Override
+    public void setCurrentObservationScope(Observation.Scope current) {
+        this.observationRegistry.setCurrentObservationScope(current);
+    }
+
+    @Override
+    public ObservationConfig observationConfig() {
+        return this.observationRegistry.observationConfig();
+    }
+
+    @Override
+    public boolean isNoop() {
+        return this.observationRegistry.isNoop();
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/simple/SimpleMeterRegistryTest.java
@@ -19,8 +19,10 @@ import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
+import io.micrometer.core.instrument.search.Search;
 import io.micrometer.core.instrument.step.StepFunctionCounter;
 import io.micrometer.core.instrument.step.StepFunctionTimer;
+import io.micrometer.observation.Observation;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -155,6 +157,15 @@ class SimpleMeterRegistryTest {
                 + "request.size(DISTRIBUTION_SUMMARY)[]; count=10.0, total=1450.0 bytes, max=190.0 bytes\n"
                 + "temperature(GAUGE)[]; value=24.0 celsius");
         sample.stop();
+    }
+
+    @Test
+    void meterRegistryShouldRegisterTimerObservationHandler() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry().withTimerObservationHandler();
+
+        Observation.start("foo", meterRegistry).stop();
+
+        assertThat(Search.in(meterRegistry).name("foo").timer().count()).isEqualTo(1);
     }
 
     private SimpleMeterRegistry createRegistry(CountingMode mode) {


### PR DESCRIPTION
we've made a full circle! Since micrometer-observation is now a mandatory dependency for micrometer-core we can simplify things and make all MeterRegistries become ObservationRegistries.