### PR TITLE
Support message supplier in WarnThenDebugLogger

### DIFF
--- a/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch/src/main/java/io/micrometer/cloudwatch/CloudWatchMeterRegistry.java
@@ -301,7 +301,8 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         private boolean isAcceptableTag(Tag tag) {
             if (StringUtils.isBlank(tag.getValue())) {
-                warnThenDebugLogger.log("Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
+                warnThenDebugLogger
+                        .log(() -> "Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
                 return false;
             }
             return true;

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -295,7 +295,8 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
 
         private boolean isAcceptableTag(Tag tag) {
             if (StringUtils.isBlank(tag.getValue())) {
-                warnThenDebugLogger.log("Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
+                warnThenDebugLogger
+                        .log(() -> "Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
                 return false;
             }
             return true;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceNamingConventionV1.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceNamingConventionV1.java
@@ -64,7 +64,7 @@ public class DynatraceNamingConventionV1 implements NamingConvention {
         }
         String sanitized = NAME_CLEANUP_PATTERN.matcher(name).replaceAll("_");
         if (LEADING_NUMERIC_PATTERN.matcher(sanitized).find()) {
-            logger.log("'" + sanitized + "' (original name: '" + name + "') is not a valid meter name. "
+            logger.log(() -> "'" + sanitized + "' (original name: '" + name + "') is not a valid meter name. "
                     + "Dynatrace doesn't allow leading numeric characters after non-alphabets. "
                     + "Please rename it to conform to the constraints. "
                     + "If it comes from a third party, please use MeterFilter to rename it.");

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -89,7 +89,8 @@ public class SignalFxNamingConvention implements NamingConvention {
             conventionKey = "a" + conventionKey;
         }
         if (PATTERN_TAG_KEY_DENYLISTED_PREFIX.matcher(conventionKey).matches()) {
-            logger.log("'" + conventionKey + "' (original name: '" + key + "') is not a valid tag key. "
+            String finalConventionKey = conventionKey;
+            logger.log(() -> "'" + finalConventionKey + "' (original name: '" + key + "') is not a valid tag key. "
                     + "Must not start with any of these prefixes: aws_, gcp_, or azure_. "
                     + "Please rename it to conform to the constraints. "
                     + "If it comes from a third party, please use MeterFilter to rename it.");

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -182,7 +182,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
                 pollableMeter.getValue().poll();
             }
             catch (RuntimeException e) {
-                warnThenDebugLogger.log("Failed to poll a meter '" + pollableMeter.getKey().getName() + "'.", e);
+                warnThenDebugLogger.log(() -> "Failed to poll a meter '" + pollableMeter.getKey().getName() + "'.", e);
             }
         }
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -227,7 +227,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                     catch (Exception ex) {
                         String message = ex.getMessage();
                         if (message != null && message.contains("Prometheus requires")) {
-                            warnThenDebugLogger.log("Failed to bind meter: " + meterName + " " + tags
+                            warnThenDebugLogger.log(() -> "Failed to bind meter: " + meterName + " " + tags
                                     + ". However, this could happen and might be restored in the next refresh.");
                         }
                         else {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -95,7 +95,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
                     return valueFunction.applyAsDouble(obj2);
                 }
                 catch (Throwable ex) {
-                    logger.log("Failed to apply the value function for the gauge '" + id.getName() + "'.", ex);
+                    logger.log(() -> "Failed to apply the value function for the gauge '" + id.getName() + "'.", ex);
                 }
             }
             return nullGaugeValue();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
@@ -53,7 +53,7 @@ public class DefaultGauge<T> extends AbstractMeter implements Gauge {
                 return value.applyAsDouble(obj);
             }
             catch (Throwable ex) {
-                logger.log("Failed to apply the value function for the gauge '" + getId().getName() + "'.", ex);
+                logger.log(() -> "Failed to apply the value function for the gauge '" + getId().getName() + "'.", ex);
             }
         }
         return Double.NaN;

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/WarnThenDebugLogger.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.util.internal.logging;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 /**
  * {@link InternalLogger} which logs at warn level at first and then logs at debug level
@@ -35,16 +36,19 @@ public class WarnThenDebugLogger {
     }
 
     public void log(String message, Throwable ex) {
-        InternalLogLevel level;
-        String finalMessage;
         if (this.warnLogged.compareAndSet(false, true)) {
-            level = InternalLogLevel.WARN;
-            finalMessage = message + " Note that subsequent logs will be logged at debug level.";
+            log(InternalLogLevel.WARN, getWarnMessage(message), ex);
         }
         else {
-            level = InternalLogLevel.DEBUG;
-            finalMessage = message;
+            log(InternalLogLevel.DEBUG, message, ex);
         }
+    }
+
+    private String getWarnMessage(String message) {
+        return message + " Note that subsequent logs will be logged at debug level.";
+    }
+
+    private void log(InternalLogLevel level, String finalMessage, Throwable ex) {
         if (ex != null) {
             this.logger.log(level, finalMessage, ex);
         }
@@ -55,6 +59,21 @@ public class WarnThenDebugLogger {
 
     public void log(String message) {
         log(message, null);
+    }
+
+    public void log(Supplier<String> messageSupplier, Throwable ex) {
+        if (this.warnLogged.compareAndSet(false, true)) {
+            log(InternalLogLevel.WARN, getWarnMessage(messageSupplier.get()), ex);
+        }
+        else {
+            if (this.logger.isDebugEnabled()) {
+                log(InternalLogLevel.DEBUG, messageSupplier.get(), ex);
+            }
+        }
+    }
+
+    public void log(Supplier<String> messageSupplier) {
+        log(messageSupplier, null);
     }
 
 }


### PR DESCRIPTION
This PR updates `WarnThenDebugLogger` to support message supplier to reduce `String` instance creation when debug level is not enabled.

This PR also updates to use its supplier variants where beneficial.