### PR TITLE
Make conventions more deterministic for name, contextualName and keyValues

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
@@ -85,6 +85,7 @@ public class OkHttpObservationInterceptor implements Interceptor {
         OkHttpContext okHttpContext = new OkHttpContext(this.urlMapper, this.extraTags, this.contextSpecificTags,
                 this.unknownRequestTags, this.includeHostTag);
         okHttpContext.setCarrier(newRequestBuilder);
+        okHttpContext.setState(new CallState(newRequestBuilder.build()));
         Observation observation = OkHttpDocumentedObservation.DEFAULT
                 .observation(this.observationConvention, new DefaultOkHttpObservationConvention(requestMetricName),
                         okHttpContext, this.registry)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptorTest.java
@@ -45,7 +45,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests for {@link OkHttpMetricsEventListener}.
+ * Tests for {@link OkHttpObservationInterceptor}.
  *
  * @author Bjarte S. Karlsen
  * @author Jon Schneider

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -227,12 +227,8 @@ public interface Observation {
                 || observationConvention == NoopObservationConvention.INSTANCE) {
             return NoopObservation.INSTANCE;
         }
-        Context contextToUse = context == null ? new Context() : context;
-        SimpleObservation simpleObservation = new SimpleObservation(observationConvention, registry, contextToUse);
-        if (context != null) {
-            simpleObservation.contextualName(observationConvention.getContextualName(context));
-        }
-        return simpleObservation;
+
+        return new SimpleObservation(observationConvention, registry, context == null ? new Context() : context);
     }
 
     /**


### PR DESCRIPTION
Before this change overriding the name and the contextual name were dependent on where the convention was set.
Also, overriding the name and adding tags from the convention did not have any effect on the context at the time start was invoked.
This behavior might resulted in non-deterministic behavior and LongTaskTimer not having the right tags and name.