### PR TITLE
Jetty Client instrumentation with Observation API

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
@@ -57,6 +57,7 @@ public enum Outcome {
     UNKNOWN;
 
     private final Tag tag;
+
     private final KeyValue keyValue;
 
     Outcome() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
@@ -76,7 +76,7 @@ public enum Outcome {
     /**
      * Returns the {@code Outcome} as a {@link KeyValue} named {@code outcome}.
      * @return the {@code outcome} {@code KeyValue}
-     * @since 1.10.0
+     * @since 1.11.0
      */
     public KeyValue asKeyValue() {
         return this.keyValue;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/Outcome.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.http;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.core.instrument.Tag;
 
 /**
@@ -56,9 +57,11 @@ public enum Outcome {
     UNKNOWN;
 
     private final Tag tag;
+    private final KeyValue keyValue;
 
     Outcome() {
         this.tag = Tag.of("outcome", name());
+        this.keyValue = KeyValue.of("outcome", name());
     }
 
     /**
@@ -67,6 +70,15 @@ public enum Outcome {
      */
     public Tag asTag() {
         return this.tag;
+    }
+
+    /**
+     * Returns the {@code Outcome} as a {@link KeyValue} named {@code outcome}.
+     * @return the {@code outcome} {@code KeyValue}
+     * @since 1.10.0
+     */
+    public KeyValue asKeyValue() {
+        return this.keyValue;
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
@@ -38,4 +38,9 @@ public class DefaultJettyClientObservationConvention extends JettyClientObservat
                 JettyClientKeyValues.outcome(result));
     }
 
+    @Override
+    public String getName() {
+        return JettyClientMetrics.DEFAULT_JETTY_CLIENT_REQUESTS_TIMER_NAME;
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
@@ -33,7 +33,7 @@ public class DefaultJettyClientObservationConvention extends JettyClientObservat
         Request request = context.getCarrier();
         Result result = context.getResponse();
         return KeyValues.of(JettyClientKeyValues.method(request), JettyClientKeyValues.host(request),
-                JettyClientKeyValues.uri(result, context.getUriPatternFunction()),
+                JettyClientKeyValues.uri(request, result, context.getUriPatternFunction()),
                 JettyClientKeyValues.exception(result), JettyClientKeyValues.status(result),
                 JettyClientKeyValues.outcome(result));
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.common.KeyValues;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Result;
+
+/**
+ * Default implementation of {@link JettyClientObservationConvention}.
+ *
+ * @since 1.10.0
+ */
+public class DefaultJettyClientObservationConvention extends JettyClientObservationConvention {
+
+    public static DefaultJettyClientObservationConvention INSTANCE = new DefaultJettyClientObservationConvention();
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(JettyClientContext context) {
+        Request request = context.getCarrier();
+        Result result = context.getResponse();
+        return KeyValues.of(JettyClientKeyValues.method(request), JettyClientKeyValues.host(request),
+                JettyClientKeyValues.uri(result, context.getUriPatternFunction()),
+                JettyClientKeyValues.exception(result), JettyClientKeyValues.status(result),
+                JettyClientKeyValues.outcome(result));
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
@@ -22,9 +22,9 @@ import org.eclipse.jetty.client.api.Result;
 /**
  * Default implementation of {@link JettyClientObservationConvention}.
  *
- * @since 1.10.0
+ * @since 1.11.0
  */
-public class DefaultJettyClientObservationConvention extends JettyClientObservationConvention {
+public class DefaultJettyClientObservationConvention implements JettyClientObservationConvention {
 
     public static DefaultJettyClientObservationConvention INSTANCE = new DefaultJettyClientObservationConvention();
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.observation.transport.RequestReplySenderContext;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Result;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Context to use when instrumenting Jetty client metrics with the Observation API.
+ *
+ * @since 1.10.0
+ * @see JettyClientMetrics
+ */
+public class JettyClientContext extends RequestReplySenderContext<Request, Result> {
+
+    private final Function<Result, String> uriPatternFunction;
+
+    public JettyClientContext(Request request, Function<Result, String> uriPatternFunction) {
+        super((carrier, key, value) -> Objects.requireNonNull(carrier).header(key, value));
+        this.uriPatternFunction = uriPatternFunction;
+        setCarrier(request);
+    }
+
+    public Function<Result, String> getUriPatternFunction() {
+        return uriPatternFunction;
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
@@ -25,7 +25,7 @@ import java.util.function.BiFunction;
 /**
  * Context to use when instrumenting Jetty client metrics with the Observation API.
  *
- * @since 1.10.0
+ * @since 1.11.0
  * @see JettyClientMetrics
  */
 public class JettyClientContext extends RequestReplySenderContext<Request, Result> {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
@@ -20,7 +20,7 @@ import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Result;
 
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
  * Context to use when instrumenting Jetty client metrics with the Observation API.
@@ -30,15 +30,15 @@ import java.util.function.Function;
  */
 public class JettyClientContext extends RequestReplySenderContext<Request, Result> {
 
-    private final Function<Result, String> uriPatternFunction;
+    private final BiFunction<Request, Result, String> uriPatternFunction;
 
-    public JettyClientContext(Request request, Function<Result, String> uriPatternFunction) {
+    public JettyClientContext(Request request, BiFunction<Request, Result, String> uriPatternFunction) {
         super((carrier, key, value) -> Objects.requireNonNull(carrier).header(key, value));
         this.uriPatternFunction = uriPatternFunction;
         setCarrier(request);
     }
 
-    public Function<Result, String> getUriPatternFunction() {
+    public BiFunction<Request, Result, String> getUriPatternFunction() {
         return uriPatternFunction;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.binder.jetty;
 
 import io.micrometer.common.KeyValue;
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.binder.http.Outcome;
 import org.eclipse.jetty.client.api.Request;
@@ -41,15 +42,23 @@ public final class JettyClientKeyValues {
 
     private static final KeyValue URI_ROOT = KeyValue.of("uri", "root");
 
+    private static final KeyValue URI_UNKNOWN = KeyValue.of("uri", "UNKNOWN");
+
     private static final KeyValue EXCEPTION_NONE = KeyValue.of("exception", "None");
+
+    private static final KeyValue EXCEPTION_UNKNOWN = KeyValue.of("exception", "UNKNOWN");
 
     private static final KeyValue METHOD_UNKNOWN = KeyValue.of("method", "UNKNOWN");
 
     private static final KeyValue HOST_UNKNOWN = KeyValue.of("host", "UNKNOWN");
 
+    public static final KeyValue STATUS_UNKNOWN = KeyValue.of("status", "UNKNOWN");
+
     private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
 
     private static final Pattern MULTIPLE_SLASH_PATTERN = Pattern.compile("//+");
+
+    private static final KeyValue OUTCOME_UNKNOWN = KeyValue.of("outcome", "UNKNOWN");
 
     private JettyClientKeyValues() {
     }
@@ -80,8 +89,9 @@ public final class JettyClientKeyValues {
      * @param result the request result
      * @return the status KeyValue derived from the status of the response
      */
-    public static KeyValue status(Result result) {
-        return KeyValue.of("status", Integer.toString(result.getResponse().getStatus()));
+    public static KeyValue status(@Nullable Result result) {
+        return result != null ? KeyValue.of("status", Integer.toString(result.getResponse().getStatus()))
+                : STATUS_UNKNOWN;
     }
 
     /**
@@ -91,7 +101,10 @@ public final class JettyClientKeyValues {
      * @param successfulUriPattern successful URI pattern
      * @return the uri KeyValue derived from the request result
      */
-    public static KeyValue uri(Result result, Function<Result, String> successfulUriPattern) {
+    public static KeyValue uri(@Nullable Result result, Function<Result, String> successfulUriPattern) {
+        if (result == null) {
+            return URI_UNKNOWN;
+        }
         Response response = result.getResponse();
         if (response != null) {
             int status = response.getStatus();
@@ -118,7 +131,10 @@ public final class JettyClientKeyValues {
      * @param result the request result
      * @return the exception KeyValue derived from the exception
      */
-    public static KeyValue exception(Result result) {
+    public static KeyValue exception(@Nullable Result result) {
+        if (result == null) {
+            return EXCEPTION_UNKNOWN;
+        }
         Throwable exception = result.getFailure();
         if (exception == null) {
             return EXCEPTION_NONE;
@@ -143,7 +159,10 @@ public final class JettyClientKeyValues {
      * @param result the request result
      * @return the outcome KeyValue derived from the status of the response
      */
-    public static KeyValue outcome(Result result) {
+    public static KeyValue outcome(@Nullable Result result) {
+        if (result == null) {
+            return OUTCOME_UNKNOWN;
+        }
         return Outcome.forStatus(result.getResponse().getStatus()).asKeyValue();
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  * is handled by Jetty {@link org.eclipse.jetty.client.HttpClient}.
  *
  * @author Jon Schneider
- * @since 1.10.0
+ * @since 1.11.0
  */
 public final class JettyClientKeyValues {
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.core.instrument.binder.http.Outcome;
+import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.http.HttpStatus;
+
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Factory methods for {@link KeyValue} associated with a request-response exchange that
+ * is handled by Jetty {@link org.eclipse.jetty.client.HttpClient}.
+ *
+ * @author Jon Schneider
+ * @since 1.10.0
+ */
+public final class JettyClientKeyValues {
+
+    private static final KeyValue URI_NOT_FOUND = KeyValue.of("uri", "NOT_FOUND");
+
+    private static final KeyValue URI_REDIRECTION = KeyValue.of("uri", "REDIRECTION");
+
+    private static final KeyValue URI_ROOT = KeyValue.of("uri", "root");
+
+    private static final KeyValue EXCEPTION_NONE = KeyValue.of("exception", "None");
+
+    private static final KeyValue METHOD_UNKNOWN = KeyValue.of("method", "UNKNOWN");
+
+    private static final KeyValue HOST_UNKNOWN = KeyValue.of("host", "UNKNOWN");
+
+    private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
+
+    private static final Pattern MULTIPLE_SLASH_PATTERN = Pattern.compile("//+");
+
+    private JettyClientKeyValues() {
+    }
+
+    /**
+     * Creates a {@code method} KeyValue based on the {@link Request#getMethod() method}
+     * of the given {@code request}.
+     * @param request the request
+     * @return the method KeyValue whose value is a capitalized method (e.g. GET).
+     */
+    public static KeyValue method(Request request) {
+        return (request != null) ? KeyValue.of("method", request.getMethod()) : METHOD_UNKNOWN;
+    }
+
+    /**
+     * Creates a {@code host} KeyValue based on the {@link Request#getHost()} of the given
+     * {@code request}.
+     * @param request the request
+     * @return the host KeyValue derived from request
+     * @since 1.7.0
+     */
+    public static KeyValue host(Request request) {
+        return (request != null) ? KeyValue.of("host", request.getHost()) : HOST_UNKNOWN;
+    }
+
+    /**
+     * Creates a {@code status} KeyValue based on the status of the given {@code result}.
+     * @param result the request result
+     * @return the status KeyValue derived from the status of the response
+     */
+    public static KeyValue status(Result result) {
+        return KeyValue.of("status", Integer.toString(result.getResponse().getStatus()));
+    }
+
+    /**
+     * Creates a {@code uri} KeyValue based on the URI of the given {@code result}.
+     * {@code REDIRECTION} for 3xx responses, {@code NOT_FOUND} for 404 responses.
+     * @param result the request result
+     * @param successfulUriPattern successful URI pattern
+     * @return the uri KeyValue derived from the request result
+     */
+    public static KeyValue uri(Result result, Function<Result, String> successfulUriPattern) {
+        Response response = result.getResponse();
+        if (response != null) {
+            int status = response.getStatus();
+            if (HttpStatus.isRedirection(status)) {
+                return URI_REDIRECTION;
+            }
+            if (status == 404) {
+                return URI_NOT_FOUND;
+            }
+        }
+
+        String matchingPattern = successfulUriPattern.apply(result);
+        matchingPattern = MULTIPLE_SLASH_PATTERN.matcher(matchingPattern).replaceAll("/");
+        if (matchingPattern.equals("/")) {
+            return URI_ROOT;
+        }
+        matchingPattern = TRAILING_SLASH_PATTERN.matcher(matchingPattern).replaceAll("");
+        return KeyValue.of("uri", matchingPattern);
+    }
+
+    /**
+     * Creates an {@code exception} KeyValue based on the {@link Class#getSimpleName()
+     * simple name} of the class of the given {@code exception}.
+     * @param result the request result
+     * @return the exception KeyValue derived from the exception
+     */
+    public static KeyValue exception(Result result) {
+        Throwable exception = result.getFailure();
+        if (exception == null) {
+            return EXCEPTION_NONE;
+        }
+        if (result.getResponse() != null) {
+            int status = result.getResponse().getStatus();
+            if (status == 404 || HttpStatus.isRedirection(status)) {
+                return EXCEPTION_NONE;
+            }
+        }
+        if (exception.getCause() != null) {
+            exception = exception.getCause();
+        }
+        String simpleName = exception.getClass().getSimpleName();
+        return KeyValue.of("exception",
+                StringUtils.isNotEmpty(simpleName) ? simpleName : exception.getClass().getName());
+    }
+
+    /**
+     * Creates an {@code outcome} KeyValue based on the status of the given
+     * {@code result}.
+     * @param result the request result
+     * @return the outcome KeyValue derived from the status of the response
+     */
+    public static KeyValue outcome(Result result) {
+        return Outcome.forStatus(result.getResponse().getStatus()).asKeyValue();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
@@ -42,6 +42,8 @@ import java.util.Optional;
 @Incubating(since = "1.5.0")
 public class JettyClientMetrics implements Request.Listener {
 
+    static final String DEFAULT_JETTY_CLIENT_REQUESTS_TIMER_NAME = "jetty.client.requests";
+
     private final MeterRegistry registry;
 
     private final JettyClientTagsProvider tagsProvider;
@@ -121,7 +123,7 @@ public class JettyClientMetrics implements Request.Listener {
 
         private final JettyClientTagsProvider tagsProvider;
 
-        private String timingMetricName = "jetty.client.requests";
+        private String timingMetricName = DEFAULT_JETTY_CLIENT_REQUESTS_TIMER_NAME;
 
         private String contentSizeMetricName = "jetty.client.request.size";
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
@@ -135,7 +135,7 @@ public class JettyClientMetrics implements Request.Listener {
      * @param registry meter registry to use
      * @param uriPatternFunction how to extract the URI pattern for tagging
      * @return builder
-     * @since 1.10.0
+     * @since 1.11.0
      */
     public static Builder builder(MeterRegistry registry, BiFunction<Request, Result, String> uriPatternFunction) {
         return new Builder(registry, uriPatternFunction);
@@ -187,7 +187,7 @@ public class JettyClientMetrics implements Request.Listener {
          * {@link #observationRegistry(ObservationRegistry)} is configured.
          * @param tagsProvider tags provider to use with metrics instrumentation
          * @return this builder
-         * @since 1.10.0
+         * @since 1.11.0
          */
         public Builder tagsProvider(JettyClientTagsProvider tagsProvider) {
             this.tagsProvider = tagsProvider;
@@ -199,7 +199,7 @@ public class JettyClientMetrics implements Request.Listener {
          * API instead of directly with a {@link Timer}.
          * @param observationRegistry registry with which to instrument
          * @return this builder
-         * @since 1.10.0
+         * @since 1.11.0
          */
         public Builder observationRegistry(ObservationRegistry observationRegistry) {
             this.observationRegistry = observationRegistry;
@@ -213,6 +213,7 @@ public class JettyClientMetrics implements Request.Listener {
          * @param convention semantic convention to use
          * @return This builder instance.
          * @see #observationRegistry(ObservationRegistry)
+         * @since 1.11.0
          */
         public Builder observationConvention(JettyClientObservationConvention convention) {
             this.observationConvention = convention;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
@@ -91,8 +91,8 @@ public class JettyClientMetrics implements Request.Listener {
     @Override
     public void onQueued(Request request) {
         ObservationOrTimerCompatibleInstrumentation<JettyClientContext> sample = ObservationOrTimerCompatibleInstrumentation
-                .start(registry, observationRegistry, () -> new JettyClientContext(request, tagsProvider::uriPattern), convention,
-                        DefaultJettyClientObservationConvention.INSTANCE);
+                .start(registry, observationRegistry, () -> new JettyClientContext(request, tagsProvider::uriPattern),
+                        convention, DefaultJettyClientObservationConvention.INSTANCE);
 
         request.onComplete(result -> {
             sample.setResponse(result);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
@@ -21,12 +21,12 @@ import io.micrometer.observation.ObservationConvention;
 /**
  * Convention used with Jetty client instrumentation {@link JettyClientMetrics}.
  *
- * @since 1.10.0
+ * @since 1.11.0
  */
-public class JettyClientObservationConvention implements ObservationConvention<JettyClientContext> {
+public interface JettyClientObservationConvention extends ObservationConvention<JettyClientContext> {
 
     @Override
-    public boolean supportsContext(Observation.Context context) {
+    default boolean supportsContext(Observation.Context context) {
         return context instanceof JettyClientContext;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
@@ -13,11 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Meter binders for Jetty.
- */
-@NonNullApi
 package io.micrometer.core.instrument.binder.jetty;
 
-import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * Convention used with Jetty client instrumentation {@link JettyClientMetrics}.
+ *
+ * @since 1.10.0
+ */
+public class JettyClientObservationConvention implements ObservationConvention<JettyClientContext> {
+
+    @Override
+    public boolean supportsContext(Observation.Context context) {
+        return context instanceof JettyClientContext;
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationDocumentation.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+/**
+ * {@link ObservationDocumentation} for the Jetty HTTP client.
+ *
+ * @since 1.11.0
+ * @see JettyClientMetrics
+ */
+public enum JettyClientObservationDocumentation implements ObservationDocumentation {
+
+    /**
+     * Default instrumentation from {@link JettyClientMetrics}.
+     */
+    DEFAULT {
+        @Override
+        public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+            return JettyClientObservationConvention.class;
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return JettyClientLowCardinalityTags.values();
+        }
+    };
+
+    enum JettyClientLowCardinalityTags implements KeyName {
+
+        /**
+         * URI of the request. Ideally it should be the templated URI pattern to maintain
+         * low cardinality and support useful aggregation.
+         */
+        URI {
+            @Override
+            public String asString() {
+                return "uri";
+            }
+        },
+        /**
+         * Exception thrown, if any.
+         */
+        EXCEPTION {
+            @Override
+            public String asString() {
+                return "exception";
+            }
+        },
+        /**
+         * HTTP method of the request, if available.
+         */
+        METHOD {
+            @Override
+            public String asString() {
+                return "method";
+            }
+        },
+        /**
+         * Description of the outcome of an HTTP request based on the HTTP status code
+         * category, if known.
+         */
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
+        /**
+         * HTTP status of the response, if available.
+         */
+        STATUS {
+            @Override
+            public String asString() {
+                return "status";
+            }
+        },
+        /**
+         * Host used in the request.
+         */
+        HOST {
+            @Override
+            public String asString() {
+                return "host";
+            }
+        }
+
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientTagsProvider.java
@@ -16,9 +16,12 @@
 package io.micrometer.core.instrument.binder.jetty;
 
 import io.micrometer.core.annotation.Incubating;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.eclipse.jetty.client.api.Result;
+
+import java.util.function.BiFunction;
 
 /**
  * Provides {@link Tag Tags} for Jetty {@link org.eclipse.jetty.client.HttpClient} request
@@ -47,7 +50,10 @@ public interface JettyClientTagsProvider {
      * that goes to a certain endpoint, regardless of the parameters to that endpoint.
      * @param result The result which also contains the original request.
      * @return A URI pattern with path variables and query parameter unsubstituted.
+     * @deprecated use {@link JettyClientMetrics#builder(MeterRegistry, BiFunction)}
+     * instead to configure the uri pattern function
      */
+    @Deprecated
     String uriPattern(Result result);
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
@@ -39,17 +39,17 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JettyClientMetricsTest {
+class JettyClientMetricsTest {
 
-    private SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    protected SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
 
     private Server server = new Server(0);
 
-    private ServerConnector connector = new ServerConnector(server);
+    protected ServerConnector connector = new ServerConnector(server);
 
-    private CountDownLatch singleRequestLatch = new CountDownLatch(1);
+    protected CountDownLatch singleRequestLatch = new CountDownLatch(1);
 
-    private HttpClient httpClient = new HttpClient();
+    protected HttpClient httpClient = new HttpClient();
 
     @BeforeEach
     void beforeEach() throws Exception {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jetty;
+
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
+
+    private final ObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+    @BeforeEach
+    @Override
+    void beforeEach() throws Exception {
+        super.beforeEach();
+        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        this.httpClient.getRequestListeners().removeIf(listener -> true);
+        this.httpClient.getRequestListeners()
+                .add(JettyClientMetrics.builder(registry, (request, result) -> request.getURI().getPath())
+                        .observationRegistry(observationRegistry).build());
+    }
+
+    @Test
+    void activeTimer() throws Exception {
+        httpClient.GET("http://localhost:" + connector.getLocalPort() + "/ok");
+        assertThat(registry.get("jetty.client.requests.active").tags("uri", "/ok", "method", "GET").longTaskTimer()
+                .activeTasks()).isOne();
+        httpClient.stop();
+
+        assertTrue(singleRequestLatch.await(10, SECONDS));
+        assertThat(registry.get("jetty.client.requests").tag("outcome", "SUCCESS").tag("status", "200")
+                .tag("uri", "/ok").timer().count()).isEqualTo(1);
+    }
+
+}

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/JettyClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/JettyClientTimingInstrumentationVerificationTests.java
@@ -35,33 +35,13 @@ class JettyClientTimingInstrumentationVerificationTests
 
     @Override
     protected HttpClient clientInstrumentedWithMetrics() {
-        HttpClient httpClient = new HttpClient();
-        httpClient.getRequestListeners().add(JettyClientMetrics
-                .builder(getRegistry(), result -> result.getRequest().getHeaders().get(HEADER_URI_PATTERN)).build());
-        try {
-            httpClient.start();
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return httpClient;
+        return createHttpClient(false);
     }
 
     @Nullable
     @Override
     protected HttpClient clientInstrumentedWithObservations() {
-        HttpClient httpClient = new HttpClient();
-        httpClient.getRequestListeners()
-                .add(JettyClientMetrics
-                        .builder(getRegistry(), result -> result.getRequest().getHeaders().get(HEADER_URI_PATTERN))
-                        .observationRegistry(getObservationRegistry()).build());
-        try {
-            httpClient.start();
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return httpClient;
+        return createHttpClient(true);
     }
 
     @Override
@@ -80,6 +60,23 @@ class JettyClientTimingInstrumentationVerificationTests
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private HttpClient createHttpClient(boolean withObservationRegistry) {
+        HttpClient httpClient = new HttpClient();
+        JettyClientMetrics.Builder builder = JettyClientMetrics.builder(getRegistry(),
+                (request, result) -> request.getHeaders().get(HEADER_URI_PATTERN));
+        if (withObservationRegistry) {
+            builder.observationRegistry(getObservationRegistry());
+        }
+        httpClient.getRequestListeners().add(builder.build());
+        try {
+            httpClient.start();
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return httpClient;
     }
 
 }

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/JettyClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/JettyClientTimingInstrumentationVerificationTests.java
@@ -17,6 +17,8 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.binder.jetty.JettyClientMetrics;
+import io.micrometer.core.instrument.binder.jetty.JettyClientObservationDocumentation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.util.BytesContentProvider;
@@ -31,6 +33,11 @@ class JettyClientTimingInstrumentationVerificationTests
     @Override
     protected String timerName() {
         return "jetty.client.requests";
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return JettyClientObservationDocumentation.DEFAULT;
     }
 
     @Override


### PR DESCRIPTION
Allow configuring an ObservationRegistry so that the JettyClientMetrics can instrument with Observation API in addition to its previously existing functionality.

TODO:

- [x] Tests with Observation
- [x] ObservationDocumentation