### PR TITLE
Fix module exclude in micrometer-samples-boot2

### DIFF
--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -9,12 +9,15 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation(project(":micrometer-core")) {
-        // see gh-1599; pause detection and percentiles are not configured so these dependencies can be excluded
+configurations {
+    implementation {
+        // see gh-1599; pause detection is not configured so this dependency can be excluded
         exclude module: 'LatencyUtils'
-        exclude module: 'HdrHistogram'
     }
+}
+
+dependencies {
+    implementation project(":micrometer-core")
     ['atlas', 'azure-monitor', 'prometheus', 'datadog', 'elastic', 'ganglia', 'graphite', 'health', 'jmx', 'influx', 'statsd', 'new-relic', 'cloudwatch', 'cloudwatch2', 'signalfx', 'wavefront', 'elastic', 'dynatrace', 'humio', 'appoptics', 'stackdriver'].each { sys ->
         implementation project(":micrometer-registry-$sys")
     }

--- a/samples/micrometer-samples-boot2/gradle.lockfile
+++ b/samples/micrometer-samples-boot2/gradle.lockfile
@@ -127,7 +127,6 @@ org.codehaus.mojo:animal-sniffer-annotations:1.20=default,productionRuntimeClass
 org.conscrypt:conscrypt-openjdk-uber:2.5.1=default,productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 org.hdrhistogram:HdrHistogram:2.1.12=compileClasspath,default,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.javassist:javassist:3.26.0-GA=checkstyle
-org.latencyutils:LatencyUtils:2.0.3=default,productionRuntimeClasspath,runtimeClasspath,testRuntimeClasspath
 org.reactivestreams:reactive-streams:1.0.3=compileClasspath,default,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.reflections:reflections:0.9.12=checkstyle
 org.slf4j:jul-to-slf4j:1.7.32=compileClasspath,default,productionRuntimeClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath


### PR DESCRIPTION
This PR fixes module exclude in `micrometer-samples-boot2` as it doesn't seem to work.

This PR also removes module exclude for `HdrHistogram` as it is required by `PersonController`.