### PR TITLE
Override default spliterator method in Tags and KeyValues

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
@@ -150,13 +150,18 @@ public final class KeyValues implements Iterable<KeyValue> {
 
     }
 
+    @Override
+    public Spliterator<KeyValue> spliterator() {
+        return Spliterators.spliterator(keyValues, 0, last, Spliterator.IMMUTABLE | Spliterator.ORDERED
+                | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.SORTED);
+    }
+
     /**
      * Return a stream of the contained key values.
      * @return a key value stream
      */
     public Stream<KeyValue> stream() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(),
-                Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.SORTED), false);
+        return StreamSupport.stream(spliterator(), false);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -149,13 +149,18 @@ public final class Tags implements Iterable<Tag> {
 
     }
 
+    @Override
+    public Spliterator<Tag> spliterator() {
+        return Spliterators.spliterator(tags, 0, last, Spliterator.IMMUTABLE | Spliterator.ORDERED
+                | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.SORTED);
+    }
+
     /**
      * Return a stream of the contained tags.
      * @return a tags stream
      */
     public Stream<Tag> stream() {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator(),
-                Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.SORTED), false);
+        return StreamSupport.stream(spliterator(), false);
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
@@ -55,6 +55,15 @@ class TagsTest {
     }
 
     @Test
+    void spliterator() {
+        Tags tags = Tags.of("k1", "v1", "k2", "v2", "k3", "v4");
+        Spliterator<Tag> spliterator = tags.spliterator();
+        assertThat(spliterator).hasCharacteristics(Spliterator.IMMUTABLE, Spliterator.ORDERED, Spliterator.SORTED,
+                Spliterator.DISTINCT);
+        assertThat(spliterator.getExactSizeIfKnown()).isEqualTo(3);
+    }
+
+    @Test
     void tagsHashCode() {
         Tags tags = Tags.of(Tag.of("k1", "v1"), Tag.of("k1", "v1"), Tag.of("k2", "v2"));
         Tags tags2 = Tags.of(Tag.of("k1", "v1"), Tag.of("k2", "v2"));


### PR DESCRIPTION
Tags and KeyValues were inheriting their spliterator method from Iterable, which returns a Spliterator with unknown size and no characteristics set.