### PR TITLE
Enable Gradle's stable configuration cache feature flag

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,8 @@ plugins {
 
 rootProject.name = 'micrometer'
 
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 buildCache {
     remote(HttpBuildCache) {
         url = 'https://ge.micrometer.io/cache/'


### PR DESCRIPTION
This PR enables Gradle's stable configuration cache feature flag.

See https://github.com/spring-projects/spring-boot/issues/32061