### PR TITLE
Move Flux specific implementation out of Statsd registry

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdCounter.java
@@ -17,9 +17,9 @@ package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Counter;
-import reactor.core.publisher.FluxSink;
 
 import java.util.concurrent.atomic.DoubleAdder;
+import java.util.function.Consumer;
 
 /**
  * @author Jon Schneider
@@ -28,13 +28,13 @@ public class StatsdCounter extends AbstractMeter implements Counter {
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private DoubleAdder count = new DoubleAdder();
 
     private volatile boolean shutdown;
 
-    StatsdCounter(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink) {
+    StatsdCounter(Id id, StatsdLineBuilder lineBuilder, Consumer<String> sink) {
         super(id);
         this.lineBuilder = lineBuilder;
         this.sink = sink;
@@ -44,7 +44,7 @@ public class StatsdCounter extends AbstractMeter implements Counter {
     public void increment(double amount) {
         if (!shutdown && amount > 0) {
             count.add(amount);
-            sink.next(lineBuilder.count((long) amount));
+            sink.accept(lineBuilder.count((long) amount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdDistributionSummary.java
@@ -19,7 +19,8 @@ import io.micrometer.core.instrument.AbstractDistributionSummary;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.TimeWindowMax;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
@@ -34,11 +35,11 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private volatile boolean shutdown;
 
-    StatsdDistributionSummary(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock,
+    StatsdDistributionSummary(Id id, StatsdLineBuilder lineBuilder, Consumer<String> sink, Clock clock,
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         super(id, clock, distributionStatisticConfig, scale, false);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
@@ -52,7 +53,7 @@ public class StatsdDistributionSummary extends AbstractDistributionSummary {
             count.increment();
             this.amount.add(amount);
             max.record(amount);
-            sink.next(lineBuilder.histogram(amount));
+            sink.accept(lineBuilder.histogram(amount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionCounter.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionCounter.java
@@ -16,7 +16,8 @@
 package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.ToDoubleFunction;
@@ -31,11 +32,11 @@ public class StatsdFunctionCounter<T> extends CumulativeFunctionCounter<T> imple
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private final AtomicReference<Long> lastValue = new AtomicReference<>(0L);
 
-    StatsdFunctionCounter(Id id, T obj, ToDoubleFunction<T> f, StatsdLineBuilder lineBuilder, FluxSink<String> sink) {
+    StatsdFunctionCounter(Id id, T obj, ToDoubleFunction<T> f, StatsdLineBuilder lineBuilder, Consumer<String> sink) {
         super(id, obj, f);
         this.lineBuilder = lineBuilder;
         this.sink = sink;
@@ -45,7 +46,7 @@ public class StatsdFunctionCounter<T> extends CumulativeFunctionCounter<T> imple
     public void poll() {
         lastValue.updateAndGet(prev -> {
             long count = (long) count();
-            sink.next(lineBuilder.count(count - prev));
+            sink.accept(lineBuilder.count(count - prev));
             return count;
         });
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdFunctionTimer.java
@@ -16,7 +16,8 @@
 package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -27,7 +28,7 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private final AtomicReference<Long> lastCount = new AtomicReference<>(0L);
 
@@ -35,7 +36,7 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
 
     StatsdFunctionTimer(Id id, T obj, ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction,
             TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit, StatsdLineBuilder lineBuilder,
-            FluxSink<String> sink) {
+            Consumer<String> sink) {
         super(id, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, baseTimeUnit);
         this.lineBuilder = lineBuilder;
         this.sink = sink;
@@ -59,7 +60,7 @@ public class StatsdFunctionTimer<T> extends CumulativeFunctionTimer<T> implement
                     // occurrences.
                     double timingAverage = newTimingsSum / newTimingsCount;
                     for (int i = 0; i < newTimingsCount; i++) {
-                        sink.next(lineBuilder.timing(timingAverage));
+                        sink.accept(lineBuilder.timing(timingAverage));
                     }
 
                     return totalTime;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
@@ -18,7 +18,8 @@ package io.micrometer.statsd;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,7 +29,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private final WeakReference<T> ref;
 
@@ -38,7 +39,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
 
     private final boolean alwaysPublish;
 
-    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, @Nullable T obj, ToDoubleFunction<T> value,
+    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, Consumer<String> sink, @Nullable T obj, ToDoubleFunction<T> value,
             boolean alwaysPublish) {
         super(id);
         this.lineBuilder = lineBuilder;
@@ -58,7 +59,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
     public void poll() {
         double val = value();
         if (Double.isFinite(val) && (alwaysPublish || lastValue.getAndSet(val) != val)) {
-            sink.next(lineBuilder.gauge(val));
+            sink.accept(lineBuilder.gauge(val));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdLongTaskTimer.java
@@ -19,7 +19,8 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -28,7 +29,7 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private final AtomicReference<Long> lastActive = new AtomicReference<>(Long.MIN_VALUE);
 
@@ -36,7 +37,7 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
 
     private final boolean alwaysPublish;
 
-    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock, boolean alwaysPublish,
+    StatsdLongTaskTimer(Id id, StatsdLineBuilder lineBuilder, Consumer<String> sink, Clock clock, boolean alwaysPublish,
             DistributionStatisticConfig distributionStatisticConfig, TimeUnit baseTimeUnit) {
         super(id, clock, baseTimeUnit, distributionStatisticConfig, false);
         this.lineBuilder = lineBuilder;
@@ -48,17 +49,17 @@ public class StatsdLongTaskTimer extends DefaultLongTaskTimer implements StatsdP
     public void poll() {
         long active = activeTasks();
         if (alwaysPublish || lastActive.getAndSet(active) != active) {
-            sink.next(lineBuilder.gauge(active, Statistic.ACTIVE_TASKS));
+            sink.accept(lineBuilder.gauge(active, Statistic.ACTIVE_TASKS));
         }
 
         double duration = duration(TimeUnit.MILLISECONDS);
         if (alwaysPublish || lastDuration.getAndSet(duration) != duration) {
-            sink.next(lineBuilder.gauge(duration, Statistic.DURATION));
+            sink.accept(lineBuilder.gauge(duration, Statistic.DURATION));
         }
 
         double max = max(TimeUnit.MILLISECONDS);
         if (alwaysPublish || lastDuration.getAndSet(duration) != duration) {
-            sink.next(lineBuilder.gauge(max, Statistic.MAX));
+            sink.accept(lineBuilder.gauge(max, Statistic.MAX));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdTimer.java
@@ -21,7 +21,8 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.step.StepDouble;
 import io.micrometer.core.instrument.util.TimeUtils;
-import reactor.core.publisher.FluxSink;
+
+import java.util.function.Consumer;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.DoubleAdder;
@@ -35,13 +36,13 @@ public class StatsdTimer extends AbstractTimer {
 
     private final StatsdLineBuilder lineBuilder;
 
-    private final FluxSink<String> sink;
+    private final Consumer<String> sink;
 
     private StepDouble max;
 
     private volatile boolean shutdown;
 
-    StatsdTimer(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, Clock clock,
+    StatsdTimer(Id id, StatsdLineBuilder lineBuilder, Consumer<String> sink, Clock clock,
             DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector, TimeUnit baseTimeUnit,
             long stepMillis) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, false);
@@ -61,7 +62,7 @@ public class StatsdTimer extends AbstractTimer {
             // not necessary to ship max, as most StatsD agents calculate this themselves
             max.getCurrent().add(Math.max(msAmount - max.getCurrent().doubleValue(), 0));
 
-            sink.next(lineBuilder.timing(msAmount));
+            sink.accept(lineBuilder.timing(msAmount));
         }
     }
 

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/MeterProcessor.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/MeterProcessor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Spaceteams GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.statsd.internal;
+
+public interface MeterProcessor {
+
+    public void start(Runnable poll);
+
+    public void stop();
+
+    public void next(String line);
+
+}

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/BufferingFlux.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/BufferingFlux.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.statsd.internal;
+package io.micrometer.statsd.internal.flux;
 
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/FluxMeterProcessor.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/FluxMeterProcessor.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ * Copyright 2022 Spaceteams GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.statsd.internal.flux;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.statsd.internal.MeterProcessor;
+import io.micrometer.statsd.StatsdConfig;
+import io.micrometer.statsd.StatsdProtocol;
+
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.publisher.FluxProcessor;
+import reactor.core.publisher.DirectProcessor;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.FluxSink;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.udp.UdpClient;
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
+import reactor.util.retry.Retry;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.util.AttributeKey;
+
+import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.*;
+
+public class FluxMeterProcessor implements MeterProcessor {
+
+    private StatsdConfig statsdConfig;
+
+    private FluxProcessor<String, String> processor;
+
+    private FluxSink<String> sink = new NoopFluxSink();
+
+    private Disposable.Swap statsdConnection = Disposables.swap();
+
+    private Disposable.Swap meterPoller = Disposables.swap();
+
+    private Consumer<String> lineSink;
+
+    private Runnable pollFunction;
+
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    private static final AttributeKey<Boolean> CONNECTION_DISPOSED = AttributeKey.valueOf("doOnDisconnectCalled");
+
+    public FluxMeterProcessor(StatsdConfig statsdConfig) {
+        this(statsdConfig, null, null);
+    }
+
+    public FluxMeterProcessor(StatsdConfig statsdConfig, @Nullable Consumer<String> lineSink,
+            @Nullable FluxProcessor<String, String> processor) {
+        this.statsdConfig = statsdConfig;
+        this.lineSink = lineSink;
+
+        if (processor == null) {
+            this.processor = DirectProcessor.create();
+        }
+        else {
+            this.processor = processor;
+        }
+
+        this.sink = this.processor.sink();
+
+        try {
+            Class.forName("ch.qos.logback.classic.turbo.TurboFilter", false, getClass().getClassLoader());
+            this.sink = new LogbackMetricsSuppressingFluxSink(this.sink);
+        }
+        catch (ClassNotFoundException ignore) {
+        }
+    }
+
+    private void prepareUdpClient(Publisher<String> publisher, Supplier<SocketAddress> remoteAddress) {
+        AtomicReference<UdpClient> udpClientReference = new AtomicReference<>();
+        UdpClient udpClient = UdpClient.create().remoteAddress(remoteAddress)
+                .handle((in, out) -> out.sendString(publisher).neverComplete().retryWhen(
+                        Retry.indefinitely().filter(throwable -> throwable instanceof PortUnreachableException)))
+                .doOnDisconnected(connection -> {
+                    Boolean connectionDisposed = connection.channel().attr(CONNECTION_DISPOSED).getAndSet(Boolean.TRUE);
+                    if (connectionDisposed == null || !connectionDisposed) {
+                        connectAndSubscribe(udpClientReference.get());
+                    }
+                });
+        udpClientReference.set(udpClient);
+        connectAndSubscribe(udpClient);
+    }
+
+    private void prepareTcpClient(Publisher<String> publisher) {
+        AtomicReference<TcpClient> tcpClientReference = new AtomicReference<>();
+        TcpClient tcpClient = TcpClient.create().host(statsdConfig.host()).port(statsdConfig.port())
+                .handle((in, out) -> out.sendString(publisher).neverComplete()).doOnDisconnected(connection -> {
+                    Boolean connectionDisposed = connection.channel().attr(CONNECTION_DISPOSED).getAndSet(Boolean.TRUE);
+                    if (connectionDisposed == null || !connectionDisposed) {
+                        connectAndSubscribe(tcpClientReference.get());
+                    }
+                });
+        tcpClientReference.set(tcpClient);
+        connectAndSubscribe(tcpClient);
+    }
+
+    private void connectAndSubscribe(TcpClient tcpClient) {
+        retryReplaceClient(Mono.defer(() -> {
+            if (started.get()) {
+                return tcpClient.connect();
+            }
+            return Mono.empty();
+        }));
+    }
+
+    private void connectAndSubscribe(UdpClient udpClient) {
+        retryReplaceClient(Mono.defer(() -> {
+            if (started.get()) {
+                return udpClient.connect();
+            }
+            return Mono.empty();
+        }));
+    }
+
+    private void retryReplaceClient(Mono<? extends Connection> connectMono) {
+        connectMono.retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1)).maxBackoff(Duration.ofMinutes(1)))
+                .subscribe(connection -> {
+                    this.statsdConnection.replace(connection);
+
+                    // now that we're connected, start polling gauges and other pollable
+                    // meter types
+                    startPolling();
+                });
+    }
+
+    private void poll() {
+        if (pollFunction != null) {
+            pollFunction.run();
+        }
+    }
+
+    public void start(Runnable poll) {
+        if (started.compareAndSet(false, true)) {
+            pollFunction = poll;
+
+            if (lineSink != null) {
+                this.processor.subscribe(new Subscriber<String>() {
+                    @Override
+                    public void onSubscribe(Subscription s) {
+                        s.request(Long.MAX_VALUE);
+                    }
+
+                    @Override
+                    public void onNext(String line) {
+                        if (started.get()) {
+                            lineSink.accept(line);
+                        }
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        meterPoller.dispose();
+                    }
+                });
+
+                startPolling();
+            }
+            else {
+                final Publisher<String> publisher;
+                if (statsdConfig.buffered()) {
+                    publisher = BufferingFlux.create(Flux.from(this.processor), "\n", statsdConfig.maxPacketLength(),
+                            statsdConfig.pollingFrequency().toMillis()).onBackpressureLatest();
+                }
+                else {
+                    publisher = this.processor;
+                }
+                if (statsdConfig.protocol() == StatsdProtocol.UDP) {
+                    prepareUdpClient(publisher,
+                            () -> InetSocketAddress.createUnresolved(statsdConfig.host(), statsdConfig.port()));
+                }
+                else if (statsdConfig.protocol() == StatsdProtocol.UDS_DATAGRAM) {
+                    prepareUdpClient(publisher, () -> new DomainSocketAddress(statsdConfig.host()));
+                }
+                else if (statsdConfig.protocol() == StatsdProtocol.TCP) {
+                    prepareTcpClient(publisher);
+                }
+            }
+        }
+    }
+
+    public void stop() {
+        if (started.compareAndSet(true, false)) {
+            if (statsdConnection.get() != null) {
+                statsdConnection.get().dispose();
+            }
+            if (meterPoller.get() != null) {
+                meterPoller.get().dispose();
+            }
+        }
+    }
+
+    private void startPolling() {
+        meterPoller.update(Flux.interval(statsdConfig.pollingFrequency()).doOnEach(n -> poll()).subscribe());
+    }
+
+    public void next(String line) {
+        this.sink.next(line);
+    }
+
+    private static final class NoopFluxSink implements FluxSink<String> {
+
+        @Override
+        public FluxSink<String> next(String s) {
+            return this;
+        }
+
+        @Override
+        public void complete() {
+        }
+
+        @Override
+        public void error(Throwable e) {
+        }
+
+        @Override
+        public Context currentContext() {
+            return Context.empty();
+        }
+
+        @Override
+        public ContextView contextView() {
+            return Context.empty();
+        }
+
+        @Override
+        public long requestedFromDownstream() {
+            return 0;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public FluxSink<String> onRequest(LongConsumer consumer) {
+            return this;
+        }
+
+        @Override
+        public FluxSink<String> onCancel(Disposable d) {
+            return this;
+        }
+
+        @Override
+        public FluxSink<String> onDispose(Disposable d) {
+            return this;
+        }
+
+    }
+
+    // VisibleForTesting
+    public Disposable getConnection() {
+        return this.statsdConnection.get();
+    }
+
+}

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/LogbackMetricsSuppressingFluxSink.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/LogbackMetricsSuppressingFluxSink.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.statsd.internal;
+package io.micrometer.statsd.internal.flux;
 
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import reactor.core.Disposable;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/package-info.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/flux/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.micrometer.statsd.internal.flux;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/flux/BufferingFluxTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/internal/flux/BufferingFluxTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.statsd.internal;
+package io.micrometer.statsd.internal.flux;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;


### PR DESCRIPTION
The current implementation of the Statsd registry is tightly coupled to
the internal flux reactor event loop. This coupling makes it difficult
to plug in alternatives. This change intends to abstract the event loop
from the actual implementation of the event loop by hiding the flux
reactor loop behind the `MeterProcessor` interface and extending the builder
to allow advanced users to provide their own implementation.