### PR TITLE
Removing KeyValuesProvider

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
@@ -385,8 +385,9 @@ public abstract class ObservationRegistryCompatibilityKit {
     @Test
     void observationFieldsShouldBeSetOnContext() {
         AssertingHandler assertingHandler = new AssertingHandler();
-        registry.observationConfig().keyValuesProvider(new TestKeyValuesProvider("global"))
-                .keyValuesProvider(new UnsupportedKeyValuesProvider("global")).observationHandler(assertingHandler);
+        registry.observationConfig().observationConvention(new TestObservationConvention("global"))
+                .observationConvention(new UnsupportedObservationConvention("global"))
+                .observationHandler(assertingHandler);
 
         TestContext testContext = new TestContext();
         testContext.put("context.field", "42");
@@ -394,9 +395,9 @@ public abstract class ObservationRegistryCompatibilityKit {
         Observation observation = Observation.start("test.observation", testContext, registry)
                 .lowCardinalityKeyValue("lcTag1", "1").lowCardinalityKeyValues(KeyValues.of("lcTag2", "2"))
                 .highCardinalityKeyValue("hcTag1", "3").highCardinalityKeyValues(KeyValues.of("hcTag2", "4"))
-                .keyValuesProvider(new TestKeyValuesProvider("local"))
-                .keyValuesProvider(new UnsupportedKeyValuesProvider("local")).contextualName("test.observation.42")
-                .error(exception);
+                .observationConvention(new TestObservationConvention("local"))
+                .observationConvention(new UnsupportedObservationConvention("local"))
+                .contextualName("test.observation.42").error(exception);
         observation.stop();
 
         assertingHandler.checkAssertions(context -> {
@@ -437,11 +438,11 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     }
 
-    static class TestKeyValuesProvider implements Observation.GlobalKeyValuesProvider<TestContext> {
+    static class TestObservationConvention implements Observation.GlobalObservationConvention<TestContext> {
 
         private final String id;
 
-        public TestKeyValuesProvider(String id) {
+        public TestObservationConvention(String id) {
             this.id = id;
         }
 
@@ -462,11 +463,12 @@ public abstract class ObservationRegistryCompatibilityKit {
 
     }
 
-    static class UnsupportedKeyValuesProvider implements Observation.GlobalKeyValuesProvider<Observation.Context> {
+    static class UnsupportedObservationConvention
+            implements Observation.GlobalObservationConvention<Observation.Context> {
 
         private final String id;
 
-        public UnsupportedKeyValuesProvider(String id) {
+        public UnsupportedObservationConvention(String id) {
             this.id = id;
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -69,7 +69,7 @@ final class NoopObservation implements Observation {
     }
 
     @Override
-    public Observation keyValuesProvider(KeyValuesProvider<?> keyValuesProvider) {
+    public Observation observationConvention(ObservationConvention<?> observationConvention) {
         return this;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
@@ -48,23 +48,12 @@ final class NoopObservationConfig extends ObservationRegistry.ObservationConfig 
     }
 
     @Override
-    public ObservationRegistry.ObservationConfig keyValuesProvider(
-            Observation.GlobalKeyValuesProvider<?> keyValuesProvider) {
-        return this;
-    }
-
-    @Override
     public boolean isObservationEnabled(String name, Observation.Context context) {
         return false;
     }
 
     @Override
     Collection<ObservationHandler<?>> getObservationHandlers() {
-        return Collections.emptyList();
-    }
-
-    @Override
-    Collection<Observation.GlobalKeyValuesProvider<?>> getKeyValuesProviders() {
         return Collections.emptyList();
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConvention.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConvention.java
@@ -48,17 +48,17 @@ final class NoopObservationConvention implements Observation.ObservationConventi
 
     @Override
     public boolean supportsContext(Observation.Context context) {
-        return Observation.KeyValuesProvider.EMPTY.supportsContext(context);
+        return Observation.ObservationConvention.EMPTY.supportsContext(context);
     }
 
     @Override
     public KeyValues getLowCardinalityKeyValues(Observation.Context context) {
-        return Observation.KeyValuesProvider.EMPTY.getLowCardinalityKeyValues(context);
+        return Observation.ObservationConvention.EMPTY.getLowCardinalityKeyValues(context);
     }
 
     @Override
     public KeyValues getHighCardinalityKeyValues(Observation.Context context) {
-        return Observation.KeyValuesProvider.EMPTY.getHighCardinalityKeyValues(context);
+        return Observation.ObservationConvention.EMPTY.getHighCardinalityKeyValues(context);
     }
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -98,8 +98,6 @@ public interface ObservationRegistry {
 
         private final List<ObservationPredicate> observationPredicates = new CopyOnWriteArrayList<>();
 
-        private final List<Observation.GlobalKeyValuesProvider<?>> keyValuesProviders = new CopyOnWriteArrayList<>();
-
         private final List<Observation.ObservationConvention<?>> observationConventions = new CopyOnWriteArrayList<>();
 
         private final List<ObservationFilter> observationFilters = new CopyOnWriteArrayList<>();
@@ -122,17 +120,6 @@ public interface ObservationRegistry {
          */
         public ObservationConfig observationPredicate(ObservationPredicate predicate) {
             this.observationPredicates.add(predicate);
-            return this;
-        }
-
-        /**
-         * Register a key values provider for the {@link Observation observations}.
-         * @param keyValuesProvider key values provider to add to the current
-         * configuration
-         * @return This configuration instance
-         */
-        public ObservationConfig keyValuesProvider(Observation.GlobalKeyValuesProvider<?> keyValuesProvider) {
-            this.keyValuesProviders.add(keyValuesProvider);
             return this;
         }
 
@@ -199,10 +186,6 @@ public interface ObservationRegistry {
         // package-private for minimal visibility
         Collection<ObservationHandler<?>> getObservationHandlers() {
             return observationHandlers;
-        }
-
-        Collection<Observation.GlobalKeyValuesProvider<?>> getKeyValuesProviders() {
-            return keyValuesProviders;
         }
 
         Collection<ObservationFilter> getObservationFilters() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -78,7 +78,7 @@ public class ObservedAspect {
     private final ObservationRegistry registry;
 
     @Nullable
-    private final Observation.KeyValuesProvider<ObservedAspectContext> keyValuesProvider;
+    private final Observation.ObservationConvention<ObservedAspectContext> observationConvention;
 
     private final Predicate<ProceedingJoinPoint> shouldSkip;
 
@@ -87,8 +87,8 @@ public class ObservedAspect {
     }
 
     public ObservedAspect(ObservationRegistry registry,
-            Observation.KeyValuesProvider<ObservedAspectContext> keyValuesProvider) {
-        this(registry, keyValuesProvider, DONT_SKIP_ANYTHING);
+            Observation.ObservationConvention<ObservedAspectContext> observationConvention) {
+        this(registry, observationConvention, DONT_SKIP_ANYTHING);
     }
 
     public ObservedAspect(ObservationRegistry registry, Predicate<ProceedingJoinPoint> shouldSkip) {
@@ -96,10 +96,10 @@ public class ObservedAspect {
     }
 
     public ObservedAspect(ObservationRegistry registry,
-            @Nullable Observation.KeyValuesProvider<ObservedAspectContext> keyValuesProvider,
+            @Nullable Observation.ObservationConvention<ObservedAspectContext> observationConvention,
             Predicate<ProceedingJoinPoint> shouldSkip) {
         this.registry = registry;
-        this.keyValuesProvider = keyValuesProvider;
+        this.observationConvention = observationConvention;
         this.shouldSkip = shouldSkip;
     }
 
@@ -128,7 +128,8 @@ public class ObservedAspect {
     }
 
     private Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
-        Observation observation = ObservedAspectObservation.of(pjp, observed, this.registry, this.keyValuesProvider);
+        Observation observation = ObservedAspectObservation.of(pjp, observed, this.registry,
+                this.observationConvention);
         if (CompletionStage.class.isAssignableFrom(method.getReturnType())) {
             observation.start();
             Observation.Scope scope = observation.openScope();

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservation.java
@@ -39,7 +39,7 @@ enum ObservedAspectObservation implements DocumentedObservation {
     DEFAULT;
 
     static Observation of(ProceedingJoinPoint pjp, Observed observed, ObservationRegistry registry,
-            @Nullable Observation.KeyValuesProvider<ObservedAspect.ObservedAspectContext> keyValuesProvider) {
+            @Nullable Observation.ObservationConvention<ObservedAspect.ObservedAspectContext> observationConvention) {
         String name = observed.name().isEmpty() ? "method.observed" : observed.name();
         Signature signature = pjp.getStaticPart().getSignature();
         String contextualName = observed.contextualName().isEmpty()
@@ -52,8 +52,8 @@ enum ObservedAspectObservation implements DocumentedObservation {
                 .lowCardinalityKeyValue(METHOD_NAME.getKeyName(), signature.getName())
                 .lowCardinalityKeyValues(KeyValues.of(observed.lowCardinalityKeyValues()));
 
-        if (keyValuesProvider != null) {
-            observation.keyValuesProvider(keyValuesProvider);
+        if (observationConvention != null) {
+            observation.observationConvention(observationConvention);
         }
 
         return observation;

--- a/micrometer-observation/src/test/java/io/micrometer/observation/KeyValuesProviderTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/KeyValuesProviderTest.java
@@ -22,33 +22,21 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link Observation.KeyValuesProvider}.
+ * Tests for {@link Observation.ObservationConvention}.
  *
  * @author Jonatan Ivanov
  */
-class KeyValuesProviderTest {
+class ObservationConventionTest {
 
     @Test
     void tagsShouldBeEmptyByDefault() {
-        Observation.KeyValuesProvider<Observation.Context> keyValuesProvider = new TestKeyValuesProvider();
+        Observation.ObservationConvention<Observation.Context> ObservationConvention = new TestObservationConvention();
 
-        assertThat(keyValuesProvider.getLowCardinalityKeyValues(new Observation.Context())).isEmpty();
-        assertThat(keyValuesProvider.getHighCardinalityKeyValues(new Observation.Context())).isEmpty();
+        assertThat(ObservationConvention.getLowCardinalityKeyValues(new Observation.Context())).isEmpty();
+        assertThat(ObservationConvention.getHighCardinalityKeyValues(new Observation.Context())).isEmpty();
     }
 
-    @Test
-    void tagsShouldBeMergedIntoCompositeByDefault() {
-        Observation.KeyValuesProvider<Observation.Context> keyValuesProvider = new Observation.KeyValuesProvider.CompositeKeyValuesProvider(
-                new MatchingTestKeyValuesProvider(), new AnotherMatchingTestKeyValuesProvider(),
-                new NotMatchingTestKeyValuesProvider());
-
-        assertThat(keyValuesProvider.getLowCardinalityKeyValues(new Observation.Context()))
-                .containsExactlyInAnyOrder(KeyValue.of("matching-low-1", ""), KeyValue.of("matching-low-2", ""));
-        assertThat(keyValuesProvider.getHighCardinalityKeyValues(new Observation.Context()))
-                .containsExactlyInAnyOrder(KeyValue.of("matching-high-1", ""), KeyValue.of("matching-high-2", ""));
-    }
-
-    static class TestKeyValuesProvider implements Observation.KeyValuesProvider<Observation.Context> {
+    static class TestObservationConvention implements Observation.ObservationConvention<Observation.Context> {
 
         @Override
         public boolean supportsContext(Observation.Context context) {
@@ -57,7 +45,7 @@ class KeyValuesProviderTest {
 
     }
 
-    static class MatchingTestKeyValuesProvider implements Observation.KeyValuesProvider<Observation.Context> {
+    static class MatchingTestObservationConvention implements Observation.ObservationConvention<Observation.Context> {
 
         @Override
         public boolean supportsContext(Observation.Context context) {
@@ -76,7 +64,8 @@ class KeyValuesProviderTest {
 
     }
 
-    static class AnotherMatchingTestKeyValuesProvider implements Observation.KeyValuesProvider<Observation.Context> {
+    static class AnotherMatchingTestObservationConvention
+            implements Observation.ObservationConvention<Observation.Context> {
 
         @Override
         public boolean supportsContext(Observation.Context context) {
@@ -95,7 +84,8 @@ class KeyValuesProviderTest {
 
     }
 
-    static class NotMatchingTestKeyValuesProvider implements Observation.KeyValuesProvider<Observation.Context> {
+    static class NotMatchingTestObservationConvention
+            implements Observation.ObservationConvention<Observation.Context> {
 
         @Override
         public boolean supportsContext(Observation.Context context) {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -101,9 +101,11 @@ class ObservationRegistryTest {
 
         Observation.Context myContext = new MessagingContext().put("foo", "hello");
         // KeyValues provider wants to use a MessagingConvention
-        MessagingKeyValuesProvider messagingKeyValuesProvider = new MessagingKeyValuesProvider(messagingConvention);
+        MessagingObservationConvention messagingObservationConvention = new MessagingObservationConvention(
+                messagingConvention);
 
-        Observation.start("observation", myContext, registry).keyValuesProvider(messagingKeyValuesProvider).stop();
+        Observation.start("observation", myContext, registry).observationConvention(messagingObservationConvention)
+                .stop();
 
         then(myContext.getLowCardinalityKeyValues().stream().filter(keyValue -> keyValue.getKey().equals("baz"))
                 .findFirst().orElseThrow(() -> new AssertionError("No <baz> key value found")).getValue())
@@ -115,11 +117,11 @@ class ObservationRegistryTest {
 
     }
 
-    static class MessagingKeyValuesProvider implements Observation.KeyValuesProvider<MessagingContext> {
+    static class MessagingObservationConvention implements Observation.ObservationConvention<MessagingContext> {
 
         private final MessagingConvention messagingConvention;
 
-        MessagingKeyValuesProvider(MessagingConvention messagingConvention) {
+        MessagingObservationConvention(MessagingConvention messagingConvention) {
             this.messagingConvention = messagingConvention;
         }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -132,12 +132,12 @@ class ObservedAspectTests {
     }
 
     @Test
-    void customKeyValuesProviderShouldBeUsed() {
+    void customObservationConventionShouldBeUsed() {
         TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
-        pf.addAspect(new ObservedAspect(registry, new CustomKeyValuesProvider()));
+        pf.addAspect(new ObservedAspect(registry, new CustomObservationConvention()));
 
         ObservedService service = pf.getProxy();
         service.call();
@@ -253,12 +253,12 @@ class ObservedAspectTests {
     }
 
     @Test
-    void customKeyValuesProviderShouldBeUsedForClass() {
+    void customObservationConventionShouldBeUsedForClass() {
         TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
-        pf.addAspect(new ObservedAspect(registry, new CustomKeyValuesProvider()));
+        pf.addAspect(new ObservedAspect(registry, new CustomObservationConvention()));
 
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         service.call();
@@ -377,8 +377,8 @@ class ObservedAspectTests {
 
     }
 
-    static class CustomKeyValuesProvider
-            implements Observation.KeyValuesProvider<ObservedAspect.ObservedAspectContext> {
+    static class CustomObservationConvention
+            implements Observation.ObservationConvention<ObservedAspect.ObservedAspectContext> {
 
         @Override
         @NonNull

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -36,14 +36,14 @@ public class ObservationHandlerSample {
     public static void main(String[] args) throws InterruptedException {
         observationRegistry.observationConfig().observationHandler(new ObservationTextPublisher())
                 .observationHandler(new DefaultMeterObservationHandler(registry));
-        observationRegistry.observationConfig().keyValuesProvider(new CustomKeyValuesProvider())
+        observationRegistry.observationConfig().observationConvention(new CustomObservationConvention())
                 .observationPredicate(new IgnoringObservationPredicate());
 
         Observation observation = Observation
                 .createNotStarted("sample.operation", new CustomContext(), observationRegistry)
                 .contextualName("CALL sampleOperation").lowCardinalityKeyValue("a", "1")
                 .highCardinalityKeyValue("time", Instant.now().toString())
-                .keyValuesProvider(new CustomLocalKeyValuesProvider()).start();
+                .observationConvention(new CustomLocalObservationConvention()).start();
 
         try (Observation.Scope scope = observation.openScope()) {
             Thread.sleep(1_000);
@@ -71,7 +71,7 @@ public class ObservationHandlerSample {
 
     }
 
-    static class CustomKeyValuesProvider implements Observation.GlobalKeyValuesProvider<CustomContext> {
+    static class CustomObservationConvention implements Observation.GlobalObservationConvention<CustomContext> {
 
         @Override
         public KeyValues getLowCardinalityKeyValues(CustomContext context) {
@@ -90,7 +90,7 @@ public class ObservationHandlerSample {
 
     }
 
-    static class CustomLocalKeyValuesProvider implements Observation.KeyValuesProvider<CustomContext> {
+    static class CustomLocalObservationConvention implements Observation.ObservationConvention<CustomContext> {
 
         @Override
         public KeyValues getLowCardinalityKeyValues(CustomContext context) {


### PR DESCRIPTION
we came to the conclusion that the ObservationConvention can serve the purpose of KeyValuesProvider. We don't need 2 separate interfaces.
with this change ObservationConvention does what the KeyValuesProvider did, plus it has a default method getName so that we only rename an observation when ObservationConvention actually implements the getName method.