### PR TITLE
Configure Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "1.8.x" # oldest OSS supported branch
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR configures Dependabot for GitHub Actions.

See https://github.com/spring-projects/spring-boot/pull/31567