### PR TITLE
Generify throwable in CheckedCallable/CheckedRunnable

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
@@ -149,7 +149,8 @@ public abstract class ObservationRegistryCompatibilityKit {
         registry.observationConfig().observationHandler(handler);
         Observation observation = Observation.createNotStarted("myObservation", registry);
 
-        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation()).isSameAs(observation);
+        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation())
+                .isSameAs(observation);
         observation.observeChecked(checkedRunnable);
         assertThat(registry.getCurrentObservation()).isNull();
 
@@ -174,7 +175,8 @@ public abstract class ObservationRegistryCompatibilityKit {
             assertThat(registry.getCurrentObservation()).isSameAs(observation);
             throw new IOException("simulated");
         };
-        assertThatThrownBy(() -> observation.observeChecked(checkedRunnable)).isInstanceOf(IOException.class).hasMessage("simulated").hasNoCause();
+        assertThatThrownBy(() -> observation.observeChecked(checkedRunnable)).isInstanceOf(IOException.class)
+                .hasMessage("simulated").hasNoCause();
 
         assertThat(registry.getCurrentObservation()).isNull();
 
@@ -336,7 +338,8 @@ public abstract class ObservationRegistryCompatibilityKit {
         when(handler.supportsContext(isA(Observation.Context.class))).thenReturn(true);
         registry.observationConfig().observationHandler(handler);
         Observation observation = Observation.start("myObservation", registry);
-        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation()).isSameAs(observation);
+        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation())
+                .isSameAs(observation);
         observation.scopedChecked(checkedRunnable);
         assertThat(registry.getCurrentObservation()).isNull();
         assertThat(observation.getContext().getError()).isEmpty();
@@ -479,14 +482,16 @@ public abstract class ObservationRegistryCompatibilityKit {
     void checkedRunnableShouldBeParentScoped() throws Throwable {
         registry.observationConfig().observationHandler(c -> true);
         Observation parent = Observation.start("myObservation", registry);
-        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation()).isSameAs(parent);
+        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation())
+                .isSameAs(parent);
         Observation.tryScopedChecked(parent, checkedRunnable);
         assertThat(registry.getCurrentObservation()).isNull();
     }
 
     @Test
     void checkedRunnableShouldNotBeParentScopedIfParentIsNull() throws Throwable {
-        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation()).isNull();
+        Observation.CheckedRunnable<Throwable> checkedRunnable = () -> assertThat(registry.getCurrentObservation())
+                .isNull();
         Observation.tryScopedChecked(null, checkedRunnable);
         assertThat(registry.getCurrentObservation()).isNull();
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -415,9 +415,10 @@ public interface Observation {
      * <li>Stops the {@code Observation}</li>
      * </ul>
      * @param checkedRunnable the {@link CheckedRunnable} to run
+     * @param <E> type of exception thrown
      */
     @SuppressWarnings("unused")
-    default void observeChecked(CheckedRunnable checkedRunnable) throws Throwable {
+    default <E extends Throwable> void observeChecked(CheckedRunnable<E> checkedRunnable) throws E {
         this.start();
         try (Scope scope = openScope()) {
             checkedRunnable.run();
@@ -473,11 +474,12 @@ public interface Observation {
      * <li>Stops the {@code Observation}</li>
      * </ul>
      * @param checkedCallable the {@link CheckedCallable} to call
-     * @param <T> the type parameter of the {@link CheckedCallable}
+     * @param <T> the return type of the {@link CheckedCallable}
+     * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
     @SuppressWarnings("unused")
-    default <T> T observeChecked(CheckedCallable<T> checkedCallable) throws Throwable {
+    default <T, E extends Throwable> T observeChecked(CheckedCallable<T, E> checkedCallable) throws E {
         this.start();
         try (Scope scope = openScope()) {
             return checkedCallable.call();
@@ -509,9 +511,10 @@ public interface Observation {
     /**
      * Wraps the given action in a scope and signals an error.
      * @param checkedRunnable the {@link CheckedRunnable} to run
+     * @param <E> type of exception thrown
      */
     @SuppressWarnings("unused")
-    default void scopedChecked(CheckedRunnable checkedRunnable) throws Throwable {
+    default <E extends Throwable> void scopedChecked(CheckedRunnable<E> checkedRunnable) throws E {
         try (Scope scope = openScope()) {
             checkedRunnable.run();
         }
@@ -524,7 +527,7 @@ public interface Observation {
     /**
      * Wraps the given action in a scope and signals an error.
      * @param supplier the {@link Supplier} to call
-     * @param <T> the type parameter of the {@link Supplier}
+     * @param <T> the return type of the {@link Supplier}
      * @return the result from {@link Supplier#get()}
      */
     @SuppressWarnings("unused")
@@ -541,11 +544,12 @@ public interface Observation {
     /**
      * Wraps the given action in a scope and signals an error.
      * @param checkedCallable the {@link CheckedCallable} to call
-     * @param <T> the type parameter of the {@link CheckedCallable}
+     * @param <T> the return type of the {@link CheckedCallable}
+     * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
     @SuppressWarnings("unused")
-    default <T> T scopedChecked(CheckedCallable<T> checkedCallable) throws Throwable {
+    default <T, E extends Throwable> T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
         try (Scope scope = openScope()) {
             return checkedCallable.call();
         }
@@ -575,8 +579,10 @@ public interface Observation {
      * run the action, otherwise we run the action in scope.
      * @param parent observation, potentially {@code null}
      * @param checkedRunnable the {@link CheckedRunnable} to run
+     * @param <E> type of exception checkedRunnable throws
      */
-    static void tryScopedChecked(@Nullable Observation parent, CheckedRunnable checkedRunnable) throws Throwable {
+    static <E extends Throwable> void tryScopedChecked(@Nullable Observation parent, CheckedRunnable<E> checkedRunnable)
+            throws E {
         if (parent != null) {
             parent.scopedChecked(checkedRunnable);
         }
@@ -604,10 +610,12 @@ public interface Observation {
      * run the action, otherwise we run the action in scope.
      * @param parent observation, potentially {@code null}
      * @param checkedCallable the {@link CheckedCallable} to call
-     * @param <T> the type parameter of the {@link CheckedCallable}
+     * @param <T> the return type of the {@link CheckedCallable}
+     * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    static <T> T tryScopedChecked(@Nullable Observation parent, CheckedCallable<T> checkedCallable) throws Throwable {
+    static <T, E extends Throwable> T tryScopedChecked(@Nullable Observation parent,
+            CheckedCallable<T, E> checkedCallable) throws E {
         if (parent != null) {
             return parent.scopedChecked(checkedCallable);
         }
@@ -1134,9 +1142,9 @@ public interface Observation {
      * A functional interface like {@link Runnable} but it can throw a {@link Throwable}.
      */
     @FunctionalInterface
-    interface CheckedRunnable {
+    interface CheckedRunnable<E extends Throwable> {
 
-        void run() throws Throwable;
+        void run() throws E;
 
     }
 
@@ -1144,9 +1152,9 @@ public interface Observation {
      * A functional interface like {@link Callable} but it can throw a {@link Throwable}.
      */
     @FunctionalInterface
-    interface CheckedCallable<T> {
+    interface CheckedCallable<T, E extends Throwable> {
 
-        T call() throws Throwable;
+        T call() throws E;
 
     }
 


### PR DESCRIPTION
This allows usage that catches or throws more a more specific type than `Throwable`. This is a bit more verbose when declaring a variable of type `CheckedCallable` or `CheckedRunnable`, but I expect most usage to be as a lambda or method reference, which avoids the need to do such.

@jonatan-ivanov let me know what you think. I may have overlooked some reason why not to do this. This change wasn't based on user feedback, so I don't feel strongly about doing this but I figured I would open the proposal for discussion.