### PR TITLE
Take Supplier<Context> instead of Context

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
@@ -68,7 +68,7 @@ public class ObservationRequestEventListener implements RequestEventListener {
             case REQUEST_MATCHED:
                 JerseyContext jerseyContext = new JerseyContext(event);
                 Observation observation = JerseyObservationDocumentation.DEFAULT.start(this.jerseyObservationConvention,
-                        new DefaultJerseyObservationConvention(this.metricName), jerseyContext, this.registry);
+                        new DefaultJerseyObservationConvention(this.metricName), () -> jerseyContext, this.registry);
                 Observation.Scope scope = observation.openScope();
                 observations.put(event.getContainerRequest(), new ObservationScopeAndContext(scope, jerseyContext));
                 break;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpContext.java
@@ -24,6 +24,7 @@ import okhttp3.Response;
 
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * A {@link SenderContext} for OkHttp3.
@@ -31,7 +32,9 @@ import java.util.function.Function;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Response> {
+@SuppressWarnings("jol")
+public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Response>
+        implements Supplier<OkHttpContext> {
 
     private final Function<Request, String> urlMapper;
 
@@ -93,6 +96,11 @@ public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Re
 
     public Request getOriginalRequest() {
         return originalRequest;
+    }
+
+    @Override
+    public OkHttpContext get() {
+        return this;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -97,13 +97,14 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
         this.defaultConvention = defaultConvention;
     }
 
+    @SuppressWarnings("unchecked")
     private void start(Supplier<T> contextSupplier) {
         if (observationRegistry.isNoop()) {
             timerSample = Timer.start(meterRegistry);
         }
         else {
-            context = contextSupplier.get();
-            observation = Observation.start(convention, defaultConvention, context, observationRegistry);
+            observation = Observation.start(convention, defaultConvention, contextSupplier, observationRegistry);
+            context = (T) observation.getContext();
         }
     }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
@@ -758,7 +758,7 @@ public abstract class ObservationRegistryCompatibilityKit {
         TestContext testContext = new TestContext();
         testContext.put("context.field", "42");
         Exception exception = new IOException("simulated");
-        Observation observation = Observation.createNotStarted("test.observation", testContext, registry)
+        Observation observation = Observation.createNotStarted("test.observation", () -> testContext, registry)
                 .lowCardinalityKeyValue("lcTag1", "0")
                 // should override the previous line
                 .lowCardinalityKeyValue("lcTag1", "1").lowCardinalityKeyValues(KeyValues.of("lcTag2", "2"))
@@ -809,7 +809,7 @@ public abstract class ObservationRegistryCompatibilityKit {
                 .observationHandler(assertingHandler);
 
         TestContext testContext = new TestContext();
-        Observation observation = Observation.createNotStarted("test.observation", testContext, registry)
+        Observation observation = Observation.createNotStarted("test.observation", () -> testContext, registry)
                 .contextualName("test.observation.42").start();
         observation.stop();
 
@@ -829,7 +829,7 @@ public abstract class ObservationRegistryCompatibilityKit {
         registry.observationConfig().observationHandler(assertingHandler);
 
         TestContext testContext = new TestContext();
-        Observation observation = Observation.createNotStarted("test.observation", testContext, registry)
+        Observation observation = Observation.createNotStarted("test.observation", () -> testContext, registry)
                 .contextualName("test.observation.42")
                 .observationConvention(new TestObservationConventionWithNameOverrides()).start();
         observation.stop();

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -20,6 +20,8 @@ import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
+
 import static io.micrometer.observation.tck.ObservationContextAssert.assertThat;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
@@ -30,13 +32,22 @@ class ObservationContextAssertTests {
 
     ObservationRegistry registry;
 
-    Observation.Context context;
+    TestContext context;
+
+    static class TestContext extends Observation.Context implements Supplier<TestContext> {
+
+        @Override
+        public TestContext get() {
+            return this;
+        }
+
+    }
 
     @BeforeEach
     void beforeEach() {
         registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(c -> true);
-        context = new Observation.Context();
+        context = new TestContext();
     }
 
     @Test

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -134,14 +134,17 @@ public interface Observation extends ObservationView {
             return Observation.NOOP;
         }
         ObservationConvention<T> convention;
+        T context = contextSupplier.get();
         if (customConvention != null) {
             convention = customConvention;
         }
         else {
-            convention = registry.observationConfig().getObservationConvention(contextSupplier.get(),
-                    defaultConvention);
+            convention = registry.observationConfig().getObservationConvention(context, defaultConvention);
         }
-        return Observation.createNotStarted(convention, contextSupplier, registry);
+        if (!registry.observationConfig().isObservationEnabled(convention.getName(), context)) {
+            return NOOP;
+        }
+        return new SimpleObservation(convention, registry, context == null ? new Context() : context);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -63,8 +63,15 @@ public interface Observation extends ObservationView {
     }
 
     /**
-     * Creates and starts an {@link Observation}. When no registry is passed or
-     * observation is not applicable will return a no-op observation.
+     * Creates and starts an {@link Observation}. When the {@link ObservationRegistry} is
+     * null or the no-op registry, this fast returns a no-op {@link Observation} and skips
+     * the creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned.
      * @param name name of the observation
      * @param contextSupplier mutable context supplier
      * @param registry observation registry
@@ -90,9 +97,16 @@ public interface Observation extends ObservationView {
 
     /**
      * Creates but <b>does not start</b> an {@link Observation}. Remember to call
-     * {@link Observation#start()} when you want the measurements to start. When no
-     * registry is passed or observation is not applicable will return a no-op
-     * observation.
+     * {@link Observation#start()} when you want the measurements to start. When the
+     * {@link ObservationRegistry} is null or the no-op registry, this fast returns a
+     * no-op {@link Observation} and skips the creation of the
+     * {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned.
      * @param name name of the observation
      * @param contextSupplier supplier for mutable context
      * @param registry observation registry
@@ -112,9 +126,16 @@ public interface Observation extends ObservationView {
 
     /**
      * Creates but <b>does not start</b> an {@link Observation}. Remember to call
-     * {@link Observation#start()} when you want the measurements to start. When no
-     * registry is passed or observation is not applicable will return a no-op
-     * observation. Allows to set a custom {@link ObservationConvention} and requires to
+     * {@link Observation#start()} when you want the measurements to start. When the
+     * {@link ObservationRegistry} is null or the no-op registry, this fast returns a
+     * no-op {@link Observation} and skips the creation of the
+     * {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned. Allows to set a custom {@link ObservationConvention} and requires to
      * provide a default one if neither a custom nor a pre-configured one (via
      * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
      * was found. The {@link ObservationConvention} implementation can override
@@ -160,8 +181,15 @@ public interface Observation extends ObservationView {
     }
 
     /**
-     * Creates and starts an {@link Observation}. When no registry is passed or
-     * observation is not applicable will return a no-op observation.
+     * Creates and starts an {@link Observation}. When the {@link ObservationRegistry} is
+     * null or the no-op registry, this fast returns a no-op {@link Observation} and skips
+     * the creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned.
      * @param <T> type of context
      * @param observationConvention observation convention
      * @param contextSupplier mutable context
@@ -174,10 +202,16 @@ public interface Observation extends ObservationView {
     }
 
     /**
-     * Creates and starts an {@link Observation}. When no registry is passed or
-     * observation is not applicable will return a no-op observation. Allows to set a
-     * custom {@link ObservationConvention} and requires to provide a default one if
-     * neither a custom nor a pre-configured one (via
+     * Creates and starts an {@link Observation}. When the {@link ObservationRegistry} is
+     * null or the no-op registry, this fast returns a no-op {@link Observation} and skips
+     * the creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned. Allows to set a custom {@link ObservationConvention} and requires to
+     * provide a default one if neither a custom nor a pre-configured one (via
      * {@link ObservationRegistry.ObservationConfig#getObservationConvention(Context, ObservationConvention)})
      * was found.
      * @param <T> type of context
@@ -210,9 +244,15 @@ public interface Observation extends ObservationView {
 
     /**
      * Creates but <b>does not start</b> an {@link Observation}. Remember to call
-     * {@link Observation#start()} when you want the measurements to start. When no
-     * registry is passed or observation is not applicable will return a no-op
-     * observation.
+     * {@link Observation#start()} when you want the measurements to start. When the
+     * {@link ObservationRegistry} is null or the no-op registry, this fast returns a
+     * no-op {@link Observation} and skips the creation of the
+     * {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled(see
+     * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
+     * ObservationConfig#observationPredicate}), a no-op observation will also be
+     * returned.
      * <p>
      * <b>Important!</b> If you're using the
      * {@link ObservationConvention#getContextualName(Context)} method to override the

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -154,9 +154,9 @@ public interface Observation extends ObservationView {
      * @param registry observation registry
      * @return started observation
      */
-    static Observation start(ObservationConvention<? extends Context> observationConvention,
+    static Observation start(ObservationConvention<Context> observationConvention,
             @Nullable ObservationRegistry registry) {
-        return start(observationConvention, () -> null, registry);
+        return start(observationConvention, Context::new, registry);
     }
 
     /**
@@ -203,9 +203,9 @@ public interface Observation extends ObservationView {
      * @param registry observation registry
      * @return created but not started observation
      */
-    static Observation createNotStarted(ObservationConvention<? extends Context> observationConvention,
+    static Observation createNotStarted(ObservationConvention<Context> observationConvention,
             @Nullable ObservationRegistry registry) {
-        return createNotStarted(observationConvention, () -> null, registry);
+        return createNotStarted(observationConvention, Context::new, registry);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -59,7 +59,7 @@ public interface Observation extends ObservationView {
      * @return started observation
      */
     static Observation start(String name, ObservationRegistry registry) {
-        return start(name, () -> null, registry);
+        return start(name, Context::new, registry);
     }
 
     /**
@@ -85,7 +85,7 @@ public interface Observation extends ObservationView {
      * @return created but not started observation
      */
     static Observation createNotStarted(String name, @Nullable ObservationRegistry registry) {
-        return createNotStarted(name, () -> null, registry);
+        return createNotStarted(name, Context::new, registry);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -66,7 +66,7 @@ public interface Observation extends ObservationView {
      * Creates and starts an {@link Observation}. When no registry is passed or
      * observation is not applicable will return a no-op observation.
      * @param name name of the observation
-     * @param contextSupplier mutable context
+     * @param contextSupplier mutable context supplier
      * @param registry observation registry
      * @return started observation
      */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
@@ -47,7 +47,7 @@ enum ObservedAspectObservationDocumentation implements ObservationDocumentation 
                 ? signature.getDeclaringType().getSimpleName() + "#" + signature.getName() : observed.contextualName();
 
         Observation observation = Observation
-                .createNotStarted(name, new ObservedAspect.ObservedAspectContext(pjp), registry)
+                .createNotStarted(name, () -> new ObservedAspect.ObservedAspectContext(pjp), registry)
                 .contextualName(contextualName)
                 .lowCardinalityKeyValue(CLASS_NAME.asString(), signature.getDeclaringTypeName())
                 .lowCardinalityKeyValue(METHOD_NAME.asString(), signature.getName())

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -16,10 +16,8 @@
 package io.micrometer.observation.docs;
 
 import io.micrometer.common.docs.KeyName;
-import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
-import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.ObservationConvention;
@@ -143,7 +141,7 @@ public interface ObservationDocumentation {
      * @param context observation context
      * @return observation
      */
-    default Observation observation(ObservationRegistry registry, @Nullable Observation.Context context) {
+    default Observation observation(ObservationRegistry registry, @Nullable Supplier<Observation.Context> context) {
         Observation observation = Observation.createNotStarted(getName(), context, registry);
         if (getContextualName() != null) {
             observation.contextualName(getContextualName());
@@ -159,13 +157,12 @@ public interface ObservationDocumentation {
      * @param defaultConvention default convention that will be picked if there was
      * neither custom convention nor a pre-configured one via
      * {@link ObservationRegistry.ObservationConfig#observationConvention(GlobalObservationConvention)}
-     * @param context observation context
+     * @param contextSupplier observation context
      * @param registry observation registry
      * @return observation
      */
     default <T extends Observation.Context> Observation observation(@Nullable ObservationConvention<T> customConvention,
-            @NonNull ObservationConvention<T> defaultConvention, @NonNull T context,
-            @NonNull ObservationRegistry registry) {
+            ObservationConvention<T> defaultConvention, Supplier<T> contextSupplier, ObservationRegistry registry) {
         if (getDefaultConvention() == null) {
             throw new IllegalStateException("You've decided to use convention based naming yet this observation ["
                     + getClass() + "] has not defined any default convention");
@@ -179,40 +176,15 @@ public interface ObservationDocumentation {
                     + "] defined default convention to be of type [" + getDefaultConvention()
                     + "] but you have provided an incompatible one of type [" + defaultConvention.getClass() + "]");
         }
-        Observation observation = Observation.createNotStarted(customConvention, defaultConvention, context, registry);
+        Observation observation = Observation.createNotStarted(customConvention, defaultConvention, contextSupplier,
+                registry);
         if (getName() != null) {
-            context.setName(getName());
+            observation.getContext().setName(getName());
         }
         if (getContextualName() != null) {
             observation.contextualName(getContextualName());
         }
         return observation;
-    }
-
-    /**
-     * Creates an {@link Observation} for the given {@link ObservationConvention}. You
-     * need to manually start it. When the {@link ObservationRegistry} is a no-op, this
-     * method fast returns a no-op {@link Observation} and skips the creation of the
-     * {@link Observation.Context}. This quick check avoids unnecessary
-     * {@link Observation.Context} creations. More detailed check, such as
-     * {@link ObservationPredicate}, is performed at the later stage after
-     * {@link Observation.Context} creation.
-     * @param customConvention convention that (if not {@code null}) will override any
-     * pre-configured conventions
-     * @param defaultConvention default convention that will be picked if there was
-     * neither custom convention nor a pre-configured one via
-     * {@link ObservationRegistry.ObservationConfig#observationConvention(GlobalObservationConvention)}
-     * @param contextSupplier observation context supplier
-     * @param registry observation registry
-     * @return observation
-     */
-    default <T extends Observation.Context> Observation observation(@Nullable ObservationConvention<T> customConvention,
-            @NonNull ObservationConvention<T> defaultConvention, @NonNull Supplier<T> contextSupplier,
-            @NonNull ObservationRegistry registry) {
-        if (registry.isNoop()) {
-            return Observation.NOOP;
-        }
-        return observation(customConvention, defaultConvention, contextSupplier.get(), registry);
     }
 
     /**
@@ -227,11 +199,11 @@ public interface ObservationDocumentation {
     /**
      * Creates and starts an {@link Observation}.
      * @param registry observation registry
-     * @param context observation context
+     * @param contextSupplier observation context
      * @return observation
      */
-    default Observation start(ObservationRegistry registry, @Nullable Observation.Context context) {
-        return observation(registry, context).start();
+    default Observation start(ObservationRegistry registry, Supplier<Observation.Context> contextSupplier) {
+        return observation(registry, contextSupplier).start();
     }
 
     /**
@@ -241,14 +213,13 @@ public interface ObservationDocumentation {
      * @param defaultConvention default convention that will be picked if there was
      * neither custom convention nor a pre-configured one via
      * {@link ObservationRegistry.ObservationConfig#observationConvention(GlobalObservationConvention)}
-     * @param context observation context
+     * @param contextSupplier observation context
      * @param registry observation registry
      * @return observation
      */
     default <T extends Observation.Context> Observation start(@Nullable ObservationConvention<T> customConvention,
-            @NonNull ObservationConvention<T> defaultConvention, @NonNull T context,
-            @NonNull ObservationRegistry registry) {
-        return observation(customConvention, defaultConvention, context, registry).start();
+            ObservationConvention<T> defaultConvention, Supplier<T> contextSupplier, ObservationRegistry registry) {
+        return observation(customConvention, defaultConvention, contextSupplier, registry).start();
     }
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -17,10 +17,7 @@ package io.micrometer.observation.docs;
 
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.common.lang.Nullable;
-import io.micrometer.observation.Observation;
-import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.observation.GlobalObservationConvention;
-import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.*;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -136,7 +133,13 @@ public interface ObservationDocumentation {
     }
 
     /**
-     * Creates an {@link Observation}. You need to manually start it.
+     * Creates an {@link Observation}. You need to manually start it. When the
+     * {@link ObservationRegistry} is null or the no-op registry, this fast returns a
+     * no-op {@link Observation} and skips the creation of the
+     * {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled by
+     * an {@link ObservationPredicate}, a no-op observation will also be returned.
      * @param registry observation registry
      * @param contextSupplier observation context supplier
      * @return observation
@@ -151,7 +154,12 @@ public interface ObservationDocumentation {
 
     /**
      * Creates an {@link Observation} for the given {@link ObservationConvention}. You
-     * need to manually start it.
+     * need to manually start it. When the {@link ObservationRegistry} is null or the
+     * no-op registry, this fast returns a no-op {@link Observation} and skips the
+     * creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled by
+     * an {@link ObservationPredicate}, a no-op observation will also be returned.
      * @param customConvention convention that (if not {@code null}) will override any
      * pre-configured conventions
      * @param defaultConvention default convention that will be picked if there was
@@ -197,7 +205,12 @@ public interface ObservationDocumentation {
     }
 
     /**
-     * Creates and starts an {@link Observation}.
+     * Creates and starts an {@link Observation}. When the {@link ObservationRegistry} is
+     * null or the no-op registry, this fast returns a no-op {@link Observation} and skips
+     * the creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled by
+     * an {@link ObservationPredicate}, a no-op observation will also be returned.
      * @param registry observation registry
      * @param contextSupplier observation context supplier
      * @return observation
@@ -207,7 +220,12 @@ public interface ObservationDocumentation {
     }
 
     /**
-     * Creates and starts an {@link Observation}.
+     * Creates and starts an {@link Observation}. When the {@link ObservationRegistry} is
+     * null or the no-op registry, this fast returns a no-op {@link Observation} and skips
+     * the creation of the {@link Observation.Context}. This check avoids unnecessary
+     * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
+     * the context rather than the context directly. If the observation is not enabled by
+     * an {@link ObservationPredicate}, a no-op observation will also be returned.
      * @param customConvention convention that (if not {@code null}) will override any
      * pre-configured conventions
      * @param defaultConvention default convention that will be picked if there was

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -132,7 +132,7 @@ public interface ObservationDocumentation {
      * @return observation
      */
     default Observation observation(ObservationRegistry registry) {
-        return observation(registry, null);
+        return observation(registry, Observation.Context::new);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -138,11 +138,11 @@ public interface ObservationDocumentation {
     /**
      * Creates an {@link Observation}. You need to manually start it.
      * @param registry observation registry
-     * @param context observation context
+     * @param contextSupplier observation context supplier
      * @return observation
      */
-    default Observation observation(ObservationRegistry registry, @Nullable Supplier<Observation.Context> context) {
-        Observation observation = Observation.createNotStarted(getName(), context, registry);
+    default Observation observation(ObservationRegistry registry, Supplier<Observation.Context> contextSupplier) {
+        Observation observation = Observation.createNotStarted(getName(), contextSupplier, registry);
         if (getContextualName() != null) {
             observation.contextualName(getContextualName());
         }
@@ -193,13 +193,13 @@ public interface ObservationDocumentation {
      * @return observation
      */
     default Observation start(ObservationRegistry registry) {
-        return start(registry, null);
+        return start(registry, Observation.Context::new);
     }
 
     /**
      * Creates and starts an {@link Observation}.
      * @param registry observation registry
-     * @param contextSupplier observation context
+     * @param contextSupplier observation context supplier
      * @return observation
      */
     default Observation start(ObservationRegistry registry, Supplier<Observation.Context> contextSupplier) {
@@ -213,7 +213,7 @@ public interface ObservationDocumentation {
      * @param defaultConvention default convention that will be picked if there was
      * neither custom convention nor a pre-configured one via
      * {@link ObservationRegistry.ObservationConfig#observationConvention(GlobalObservationConvention)}
-     * @param contextSupplier observation context
+     * @param contextSupplier observation context supplier
      * @param registry observation registry
      * @return observation
      */

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -73,9 +73,9 @@ class ObservationRegistryTest {
     @Test
     void observationShouldBeNoopWhenNullRegistry() {
         assertThat(Observation.start("test.timer", null)).isSameAs(NOOP);
-        assertThat(Observation.start("test.timer", new Observation.Context(), null)).isSameAs(NOOP);
+        assertThat(Observation.start("test.timer", Observation.Context::new, null)).isSameAs(NOOP);
         assertThat(Observation.createNotStarted("test.timer", null)).isSameAs(NOOP);
-        assertThat(Observation.createNotStarted("test.timer", new Observation.Context(), null)).isSameAs(NOOP);
+        assertThat(Observation.createNotStarted("test.timer", Observation.Context::new, null)).isSameAs(NOOP);
     }
 
     @Test
@@ -83,10 +83,10 @@ class ObservationRegistryTest {
         ObservationRegistry registry = ObservationRegistry.create();
         registry.observationConfig().observationHandler(c -> true);
         assertThat(Observation.start("test.timer", registry)).isInstanceOf(SimpleObservation.class);
-        assertThat(Observation.start("test.timer", new Observation.Context(), registry))
+        assertThat(Observation.start("test.timer", Observation.Context::new, registry))
                 .isInstanceOf(SimpleObservation.class);
         assertThat(Observation.createNotStarted("test.timer", registry)).isInstanceOf(SimpleObservation.class);
-        assertThat(Observation.createNotStarted("test.timer", new Observation.Context(), registry))
+        assertThat(Observation.createNotStarted("test.timer", Observation.Context::new, registry))
                 .isInstanceOf(SimpleObservation.class);
     }
 
@@ -104,7 +104,7 @@ class ObservationRegistryTest {
         MessagingObservationConvention messagingObservationConvention = new MessagingObservationConvention(
                 messagingConvention);
 
-        Observation.createNotStarted("observation", myContext, registry)
+        Observation.createNotStarted("observation", () -> myContext, registry)
                 .observationConvention(messagingObservationConvention).start().stop();
 
         then(myContext.getLowCardinalityKeyValues().stream().filter(keyValue -> keyValue.getKey().equals("baz"))

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -73,7 +73,7 @@ class ObservationTests {
         registry.observationConfig().observationFilter(context -> context.put("foo", "bar"));
         Observation.Context context = new Observation.Context();
 
-        Observation.start("foo", context, registry).stop();
+        Observation.start("foo", () -> context, registry).stop();
 
         assertThat((String) context.get("foo")).isEqualTo("bar");
     }
@@ -83,11 +83,11 @@ class ObservationTests {
         registry.observationConfig().observationHandler(context -> true);
 
         Observation.Context parentContext = new Observation.Context();
-        Observation parent = Observation.start("parent", parentContext, registry);
+        Observation parent = Observation.start("parent", () -> parentContext, registry);
 
         Observation.Context childContext = new Observation.Context();
-        Observation child = Observation.createNotStarted("child", childContext, registry).parentObservation(parent)
-                .start();
+        Observation child = Observation.createNotStarted("child", () -> childContext, registry)
+                .parentObservation(parent).start();
 
         parent.stop();
         child.stop();
@@ -103,11 +103,11 @@ class ObservationTests {
         registry.observationConfig().observationHandler(context -> true);
 
         Observation.Context parentContext = new Observation.Context();
-        Observation parent = Observation.start("parent", parentContext, registry);
+        Observation parent = Observation.start("parent", () -> parentContext, registry);
         Observation.Context childContext = new Observation.Context();
         parent.scoped(() -> {
             assertThat(childContext.getParentObservation()).isNull();
-            Observation.createNotStarted("child", childContext, registry).observe(() -> {
+            Observation.createNotStarted("child", () -> childContext, registry).observe(() -> {
                 assertThat(childContext.getParentObservation().getContextView()).isSameAs(parentContext);
             });
             assertThat(childContext.getParentObservation()).isNull();

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
@@ -40,7 +40,7 @@ class ObservationDocumentationTests {
         ObservationRegistry registry = observationRegistry();
 
         thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(null, null,
-                new Observation.Context(), registry)).isInstanceOf(IllegalStateException.class)
+                Observation.Context::new, registry)).isInstanceOf(IllegalStateException.class)
                         .hasMessageContaining("You've decided to use convention based naming yet this observation");
     }
 
@@ -49,7 +49,7 @@ class ObservationDocumentationTests {
         ObservationRegistry registry = observationRegistry();
 
         thenThrownBy(
-                () -> TestConventionObservation.OVERRIDDEN.observation(null, null, new Observation.Context(), registry))
+                () -> TestConventionObservation.OVERRIDDEN.observation(null, null, Observation.Context::new, registry))
                         .isInstanceOf(NullPointerException.class).hasMessageContaining(
                                 "You have not provided a default convention in the Observation factory method");
     }
@@ -59,7 +59,7 @@ class ObservationDocumentationTests {
         ObservationRegistry registry = observationRegistry();
 
         thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(null, new SecondObservationConvention(),
-                new Observation.Context(), registry)).isInstanceOf(IllegalArgumentException.class)
+                Observation.Context::new, registry)).isInstanceOf(IllegalArgumentException.class)
                         .hasMessageContaining("but you have provided an incompatible one of type");
     }
 
@@ -68,8 +68,8 @@ class ObservationDocumentationTests {
         ObservationRegistry registry = observationRegistry();
         Observation.Context context = new Observation.Context();
 
-        TestConventionObservation.OVERRIDDEN.observation(null, new ThirdObservationConvention(), context, registry)
-                .start().stop();
+        TestConventionObservation.OVERRIDDEN
+                .observation(null, new ThirdObservationConvention(), () -> context, registry).start().stop();
 
         then(context.getName()).isEqualTo("three");
         then(context.getContextualName()).isEqualTo("contextual");
@@ -83,7 +83,7 @@ class ObservationDocumentationTests {
         Observation.Context context = new Observation.Context();
 
         TestConventionObservation.CONTEXTUAL_NAME
-                .observation(null, new ContextualObservationConvention(), context, registry).start().stop();
+                .observation(null, new ContextualObservationConvention(), () -> context, registry).start().stop();
 
         then(context.getName()).isEqualTo("technical name");
         then(context.getContextualName()).isEqualTo("contextual name");
@@ -95,8 +95,8 @@ class ObservationDocumentationTests {
         registry.observationConfig().observationConvention(new GlobalConvention());
         Observation.Context context = new Observation.Context();
 
-        TestConventionObservation.CONTEXTUAL_NAME.observation(null, new FirstObservationConvention(), context, registry)
-                .start().stop();
+        TestConventionObservation.CONTEXTUAL_NAME
+                .observation(null, new FirstObservationConvention(), () -> context, registry).start().stop();
 
         then(context.getName()).isEqualTo("global name");
         then(context.getContextualName()).isEqualTo("global contextual name");
@@ -111,8 +111,8 @@ class ObservationDocumentationTests {
         registry.observationConfig().observationFilter(new KeyValueAddingObservationFilter());
         Observation.Context context = new Observation.Context();
 
-        TestConventionObservation.CONTEXTUAL_NAME.observation(null, new FirstObservationConvention(), context, registry)
-                .start().stop();
+        TestConventionObservation.CONTEXTUAL_NAME
+                .observation(null, new FirstObservationConvention(), () -> context, registry).start().stop();
 
         then(context.getName()).isEqualTo("global name");
         then(context.getContextualName()).isEqualTo("global contextual name");

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -42,7 +42,7 @@ public class ObservationHandlerSample {
                 .observationPredicate(new IgnoringObservationPredicate());
 
         Observation observation = Observation
-                .createNotStarted("sample.operation", new CustomContext(), observationRegistry)
+                .createNotStarted("sample.operation", CustomContext::new, observationRegistry)
                 .contextualName("CALL sampleOperation").lowCardinalityKeyValue("a", "1")
                 .highCardinalityKeyValue("time", Instant.now().toString())
                 .observationConvention(new CustomLocalObservationConvention()).start();
@@ -60,8 +60,8 @@ public class ObservationHandlerSample {
         observation.stop();
 
         Observation.start("sample.no-context", observationRegistry).stop();
-        Observation.start("sample.unsupported", new UnsupportedContext(), observationRegistry).stop();
-        Observation.start("sample.ignored", new CustomContext(), observationRegistry).stop();
+        Observation.start("sample.unsupported", UnsupportedContext::new, observationRegistry).stop();
+        Observation.start("sample.ignored", CustomContext::new, observationRegistry).stop();
 
         System.out.println("--- Meters:");
         System.out.println(registry.getMetersAsString());


### PR DESCRIPTION
This allows avoiding instantiation of a Context object in the case that the ObservationRegistry is a no-op. This does not overload the methods by having a variant that takes a Context and one that takes a Supplier because this becomes ambiguous for the compiler in some cases (reported to us when we added one such method to `ObservationDocumentation` previously). A lambda can be used in cases where you have a Context object to pass. Alternatively, you can implement Supplier in your custom Context class to avoid needing a lambda.

### Migration guide

Anywhere you were passing a `Context` object to an `Observation` factory method (static methods on `Observation` and instance methods on `ObservationDocumentation`), the parameter type has been changed to `Supplier<Context>` to allow for lazy instantiation of the context. There are a few options available on how to migrate your code.

#### Lambda

Using a lambda is one way to adapt code to the new API. Before where you may have had code like the following:

```java
JerseyContext jerseyContext = new JerseyContext(event);
Observation observation = JerseyObservationDocumentation.DEFAULT.start(this.jerseyObservationConvention,
                        new DefaultJerseyObservationConvention(this.metricName), jerseyContext, this.registry);
```

It can be updated to:

```java
JerseyContext jerseyContext = new JerseyContext(event);
Observation observation = JerseyObservationDocumentation.DEFAULT.start(this.jerseyObservationConvention,
                        new DefaultJerseyObservationConvention(this.metricName), () -> jerseyContext, this.registry);
```

#### Method reference

If you do not need to pass arguments to the context, you can use a method reference to the constructor.

```java
Observation.start("my.observation", Context::new, observationRegistry)
```

#### Make your context a supplier

Another alternative if you are using a custom context is to make it implement `Supplier` and then you can pass the context object as you were before. For example, an `OkHttpContext` class could be updated to the following.

```java
public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Response>
        implements Supplier<OkHttpContext> {
    // ...
    @Override
    public OkHttpContext get() {
        return this;
    }
```

And then used the same as before, such as:

```java
Observation observation = OkHttpObservationDocumentation.DEFAULT.observation(this.observationConvention,
        new DefaultOkHttpObservationConvention(requestMetricName), okHttpContext, this.registry).start();
```