### PR TITLE
StatsdMeterRegistryPublishTest fails randomly.

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -63,7 +63,7 @@ class StatsdMeterRegistryPublishTest {
 
     DisposableChannel server;
 
-    CountDownLatch serverLatch;
+    volatile CountDownLatch serverLatch;
 
     AtomicInteger serverMetricReadCount = new AtomicInteger();
 


### PR DESCRIPTION
There is serverLatch variable that is initialized multiple times during the test and is used concurrently from multiple threads. This requires some form of synchronization (to guarantee 'happens-before' property between modification/observation code). At least serverLatch should be made volatile. Otherwise countdown() maight be called on the wrong instance..