### PR TITLE
Exclude buildscript-gradle.lockfile in deleteLockFiles task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -413,7 +413,7 @@ nexusPublishing {
 }
 
 task deleteLockFiles(type: Delete) {
-    delete fileTree(dir: '.', include: '**/*.lockfile')
+    delete fileTree(dir: '.', include: '**/gradle.lockfile')
 }
 
 wrapper {


### PR DESCRIPTION
`buildscript-gradle.lockfile` has been regenerated in a043689b00c9e36981996effef9e92b8ff48983a, but if the `deleteLockFiles` task is run in the next release, the file will be removed again.

This PR excludes the `buildscript-gradle.lockfile` in the `deleteLockFiles` task by limiting it to `gradle.lockfile` files.