### PR TITLE
signalfx: remove unnecessary allocation if the distribution summary does not have histogram

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxDistributionSummary.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxDistributionSummary.java
@@ -54,7 +54,7 @@ final class SignalfxDistributionSummary extends AbstractDistributionSummary {
         super(id, clock, CumulativeHistogramConfigUtil.updateConfig(distributionStatisticConfig), scale, false);
         this.countTotal = new StepTuple2<>(clock, stepMillis, 0L, 0.0, count::sumThenReset, total::sumThenReset);
         max = new TimeWindowMax(clock, distributionStatisticConfig);
-        if (isDelta) {
+        if (distributionStatisticConfig.isPublishingHistogram() && isDelta) {
             deltaHistogramCounts = new DeltaHistogramCounts();
         }
         else {

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxTimer.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalfxTimer.java
@@ -56,8 +56,7 @@ final class SignalfxTimer extends AbstractTimer {
                 baseTimeUnit, false);
         countTotal = new StepTuple2<>(clock, stepMillis, 0L, 0L, count::sumThenReset, total::sumThenReset);
         max = new TimeWindowMax(clock, distributionStatisticConfig);
-        if (!distributionStatisticConfig.isPublishingPercentiles()
-                && distributionStatisticConfig.isPublishingHistogram() && isDelta) {
+        if (distributionStatisticConfig.isPublishingHistogram() && isDelta) {
             deltaHistogramCounts = new DeltaHistogramCounts();
         }
         else {


### PR DESCRIPTION
This optimization already in place for Timer.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>