### PR TITLE
Update OtlpMeterRegistryTest to run builds on Java 19

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -220,10 +220,9 @@ class OtlpMeterRegistryTest {
         clock.add(OtlpConfig.DEFAULT.step());
         size.record(204);
 
-        assertThat(registry.writeHistogramSupport(size).toString()).isEqualTo("name: \"http.request.size\"\n"
-                + "unit: \"bytes\"\n" + "histogram {\n" + "  data_points {\n" + "    start_time_unix_nano: 1000000\n"
-                + "    time_unix_nano: 60001000000\n" + "    count: 4\n" + "    sum: 2552.0\n"
-                + "    bucket_counts: 0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n"
+        String expected = "name: \"http.request.size\"\n" + "unit: \"bytes\"\n" + "histogram {\n" + "  data_points {\n"
+                + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 60001000000\n" + "    count: 4\n"
+                + "    sum: 2552.0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n"
                 + "    bucket_counts: 0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n"
                 + "    bucket_counts: 0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n"
                 + "    bucket_counts: 0\n" + "    bucket_counts: 0\n" + "    bucket_counts: 0\n"
@@ -442,7 +441,33 @@ class OtlpMeterRegistryTest {
                 + "    explicit_bounds: 3.0744573456182584E18\n" + "    explicit_bounds: 3.4587645138205409E18\n"
                 + "    explicit_bounds: 3.8430716820228234E18\n" + "    explicit_bounds: 4.2273788502251054E18\n"
                 + "    explicit_bounds: Infinity\n" + "  }\n"
-                + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
+                + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n";
+        String[] expectedLines = expected.split("\n");
+        String actual = registry.writeHistogramSupport(size).toString();
+        String[] actualLines = actual.split("\n");
+        assertThat(actualLines).hasSameSizeAs(expectedLines);
+        for (int i = 0; i < actualLines.length; i++) {
+            String actualLine = actualLines[i];
+            String expectedLine = expectedLines[i];
+
+            // Comparing with double values, not with their String representation is
+            // required since Java 19 as it has changed String representation for double
+            // slightly.
+            // See "Double.toString(double) and Float.toString(float) may Return Slightly
+            // Different Results" item in https://jdk.java.net/19/release-notes
+            if (actualLine.contains("explicit_bounds") && !actualLine.contains("Infinity")) {
+                double actualValue = extractValue(actualLine);
+                double expectedValue = extractValue(expectedLine);
+                assertThat(actualValue).isEqualTo(expectedValue);
+            }
+            else {
+                assertThat(actualLine).isEqualTo(expectedLine);
+            }
+        }
+    }
+
+    private double extractValue(String line) {
+        return Double.parseDouble(line.substring(line.lastIndexOf(' ')));
     }
 
     @Test


### PR DESCRIPTION
The following tests are failing:

- `ofEmptyDoesNotAllocate()` and `andEmptyDoesNotAllocate()` in `TagsTest` are failing as their allocated bytes have been changed from 0 to 16 somehow. I'm not sure what makes the difference, so it might be better to investigate further with a dedicated issue if possible.
- `OtlpMeterRegistryTest.distributionSummaryWithHistogramBuckets()` is failing as String representation for `double` has been changed slightly. See "Double.toString(double) and Float.toString(float) may Return Slightly Different Results" item in https://jdk.java.net/19/release-notes

For the first two tests, I just split the tests into two, one for prior versions and the other for 19+.

For the second test, I changed it to compare with `double` values, not with their `String` representation.