### PR TITLE
Add "createNotStarted" method that lazily creates context

### DIFF
--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/DocumentedObservationTests.java
@@ -15,9 +15,13 @@
  */
 package io.micrometer.observation.docs;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.ObservationFilter;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.GlobalObservationConvention;
@@ -114,6 +118,22 @@ class DocumentedObservationTests {
         assertThat(context.getLowCardinalityKeyValues()).containsOnly(KeyValue.of("always added", "tag"),
                 KeyValue.of("global", "low cardinality"));
         assertThat(context.getHighCardinalityKeyValues()).containsOnly(KeyValue.of("global", "high cardinality"));
+    }
+
+    @Test
+    void createNotStartedShouldNotCreateContextWithNoopRegistry() {
+        ObservationRegistry registry = ObservationRegistry.NOOP;
+
+        AtomicBoolean isCalled = new AtomicBoolean();
+        Supplier<Context> supplier = () -> {
+            isCalled.set(true);
+            return new Observation.Context();
+        };
+
+        Observation observation = TestConventionObservation.CONTEXTUAL_NAME.createNotStarted(null,
+                new FirstObservationConvention(), supplier, registry);
+        assertThat(observation.isNoop()).isTrue();
+        assertThat(isCalled).isFalse();
     }
 
     private ObservationRegistry observationRegistry() {


### PR DESCRIPTION
Add another variant of `observation` method to delay the observation context creation.  When the registry is a no-op, it fast returns the no-op observation and skips calling the supplier.  This avoids the creation of the observation context.

Ideally, the supplier should be pushed down to more method calls to further delay the context creation, but at least this gives an API that minimize the creation of context.