### PR TITLE
Handle IO_ERROR for Apache HTTP client with observation API

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -117,11 +117,12 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
         try {
             HttpResponse response = super.execute(request, conn, context);
             sample.setResponse(response);
-            statusCodeOrError = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusValue(response);
+            statusCodeOrError = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusValue(response, null);
             return response;
         }
         catch (IOException | HttpException | RuntimeException e) {
             statusCodeOrError = "IO_ERROR";
+            sample.setThrowable(e);
             throw e;
         }
         finally {


### PR DESCRIPTION
Adding a test mentioned in https://github.com/micrometer-metrics/micrometer/pull/3312#pullrequestreview-1080368149 revealed that handling `IO_ERROR` with observation API is missing.

This PR tries to fix it.