### PR TITLE
Add option to disable step allignment of the report in PushRegistryConfig

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -52,6 +52,11 @@ public interface OtlpConfig extends PushRegistryConfig {
         return getUrlString(this, "url").orElse("http://localhost:4318/v1/metrics");
     }
 
+    @Override
+    default boolean stepAlignment() {
+        return false;
+    }
+
     /**
      * Attributes to set on the Resource that will be used for all metrics published. This
      * should include a {@code service.name} attribute that identifies your service.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -75,9 +75,14 @@ public abstract class PushMeterRegistry extends MeterRegistry {
                     + TimeUtils.format(config.step()));
 
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
-            // time publication to happen just after StepValue finishes the step
             long stepMillis = config.step().toMillis();
-            long initialDelayMillis = stepMillis - (clock.wallTime() % stepMillis) + 1;
+            // If alignment with the step is necessary then time publication to happen
+            // just after "StepValue" finishes the step, otherwise start after initial
+            // stepMillis.
+            long initialDelayMillis = stepMillis;
+            if (config.stepAlignment()) {
+                initialDelayMillis = stepMillis - (clock.wallTime() % stepMillis) + 1;
+            }
             scheduledExecutorService.scheduleAtFixedRate(this::publishSafely, initialDelayMillis, stepMillis,
                     TimeUnit.MILLISECONDS);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -48,6 +48,13 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     }
 
     /**
+     * @return {@code true} if step alignment is enabled. Default is {@code true}.
+     */
+    default boolean stepAlignment() {
+        return getBoolean(this, "stepAlignment").orElse(true);
+    }
+
+    /**
      * Return the number of threads to use with the scheduler.
      * <p>
      * Note that this configuration is NOT supported.


### PR DESCRIPTION
The problem with the current implementation is that if we use a 60sec (1min) step by default, all the reporting will happen at the same time across all the application on the globe.
That cause huge issues for backends or intermediary services, such as Otel Collector which has to handle a large burst, and because of that a larger footprint is needed.

<img width="1325" alt="Screen Shot 2022-08-09 at 4 28 35 PM" src="https://user-images.githubusercontent.com/1373887/183779322-1f46ee3c-3376-45ab-97a8-a84bcce0ba59.png">

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>