### PR TITLE
Make observation return its context and immutable access to parent

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -18,6 +18,7 @@ package io.micrometer.observation.tck;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationView;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ThrowingConsumer;
@@ -354,9 +355,9 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
-    private Observation checkedParentObservation() {
+    private ObservationView checkedParentObservation() {
         isNotNull();
-        Observation p = this.actual.getParentObservation();
+        ObservationView p = this.actual.getParentObservation();
         if (p == null) {
             failWithMessage("Observation should have a parent");
         }
@@ -371,7 +372,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      */
     public SELF hasParentObservationEqualTo(Observation expectedParent) {
         isNotNull();
-        Observation realParent = this.actual.getParentObservation();
+        ObservationView realParent = this.actual.getParentObservation();
         if (realParent == null) {
             failWithMessage("Observation should have parent <%s> but has none", expectedParent);
         }
@@ -403,9 +404,9 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      */
     public SELF hasParentObservationContextSatisfying(
             ThrowingConsumer<Observation.ContextView> parentContextViewAssertion) {
-        Observation p = checkedParentObservation();
+        ObservationView p = checkedParentObservation();
         try {
-            parentContextViewAssertion.accept(p.getContext());
+            parentContextViewAssertion.accept(p.getContextView());
         }
         catch (Throwable e) {
             failWithMessage("Parent observation does not satisfy given assertion: " + e.getMessage());
@@ -423,8 +424,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      */
     public SELF hasParentObservationContextMatching(
             Predicate<? super Observation.ContextView> parentContextViewPredicate) {
-        Observation p = checkedParentObservation();
-        if (!parentContextViewPredicate.test(p.getContext())) {
+        ObservationView p = checkedParentObservation();
+        if (!parentContextViewPredicate.test(p.getContextView())) {
             failWithMessage("Observation should have parent that matches given predicate but <%s> didn't", p);
         }
         return (SELF) this;
@@ -438,8 +439,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
      */
     public SELF hasParentObservationContextMatching(
             Predicate<? super Observation.ContextView> parentContextViewPredicate, String description) {
-        Observation p = checkedParentObservation();
-        if (!parentContextViewPredicate.test(p.getContext())) {
+        ObservationView p = checkedParentObservation();
+        if (!parentContextViewPredicate.test(p.getContextView())) {
             failWithMessage("Observation should have parent that matches '%s' predicate but <%s> didn't", description,
                     p);
         }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -33,7 +33,7 @@ final class NoopObservation implements Observation {
      */
     static final NoopObservation INSTANCE = new NoopObservation();
 
-    private static final ContextView CONTEXT = new Context();
+    private static final Context CONTEXT = new Context();
 
     private NoopObservation() {
     }
@@ -89,7 +89,7 @@ final class NoopObservation implements Observation {
     }
 
     @Override
-    public ContextView getContext() {
+    public Context getContext() {
         return CONTEXT;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public interface Observation {
+public interface Observation extends ObservationView {
 
     /**
      * No-op observation.
@@ -356,12 +356,19 @@ public interface Observation {
     Observation start();
 
     /**
-     * Returns the context attached to this observation. This returns a mutable
-     * {@link Context} for this observation. However, it is strongly discouraged to modify
-     * the {@link Context} in the <em>parent observation</em>.
+     * Returns the context attached to this observation.
      * @return corresponding context
      */
     Context getContext();
+
+    /**
+     * Returns the context attached to this observation as a read only view.
+     * @return corresponding context
+     */
+    @Override
+    default ContextView getContextView() {
+        return this.getContext();
+    }
 
     /**
      * Stop the observation. Remember to call this method, otherwise timing calculations
@@ -676,7 +683,7 @@ public interface Observation {
         private Throwable error;
 
         @Nullable
-        private Observation parentObservation;
+        private ObservationView parentObservation;
 
         private final Set<KeyValue> lowCardinalityKeyValues = new LinkedHashSet<>();
 
@@ -718,12 +725,11 @@ public interface Observation {
         }
 
         /**
-         * Returns the parent {@link Observation}.
+         * Returns the parent {@link ObservationView}.
          * @return parent observation or {@code null} if there was no parent
          */
-        @Override
         @Nullable
-        public Observation getParentObservation() {
+        public ObservationView getParentObservation() {
             return parentObservation;
         }
 
@@ -731,7 +737,7 @@ public interface Observation {
          * Sets the parent {@link Observation}.
          * @param parentObservation parent observation to set
          */
-        public void setParentObservation(@Nullable Observation parentObservation) {
+        public void setParentObservation(@Nullable ObservationView parentObservation) {
             this.parentObservation = parentObservation;
         }
 
@@ -1013,11 +1019,11 @@ public interface Observation {
         String getContextualName();
 
         /**
-         * Returns the parent {@link Observation}.
+         * Returns the parent {@link ObservationView}.
          * @return parent observation or {@code null} if there was no parent
          */
         @Nullable
-        Observation getParentObservation();
+        ObservationView getParentObservation();
 
         /**
          * Optional error that occurred while processing the {@link Observation}.

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -356,10 +356,12 @@ public interface Observation {
     Observation start();
 
     /**
-     * Returns the context attached to this observation.
+     * Returns the context attached to this observation. This returns a mutable
+     * {@link Context} for this observation. However, it is strongly discouraged to modify
+     * the {@link Context} in the <em>parent observation</em>.
      * @return corresponding context
      */
-    ContextView getContext();
+    Context getContext();
 
     /**
      * Stop the observation. Remember to call this method, otherwise timing calculations

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.observation.Observation.ContextView;
+
+/**
+ * Read only view on the {@link Observation}.
+ *
+ * @since 1.10.0
+ */
+public interface ObservationView {
+
+    /**
+     * Returns the {@link ContextView} attached to this observation.
+     * @return corresponding context
+     */
+    ContextView getContextView();
+
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -232,13 +232,13 @@ class SimpleObservation implements Observation {
         private final Observation.Scope previousObservationScope;
 
         @Nullable
-        private final Observation previousParentObservation;
+        private final ObservationView previousParentObservationView;
 
         SimpleScope(ObservationRegistry registry, SimpleObservation current) {
             this.registry = registry;
             this.currentObservation = current;
             this.previousObservationScope = registry.getCurrentObservationScope();
-            this.previousParentObservation = current.context.getParentObservation();
+            this.previousParentObservationView = current.context.getParentObservation();
             if (this.previousObservationScope != null) {
                 current.context.setParentObservation(this.previousObservationScope.getCurrentObservation());
             }
@@ -254,7 +254,7 @@ class SimpleObservation implements Observation {
         public void close() {
             this.registry.setCurrentObservationScope(previousObservationScope);
             this.currentObservation.notifyOnScopeClosed();
-            this.currentObservation.context.setParentObservation(this.previousParentObservation);
+            this.currentObservation.context.setParentObservation(this.previousParentObservationView);
         }
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -145,7 +145,7 @@ class SimpleObservation implements Observation {
     }
 
     @Override
-    public ContextView getContext() {
+    public Context getContext() {
         return this.context;
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -92,7 +92,10 @@ class ObservationTests {
         parent.stop();
         child.stop();
 
-        assertThat(childContext.getParentObservation().getContext()).isSameAs(parentContext);
+        assertThat(child.getContextView()).isSameAs(childContext);
+        assertThat(parent.getContextView()).isSameAs(parentContext);
+
+        assertThat(childContext.getParentObservation().getContextView()).isSameAs(parentContext);
     }
 
     @Test
@@ -105,7 +108,7 @@ class ObservationTests {
         parent.scoped(() -> {
             assertThat(childContext.getParentObservation()).isNull();
             Observation.createNotStarted("child", childContext, registry).observe(() -> {
-                assertThat(childContext.getParentObservation().getContext()).isSameAs(parentContext);
+                assertThat(childContext.getParentObservation().getContextView()).isSameAs(parentContext);
             });
             assertThat(childContext.getParentObservation()).isNull();
         });


### PR DESCRIPTION
This PR changes `Observation#getContext()` to return `Context`. Then, callers can obtain the actual `Context` object from observation and perform any update on it.

To prevent users modify the parent observation context, this PR  introduces `ObservationView` interface. The interface provides a method that returns `ContextView` for the observation.
Then, the `Observation.Context#getParentObservation()` is updated to return `ObservationView` instead of the parent `Observation`.
By the API contract, users cannot modify the parent observation context.

The `getParentObservation()` return type change is a small breaking change on API.
However, modifying the parent observation is a bad practice. Nobody should be doing it and the impact should be minimal.