### PR TITLE
Update to latest CloudWatch constraints

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchConfig.java
@@ -36,7 +36,8 @@ import static io.micrometer.core.instrument.config.validate.PropertyValidator.ge
  */
 public interface CloudWatchConfig extends StepRegistryConfig {
 
-    int MAX_BATCH_SIZE = 20;
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
+    int MAX_BATCH_SIZE = 1000;
 
     @Override
     default String prefix() {

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchNamingConvention.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchNamingConvention.java
@@ -31,7 +31,7 @@ public class CloudWatchNamingConvention implements NamingConvention {
     // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html
     private static final int MAX_TAG_KEY_LENGTH = 255;
 
-    private static final int MAX_TAG_VALUE_LENGTH = 255;
+    private static final int MAX_TAG_VALUE_LENGTH = 1024;
 
     private final NamingConvention delegate;
 

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistryTest.java
@@ -239,7 +239,7 @@ class CloudWatchMeterRegistryTest {
     @Test
     void batchSizeShouldWorkOnMetricDatum() throws InterruptedException {
         List<Meter> meters = new ArrayList<>();
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < CloudWatchConfig.MAX_BATCH_SIZE; i++) {
             Timer timer = Timer.builder("timer." + i).register(this.registry);
             meters.add(timer);
         }
@@ -250,8 +250,8 @@ class CloudWatchMeterRegistryTest {
         ArgumentCaptor<List<MetricDatum>> argumentCaptor = ArgumentCaptor.forClass(List.class);
         verify(this.registry, times(2)).sendMetricData(argumentCaptor.capture());
         List<List<MetricDatum>> allValues = argumentCaptor.getAllValues();
-        assertThat(allValues.get(0)).hasSize(20);
-        assertThat(allValues.get(1)).hasSize(20);
+        assertThat(allValues.get(0)).hasSize(CloudWatchConfig.MAX_BATCH_SIZE);
+        assertThat(allValues.get(1)).hasSize(CloudWatchConfig.MAX_BATCH_SIZE);
     }
 
     @Test

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchNamingConventionTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchNamingConventionTest.java
@@ -39,7 +39,7 @@ class CloudWatchNamingConventionTest {
 
     @Test
     void truncateTagValue() {
-        assertThat(namingConvention.tagValue(repeat("x", 256))).hasSize(255);
+        assertThat(namingConvention.tagValue(repeat("x", 1025))).hasSize(1024);
     }
 
     private String repeat(String s, int repeat) {


### PR DESCRIPTION
* Dimension value max length: 255 → 1024
* Max dimensions per metric: 10 → 30 (this was previously missing)
* Max metrics per PutMetricDataRequest: 20 → 1000

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html
See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html

Closes gh-3376