### PR TITLE
Avoid allocation of iterator with Tags#empty instance

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -112,7 +112,7 @@ public final class Tags implements Iterable<Tag> {
      * @return a new {@code Tags} instance
      */
     public Tags and(@Nullable Iterable<? extends Tag> tags) {
-        if (tags == null || !tags.iterator().hasNext()) {
+        if (tags == null || tags == EMPTY || !tags.iterator().hasNext()) {
             return this;
         }
 
@@ -216,7 +216,7 @@ public final class Tags implements Iterable<Tag> {
      * @return a new {@code Tags} instance
      */
     public static Tags of(@Nullable Iterable<? extends Tag> tags) {
-        if (tags == null || !tags.iterator().hasNext()) {
+        if (tags == null || tags == EMPTY || !tags.iterator().hasNext()) {
             return Tags.empty();
         }
         else if (tags instanceof Tags) {


### PR DESCRIPTION
Special case calling Tags.and and Tags.of on a Tags.empty() instance to avoid instantiating an iterator for the EMPTY constant static instance.
I've checked this change locally with a JMH test and profiling. This change avoids unnecessary allocation in e.g. the following code:

```java
Tags extraTags = Tags.empty();
Tags anotherTag = Tags.of("a", "b");
Tags combined = anotherTag.and(extraTags);
combined = Tags.concat(extraTags, "a", "b");
```

This shows up in several places in our instrumentation where we allow passing `extraTags` to add to meters created by the instrumentation, and the default is no extra tags (`Tags.empty()`).