### PR TITLE
Add getContextualName(Context c) on Observation.Convention

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -152,12 +152,13 @@ public interface Observation {
     /**
      * Creates and starts an {@link Observation}. When no registry is passed or
      * observation is not applicable will return a no-op observation.
+     * @param <T> type of context
      * @param observationConvention observation convention
      * @param context mutable context
      * @param registry observation registry
      * @return started observation
      */
-    static Observation start(ObservationConvention<?> observationConvention, @Nullable Context context,
+    static <T extends Context> Observation start(ObservationConvention<T> observationConvention, @Nullable T context,
             @Nullable ObservationRegistry registry) {
         return createNotStarted(observationConvention, context, registry).start();
     }
@@ -204,19 +205,25 @@ public interface Observation {
      * {@link Observation#start()} when you want the measurements to start. When no
      * registry is passed or observation is not applicable will return a no-op
      * observation.
+     * @param <T> type of context
      * @param observationConvention observation convention
      * @param context mutable context
      * @param registry observation registry
      * @return created but not started observation
      */
-    static Observation createNotStarted(ObservationConvention<?> observationConvention, @Nullable Context context,
-            @Nullable ObservationRegistry registry) {
+    static <T extends Observation.Context> Observation createNotStarted(ObservationConvention<T> observationConvention,
+            @Nullable T context, @Nullable ObservationRegistry registry) {
         if (registry == null || registry.isNoop()
                 || !registry.observationConfig().isObservationEnabled(observationConvention.getName(), context)
                 || observationConvention == NoopObservationConvention.INSTANCE) {
             return NoopObservation.INSTANCE;
         }
-        return new SimpleObservation(observationConvention, registry, context == null ? new Context() : context);
+        Context c = context == null ? new Context() : context;
+        SimpleObservation simpleObservation = new SimpleObservation(observationConvention, registry, c);
+        if (context != null) {
+            simpleObservation.contextualName(observationConvention.getContextualName(context));
+        }
+        return simpleObservation;
     }
 
     /**
@@ -938,6 +945,17 @@ public interface Observation {
          * @return the new name for the observation
          */
         String getName();
+
+        /**
+         * Allows to override the contextual name for an observation. The Observation will
+         * be renamed only when an explicit context was passed - if an implicit context is
+         * used this method won't be called.
+         * @param context context
+         * @return the new, contextual name for the observation
+         */
+        default String getContextualName(T context) {
+            return null;
+        }
 
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -114,7 +114,8 @@ public interface Observation {
      * observation. Allows to set a custom {@link ObservationConvention} and requires to
      * provide a default one if a neither a custom nor a pre-configured one (via
      * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
-     * was found.
+     * was found. The {@link ObservationConvention} implementation can override
+     * {@link Observation} names (i.e. name and contextual name) and key values.
      * @param <T> type of context
      * @param customConvention custom convention. If {@code null}, the default one will be
      * picked
@@ -205,6 +206,15 @@ public interface Observation {
      * {@link Observation#start()} when you want the measurements to start. When no
      * registry is passed or observation is not applicable will return a no-op
      * observation.
+     * <p>
+     * <b>Important!</b> If you're using the
+     * {@link ObservationConvention#getContextualName(Context)} method to override the
+     * contextual name <b>you MUST use a non {@code null} context</b> (i.e. the
+     * {@code context} parameter of this method MUST NOT be {@code null}. The
+     * {@link ObservationConvention#getContextualName(Context)} requires a concrete type
+     * of {@link Observation.Context} to be passed and if you're not providing one we
+     * won't be able to initialize it ourselves.
+     * </p>
      * @param <T> type of context
      * @param observationConvention observation convention
      * @param context mutable context
@@ -947,9 +957,9 @@ public interface Observation {
         String getName();
 
         /**
-         * Allows to override the contextual name for an observation. The Observation will
-         * be renamed only when an explicit context was passed - if an implicit context is
-         * used this method won't be called.
+         * Allows to override the contextual name for an {@link Observation}. The
+         * {@link Observation} will be renamed only when an explicit context was passed -
+         * if an implicit context is used this method won't be called.
          * @param context context
          * @return the new, contextual name for the observation
          */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/DocumentedObservation.java
@@ -65,8 +65,9 @@ public interface DocumentedObservation {
     }
 
     /**
-     * Default naming convention (sets a technical name and key values). You can set the
-     * name either by this method or {@link #getName()} ()}. You can't use both.
+     * Default naming convention (sets a technical and contextual names, and key values).
+     * You can set the names either by this method or {@link #getName()} and
+     * {@link #getContextualName()}.
      * @return default naming convention
      */
     default Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
@@ -74,7 +75,9 @@ public interface DocumentedObservation {
     }
 
     /**
-     * More human readable name available within the given context (e.g. span name).
+     * More human readable name available within the given context (e.g. span name). You
+     * can set the name either by this method or {@link #getDefaultConvention()}. This
+     * method will override what {@link #getDefaultConvention()} has set.
      * @return contextual name
      */
     default String getContextualName() {
@@ -154,8 +157,11 @@ public interface DocumentedObservation {
                     + "] defined default convention to be of type [" + getDefaultConvention()
                     + "] but you have provided an incompatible one of type [" + defaultConvention.getClass() + "]");
         }
-        return Observation.createNotStarted(customConvention, defaultConvention, context, registry)
-                .contextualName(getContextualName());
+        Observation observation = Observation.createNotStarted(customConvention, defaultConvention, context, registry);
+        if (getContextualName() != null) {
+            observation.contextualName(getContextualName());
+        }
+        return observation;
     }
 
     /**

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
@@ -67,6 +67,18 @@ class DocumentedObservationTests {
         then(context.getHighCardinalityKeyValues()).isEqualTo(KeyValues.of("high key", "high value"));
     }
 
+    @Test
+    void contextualNameShouldBeOverridden() {
+        ObservationRegistry registry = observationRegistry();
+        Observation.Context context = new Observation.Context();
+
+        TestConventionObservation.CONTEXTUAL_NAME.observation(null, new ContextualObservation(), context, registry)
+                .start().stop();
+
+        then(context.getName()).isEqualTo("technical name");
+        then(context.getContextualName()).isEqualTo("contextual name");
+    }
+
     private ObservationRegistry observationRegistry() {
         ObservationRegistry registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(context -> true);
@@ -84,6 +96,14 @@ class DocumentedObservationTests {
             public String getContextualName() {
                 return "contextual";
             }
+
+            @Override
+            public Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+                return FirstObservationConvention.class;
+            }
+        },
+
+        CONTEXTUAL_NAME {
 
             @Override
             public Class<? extends Observation.ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
@@ -126,6 +146,35 @@ class DocumentedObservationTests {
         @Override
         public String getName() {
             return "three";
+        }
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("low key", "low value");
+        }
+
+        @Override
+        public KeyValues getHighCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("high key", "high value");
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+
+    }
+
+    static class ContextualObservation extends FirstObservationConvention {
+
+        @Override
+        public String getName() {
+            return "technical name";
+        }
+
+        @Override
+        public String getContextualName(Observation.Context context) {
+            return "contextual name";
         }
 
         @Override


### PR DESCRIPTION
without this change we can't provide a naming convention for objects that rely on contextual names e.g. all spans
with this change we can provide a standard naming convention for objects that rely on contextual names for e.g. spans