### PR TITLE
Common ResponseContext interface for interacting with the response

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.transport.RequestReplySenderContext;
+import io.micrometer.observation.transport.ResponseContext;
 
 import java.util.function.Supplier;
 
@@ -113,12 +114,11 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
      * @param <RES> type of the response
      */
     public <RES> void setResponse(RES response) {
-        if (observationRegistry.isNoop() || !(context instanceof RequestReplySenderContext)) {
+        if (observationRegistry.isNoop() || !(context instanceof ResponseContext)) {
             return;
         }
-        // TODO Support RequestReplyReceiverContext
-        RequestReplySenderContext<?, ? super RES> requestReplySenderContext = (RequestReplySenderContext<?, ? super RES>) context;
-        requestReplySenderContext.setResponse(response);
+        ResponseContext<? super RES> responseContext = (ResponseContext<? super RES>) context;
+        responseContext.setResponse(response);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
@@ -27,7 +27,7 @@ import io.micrometer.common.lang.Nullable;
  * @param <C> type of the carrier object
  * @param <RES> type of the response object
  */
-public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> {
+public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> implements ResponseContext<RES> {
 
     @Nullable
     private RES response;
@@ -49,11 +49,13 @@ public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> {
         this(getter, Kind.SERVER);
     }
 
+    @Override
     @Nullable
     public RES getResponse() {
         return response;
     }
 
+    @Override
     public void setResponse(RES response) {
         this.response = response;
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
@@ -27,7 +27,7 @@ import io.micrometer.common.lang.Nullable;
  * @param <C> type of the carrier object
  * @param <RES> type of the response object
  */
-public class RequestReplySenderContext<C, RES> extends SenderContext<C> {
+public class RequestReplySenderContext<C, RES> extends SenderContext<C> implements ResponseContext<RES> {
 
     @Nullable
     private RES response;
@@ -49,11 +49,13 @@ public class RequestReplySenderContext<C, RES> extends SenderContext<C> {
         this(setter, Kind.CLIENT);
     }
 
+    @Override
     @Nullable
     public RES getResponse() {
         return response;
     }
 
+    @Override
     public void setResponse(RES response) {
         this.response = response;
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation.transport;
+
+import io.micrometer.common.lang.Nullable;
+
+/**
+ * Common interface for getting/setting the response object on
+ * {@link io.micrometer.observation.Observation.Context} implementations that handle a
+ * response.
+ *
+ * @param <RES> type of response object
+ * @since 1.10.0
+ */
+public interface ResponseContext<RES> {
+
+    /**
+     * Getter for the response object.
+     * @return the response
+     */
+    @Nullable
+    RES getResponse();
+
+    /**
+     * Setter for the response object.
+     * @param response the response
+     */
+    void setResponse(RES response);
+
+}


### PR DESCRIPTION
Without this, we need to check two different types (currently) that have the same getter/setter methods for response. This allows us to use a common interface as shown by the changes in ObservationOrTimerCompatibleInstrumentation.

This is a follow-up to https://github.com/micrometer-metrics/micrometer/pull/3357#discussion_r948809106