### PR TITLE
Added option to set a parent Observation on an existing Observation

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -128,7 +128,6 @@ public class TestObservationRegistryAssert
 
     /**
      * Verifies that there are no observations registered.
-     * @return this
      * @throws AssertionError if there are any registered observations
      */
     public void doesNotHaveAnyObservation() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -33,11 +33,18 @@ final class NoopObservation implements Observation {
      */
     static final NoopObservation INSTANCE = new NoopObservation();
 
+    private static final ContextView CONTEXT = new Context();
+
     private NoopObservation() {
     }
 
     @Override
     public Observation contextualName(String contextualName) {
+        return this;
+    }
+
+    @Override
+    public Observation parentObservation(Observation parentObservation) {
         return this;
     }
 
@@ -74,6 +81,11 @@ final class NoopObservation implements Observation {
     @Override
     public Observation start() {
         return this;
+    }
+
+    @Override
+    public ContextView getContext() {
+        return CONTEXT;
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -229,7 +229,12 @@ public interface Observation {
     Observation contextualName(String contextualName);
 
     /**
-     * Sets the parent {@link Observation}.
+     * If you have access to a previously created {@link Observation} you can manually set
+     * the parent {@link Observation} using this method - that way you won't need to open
+     * scopes just to create a child observation.
+     *
+     * If you're using the {@link #openScope()} method then the parent observation will be
+     * automatically set, and you don't have to call this method.
      * @param parentObservation parent observation to set
      * @return this
      */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -16,16 +16,12 @@
 package io.micrometer.observation;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.KeyValues;
-import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.StringUtils;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -235,142 +231,6 @@ class SimpleObservation implements Observation {
             if (this.previousParentObservation != null) {
                 this.currentObservation.context.setParentObservation(this.previousParentObservation);
             }
-        }
-
-    }
-
-    static class ImmutableContext extends Context {
-
-        private final Context delegate;
-
-        ImmutableContext(Context delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public String getName() {
-            return delegate.getName();
-        }
-
-        @Override
-        public Context setName(String name) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public String getContextualName() {
-            return delegate.getContextualName();
-        }
-
-        @Override
-        public Context setContextualName(String contextualName) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        @Nullable
-        public Observation getParentObservation() {
-            return delegate.getParentObservation();
-        }
-
-        @Override
-        public void setParentObservation(Observation parentObservation) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public Optional<Throwable> getError() {
-            return delegate.getError();
-        }
-
-        @Override
-        public Context setError(Throwable error) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public <T> Context put(Object key, T object) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        @Nullable
-        public <T> T get(Object key) {
-            return delegate.get(key);
-        }
-
-        @Override
-        public Object remove(Object key) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        @NonNull
-        public <T> T getRequired(Object key) {
-            return delegate.getRequired(key);
-        }
-
-        @Override
-        public boolean containsKey(Object key) {
-            return delegate.containsKey(key);
-        }
-
-        @Override
-        public <T> T getOrDefault(Object key, T defaultObject) {
-            return delegate.getOrDefault(key, defaultObject);
-        }
-
-        @Override
-        public <T> T computeIfAbsent(Object key, Function<Object, ? extends T> mappingFunction) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public void clear() {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public void addLowCardinalityKeyValue(KeyValue keyValue) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public void addHighCardinalityKeyValue(KeyValue keyValue) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public void addLowCardinalityKeyValues(KeyValues keyValues) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        public void addHighCardinalityKeyValues(KeyValues keyValues) {
-            throw new UnsupportedOperationException("Context is immutable");
-        }
-
-        @Override
-        @NonNull
-        public KeyValues getLowCardinalityKeyValues() {
-            return delegate.getLowCardinalityKeyValues();
-        }
-
-        @Override
-        @NonNull
-        public KeyValues getHighCardinalityKeyValues() {
-            return delegate.getHighCardinalityKeyValues();
-        }
-
-        @Override
-        @NonNull
-        public KeyValues getAllKeyValues() {
-            return delegate.getAllKeyValues();
-        }
-
-        @Override
-        public String toString() {
-            return delegate.toString();
         }
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -228,9 +228,7 @@ class SimpleObservation implements Observation {
         public void close() {
             this.registry.setCurrentObservationScope(previousObservationScope);
             this.currentObservation.notifyOnScopeClosed();
-            if (this.previousParentObservation != null) {
-                this.currentObservation.context.setParentObservation(this.previousParentObservation);
-            }
+            this.currentObservation.context.setParentObservation(this.previousParentObservation);
         }
 
     }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -78,4 +78,22 @@ class ObservationTests {
         assertThat((String) context.get("foo")).isEqualTo("bar");
     }
 
+    @Test
+    void settingParentObservationMakesAReferenceOnParentContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+
+        Observation.Context parentContext = new Observation.Context();
+        Observation parent = Observation.start("parent", parentContext, registry);
+
+        Observation.Context childContext = new Observation.Context();
+        Observation child = Observation.createNotStarted("child", childContext, registry).parentObservation(parent)
+                .start();
+
+        parent.stop();
+        child.stop();
+
+        assertThat(childContext.getParentObservation().getContext()).isSameAs(parentContext);
+    }
+
 }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -96,4 +96,23 @@ class ObservationTests {
         assertThat(childContext.getParentObservation().getContext()).isSameAs(parentContext);
     }
 
+    @Test
+    void settingScopeMakesAReferenceOnParentContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+
+        Observation.Context parentContext = new Observation.Context();
+        Observation parent = Observation.start("parent", parentContext, registry);
+        Observation.Context childContext = new Observation.Context();
+        parent.scoped(() -> {
+            assertThat(childContext.getParentObservation()).isNull();
+            Observation.createNotStarted("child", childContext, registry).observe(() -> {
+                assertThat(childContext.getParentObservation().getContext()).isSameAs(parentContext);
+            });
+            assertThat(childContext.getParentObservation()).isNull();
+        });
+        parent.stop();
+        assertThat(childContext.getParentObservation()).isNull();
+    }
+
 }


### PR DESCRIPTION
without this change in order to e.g. create spans we always need to put an observation in scope so that spans are put in thread local and a child span is being set. That doesn't make a lot of sense when we exactly know what the parent observation is.
with this change we're allowing to set a parent observation direcly on an existing observation. That way we're able to maintain a parent child relationship of observations and of e.g. spans