### PR TITLE
Rename DocumentedObservation to ObservationDocumentation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
@@ -13,73 +13,68 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jersey.server;
+package io.micrometer.core.instrument.binder.httpcomponents;
 
 import io.micrometer.common.docs.KeyName;
-import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
-import io.micrometer.observation.docs.DocumentedObservation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
- * A {@link DocumentedObservation} for Jersey.
- *
- * @author Marcin Grzejszczak
+ * {@link ObservationDocumentation} for Apache HTTP client instrumentation.
  * @since 1.10.0
+ * @see MicrometerHttpRequestExecutor
  */
-@NonNullApi
-public enum JerseyDocumentedObservation implements DocumentedObservation {
+public enum ApacheHttpClientObservationDocumentation implements ObservationDocumentation {
 
-    /**
-     * Default observation for Jersey.
-     */
     DEFAULT {
         @Override
         public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
-            return DefaultJerseyObservationConvention.class;
+            return DefaultApacheHttpClientObservationConvention.class;
         }
 
         @Override
         public KeyName[] getLowCardinalityKeyNames() {
-            return JerseyLegacyLowCardinalityTags.values();
+            return ApacheHttpClientKeyNames.values();
         }
     };
 
-    @NonNullApi
-    enum JerseyLegacyLowCardinalityTags implements KeyName {
+    enum ApacheHttpClientKeyNames implements KeyName {
 
-        OUTCOME {
+        STATUS {
             @Override
             public String asString() {
-                return "outcome";
+                return "status";
             }
         },
-
         METHOD {
             @Override
             public String asString() {
                 return "method";
             }
         },
-
         URI {
             @Override
             public String asString() {
                 return "uri";
             }
         },
-
-        EXCEPTION {
+        TARGET_SCHEME {
             @Override
             public String asString() {
-                return "exception";
+                return "target.scheme";
             }
         },
-
-        STATUS {
+        TARGET_HOST {
             @Override
             public String asString() {
-                return "status";
+                return "target.host";
+            }
+        },
+        TARGET_PORT {
+            @Override
+            public String asString() {
+                return "target.port";
             }
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultApacheHttpClientObservationConvention.java
@@ -27,7 +27,7 @@ import java.io.IOException;
  * Default implementation of {@link ApacheHttpClientObservationConvention}.
  *
  * @since 1.10.0
- * @see ApacheHttpClientDocumentedObservation
+ * @see ApacheHttpClientObservationDocumentation
  */
 public class DefaultApacheHttpClientObservationConvention implements ApacheHttpClientObservationConvention {
 
@@ -54,11 +54,11 @@ public class DefaultApacheHttpClientObservationConvention implements ApacheHttpC
     @Override
     public KeyValues getLowCardinalityKeyValues(ApacheHttpClientContext context) {
         KeyValues keyValues = KeyValues.of(
-                ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.METHOD
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.METHOD
                         .withValue(getMethodString(context.getCarrier())),
-                ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.URI
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.URI
                         .withValue(context.getUriMapper().apply(context.getCarrier())),
-                ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.STATUS
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.STATUS
                         .withValue(getStatusValue(context.getResponse(), context.getError())));
         if (context.shouldExportTagsForRoute()) {
             keyValues = keyValues.and(HttpContextUtils.generateTagStringsForRoute(context.getApacheHttpContext()));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/HttpContextUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/HttpContextUtils.java
@@ -37,9 +37,10 @@ class HttpContextUtils {
             targetHost = host.getHostName();
             targetPort = String.valueOf(host.getPort());
         }
-        return new String[] { ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.TARGET_SCHEME.asString(),
-                targetScheme, ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.TARGET_HOST.asString(),
-                targetHost, ApacheHttpClientDocumentedObservation.ApacheHttpClientKeyNames.TARGET_PORT.asString(),
+        return new String[] {
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_SCHEME.asString(),
+                targetScheme, ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_HOST.asString(),
+                targetHost, ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_PORT.asString(),
                 targetPort };
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyKeyValues.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyKeyValues.java
@@ -29,22 +29,22 @@ import org.glassfish.jersey.server.monitoring.RequestEvent;
  */
 class JerseyKeyValues {
 
-    private static final KeyValue URI_NOT_FOUND = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.URI
+    private static final KeyValue URI_NOT_FOUND = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.URI
             .withValue("NOT_FOUND");
 
-    private static final KeyValue URI_REDIRECTION = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.URI
+    private static final KeyValue URI_REDIRECTION = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.URI
             .withValue("REDIRECTION");
 
-    private static final KeyValue URI_ROOT = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.URI
+    private static final KeyValue URI_ROOT = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.URI
             .withValue("root");
 
-    private static final KeyValue EXCEPTION_NONE = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.EXCEPTION
+    private static final KeyValue EXCEPTION_NONE = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.EXCEPTION
             .withValue("None");
 
-    private static final KeyValue STATUS_SERVER_ERROR = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.STATUS
+    private static final KeyValue STATUS_SERVER_ERROR = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.STATUS
             .withValue("500");
 
-    private static final KeyValue METHOD_UNKNOWN = JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.METHOD
+    private static final KeyValue METHOD_UNKNOWN = JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.METHOD
             .withValue("UNKNOWN");
 
     private JerseyKeyValues() {
@@ -58,7 +58,7 @@ class JerseyKeyValues {
      */
     static KeyValue method(ContainerRequest request) {
         return (request != null)
-                ? JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.METHOD.withValue(request.getMethod())
+                ? JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.METHOD.withValue(request.getMethod())
                 : METHOD_UNKNOWN;
     }
 
@@ -70,7 +70,7 @@ class JerseyKeyValues {
      */
     static KeyValue status(ContainerResponse response) {
         /* In case there is no response we are dealing with an unmapped exception. */
-        return (response != null) ? JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.STATUS
+        return (response != null) ? JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.STATUS
                 .withValue(Integer.toString(response.getStatus())) : STATUS_SERVER_ERROR;
     }
 
@@ -96,7 +96,7 @@ class JerseyKeyValues {
         if (matchingPattern.equals("/")) {
             return URI_ROOT;
         }
-        return JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.URI.withValue(matchingPattern);
+        return JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.URI.withValue(matchingPattern);
     }
 
     /**
@@ -134,10 +134,10 @@ class JerseyKeyValues {
     static KeyValue outcome(ContainerResponse response) {
         if (response != null) {
             Outcome outcome = Outcome.forStatus(response.getStatus());
-            return JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.OUTCOME.withValue(outcome.name());
+            return JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.OUTCOME.withValue(outcome.name());
         }
         /* In case there is no response we are dealing with an unmapped exception. */
-        return JerseyDocumentedObservation.JerseyLegacyLowCardinalityTags.OUTCOME
+        return JerseyObservationDocumentation.JerseyLegacyLowCardinalityTags.OUTCOME
                 .withValue(Outcome.SERVER_ERROR.name());
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyObservationDocumentation.java
@@ -13,36 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jdk;
+package io.micrometer.core.instrument.binder.jersey.server;
 
 import io.micrometer.common.docs.KeyName;
+import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
-import io.micrometer.observation.docs.DocumentedObservation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 
-enum HttpClientDocumentedObservation implements DocumentedObservation {
+/**
+ * A {@link ObservationDocumentation} for Jersey.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.10.0
+ */
+@NonNullApi
+public enum JerseyObservationDocumentation implements ObservationDocumentation {
 
     /**
-     * Observation when an HTTP call is being made.
+     * Default observation for Jersey.
      */
-    HTTP_CALL {
+    DEFAULT {
         @Override
         public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
-            return DefaultHttpClientObservationConvention.class;
+            return DefaultJerseyObservationConvention.class;
         }
 
         @Override
         public KeyName[] getLowCardinalityKeyNames() {
-            return LowCardinalityKeys.values();
+            return JerseyLegacyLowCardinalityTags.values();
         }
-
     };
 
-    enum LowCardinalityKeys implements KeyName {
+    @NonNullApi
+    enum JerseyLegacyLowCardinalityTags implements KeyName {
 
-        /**
-         * HTTP Method.
-         */
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
+
         METHOD {
             @Override
             public String asString() {
@@ -50,23 +62,24 @@ enum HttpClientDocumentedObservation implements DocumentedObservation {
             }
         },
 
-        /**
-         * HTTP Status.
-         */
-        STATUS {
-            @Override
-            public String asString() {
-                return "status";
-            }
-        },
-
-        /**
-         * HTTP URI.
-         */
         URI {
             @Override
             public String asString() {
                 return "uri";
+            }
+        },
+
+        EXCEPTION {
+            @Override
+            public String asString() {
+                return "exception";
+            }
+        },
+
+        STATUS {
+            @Override
+            public String asString() {
+                return "status";
             }
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
@@ -67,7 +67,7 @@ public class ObservationRequestEventListener implements RequestEventListener {
                 }
             case REQUEST_MATCHED:
                 JerseyContext jerseyContext = new JerseyContext(event);
-                Observation observation = JerseyDocumentedObservation.DEFAULT.start(this.jerseyObservationConvention,
+                Observation observation = JerseyObservationDocumentation.DEFAULT.start(this.jerseyObservationConvention,
                         new DefaultJerseyObservationConvention(this.metricName), jerseyContext, this.registry);
                 Observation.Scope scope = observation.openScope();
                 observations.put(event.getContainerRequest(), new ObservationScopeAndContext(scope, jerseyContext));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
@@ -33,7 +33,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.micrometer.core.instrument.binder.okhttp3.OkHttpDocumentedObservation.OkHttpLegacyLowCardinalityTags.*;
+import static io.micrometer.core.instrument.binder.okhttp3.OkHttpObservationDocumentation.OkHttpLegacyLowCardinalityTags.*;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
@@ -19,16 +19,16 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
-import io.micrometer.observation.docs.DocumentedObservation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 
 /**
- * A {@link DocumentedObservation} for OkHttp3 metrics.
+ * A {@link ObservationDocumentation} for OkHttp3 metrics.
  *
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
 @NonNullApi
-public enum OkHttpDocumentedObservation implements DocumentedObservation {
+public enum OkHttpObservationDocumentation implements ObservationDocumentation {
 
     /**
      * Default observation for OK HTTP.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
@@ -86,7 +86,7 @@ public class OkHttpObservationInterceptor implements Interceptor {
                 this.unknownRequestTags, this.includeHostTag, request);
         okHttpContext.setCarrier(newRequestBuilder);
         okHttpContext.setState(new CallState(newRequestBuilder.build()));
-        Observation observation = OkHttpDocumentedObservation.DEFAULT.observation(this.observationConvention,
+        Observation observation = OkHttpObservationDocumentation.DEFAULT.observation(this.observationConvention,
                 new DefaultOkHttpObservationConvention(requestMetricName), okHttpContext, this.registry).start();
         Request newRequest = newRequestBuilder.build();
         OkHttpObservationInterceptor.CallState callState = new CallState(newRequest);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/docs/MeterDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/docs/MeterDocumentation.java
@@ -29,10 +29,10 @@ import io.micrometer.core.instrument.Meter;
  *
  * <ul>
  * <li>Metrics are grouped within an enum - the enum implements the
- * {@link DocumentedMeter} interface</li>
+ * {@link MeterDocumentation} interface</li>
  * <li>If the span contains {@link KeyName} then those need to be declared as nested
  * enums</li>
- * <li>The {@link DocumentedMeter#getKeyNames()} need to call the nested enum's
+ * <li>The {@link MeterDocumentation#getKeyNames()} need to call the nested enum's
  * {@code values()} method to retrieve the array of allowed keys / events</li>
  * <li>Javadocs around enums will be used as description</li>
  * </ul>
@@ -40,7 +40,7 @@ import io.micrometer.core.instrument.Meter;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public interface DocumentedMeter {
+public interface MeterDocumentation {
 
     /**
      * Empty key names.
@@ -84,7 +84,7 @@ public interface DocumentedMeter {
     /**
      * Allowed key names.
      * @return allowed key names - if set will override any key names coming from
-     * {@link DocumentedMeter#overridesDefaultMetricFrom()}
+     * {@link MeterDocumentation#overridesDefaultMetricFrom()}
      */
     default KeyName[] getKeyNames() {
         return EMPTY;
@@ -93,7 +93,7 @@ public interface DocumentedMeter {
     /**
      * Additional key names.
      * @return additional key names - if set will append any key names coming from
-     * {@link DocumentedMeter#overridesDefaultMetricFrom()}
+     * {@link MeterDocumentation#overridesDefaultMetricFrom()}
      */
     default KeyName[] getAdditionalKeyNames() {
         return EMPTY;
@@ -102,8 +102,8 @@ public interface DocumentedMeter {
     /**
      * Override this when custom metric should be documented instead of the default one.
      * Requires the Observation module on the classpath.
-     * @return {@link io.micrometer.observation.docs.DocumentedObservation} for which you
-     * don't want to create a default metric documentation
+     * @return {@link MeterDocumentation} for which you don't want to create a default
+     * metric documentation
      */
     default Enum<?> overridesDefaultMetricFrom() {
         return null;

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -43,11 +43,11 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
         }
         HttpRequest httpRequest = context.getCarrier().build();
         KeyValues keyValues = KeyValues.of(
-                HttpClientDocumentedObservation.LowCardinalityKeys.METHOD.withValue(httpRequest.method()),
-                HttpClientDocumentedObservation.LowCardinalityKeys.URI
+                HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.withValue(httpRequest.method()),
+                HttpClientObservationDocumentation.LowCardinalityKeys.URI
                         .withValue(getUriTag(httpRequest, context.getResponse(), context.getUriMapper())));
         if (context.getResponse() != null) {
-            keyValues = keyValues.and(HttpClientDocumentedObservation.LowCardinalityKeys.STATUS
+            keyValues = keyValues.and(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
                     .withValue(String.valueOf(context.getResponse().statusCode())));
         }
         return keyValues;

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
@@ -13,68 +13,60 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.httpcomponents;
+package io.micrometer.core.instrument.binder.jdk;
 
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
-import io.micrometer.observation.docs.DocumentedObservation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 
-/**
- * {@link DocumentedObservation} for Apache HTTP client instrumentation.
- * @since 1.10.0
- * @see MicrometerHttpRequestExecutor
- */
-public enum ApacheHttpClientDocumentedObservation implements DocumentedObservation {
+enum HttpClientObservationDocumentation implements ObservationDocumentation {
 
-    DEFAULT {
+    /**
+     * Observation when an HTTP call is being made.
+     */
+    HTTP_CALL {
         @Override
         public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
-            return DefaultApacheHttpClientObservationConvention.class;
+            return DefaultHttpClientObservationConvention.class;
         }
 
         @Override
         public KeyName[] getLowCardinalityKeyNames() {
-            return ApacheHttpClientKeyNames.values();
+            return LowCardinalityKeys.values();
         }
+
     };
 
-    enum ApacheHttpClientKeyNames implements KeyName {
+    enum LowCardinalityKeys implements KeyName {
 
-        STATUS {
-            @Override
-            public String asString() {
-                return "status";
-            }
-        },
+        /**
+         * HTTP Method.
+         */
         METHOD {
             @Override
             public String asString() {
                 return "method";
             }
         },
+
+        /**
+         * HTTP Status.
+         */
+        STATUS {
+            @Override
+            public String asString() {
+                return "status";
+            }
+        },
+
+        /**
+         * HTTP URI.
+         */
         URI {
             @Override
             public String asString() {
                 return "uri";
-            }
-        },
-        TARGET_SCHEME {
-            @Override
-            public String asString() {
-                return "target.scheme";
-            }
-        },
-        TARGET_HOST {
-            @Override
-            public String asString() {
-                return "target.host";
-            }
-        },
-        TARGET_PORT {
-            @Override
-            public String asString() {
-                return "target.port";
             }
         }
 

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
@@ -233,11 +233,11 @@ public class MicrometerHttpClient extends HttpClient {
             @Nullable HttpResponse<T> res) {
         instrumentation.stop(DefaultHttpClientObservationConvention.INSTANCE.getName(), "Timer for JDK's HttpClient",
                 () -> {
-                    Tags tags = Tags.of(HttpClientDocumentedObservation.LowCardinalityKeys.METHOD.asString(),
-                            request.method(), HttpClientDocumentedObservation.LowCardinalityKeys.URI.asString(),
+                    Tags tags = Tags.of(HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.asString(),
+                            request.method(), HttpClientObservationDocumentation.LowCardinalityKeys.URI.asString(),
                             DefaultHttpClientObservationConvention.INSTANCE.getUriTag(request, res, uriMapper));
                     if (res != null) {
-                        tags = tags.and(Tag.of(HttpClientDocumentedObservation.LowCardinalityKeys.STATUS.asString(),
+                        tags = tags.and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
                                 String.valueOf(res.statusCode())));
                     }
                     return tags;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -129,7 +129,7 @@ public class ObservedAspect {
     }
 
     private Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
-        Observation observation = ObservedAspectObservation.of(pjp, observed, this.registry,
+        Observation observation = ObservedAspectObservationDocumentation.of(pjp, observed, this.registry,
                 this.observationConvention);
         if (CompletionStage.class.isAssignableFrom(method.getReturnType())) {
             observation.start();

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
@@ -22,20 +22,20 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.annotation.Observed;
 import io.micrometer.observation.ObservationConvention;
-import io.micrometer.observation.docs.DocumentedObservation;
+import io.micrometer.observation.docs.ObservationDocumentation;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
 
-import static io.micrometer.observation.aop.ObservedAspectObservation.ObservedAspectLowCardinalityKeyName.CLASS_NAME;
-import static io.micrometer.observation.aop.ObservedAspectObservation.ObservedAspectLowCardinalityKeyName.METHOD_NAME;
+import static io.micrometer.observation.aop.ObservedAspectObservationDocumentation.ObservedAspectLowCardinalityKeyName.CLASS_NAME;
+import static io.micrometer.observation.aop.ObservedAspectObservationDocumentation.ObservedAspectLowCardinalityKeyName.METHOD_NAME;
 
 /**
- * A {@link DocumentedObservation} for {@link ObservedAspect}.
+ * A {@link ObservationDocumentation} for {@link ObservedAspect}.
  *
  * @author Jonatan Ivanov
  * @since 1.10.0
  */
-enum ObservedAspectObservation implements DocumentedObservation {
+enum ObservedAspectObservationDocumentation implements ObservationDocumentation {
 
     DEFAULT;
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -37,12 +37,12 @@ import java.util.function.Supplier;
  *
  * <ul>
  * <li>Observations are grouped within an enum - the enum implements the
- * {@code DocumentedObservation} interface</li>
+ * {@code ObservationDocumentation} interface</li>
  * <li>If the observation contains {@link KeyName} then those need to be declared as
  * nested enums</li>
- * <li>The {@link DocumentedObservation#getHighCardinalityKeyNames()} need to call the
+ * <li>The {@link ObservationDocumentation#getHighCardinalityKeyNames()} need to call the
  * nested enum's {@code values()} method to retrieve the array of allowed keys</li>
- * <li>The {@link DocumentedObservation#getLowCardinalityKeyNames()} need to call the
+ * <li>The {@link ObservationDocumentation#getLowCardinalityKeyNames()} need to call the
  * nested enum's {@code values()} method to retrieve the array of allowed keys</li>
  * <li>Javadocs around enums will be used as description</li>
  * <li>If you want to merge different {@link KeyName} enum {@code values()} methods you
@@ -52,7 +52,7 @@ import java.util.function.Supplier;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public interface DocumentedObservation {
+public interface ObservationDocumentation {
 
     /**
      * Empty key names.

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
-class DocumentedObservationTests {
+class ObservationDocumentationTests {
 
     @Test
     void iseShouldBeThrownWhenDocumentedObservationHasNotOverriddenDefaultConvention() {
@@ -142,7 +142,7 @@ class DocumentedObservationTests {
         return registry;
     }
 
-    enum TestConventionObservation implements DocumentedObservation {
+    enum TestConventionObservation implements ObservationDocumentation {
 
         NOT_OVERRIDDEN_METHODS {
 


### PR DESCRIPTION
The previous naming implied that it was a type of `Observation` but it is rather the documentation for observations. The goal of this new naming is to make that more clear. It also improves consistency with the naming of most of the methods, though some inconsistency remains, which we can address in a follow-up change.

For the same reasons and consistency, this also renames DocumentedMeter to MeterDocumentation.

This will require an update to instrumentation using `DocumentedObservation`, which should be achievable with a find-and-replace search of the source code.

The micrometer-docs-generator will need to be updated as well.