### PR TITLE
Abstraction for instrumentating with a Timer or Observation (optionally)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.observation;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.transport.RequestReplySenderContext;
+
+import java.util.function.Supplier;
+
+/**
+ * Abstracts instrumenting code with a {@link Timer} or an {@link Observation}. This can
+ * be useful for avoiding complexity and minimizing overhead when converting
+ * instrumentation that was previously instrumented with a {@link Timer} to being
+ * optionally instrumented with an {@link Observation}. This may be necessary where
+ * backwards compatibility is a concern such that you cannot require an
+ * {@link ObservationRegistry}. If there are no backwards compatibility concerns,
+ * generally direct instrumentation with {@link Observation} should be preferred. While
+ * this was designed for use internally in micrometer-core where we have this need, it may
+ * also be useful to other libraries with pre-existing {@link Timer}-based
+ * instrumentation. If an {@link ObservationRegistry} is provided that is not the no-op
+ * registry, an {@link Observation} will be used for instrumentation. Otherwise, a
+ * {@link Timer} will be used.
+ *
+ * @param <T> context type if Observation used for instrumentation
+ */
+public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.Context> {
+
+    private final MeterRegistry meterRegistry;
+
+    private final ObservationRegistry observationRegistry;
+
+    @Nullable
+    private final Observation.ObservationConvention<T> convention;
+
+    private final Observation.ObservationConvention<T> defaultConvention;
+
+    @Nullable
+    private Timer.Sample sample;
+
+    @Nullable
+    private Observation observation;
+
+    @Nullable
+    private T context;
+
+    /**
+     * Start timing based on Observation and the convention for it if
+     * {@link ObservationRegistry} is not null and not the no-op registry. Otherwise,
+     * timing will be instrumented with a {@link Timer} using the {@link MeterRegistry}.
+     * @param meterRegistry registry for Timer-based instrumentation
+     * @param observationRegistry registry for Observation-based instrumentation
+     * @param context supplier for the context to use if instrumenting with Observation
+     * @param convention convention that overrides the default convention and any
+     * conventions configured on the registry, if not null
+     * @param defaultConvention convention to use if one is not configured
+     * @return a started instrumentation
+     * @param <T> context type if Observation used for instrumentation
+     */
+    public static <T extends Observation.Context> ObservationOrTimerCompatibleInstrumentation<T> start(
+            MeterRegistry meterRegistry, @Nullable ObservationRegistry observationRegistry, Supplier<T> context,
+            @Nullable Observation.ObservationConvention<T> convention,
+            Observation.ObservationConvention<T> defaultConvention) {
+        ObservationOrTimerCompatibleInstrumentation<T> observationOrTimer = new ObservationOrTimerCompatibleInstrumentation<>(
+                meterRegistry, observationRegistry, convention, defaultConvention);
+        observationOrTimer.start(context);
+        return observationOrTimer;
+    }
+
+    private ObservationOrTimerCompatibleInstrumentation(MeterRegistry meterRegistry,
+            @Nullable ObservationRegistry observationRegistry,
+            @Nullable Observation.ObservationConvention<T> convention,
+            Observation.ObservationConvention<T> defaultConvention) {
+        this.meterRegistry = meterRegistry;
+        this.observationRegistry = observationRegistry == null ? ObservationRegistry.NOOP : observationRegistry;
+        this.convention = convention;
+        this.defaultConvention = defaultConvention;
+    }
+
+    private void start(Supplier<T> contextSupplier) {
+        if (observationRegistry.isNoop()) {
+            sample = Timer.start(meterRegistry);
+        }
+        else {
+            this.context = contextSupplier.get();
+            observation = Observation.start(convention, defaultConvention, context, observationRegistry);
+        }
+    }
+
+    /**
+     * If using an Observation for instrumentation and the context is a
+     * {@link RequestReplySenderContext}, set the response object on it. Otherwise, do
+     * nothing.
+     * @param response response for the RequestReplySenderContext
+     * @param <RES> type of the response
+     */
+    public <RES> void setResponse(RES response) {
+        if (observationRegistry.isNoop() || !(context instanceof RequestReplySenderContext)) {
+            return;
+        }
+        RequestReplySenderContext<?, ? super RES> requestReplySenderContext = (RequestReplySenderContext<?, ? super RES>) context;
+        requestReplySenderContext.setResponse(response);
+    }
+
+    /**
+     * Stop the timing. The tags that should be applied to the timer need to be passed
+     * here. These parameters will only be used if instrumentation is Timer-based.
+     * Observation-based instrumentation will use tags and the name from the applicable
+     * convention.
+     * @param timerName name of the timer if instrumentation is done with Timer
+     * @param timerDescription description for the timer
+     * @param tagsSupplier tags supplier to apply if using the Timer API
+     */
+    public void stop(String timerName, @Nullable String timerDescription, Supplier<Iterable<Tag>> tagsSupplier) {
+        if (observationRegistry.isNoop() && sample != null) {
+            sample.stop(Timer.builder(timerName).description(timerDescription).tags(tagsSupplier.get())
+                    .register(meterRegistry));
+        }
+        else if (observation != null) {
+            observation.stop();
+        }
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -116,6 +116,7 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
         if (observationRegistry.isNoop() || !(context instanceof RequestReplySenderContext)) {
             return;
         }
+        // TODO Support RequestReplyReceiverContext
         RequestReplySenderContext<?, ? super RES> requestReplySenderContext = (RequestReplySenderContext<?, ? super RES>) context;
         requestReplySenderContext.setResponse(response);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -40,6 +40,7 @@ import java.util.function.Supplier;
  * {@link Timer} will be used.
  *
  * @param <T> context type if Observation used for instrumentation
+ * @since 1.10.0
  */
 public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.Context> {
 
@@ -53,7 +54,7 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
     private final Observation.ObservationConvention<T> defaultConvention;
 
     @Nullable
-    private Timer.Sample sample;
+    private Timer.Sample timerSample;
 
     @Nullable
     private Observation observation;
@@ -96,10 +97,10 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
 
     private void start(Supplier<T> contextSupplier) {
         if (observationRegistry.isNoop()) {
-            sample = Timer.start(meterRegistry);
+            timerSample = Timer.start(meterRegistry);
         }
         else {
-            this.context = contextSupplier.get();
+            context = contextSupplier.get();
             observation = Observation.start(convention, defaultConvention, context, observationRegistry);
         }
     }
@@ -129,8 +130,8 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
      * @param tagsSupplier tags supplier to apply if using the Timer API
      */
     public void stop(String timerName, @Nullable String timerDescription, Supplier<Iterable<Tag>> tagsSupplier) {
-        if (observationRegistry.isNoop() && sample != null) {
-            sample.stop(Timer.builder(timerName).description(timerDescription).tags(tagsSupplier.get())
+        if (observationRegistry.isNoop() && timerSample != null) {
+            timerSample.stop(Timer.builder(timerName).description(timerDescription).tags(tagsSupplier.get())
                     .register(meterRegistry));
         }
         else if (observation != null) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.observation;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.Test;
+
+import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObservationOrTimerCompatibleInstrumentationTest {
+
+    MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+    @Test
+    void noObservationRegistry() {
+        ObservationOrTimerCompatibleInstrumentation.start(meterRegistry, null, null, null, null).stop("my.timer",
+                "timer description", () -> Tags.of("a", "b"));
+        assertThat(observationRegistry).doesNotHaveAnyObservation();
+        Timer timer = meterRegistry.get("my.timer").timer();
+        assertThat(timer).isNotNull();
+        assertThat(timer.getId().getDescription()).isEqualTo("timer description");
+        assertThat(timer.getId().getTags()).containsOnly(Tag.of("a", "b"));
+    }
+
+    @Test
+    void withObservationRegistry() {
+        ObservationOrTimerCompatibleInstrumentation.start(meterRegistry, observationRegistry, Observation.Context::new,
+                null, TestDefaultConvention.INSTANCE).stop("my.timer", "timer description", () -> Tags.of("a", "b"));
+        assertThat(meterRegistry.find("my.timer").timer()).isNull();
+        assertThat(observationRegistry).hasSingleObservationThat().hasBeenStarted().hasBeenStopped()
+                .hasNameEqualTo("my.observation").hasContextualNameEqualTo("observation ()").hasOnlyKeys("low", "high")
+                .hasLowCardinalityKeyValue("low", "value").hasHighCardinalityKeyValue("high", "value");
+    }
+
+    private static class TestDefaultConvention implements Observation.ObservationConvention<Observation.Context> {
+
+        public static TestDefaultConvention INSTANCE = new TestDefaultConvention();
+
+        private TestDefaultConvention() {
+        }
+
+        @Override
+        public String getName() {
+            return "my.observation";
+        }
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("low", "value");
+        }
+
+        @Override
+        public KeyValues getHighCardinalityKeyValues(Observation.Context context) {
+            return KeyValues.of("high", "value");
+        }
+
+        @Override
+        public String getContextualName(Observation.Context context) {
+            return "observation ()";
+        }
+
+        @Override
+        public boolean supportsContext(Observation.Context context) {
+            return true;
+        }
+
+    }
+
+}


### PR DESCRIPTION
We have a lot of existing instrumentations with Timer that are good candidates to be rewritten with the Observation API for added extensibility. However, we cannot break compatibility for existing users by requiring an ObservationRegistry for each instrumentation. We will want to add an option to configure an ObservationRegistry on the builder for the instrumentation or as an additional constructor if there isn't a builder. Instrumentation should still work as before without providing an ObservationRegistry. This can be handled in each instrumentation, but this added class ObservationOrTimerCompatibleInstrumentation is intended to make it easier to support this case where instrumentation may be done with a Timer or Observation depending on whether an ObservationRegistry is available. By having a common abstraction for this, we can hopefully make supporting Observation in our existing instrumentations easier, and also avoid adding overhead to instrumentation by avoiding instantiating things for Observation when a Timer is used (and the opposite situation).