### PR TITLE
Test against ObservationDocumentation in instrumentation TCK

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
@@ -64,17 +64,32 @@ public enum ApacheHttpClientObservationDocumentation implements ObservationDocum
             public String asString() {
                 return "target.scheme";
             }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
         },
         TARGET_HOST {
             @Override
             public String asString() {
                 return "target.host";
             }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
         },
         TARGET_PORT {
             @Override
             public String asString() {
                 return "target.port";
+            }
+
+            @Override
+            public boolean isRequired() {
+                return false;
             }
         }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -27,6 +27,9 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.util.Streams.stream;
+
 /**
  * Assertion methods for {@code Observation.Context}s and
  * {@link Observation.ContextView}s.
@@ -194,6 +197,24 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
                 failWithMessage("Observation is missing expected keys %s.", missingKeys);
             }
         }
+        return (SELF) this;
+    }
+
+    /**
+     * Verifies that the Observation key-value keys are a subset of the given set of keys.
+     */
+    public SELF hasSubsetOfKeys(String... keys) {
+        isNotNull();
+        Set<String> actualKeys = new LinkedHashSet<>(allKeys());
+        Set<String> expectedKeys = new LinkedHashSet<>(Arrays.asList(keys));
+
+        List<String> extra = stream(actualKeys).filter(actualElement -> !expectedKeys.contains(actualElement))
+                .collect(toList());
+
+        if (extra.size() > 0) {
+            failWithMessage("Observation keys are not a subset of %s. Found extra keys: %s", keys, extra);
+        }
+
         return (SELF) this;
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
@@ -22,6 +22,9 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import io.micrometer.observation.docs.ObservationDocumentation;
 import org.junit.jupiter.api.AfterEach;
@@ -33,7 +36,10 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -248,22 +254,41 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
             return;
         }
         Timer timer = getRegistry().get(timerName()).timer();
+        Set<String> requiredDocumentedLowCardinalityKeys = getRequiredLowCardinalityKeyNames(observationDocumentation);
+        Set<String> requiredTagKeys = new HashSet<>(requiredDocumentedLowCardinalityKeys);
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            requiredTagKeys.add("error");
+        }
+        Set<String> allDocumentedLowCardinalityKeys = getLowCardinalityKeyNames(observationDocumentation);
+        Set<String> allPossibleTagKeys = new HashSet<>(allDocumentedLowCardinalityKeys);
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            allPossibleTagKeys.add("error");
+        }
+
         // must have all required tag keys
         assertThat(timer.getId().getTags()).extracting(Tag::getKey)
-                .contains(getRequiredLowCardinalityKeyNames(observationDocumentation));
+                .containsAll(requiredTagKeys);
         // must not contain tag keys that aren't documented
         assertThat(timer.getId().getTags()).extracting(Tag::getKey)
-                .isSubsetOf(getLowCardinalityKeyNames(observationDocumentation));
+                .isSubsetOf(allPossibleTagKeys);
+
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            if (observationDocumentation.getDefaultConvention() == null) {
+                TestObservationRegistryAssert.assertThat(getObservationRegistry()).hasSingleObservationThat()
+                        .hasContextualNameEqualTo(observationDocumentation.getContextualName());
+            }
+
+        }
     }
 
-    private String[] getRequiredLowCardinalityKeyNames(ObservationDocumentation ObservationDocumentation) {
+    private Set<String> getRequiredLowCardinalityKeyNames(ObservationDocumentation ObservationDocumentation) {
         return Arrays.stream(ObservationDocumentation.getLowCardinalityKeyNames()).filter(KeyName::isRequired)
-                .map(KeyName::asString).toArray(String[]::new);
+                .map(KeyName::asString).collect(Collectors.toSet());
     }
 
-    private String[] getLowCardinalityKeyNames(ObservationDocumentation ObservationDocumentation) {
+    private Set<String> getLowCardinalityKeyNames(ObservationDocumentation ObservationDocumentation) {
         return Arrays.stream(ObservationDocumentation.getLowCardinalityKeyNames()).map(KeyName::asString)
-                .toArray(String[]::new);
+                .collect(Collectors.toSet());
     }
 
 }

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
@@ -243,17 +243,17 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
 
     @AfterEach
     void verifyObservationDocumentation() {
-        ObservationDocumentation ObservationDocumentation = observationDocumentation();
-        if (ObservationDocumentation == null) {
+        ObservationDocumentation observationDocumentation = observationDocumentation();
+        if (observationDocumentation == null) {
             return;
         }
         Timer timer = getRegistry().get(timerName()).timer();
         // must have all required tag keys
         assertThat(timer.getId().getTags()).extracting(Tag::getKey)
-                .contains(getRequiredLowCardinalityKeyNames(ObservationDocumentation));
+                .contains(getRequiredLowCardinalityKeyNames(observationDocumentation));
         // must not contain tag keys that aren't documented
         assertThat(timer.getId().getTags()).extracting(Tag::getKey)
-                .isSubsetOf(getLowCardinalityKeyNames(ObservationDocumentation));
+                .isSubsetOf(getLowCardinalityKeyNames(observationDocumentation));
     }
 
     private String[] getRequiredLowCardinalityKeyNames(ObservationDocumentation ObservationDocumentation) {

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
@@ -41,7 +41,7 @@ import static org.awaitility.Awaitility.await;
  */
 @Incubating(since = "1.8.9")
 @ExtendWith(InstrumentationVerificationTests.AfterBeforeParameterResolver.class)
-public abstract class HttpServerTimingInstrumentationVerificationTests extends InstrumentationVerificationTests {
+public abstract class HttpServerTimingInstrumentationVerificationTests extends InstrumentationTimingVerificationTests {
 
     private final HttpSender sender = new HttpUrlConnectionSender();
 
@@ -49,12 +49,7 @@ public abstract class HttpServerTimingInstrumentationVerificationTests extends I
 
     private boolean assumptionSucceeded = true;
 
-    /**
-     * A default is provided that should be preferred by new instrumentations. Existing
-     * instrumentations that use a different value to maintain backwards compatibility may
-     * override this method to run tests with a different name used in assertions.
-     * @return name of the meter timing http server requests
-     */
+    @Override
     protected String timerName() {
         return "http.server.requests";
     }

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
@@ -20,6 +20,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.docs.ObservationDocumentation;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -29,13 +30,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(InstrumentationVerificationTests.AfterBeforeParameterResolver.class)
 abstract class InstrumentationTimingVerificationTests extends InstrumentationVerificationTests {
-
-    /**
-     * Distinguish how the instrumentation is set up - with just MeterRegistry or with
-     * ObservationRegistry.
-     */
-    protected TestType testType;
 
     /**
      * A default is provided that should be preferred by new instrumentations. Existing
@@ -57,7 +53,7 @@ abstract class InstrumentationTimingVerificationTests extends InstrumentationVer
     }
 
     @AfterEach
-    protected void verifyObservationDocumentation() {
+    void verifyObservationDocumentation(TestType testType) {
         ObservationDocumentation observationDocumentation = observationDocumentation();
         if (observationDocumentation == null) {
             return;
@@ -82,11 +78,12 @@ abstract class InstrumentationTimingVerificationTests extends InstrumentationVer
 
         if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
             if (observationDocumentation.getDefaultConvention() == null) {
-                TestObservationRegistryAssert.assertThat(getObservationRegistry()).hasSingleObservationThat()
-                        .hasContextualNameEqualTo(observationDocumentation.getContextualName())
-                        .hasNameEqualTo(observationDocumentation.getName());
+                TestObservationRegistryAssert.assertThat(getObservationRegistry())
+                        .hasObservationWithNameEqualTo(observationDocumentation.getName()).that()
+                        .hasContextualNameEqualTo(observationDocumentation.getContextualName());
             }
-            TestObservationRegistryAssert.assertThat(getObservationRegistry()).hasSingleObservationThat()
+            TestObservationRegistryAssert.assertThat(getObservationRegistry())
+                    .hasObservationWithNameEqualTo(timerName()).that()
                     .hasSubsetOfKeys(getAllKeyNames(observationDocumentation));
         }
     }

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.AfterEach;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+abstract class InstrumentationTimingVerificationTests extends InstrumentationVerificationTests {
+
+    /**
+     * Distinguish how the instrumentation is set up - with just MeterRegistry or with
+     * ObservationRegistry.
+     */
+    protected TestType testType;
+
+    /**
+     * A default is provided that should be preferred by new instrumentations. Existing
+     * instrumentations that use a different value to maintain backwards compatibility may
+     * override this method to run tests with a different name used in assertions.
+     * @return name of the Timer meter produced from the timing instrumentation under test
+     */
+    protected abstract String timerName();
+
+    /**
+     * If a {@link ObservationDocumentation} is provided the tests run will check that the
+     * produced instrumentation matches the given {@link ObservationDocumentation}.
+     * @return the documented observation to compare results against, or null to do
+     * nothing
+     */
+    @Nullable
+    protected ObservationDocumentation observationDocumentation() {
+        return null;
+    }
+
+    @AfterEach
+    protected void verifyObservationDocumentation() {
+        ObservationDocumentation observationDocumentation = observationDocumentation();
+        if (observationDocumentation == null) {
+            return;
+        }
+
+        Timer timer = getRegistry().get(timerName()).timer();
+        Set<String> requiredDocumentedLowCardinalityKeys = getRequiredLowCardinalityKeyNames(observationDocumentation);
+        Set<String> requiredTagKeys = new HashSet<>(requiredDocumentedLowCardinalityKeys);
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            requiredTagKeys.add("error");
+        }
+        Set<String> allDocumentedLowCardinalityKeys = getLowCardinalityKeyNames(observationDocumentation);
+        Set<String> allPossibleTagKeys = new HashSet<>(allDocumentedLowCardinalityKeys);
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            allPossibleTagKeys.add("error");
+        }
+
+        // must have all required tag keys
+        assertThat(timer.getId().getTags()).extracting(Tag::getKey).containsAll(requiredTagKeys);
+        // must not contain tag keys that aren't documented
+        assertThat(timer.getId().getTags()).extracting(Tag::getKey).isSubsetOf(allPossibleTagKeys);
+
+        if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
+            if (observationDocumentation.getDefaultConvention() == null) {
+                TestObservationRegistryAssert.assertThat(getObservationRegistry()).hasSingleObservationThat()
+                        .hasContextualNameEqualTo(observationDocumentation.getContextualName())
+                        .hasNameEqualTo(observationDocumentation.getName());
+            }
+            TestObservationRegistryAssert.assertThat(getObservationRegistry()).hasSingleObservationThat()
+                    .hasSubsetOfKeys(getAllKeyNames(observationDocumentation));
+        }
+    }
+
+    private Set<String> getRequiredLowCardinalityKeyNames(ObservationDocumentation observationDocumentation) {
+        return Arrays.stream(observationDocumentation.getLowCardinalityKeyNames()).filter(KeyName::isRequired)
+                .map(KeyName::asString).collect(Collectors.toSet());
+    }
+
+    private Set<String> getLowCardinalityKeyNames(ObservationDocumentation observationDocumentation) {
+        return Arrays.stream(observationDocumentation.getLowCardinalityKeyNames()).map(KeyName::asString)
+                .collect(Collectors.toSet());
+    }
+
+    private String[] getAllKeyNames(ObservationDocumentation observationDocumentation) {
+        return Stream
+                .concat(Arrays.stream(observationDocumentation.getLowCardinalityKeyNames()),
+                        Arrays.stream(observationDocumentation.getHighCardinalityKeyNames()))
+                .map(KeyName::asString).toArray(String[]::new);
+    }
+
+}

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
@@ -61,7 +61,7 @@ abstract class InstrumentationVerificationTests {
         return observationRegistry;
     }
 
-    protected ObservationRegistry getObservationRegistry() {
+    protected TestObservationRegistry getObservationRegistry() {
         return this.testObservationRegistry;
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
@@ -30,9 +30,7 @@ import org.junit.platform.commons.util.AnnotationUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 abstract class InstrumentationVerificationTests {
 
@@ -75,7 +73,7 @@ abstract class InstrumentationVerificationTests {
         METRICS_VIA_METER_REGISTRY,
 
         /**
-         * Runs the tests by using the Observation API.
+         * Runs the tests by using the Observation API and a MeterObservationHandler.
          */
         METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER
 

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
@@ -17,7 +17,6 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/ApacheHttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/ApacheHttpClientTimingInstrumentationVerificationTests.java
@@ -16,8 +16,10 @@
 package io.micrometer.core.instrument;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.binder.httpcomponents.ApacheHttpClientObservationDocumentation;
 import io.micrometer.core.instrument.binder.httpcomponents.DefaultUriMapper;
 import io.micrometer.core.instrument.binder.httpcomponents.MicrometerHttpRequestExecutor;
+import io.micrometer.observation.docs.ObservationDocumentation;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -48,6 +50,11 @@ class ApacheHttpClientTimingInstrumentationVerificationTests
     @Override
     protected String timerName() {
         return "httpcomponents.httpclient.request";
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return ApacheHttpClientObservationDocumentation.DEFAULT;
     }
 
     @Override

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/JerseyServerTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/JerseyServerTimingInstrumentationVerificationTests.java
@@ -17,8 +17,10 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.binder.jersey.server.DefaultJerseyTagsProvider;
+import io.micrometer.core.instrument.binder.jersey.server.JerseyObservationDocumentation;
 import io.micrometer.core.instrument.binder.jersey.server.MetricsApplicationEventListener;
 import io.micrometer.core.instrument.binder.jersey.server.ObservationApplicationEventListener;
+import io.micrometer.observation.docs.ObservationDocumentation;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 
@@ -44,6 +46,11 @@ class JerseyServerTimingInstrumentationVerificationTests extends HttpServerTimin
     protected URI startInstrumentedWithObservationsServer() throws Exception {
         jerseyTest = jerseyWithListener(new ObservationApplicationEventListener(getObservationRegistry(), timerName()));
         return setupUri(jerseyTest);
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return JerseyObservationDocumentation.DEFAULT;
     }
 
     private JerseyTest jerseyWithListener(Object listener) {

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/OkHttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/OkHttpClientTimingInstrumentationVerificationTests.java
@@ -17,7 +17,9 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.binder.okhttp3.OkHttpMetricsEventListener;
+import io.micrometer.core.instrument.binder.okhttp3.OkHttpObservationDocumentation;
 import io.micrometer.core.instrument.binder.okhttp3.OkHttpObservationInterceptor;
+import io.micrometer.observation.docs.ObservationDocumentation;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
@@ -53,6 +55,11 @@ class OkHttpClientTimingInstrumentationVerificationTests
         return new OkHttpClient.Builder()
                 .addInterceptor(OkHttpObservationInterceptor.builder(getObservationRegistry(), timerName()).build())
                 .build();
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return OkHttpObservationDocumentation.DEFAULT;
     }
 
 }

--- a/micrometer-test/src/test/java11/io/micrometer/core/instrument/binder/jdk/JdkHttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java11/io/micrometer/core/instrument/binder/jdk/JdkHttpClientTimingInstrumentationVerificationTests.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument;
+package io.micrometer.core.instrument.binder.jdk;
 
 import io.micrometer.common.lang.Nullable;
-import io.micrometer.core.instrument.binder.jdk.MicrometerHttpClient;
+import io.micrometer.core.instrument.HttpClientTimingInstrumentationVerificationTests;
+import io.micrometer.observation.docs.ObservationDocumentation;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -52,6 +53,11 @@ class JdkHttpClientTimingInstrumentationVerificationTests
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return HttpClientObservationDocumentation.HTTP_CALL;
     }
 
     private HttpRequest makeRequest(HttpMethod method, @Nullable byte[] body, URI baseUri, String templatedPath,


### PR DESCRIPTION
Instrumentation being tested against the TCK can optionally provide the DocumentedObservation that specifies the expected semantic naming to be used in the instrumentation. This ensures that the implementation matches the specified documentation, which may be used to generate written documentation.

This adds a new abstract class in between `InstrumentationVerificationTests` and the `HttpClientTimingInstrumentationVerificationTests`/`HttpServerTimingInstrumentationVerificationTests`. The class `InstrumentationTimingVerificationTests` contains methods and logic specifically for timing instrumentation. The goal is to leave `InstrumentationVerificationTests` generic enough that it may be used for other kinds of instrumentation verification. Arguably some of the remaining stuff in there should be moved since `ObservationRegistry` is probably only relevant when verifying some kind of timing instrumentation.

TODO:

- [x] merge and rebase on #3454 before this