### PR TITLE
ObservationContextAssert now asserts ContextView, add parentObservation assertions

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -340,6 +340,12 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return assertThatError();
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} has a
+     * {@link Observation.ContextView#getParentObservation() parent Observation}.
+     *
+     * @return the instance for further fluent assertion
+     */
     public SELF hasParentObservation() {
         isNotNull();
         if (this.actual.getParentObservation() == null) {
@@ -357,6 +363,13 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return p;
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} has a
+     * {@link Observation.ContextView#getParentObservation() parent Observation}
+     * equal to the provided {@link Observation}.
+     *
+     * @return the instance for further fluent assertion
+     */
     public SELF hasParentObservationEqualTo(Observation expectedParent) {
         isNotNull();
         Observation realParent = this.actual.getParentObservation();
@@ -369,6 +382,12 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} does not have a
+     * {@link Observation.ContextView#getParentObservation() parent Observation}.
+     *
+     * @return the instance for further fluent assertion
+     */
     public SELF doesNotHaveParentObservation() {
         isNotNull();
         if (this.actual.getParentObservation() != null) {
@@ -377,6 +396,13 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} has a
+     * {@link Observation.ContextView#getParentObservation() parent Observation} and that
+     * it satisfies assertions performed in the provided {@link java.util.function.Consumer}.
+     *
+     * @return the instance for further fluent assertion
+     */
     public SELF hasParentObservationContextSatisfying(ThrowingConsumer<Observation.ContextView> parentContextViewAssertion) {
         Observation p = checkedParentObservation();
         try {
@@ -388,6 +414,14 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} has a
+     * {@link Observation.ContextView#getParentObservation() parent Observation} and that
+     * it matches the provided unnamed predicate.
+     *
+     * @see #hasParentObservationContextMatching(Predicate, String)
+     * @return the instance for further fluent assertion
+     */
     public SELF hasParentObservationContextMatching(Predicate<? super Observation.ContextView> parentContextViewPredicate) {
         Observation p = checkedParentObservation();
         if (!parentContextViewPredicate.test(p.getContext())) {
@@ -396,6 +430,13 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Verify that the Observation {@link Observation.ContextView} has a
+     * {@link Observation.ContextView#getParentObservation() parent Observation} and that
+     * it matches the provided named predicate.
+     *
+     * @return the instance for further fluent assertion
+     */
     public SELF hasParentObservationContextMatching(Predicate<? super Observation.ContextView> parentContextViewPredicate, String description) {
         Observation p = checkedParentObservation();
         if (!parentContextViewPredicate.test(p.getContext())) {

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -27,7 +27,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * Assertion methods for {@code Observation.Context}s and {@link Observation.ContextView}s.
+ * Assertion methods for {@code Observation.Context}s and
+ * {@link Observation.ContextView}s.
  * <p>
  * To create a new instance of this class, invoke
  * {@link ObservationContextAssert#assertThat(Observation.ContextView)} or
@@ -343,7 +344,6 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     /**
      * Verify that the Observation {@link Observation.ContextView} has a
      * {@link Observation.ContextView#getParentObservation() parent Observation}.
-     *
      * @return the instance for further fluent assertion
      */
     public SELF hasParentObservation() {
@@ -365,9 +365,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
 
     /**
      * Verify that the Observation {@link Observation.ContextView} has a
-     * {@link Observation.ContextView#getParentObservation() parent Observation}
-     * equal to the provided {@link Observation}.
-     *
+     * {@link Observation.ContextView#getParentObservation() parent Observation} equal to
+     * the provided {@link Observation}.
      * @return the instance for further fluent assertion
      */
     public SELF hasParentObservationEqualTo(Observation expectedParent) {
@@ -385,7 +384,6 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     /**
      * Verify that the Observation {@link Observation.ContextView} does not have a
      * {@link Observation.ContextView#getParentObservation() parent Observation}.
-     *
      * @return the instance for further fluent assertion
      */
     public SELF doesNotHaveParentObservation() {
@@ -399,11 +397,12 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
     /**
      * Verify that the Observation {@link Observation.ContextView} has a
      * {@link Observation.ContextView#getParentObservation() parent Observation} and that
-     * it satisfies assertions performed in the provided {@link java.util.function.Consumer}.
-     *
+     * it satisfies assertions performed in the provided
+     * {@link java.util.function.Consumer}.
      * @return the instance for further fluent assertion
      */
-    public SELF hasParentObservationContextSatisfying(ThrowingConsumer<Observation.ContextView> parentContextViewAssertion) {
+    public SELF hasParentObservationContextSatisfying(
+            ThrowingConsumer<Observation.ContextView> parentContextViewAssertion) {
         Observation p = checkedParentObservation();
         try {
             parentContextViewAssertion.accept(p.getContext());
@@ -422,7 +421,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      * @see #hasParentObservationContextMatching(Predicate, String)
      * @return the instance for further fluent assertion
      */
-    public SELF hasParentObservationContextMatching(Predicate<? super Observation.ContextView> parentContextViewPredicate) {
+    public SELF hasParentObservationContextMatching(
+            Predicate<? super Observation.ContextView> parentContextViewPredicate) {
         Observation p = checkedParentObservation();
         if (!parentContextViewPredicate.test(p.getContext())) {
             failWithMessage("Observation should have parent that matches given predicate but <%s> didn't", p);
@@ -434,13 +434,14 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      * Verify that the Observation {@link Observation.ContextView} has a
      * {@link Observation.ContextView#getParentObservation() parent Observation} and that
      * it matches the provided named predicate.
-     *
      * @return the instance for further fluent assertion
      */
-    public SELF hasParentObservationContextMatching(Predicate<? super Observation.ContextView> parentContextViewPredicate, String description) {
+    public SELF hasParentObservationContextMatching(
+            Predicate<? super Observation.ContextView> parentContextViewPredicate, String description) {
         Observation p = checkedParentObservation();
         if (!parentContextViewPredicate.test(p.getContext())) {
-            failWithMessage("Observation should have parent that matches '%s' predicate but <%s> didn't", description, p);
+            failWithMessage("Observation should have parent that matches '%s' predicate but <%s> didn't", description,
+                    p);
         }
         return (SELF) this;
     }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -31,7 +31,6 @@ class ObservationContextAssertTests {
 
     Observation.Context context;
 
-
     @BeforeEach
     void beforeEach() {
         registry = ObservationRegistry.create();
@@ -457,8 +456,7 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_when_no_parent_observation() {
-        thenThrownBy(() -> assertThat(context).hasParentObservation())
-                .hasMessage("Observation should have a parent");
+        thenThrownBy(() -> assertThat(context).hasParentObservation()).hasMessage("Observation should have a parent");
     }
 
     @Test
@@ -507,7 +505,8 @@ class ObservationContextAssertTests {
         parent.contextualName("expected");
         context.setParentObservation(parent);
 
-        thenNoException().isThrownBy(() -> assertThat(context).hasParentObservationContextMatching(c -> "expected".equals(c.getContextualName())));
+        thenNoException().isThrownBy(() -> assertThat(context)
+                .hasParentObservationContextMatching(c -> "expected".equals(c.getContextualName())));
     }
 
     @Test
@@ -516,8 +515,9 @@ class ObservationContextAssertTests {
         parent.contextualName("expected");
         context.setParentObservation(parent);
 
-        thenThrownBy(() -> assertThat(context).hasParentObservationContextMatching(c -> "notExpected".equals(c.getContextualName())))
-                .hasMessage("Observation should have parent that matches given predicate but <PARENT_OBSERVATION> didn't");
+        thenThrownBy(() -> assertThat(context)
+                .hasParentObservationContextMatching(c -> "notExpected".equals(c.getContextualName()))).hasMessage(
+                        "Observation should have parent that matches given predicate but <PARENT_OBSERVATION> didn't");
     }
 
     @Test
@@ -536,8 +536,9 @@ class ObservationContextAssertTests {
         parent.contextualName("expected");
         context.setParentObservation(parent);
 
-        thenThrownBy(() -> assertThat(context).hasParentObservationContextMatching(c -> "notExpected".equals(c.getContextualName()), "withDescription"))
-                .hasMessage("Observation should have parent that matches 'withDescription' predicate but <PARENT_OBSERVATION> didn't");
+        thenThrownBy(() -> assertThat(context).hasParentObservationContextMatching(
+                c -> "notExpected".equals(c.getContextualName()), "withDescription")).hasMessage(
+                        "Observation should have parent that matches 'withDescription' predicate but <PARENT_OBSERVATION> didn't");
     }
 
     @Test
@@ -546,8 +547,7 @@ class ObservationContextAssertTests {
         context.setParentObservation(parent);
 
         thenNoException().isThrownBy(() -> assertThat(context)
-                .hasParentObservationContextSatisfying(c ->
-                        assertThat(c).hasContextualNameEqualTo("expected")));
+                .hasParentObservationContextSatisfying(c -> assertThat(c).hasContextualNameEqualTo("expected")));
     }
 
     @Test
@@ -556,13 +556,13 @@ class ObservationContextAssertTests {
         parent.contextualName("expected");
         context.setParentObservation(parent);
 
-        thenThrownBy(() -> assertThat(context).hasParentObservationContextSatisfying(c ->
-                assertThat(c).hasContextualNameEqualTo("notExpected")))
-                .hasMessage("Parent observation does not satisfy given assertion: Observation should have contextual name equal to <notExpected> but has <expected>");
+        thenThrownBy(() -> assertThat(context).hasParentObservationContextSatisfying(
+                c -> assertThat(c).hasContextualNameEqualTo("notExpected"))).hasMessage(
+                        "Parent observation does not satisfy given assertion: Observation should have contextual name equal to <notExpected> but has <expected>");
 
-        thenThrownBy(() -> assertThat(context).hasParentObservationContextSatisfying(c ->
-                assertThat(c).hasError()))
-                .hasMessage("Parent observation does not satisfy given assertion: Observation should have an error, but none was found");
+        thenThrownBy(() -> assertThat(context).hasParentObservationContextSatisfying(c -> assertThat(c).hasError()))
+                .hasMessage(
+                        "Parent observation does not satisfy given assertion: Observation should have an error, but none was found");
     }
 
 }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -17,6 +17,7 @@ package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.micrometer.observation.tck.ObservationContextAssert.assertThat;
@@ -25,9 +26,17 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 class ObservationContextAssertTests {
 
-    ObservationRegistry registry = ObservationRegistry.create();
+    ObservationRegistry registry;
 
-    Observation.Context context = new Observation.Context();
+    Observation.Context context;
+
+
+    @BeforeEach
+    void beforeEach() {
+        registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(c -> true);
+        context = new Observation.Context();
+    }
 
     @Test
     void should_not_throw_exception_when_name_correct() {
@@ -147,7 +156,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_key_count_matches() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("low", "foo");
         observation.highCardinalityKeyValue("high", "bar");
@@ -157,7 +165,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_key_count_differs() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("low", "foo");
         observation.highCardinalityKeyValue("high", "bar");
@@ -171,7 +178,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_keys_match() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("low", "foo");
         observation.highCardinalityKeyValue("high", "bar");
@@ -181,7 +187,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_keys_missing() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("found", "foo");
 
@@ -191,7 +196,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_keys_extras() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("found", "foo");
         observation.lowCardinalityKeyValue("low", "foo");
@@ -203,7 +207,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_keys_both_missing_and_extras() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("found", "foo");
         observation.lowCardinalityKeyValue("low", "foo");
@@ -216,7 +219,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_low_cardinality_tag_exists() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("foo", "bar");
 
@@ -236,7 +238,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_high_cardinality_tag_exists() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "bar");
 
@@ -261,7 +262,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_high_cardinality_tag_present() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "bar");
 
@@ -273,7 +273,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_high_cardinality_tag_present_with_other_value() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "other");
 
@@ -290,7 +289,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_low_cardinality_tag_present_with_other_value() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("foo", "other");
 
@@ -302,7 +300,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_low_cardinality_tag_present() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("foo", "bar");
 
@@ -314,7 +311,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_any_tags_exist() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "bar");
 
@@ -333,7 +329,6 @@ class ObservationContextAssertTests {
 
     @Test
     void should_throw_exception_when_tags_present() {
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "bar");
 
@@ -375,7 +370,6 @@ class ObservationContextAssertTests {
     void should_throw_when_unexpected_error() {
         Throwable expected = new IllegalStateException("test");
 
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.error(expected);
 
@@ -387,7 +381,6 @@ class ObservationContextAssertTests {
     void should_not_throw_when_has_error() {
         Throwable expected = new IllegalStateException("test");
 
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.error(expected);
 
@@ -404,7 +397,6 @@ class ObservationContextAssertTests {
     void should_not_throw_when_has_specific_error() {
         Throwable expected = new IllegalStateException("test");
 
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.error(expected);
 
@@ -424,7 +416,6 @@ class ObservationContextAssertTests {
         Throwable expected = new IllegalStateException("test expected");
         Throwable actual = new IllegalArgumentException("test actual");
 
-        registry.observationConfig().observationHandler(c -> true);
         Observation observation = Observation.start("foo", context, registry);
         observation.error(actual);
 


### PR DESCRIPTION
This PR changes the target type of `ObservationContextAssert` to `ContextView`.
The Assert doesn't need the writable aspect of `Context`, and this switch allows
usage of the Assert on `Observation#getContext()`.

As a result, we can reuse the Assert on `actual.getParentObservation().getContext()`
when the user passes a `Predicate` or an asserting `Consumer` aimed at the parent.

This PR then introduces various assertions around the `getParentObservation()`.

TODO:
 - [x] javadoc
 - [x] tests