### PR TITLE
Use 5.9.+ for JUnit BOM

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -84,7 +84,7 @@ def VERSIONS = [
 def PLATFORM_BOMS = [
         'io.projectreactor:reactor-bom:2020.0.+',
         'io.netty:netty-bom:4.1.+',
-        'org.junit:junit-bom:5.8.+' // Not using latest.release to avoid using a milestone version.
+        'org.junit:junit-bom:5.9.+' // Not using latest.release to avoid using a milestone version.
 ]
 
 subprojects {


### PR DESCRIPTION
This PR changes to use 5.9.+ for JUnit BOM.