### PR TITLE
Add Javadoc since for new record() variants

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -102,6 +102,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * Executes the supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default boolean record(BooleanSupplier f) {
         Sample sample = start();
@@ -117,6 +118,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * Executes the supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default int record(IntSupplier f) {
         Sample sample = start();
@@ -132,6 +134,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * Executes the supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default long record(LongSupplier f) {
         Sample sample = start();
@@ -147,6 +150,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * Executes the supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default double record(DoubleSupplier f) {
         Sample sample = start();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -135,6 +135,7 @@ public interface Timer extends Meter, HistogramSupport {
      * Executes the Supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default boolean record(BooleanSupplier f) {
         return record((Supplier<Boolean>) f::getAsBoolean);
@@ -144,6 +145,7 @@ public interface Timer extends Meter, HistogramSupport {
      * Executes the Supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default int record(IntSupplier f) {
         return record((Supplier<Integer>) f::getAsInt);
@@ -153,6 +155,7 @@ public interface Timer extends Meter, HistogramSupport {
      * Executes the Supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default long record(LongSupplier f) {
         return record((Supplier<Long>) f::getAsLong);
@@ -162,6 +165,7 @@ public interface Timer extends Meter, HistogramSupport {
      * Executes the Supplier {@code f} and records the time taken.
      * @param f Function to execute and measure the execution time.
      * @return The return value of {@code f}.
+     * @since 1.10.0
      */
     default double record(DoubleSupplier f) {
         return record((Supplier<Double>) f::getAsDouble);


### PR DESCRIPTION
This PR adds Javadoc `@since` tag for the newly introduced `record()` variants in `Timer` and `LongTaskTimer`.

See gh-1304