### PR TITLE
Document TimeWindowPercentileHistogram as internal

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
@@ -22,6 +22,10 @@ import org.HdrHistogram.DoubleRecorder;
 import java.io.PrintStream;
 
 /**
+ * <b>NOTE: This class is intended for internal use as an implementation detail. You
+ * should not compile against its API. Please contact the project maintainers if you need
+ * this as public API.</b>
+ * <p>
  * A histogram implementation that supports the computation of percentiles by Micrometer
  * for publishing to a monitoring system.
  *


### PR DESCRIPTION
We cannot make other changes that assume this is an implementation detail if users may be directly compiling against this class.
Namely, we cannot move the HdrHistogram dependency from compile scope to runtime scope.

Without the assumption stated in this added documentation, it would be irresponsible for us to make the change in #3263 because code like the following will begin to fail to compile. I don't think users should be writing such code, but that is the point of adding this warning to the JavaDoc.

```java
try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(Clock.SYSTEM, DistributionStatisticConfig.DEFAULT, false)) {
    histogram.recordLong(5);
}
```

It is worth noting that the code compiles fine without HdrHistogram on the compile classpath if changed to:

```java
try (Histogram histogram = new TimeWindowPercentileHistogram(Clock.SYSTEM, DistributionStatisticConfig.DEFAULT, false)) {
    histogram.recordLong(5);
}
```

Then the application needs HdrHistogram only on the runtime classpath.