### PR TITLE
Added the ObservationConventionAware interface

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -796,6 +796,24 @@ public interface Observation {
     }
 
     /**
+     * Interface to be implemented by any object that wishes to be able to update the
+     * default {@link ObservationConvention}.
+     *
+     * @param <T> {@link ObservationConvention} type
+     * @author Marcin Grzejszczak
+     * @since 1.10.0
+     */
+    interface ObservationConventionAware<T extends ObservationConvention<?>> {
+
+        /**
+         * Overrides the default key values provider.
+         * @param keyValuesProvider key values provider
+         */
+        void setObservationConvention(T keyValuesProvider);
+
+    }
+
+    /**
      * A marker interface for conventions of {@link KeyValues} naming.
      *
      * @author Marcin Grzejszczak


### PR DESCRIPTION
added the convenience interface so that each of the instrumentations will be able to unify their contracts on how to give the users an option to override the default `ObservationConvention` 