### PR TITLE
Allow Timer implementation to provide their Histogram to AbstractTimer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -82,27 +82,43 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
      */
     protected AbstractTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector, TimeUnit baseTimeUnit, boolean supportsAggregablePercentiles) {
+        this(id, clock, pauseDetector, baseTimeUnit,
+                newHistogram(clock, distributionStatisticConfig, supportsAggregablePercentiles));
+    }
+
+    /**
+     * Creates a new timer.
+     * @param id The timer's name and tags.
+     * @param clock The clock used to measure latency.
+     * @param pauseDetector Compensation for coordinated omission.
+     * @param baseTimeUnit The time scale of this timer.
+     * @param histogram implementation for the distribution statistics to be sent.
+     */
+    protected AbstractTimer(Id id, Clock clock, PauseDetector pauseDetector, TimeUnit baseTimeUnit,
+            Histogram histogram) {
         super(id);
         this.clock = clock;
         this.baseTimeUnit = baseTimeUnit;
+        this.histogram = histogram;
 
         initPauseDetector(pauseDetector);
+    }
 
+    private static Histogram newHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig,
+            boolean supportsAggregablePercentiles) {
         if (distributionStatisticConfig.isPublishingPercentiles()) {
             // hdr-based histogram
-            this.histogram = new TimeWindowPercentileHistogram(clock, distributionStatisticConfig,
-                    supportsAggregablePercentiles);
+            return new TimeWindowPercentileHistogram(clock, distributionStatisticConfig, supportsAggregablePercentiles);
         }
-        else if (distributionStatisticConfig.isPublishingHistogram()) {
+
+        if (distributionStatisticConfig.isPublishingHistogram()) {
             // fixed boundary histograms, which have a slightly better memory footprint
             // when we don't need Micrometer-computed percentiles
-            this.histogram = new TimeWindowFixedBoundaryHistogram(clock, distributionStatisticConfig,
+            return new TimeWindowFixedBoundaryHistogram(clock, distributionStatisticConfig,
                     supportsAggregablePercentiles);
         }
-        else {
-            // noop histogram
-            this.histogram = NoopHistogram.INSTANCE;
-        }
+
+        return NoopHistogram.INSTANCE;
     }
 
     private void initPauseDetector(PauseDetector pauseDetectorType) {


### PR DESCRIPTION
This PR adds a new protected constructor to `AbstractTimer` that accepts an externally created Histogram. The usefulness of this API is proven by changing 2 implementation Prometheus and OTLP to use the new API.

For OtlpTimer to benefit more would require a change to CumulativeTimer as well (not sure if it is worth it since OtlpTimer will need to support delta, so will most likely needs it's own count/total/max), which I did not want to do in this PR, since the benefit of providing the Histogram is already visible.

This simplifies a lot the logic of overwriting what implementation of the Histogram to use in different implementations, and removes duplicate logic of replacing the fixed bucket histogram implementation.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>