### PR TITLE
Automated java module checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,14 +286,6 @@ subprojects {
         }
     }
 
-    task testModules(type: Exec) {
-        dependsOn "jar"
-
-        commandLine "java", "-p", "${project.buildDir.absolutePath}${File.separator}libs${File.separator}/${project.name}-${project.version}.jar", "--list-modules"
-        
-        standardOutput = new ByteArrayOutputStream()
-    }
-
     if (!['samples', 'benchmarks'].find { project.name.contains(it) }) {
         apply plugin: 'nebula.maven-publish'
         apply plugin: 'nebula.maven-manifest'
@@ -314,6 +306,22 @@ subprojects {
                     from "$rootDir/NOTICE"
                 }
             }
+
+            task testModules(type: Exec) {
+                dependsOn jar
+                String executablePath = javaToolchains.launcherFor { languageVersion = javaLanguageVersion }.get().executablePath
+                commandLine "$executablePath", '-p', "$jar.archivePath", '--list-modules'
+                standardOutput = new ByteArrayOutputStream()
+                ignoreExitValue = true
+
+                doLast {
+                    if (executionResult.get().getExitValue() != 0) {
+                        throw new GradleException("Command finished with non-zero exit value ${executionResult.get().getExitValue()}:\n$standardOutput")
+                    }
+                }
+            }
+
+            check.dependsOn("testModules")
 
             if (!(project.name in ['micrometer-commons', 'micrometer-observation', 'micrometer-observation-conventions', 'micrometer-observation-test'])) {
                 apply plugin: 'me.champeau.gradle.japicmp'

--- a/build.gradle
+++ b/build.gradle
@@ -286,6 +286,14 @@ subprojects {
         }
     }
 
+    task testModules(type: Exec) {
+        dependsOn "jar"
+
+        commandLine "java", "-p", "${project.buildDir.absolutePath}${File.separator}libs${File.separator}/${project.name}-${project.version}.jar", "--list-modules"
+        
+        standardOutput = new ByteArrayOutputStream()
+    }
+
     if (!['samples', 'benchmarks'].find { project.name.contains(it) }) {
         apply plugin: 'nebula.maven-publish'
         apply plugin: 'nebula.maven-manifest'


### PR DESCRIPTION
I've added a task called `testModules` that essentially calls

```
$ java -p module-name/build/libs/module-name-1.10.0-SNAPSHOT.jar --list-modules
```

If the module system is broken this task will fail.

The motivation to add this check is to catch issues like the one found in #3398.

TODO:

- [x] I failed to retrieve JAVA_HOME from Java Toolchain from Gradle
- [x] Maybe there's something smarter to test this?
- [x] Plug in `testModules` to the whole build