### PR TITLE
Publish relative to PushMeterRegistry initialization time and align StepMeter boundaries to that

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -104,7 +104,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected void publish() {
-        final long timestamp = clock.wallTime();
+        final long timestamp = (clock.wallTime() / config.step().toMillis()) * config.step().toMillis();
 
         AggregateMetricSender metricSender = new AggregateMetricSender(this.config.source(),
                 this.dataPointReceiverFactory, this.eventReceiverFactory,

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -104,7 +104,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
 
     @Override
     protected void publish() {
-        final long timestamp = (clock.wallTime() / config.step().toMillis()) * config.step().toMillis();
+        final long timestamp = clock.wallTime();
 
         AggregateMetricSender metricSender = new AggregateMetricSender(this.config.source(),
                 this.dataPointReceiverFactory, this.eventReceiverFactory,

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxMeterRegistryTest.java
@@ -441,11 +441,10 @@ class SignalFxMeterRegistryTest {
     void shouldNotExportCumulativeHistogramDataByDefault_Timer() {
         MockClock mockClock = new MockClock();
         SignalFxMeterRegistry registry = new SignalFxMeterRegistry(config, mockClock);
-        Timer timer = Timer.builder("my.timer")
-                .serviceLevelObjectives(Duration.ofMillis(1), Duration.ofMillis(10), Duration.ofMillis(100),
-                        Duration.ofMillis(1000))
-                .distributionStatisticExpiry(Duration.ofSeconds(10)).distributionStatisticBufferLength(1)
-                .register(registry);
+        Timer timer = Timer
+                .builder("my.timer").serviceLevelObjectives(Duration.ofMillis(1), Duration.ofMillis(10),
+                        Duration.ofMillis(100), Duration.ofMillis(1000))
+                .distributionStatisticExpiry(Duration.ofSeconds(10)).register(registry);
 
         timer.record(50, TimeUnit.MILLISECONDS);
         timer.record(5000, TimeUnit.MILLISECONDS);
@@ -457,13 +456,13 @@ class SignalFxMeterRegistryTest {
         mockClock.add(config.step().minus(Duration.ofMillis(1)));
 
         assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(8)
-                .has(gaugePoint("my.timer.avg", 0.2525), atIndex(0)).has(counterPoint("my.timer.count", 2), atIndex(1))
+                .has(gaugePoint("my.timer.avg", 2.525), atIndex(0)).has(counterPoint("my.timer.count", 2), atIndex(1))
                 .has(allOf(gaugePoint("my.timer.histogram", 0), bucket(Duration.ofMillis(1))), atIndex(2))
-                .has(allOf(gaugePoint("my.timer.histogram", 1), bucket(Duration.ofMillis(10))), atIndex(3))
-                .has(allOf(gaugePoint("my.timer.histogram", 1), bucket(Duration.ofMillis(100))), atIndex(4))
-                .has(allOf(gaugePoint("my.timer.histogram", 2), bucket(Duration.ofMillis(1000))), atIndex(5))
-                .has(gaugePoint("my.timer.max", 0.5), atIndex(6))
-                .has(counterPoint("my.timer.totalTime", 0.505), atIndex(7));
+                .has(allOf(gaugePoint("my.timer.histogram", 0), bucket(Duration.ofMillis(10))), atIndex(3))
+                .has(allOf(gaugePoint("my.timer.histogram", 0), bucket(Duration.ofMillis(100))), atIndex(4))
+                .has(allOf(gaugePoint("my.timer.histogram", 0), bucket(Duration.ofMillis(1000))), atIndex(5))
+                .has(gaugePoint("my.timer.max", 5.0), atIndex(6))
+                .has(counterPoint("my.timer.totalTime", 5.05), atIndex(7));
 
         registry.close();
     }
@@ -474,7 +473,7 @@ class SignalFxMeterRegistryTest {
         SignalFxMeterRegistry registry = new SignalFxMeterRegistry(config, mockClock);
         DistributionSummary summary = DistributionSummary.builder("my.distribution")
                 .serviceLevelObjectives(1, 10, 100, 1000).distributionStatisticExpiry(Duration.ofSeconds(10))
-                .distributionStatisticBufferLength(1).register(registry);
+                .register(registry);
 
         summary.record(50);
         summary.record(5000);
@@ -486,14 +485,14 @@ class SignalFxMeterRegistryTest {
         mockClock.add(config.step().minus(Duration.ofMillis(1)));
 
         assertThat(getDataPoints(registry, mockClock.wallTime())).hasSize(8)
-                .has(gaugePoint("my.distribution.avg", 252.5), atIndex(0))
+                .has(gaugePoint("my.distribution.avg", 2525), atIndex(0))
                 .has(counterPoint("my.distribution.count", 2), atIndex(1))
                 .has(allOf(gaugePoint("my.distribution.histogram", 0), bucket(1)), atIndex(2))
-                .has(allOf(gaugePoint("my.distribution.histogram", 1), bucket(10)), atIndex(3))
-                .has(allOf(gaugePoint("my.distribution.histogram", 1), bucket(100)), atIndex(4))
-                .has(allOf(gaugePoint("my.distribution.histogram", 2), bucket(1000)), atIndex(5))
-                .has(gaugePoint("my.distribution.max", 500), atIndex(6))
-                .has(counterPoint("my.distribution.totalTime", 505), atIndex(7));
+                .has(allOf(gaugePoint("my.distribution.histogram", 0), bucket(10)), atIndex(3))
+                .has(allOf(gaugePoint("my.distribution.histogram", 0), bucket(100)), atIndex(4))
+                .has(allOf(gaugePoint("my.distribution.histogram", 0), bucket(1000)), atIndex(5))
+                .has(gaugePoint("my.distribution.max", 5000), atIndex(6))
+                .has(counterPoint("my.distribution.totalTime", 5050), atIndex(7));
 
         registry.close();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -90,15 +90,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     // VisibleForTesting
     long calculateInitialDelayMillis() {
         long stepMillis = config.step().toMillis();
-        long initialDelayMillis;
-        if (config.alignToEpoch()) {
-            initialDelayMillis = stepMillis - (clock.wallTime() % stepMillis) + 1;
-        }
-        else {
-            initialDelayMillis = stepMillis
-                    - ((clock.wallTime() - registryCreationOffsetFromEpochStepMillis) % stepMillis) + 1;
-        }
-        return initialDelayMillis;
+        return stepMillis - ((clock.wallTime() - getOffsetFromEpochStepMillis()) % stepMillis) + 1;
     }
 
     protected long getOffsetFromEpochStepMillis() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -90,11 +90,20 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     // VisibleForTesting
     long calculateInitialDelayMillis() {
         long stepMillis = config.step().toMillis();
-        return stepMillis - ((clock.wallTime() - getOffsetFromEpochStepMillis()) % stepMillis) + 1;
+        return stepMillis - ((clock.wallTime() - getPushOffsetFromEpochStepMillis()) % stepMillis) + 1;
     }
 
-    protected long getOffsetFromEpochStepMillis() {
-        return config.alignToEpoch() ? 0 : registryCreationOffsetFromEpochStepMillis;
+    /**
+     * Publishing may be aligned globally (for example, offset 0 from step intervals
+     * starting at the Unix Epoch) with a fixed offset such that all application instances
+     * publish metrics at the same point in time, or it may be dynamic for each
+     * application instance relative to when the registry was created. This value is given
+     * in millisecond as the offset from the Unix Epoch-based step intervals.
+     * @return how many milliseconds publishing is offset from Unix Epoch-based step
+     * intervals
+     */
+    protected long getPushOffsetFromEpochStepMillis() {
+        return config.isPushAlignedGlobally() ? 0 : registryCreationOffsetFromEpochStepMillis;
     }
 
     public void stop() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -80,8 +80,16 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
             // time publication to happen just after StepValue finishes the step
             long stepMillis = config.step().toMillis();
-            long initialDelayMillis = config.publishAtStep() ? stepMillis - (clock.wallTime() % stepMillis) + 1
-                    : (stepMillis - registryStartMillis) + 1;
+            long initialDelayMillis;
+            if (config.publishAtStep()) {
+                initialDelayMillis = stepMillis - (clock.wallTime() % stepMillis) + 1;
+            }
+            else {
+                initialDelayMillis = registryStartMillis + stepMillis - (clock.wallTime() % stepMillis) + 1;
+                if (initialDelayMillis > stepMillis + 1) {
+                    initialDelayMillis = initialDelayMillis - stepMillis;
+                }
+            }
 
             scheduledExecutorService.scheduleAtFixedRate(this::publishSafely, initialDelayMillis, stepMillis,
                     TimeUnit.MILLISECONDS);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -80,7 +80,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
             // time publication to happen just after StepValue finishes the step
             long stepMillis = config.step().toMillis();
-            long initialDelayMillis = (config.publishAtStep()) ? stepMillis - (clock.wallTime() % stepMillis) + 1
+            long initialDelayMillis = config.publishAtStep() ? stepMillis - (clock.wallTime() % stepMillis) + 1
                     : (stepMillis - registryStartMillis) + 1;
 
             scheduledExecutorService.scheduleAtFixedRate(this::publishSafely, initialDelayMillis, stepMillis,

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -97,8 +97,8 @@ public abstract class PushMeterRegistry extends MeterRegistry {
         }
     }
 
-    protected long getRegistryCreationOffsetFromEpochStepMillis() {
-        return this.registryCreationOffsetFromEpochStepMillis;
+    protected long getOffsetFromEpochStepMillis() {
+        return config.alignToEpoch() ? 0 : registryCreationOffsetFromEpochStepMillis;
     }
 
     public void stop() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -90,6 +90,14 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
         return getInteger(this, "batchSize").orElse(10000);
     }
 
+    /**
+     * @return true if publishing needs to be relative to registry start time. Default is
+     * {@code false}.
+     */
+    default boolean publishAtStep() {
+        return getBoolean(this, "publishAtStep").orElse(true);
+    }
+
     @Override
     default Validated<?> validate() {
         return validate(this);
@@ -105,7 +113,8 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
         return checkAll(config, check("step", PushRegistryConfig::step),
                 check("connectTimeout", PushRegistryConfig::connectTimeout),
                 check("readTimeout", PushRegistryConfig::readTimeout),
-                check("batchSize", PushRegistryConfig::batchSize), check("numThreads", PushRegistryConfig::numThreads));
+                check("batchSize", PushRegistryConfig::batchSize), check("numThreads", PushRegistryConfig::numThreads),
+                check("publishAtStep", PushRegistryConfig::publishAtStep));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -91,13 +91,14 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     }
 
     /**
-     * This controls when the call to {@link PushMeterRegistry#publish()} needs to be
-     * triggered. By default, publish() is called at the beginning of the step.
-     * @return false if publishing needs to be relative to registry start time. Default is
-     * {@code true}.
+     * This controls when the call to {@link PushMeterRegistry#publish()} is scheduled. If
+     * this returns true, publishing is scheduled at the beginning of each step interval,
+     * relative to the Unix Epoch.
+     * @return false if publishing should be scheduled relative to registry instantiation
+     * time. Default is {@code true}.
      */
-    default boolean publishAtStep() {
-        return getBoolean(this, "publishAtStep").orElse(true);
+    default boolean alignToEpoch() {
+        return getBoolean(this, "alignToEpoch").orElse(true);
     }
 
     @Override
@@ -116,7 +117,7 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
                 check("connectTimeout", PushRegistryConfig::connectTimeout),
                 check("readTimeout", PushRegistryConfig::readTimeout),
                 check("batchSize", PushRegistryConfig::batchSize), check("numThreads", PushRegistryConfig::numThreads),
-                check("publishAtStep", PushRegistryConfig::publishAtStep));
+                check("alignToEpoch", PushRegistryConfig::alignToEpoch));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -92,12 +92,13 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
 
     /**
      * This controls when the call to {@link PushMeterRegistry#publish()} is scheduled. If
-     * this returns true, publishing is scheduled at the beginning of each step interval,
-     * relative to the Unix Epoch. This has the effect of causing all application
-     * instances publishing metrics with this configuration to publish at the same time,
-     * which may overload resources by concentrating the work to publish and ingest
-     * metrics. The more instances you have publishing metrics at the same time, the more
-     * of a problem this will be.
+     * this returns true, publishing is scheduled at the same time relative to the Unix
+     * Epoch regardless of when the registry was created. This has the effect of causing
+     * all application instances publishing metrics with the same configuration to publish
+     * at the same point in time globally, which may overload resources by concentrating
+     * the work to publish and ingest metrics from many application instances. The more
+     * instances you have publishing metrics at the same time, the more of a problem this
+     * will be.
      * @return false if publishing should be scheduled relative to registry instantiation
      * time. Default is {@code false} to avoid the documented resource exhaustion issue.
      */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -93,12 +93,15 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     /**
      * This controls when the call to {@link PushMeterRegistry#publish()} is scheduled. If
      * this returns true, publishing is scheduled at the beginning of each step interval,
-     * relative to the Unix Epoch.
+     * relative to the Unix Epoch. This has the side effect of causing all application
+     * instances publishing metrics with this configuration to publish at the same time,
+     * which may overload resources by concentrating the work to publish and ingest
+     * metrics.
      * @return false if publishing should be scheduled relative to registry instantiation
-     * time. Default is {@code true}.
+     * time. Default is {@code false}.
      */
     default boolean alignToEpoch() {
-        return getBoolean(this, "alignToEpoch").orElse(true);
+        return getBoolean(this, "alignToEpoch").orElse(false);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -91,8 +91,10 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     }
 
     /**
-     * @return true if publishing needs to be relative to registry start time. Default is
-     * {@code false}.
+     * This controls when the call to {@link PushMeterRegistry#publish()} needs to be
+     * triggered. By default, publish() is called at the beginning of the step.
+     * @return false if publishing needs to be relative to registry start time. Default is
+     * {@code true}.
      */
     default boolean publishAtStep() {
         return getBoolean(this, "publishAtStep").orElse(true);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -93,15 +93,16 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
     /**
      * This controls when the call to {@link PushMeterRegistry#publish()} is scheduled. If
      * this returns true, publishing is scheduled at the beginning of each step interval,
-     * relative to the Unix Epoch. This has the side effect of causing all application
+     * relative to the Unix Epoch. This has the effect of causing all application
      * instances publishing metrics with this configuration to publish at the same time,
      * which may overload resources by concentrating the work to publish and ingest
-     * metrics.
+     * metrics. The more instances you have publishing metrics at the same time, the more
+     * of a problem this will be.
      * @return false if publishing should be scheduled relative to registry instantiation
-     * time. Default is {@code false}.
+     * time. Default is {@code false} to avoid the documented resource exhaustion issue.
      */
-    default boolean alignToEpoch() {
-        return getBoolean(this, "alignToEpoch").orElse(false);
+    default boolean isPushAlignedGlobally() {
+        return getBoolean(this, "isPushAlignedGlobally").orElse(false);
     }
 
     @Override
@@ -120,7 +121,7 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
                 check("connectTimeout", PushRegistryConfig::connectTimeout),
                 check("readTimeout", PushRegistryConfig::readTimeout),
                 check("batchSize", PushRegistryConfig::batchSize), check("numThreads", PushRegistryConfig::numThreads),
-                check("alignToEpoch", PushRegistryConfig::alignToEpoch));
+                check("isPushAlignedGlobally", PushRegistryConfig::isPushAlignedGlobally));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
@@ -31,8 +31,12 @@ public class StepCounter extends AbstractMeter implements Counter {
     private final StepDouble value;
 
     public StepCounter(Id id, Clock clock, long stepMillis) {
+        this(id, clock, stepMillis, 0);
+    }
+
+    public StepCounter(Id id, Clock clock, long stepMillis, long registryStartMillis) {
         super(id);
-        this.value = new StepDouble(clock, stepMillis);
+        this.value = new StepDouble(clock, stepMillis, registryStartMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
@@ -34,9 +34,9 @@ public class StepCounter extends AbstractMeter implements Counter {
         this(id, clock, stepMillis, 0);
     }
 
-    public StepCounter(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
+    public StepCounter(Id id, Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis) {
         super(id);
-        this.value = new StepDouble(clock, stepMillis, offsetFromEpochStepMillis);
+        this.value = new StepDouble(clock, stepMillis, pushOffsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
@@ -34,9 +34,9 @@ public class StepCounter extends AbstractMeter implements Counter {
         this(id, clock, stepMillis, 0);
     }
 
-    public StepCounter(Id id, Clock clock, long stepMillis, long registryStartMillis) {
+    public StepCounter(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
         super(id);
-        this.value = new StepDouble(clock, stepMillis, registryStartMillis);
+        this.value = new StepDouble(clock, stepMillis, offsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -52,9 +52,9 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
      * @param supportsAggregablePercentiles whether it supports aggregable percentiles
      */
     public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            double scale, long stepMillis, long registryStartMillis, boolean supportsAggregablePercentiles) {
+            double scale, long stepMillis, long offsetFromEpochStepMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, supportsAggregablePercentiles);
-        this.countTotal = new StepTuple2<>(clock, stepMillis, registryStartMillis, 0L, 0.0, count::sumThenReset,
+        this.countTotal = new StepTuple2<>(clock, stepMillis, offsetFromEpochStepMillis, 0L, 0.0, count::sumThenReset,
                 total::sumThenReset);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -52,10 +52,10 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
      * @param supportsAggregablePercentiles whether it supports aggregable percentiles
      */
     public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            double scale, long stepMillis, long offsetFromEpochStepMillis, boolean supportsAggregablePercentiles) {
+            double scale, long stepMillis, long pushOffsetFromEpochStepMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, supportsAggregablePercentiles);
-        this.countTotal = new StepTuple2<>(clock, stepMillis, offsetFromEpochStepMillis, 0L, 0.0, count::sumThenReset,
-                total::sumThenReset);
+        this.countTotal = new StepTuple2<>(clock, stepMillis, pushOffsetFromEpochStepMillis, 0L, 0.0,
+                count::sumThenReset, total::sumThenReset);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -52,10 +52,16 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
      * @param supportsAggregablePercentiles whether it supports aggregable percentiles
      */
     public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+            double scale, long stepMillis, long registryStartMillis, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, supportsAggregablePercentiles);
-        this.countTotal = new StepTuple2<>(clock, stepMillis, 0L, 0.0, count::sumThenReset, total::sumThenReset);
+        this.countTotal = new StepTuple2<>(clock, stepMillis, registryStartMillis, 0L, 0.0, count::sumThenReset,
+                total::sumThenReset);
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
+    }
+
+    public StepDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
+            double scale, long stepMillis, boolean supportsAggregablePercentiles) {
+        this(id, clock, distributionStatisticConfig, scale, stepMillis, 0, supportsAggregablePercentiles);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
@@ -34,8 +34,8 @@ public class StepDouble extends StepValue<Double> {
         this(clock, stepMillis, 0);
     }
 
-    public StepDouble(Clock clock, long stepMillis, long registryStartMillis) {
-        super(clock, stepMillis, registryStartMillis);
+    public StepDouble(Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
+        super(clock, stepMillis, offsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
@@ -31,7 +31,11 @@ public class StepDouble extends StepValue<Double> {
     private final DoubleAdder current = new DoubleAdder();
 
     public StepDouble(Clock clock, long stepMillis) {
-        super(clock, stepMillis);
+        this(clock, stepMillis, 0);
+    }
+
+    public StepDouble(Clock clock, long stepMillis, long registryStartMillis) {
+        super(clock, stepMillis, registryStartMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDouble.java
@@ -34,8 +34,8 @@ public class StepDouble extends StepValue<Double> {
         this(clock, stepMillis, 0);
     }
 
-    public StepDouble(Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
-        super(clock, stepMillis, offsetFromEpochStepMillis);
+    public StepDouble(Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis) {
+        super(clock, stepMillis, pushOffsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -32,12 +32,12 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
 
     private StepDouble count;
 
-    public StepFunctionCounter(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis, T obj,
+    public StepFunctionCounter(Id id, Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis, T obj,
             ToDoubleFunction<T> f) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.f = f;
-        this.count = new StepDouble(clock, stepMillis, offsetFromEpochStepMillis);
+        this.count = new StepDouble(clock, stepMillis, pushOffsetFromEpochStepMillis);
     }
 
     public StepFunctionCounter(Id id, Clock clock, long stepMillis, T obj, ToDoubleFunction<T> f) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -32,11 +32,15 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
 
     private StepDouble count;
 
-    public StepFunctionCounter(Id id, Clock clock, long stepMillis, T obj, ToDoubleFunction<T> f) {
+    public StepFunctionCounter(Id id, Clock clock, long stepMillis, long stepStartMills, T obj, ToDoubleFunction<T> f) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.f = f;
-        this.count = new StepDouble(clock, stepMillis);
+        this.count = new StepDouble(clock, stepMillis, stepStartMills);
+    }
+
+    public StepFunctionCounter(Id id, Clock clock, long stepMillis, T obj, ToDoubleFunction<T> f) {
+        this(id, clock, stepMillis, 0, obj, f);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -32,11 +32,12 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
 
     private StepDouble count;
 
-    public StepFunctionCounter(Id id, Clock clock, long stepMillis, long stepStartMills, T obj, ToDoubleFunction<T> f) {
+    public StepFunctionCounter(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis, T obj,
+            ToDoubleFunction<T> f) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.f = f;
-        this.count = new StepDouble(clock, stepMillis, stepStartMills);
+        this.count = new StepDouble(clock, stepMillis, offsetFromEpochStepMillis);
     }
 
     public StepFunctionCounter(Id id, Clock clock, long stepMillis, T obj, ToDoubleFunction<T> f) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -60,8 +60,9 @@ public class StepFunctionTimer<T> implements FunctionTimer {
 
     private final StepTuple2<Long, Double> countTotal;
 
-    public StepFunctionTimer(Id id, Clock clock, long stepMillis, T obj, ToLongFunction<T> countFunction,
-            ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit) {
+    public StepFunctionTimer(Id id, Clock clock, long stepMillis, long registryStartMillis, T obj,
+            ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit,
+            TimeUnit baseTimeUnit) {
         this.id = id;
         this.clock = clock;
         this.ref = new WeakReference<>(obj);
@@ -69,7 +70,13 @@ public class StepFunctionTimer<T> implements FunctionTimer {
         this.totalTimeFunction = totalTimeFunction;
         this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.baseTimeUnit = baseTimeUnit;
-        this.countTotal = new StepTuple2<>(clock, stepMillis, 0L, 0.0, count::sumThenReset, total::sumThenReset);
+        this.countTotal = new StepTuple2<>(clock, stepMillis, registryStartMillis, 0L, 0.0, count::sumThenReset,
+                total::sumThenReset);
+    }
+
+    public StepFunctionTimer(Id id, Clock clock, long stepMillis, T obj, ToLongFunction<T> countFunction,
+            ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit, TimeUnit baseTimeUnit) {
+        this(id, clock, stepMillis, 0, obj, countFunction, totalTimeFunction, totalTimeFunctionUnit, baseTimeUnit);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -60,7 +60,7 @@ public class StepFunctionTimer<T> implements FunctionTimer {
 
     private final StepTuple2<Long, Double> countTotal;
 
-    public StepFunctionTimer(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis, T obj,
+    public StepFunctionTimer(Id id, Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis, T obj,
             ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit,
             TimeUnit baseTimeUnit) {
         this.id = id;
@@ -70,8 +70,8 @@ public class StepFunctionTimer<T> implements FunctionTimer {
         this.totalTimeFunction = totalTimeFunction;
         this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.baseTimeUnit = baseTimeUnit;
-        this.countTotal = new StepTuple2<>(clock, stepMillis, offsetFromEpochStepMillis, 0L, 0.0, count::sumThenReset,
-                total::sumThenReset);
+        this.countTotal = new StepTuple2<>(clock, stepMillis, pushOffsetFromEpochStepMillis, 0L, 0.0,
+                count::sumThenReset, total::sumThenReset);
     }
 
     public StepFunctionTimer(Id id, Clock clock, long stepMillis, T obj, ToLongFunction<T> countFunction,

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -60,7 +60,7 @@ public class StepFunctionTimer<T> implements FunctionTimer {
 
     private final StepTuple2<Long, Double> countTotal;
 
-    public StepFunctionTimer(Id id, Clock clock, long stepMillis, long registryStartMillis, T obj,
+    public StepFunctionTimer(Id id, Clock clock, long stepMillis, long offsetFromEpochStepMillis, T obj,
             ToLongFunction<T> countFunction, ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit,
             TimeUnit baseTimeUnit) {
         this.id = id;
@@ -70,7 +70,7 @@ public class StepFunctionTimer<T> implements FunctionTimer {
         this.totalTimeFunction = totalTimeFunction;
         this.totalTimeFunctionUnit = totalTimeFunctionUnit;
         this.baseTimeUnit = baseTimeUnit;
-        this.countTotal = new StepTuple2<>(clock, stepMillis, registryStartMillis, 0L, 0.0, count::sumThenReset,
+        this.countTotal = new StepTuple2<>(clock, stepMillis, offsetFromEpochStepMillis, 0L, 0.0, count::sumThenReset,
                 total::sumThenReset);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
@@ -28,8 +28,8 @@ public class StepLong extends StepValue<Long> {
         this(clock, stepMillis, 0);
     }
 
-    public StepLong(Clock clock, long stepMillis, long registryStartMillis) {
-        super(clock, stepMillis, registryStartMillis);
+    public StepLong(Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
+        super(clock, stepMillis, offsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
@@ -25,7 +25,11 @@ public class StepLong extends StepValue<Long> {
     private final LongAdder current = new LongAdder();
 
     public StepLong(Clock clock, long stepMillis) {
-        super(clock, stepMillis);
+        this(clock, stepMillis, 0);
+    }
+
+    public StepLong(Clock clock, long stepMillis, long registryStartMillis) {
+        super(clock, stepMillis, registryStartMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepLong.java
@@ -28,8 +28,8 @@ public class StepLong extends StepValue<Long> {
         this(clock, stepMillis, 0);
     }
 
-    public StepLong(Clock clock, long stepMillis, long offsetFromEpochStepMillis) {
-        super(clock, stepMillis, offsetFromEpochStepMillis);
+    public StepLong(Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis) {
+        super(clock, stepMillis, pushOffsetFromEpochStepMillis);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -51,7 +51,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected Counter newCounter(Meter.Id id) {
-        return new StepCounter(id, clock, config.step().toMillis(), this.getRegistryStartMillis());
+        return new StepCounter(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis());
     }
 
     @Override
@@ -65,7 +65,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector) {
         Timer timer = new StepTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                this.config.step().toMillis(), this.getRegistryStartMillis(), false);
+                this.config.step().toMillis(), getOffsetFromEpochStepMillis(), false);
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -74,7 +74,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected DistributionSummary newDistributionSummary(Meter.Id id,
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         DistributionSummary summary = new StepDistributionSummary(id, clock, distributionStatisticConfig, scale,
-                config.step().toMillis(), this.getRegistryStartMillis(), false);
+                config.step().toMillis(), getOffsetFromEpochStepMillis(), false);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }
@@ -82,13 +82,13 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction,
             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
-        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), this.getRegistryStartMillis(), obj,
+        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis(), obj,
                 countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
     }
 
     @Override
     protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
-        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), this.getRegistryStartMillis(), obj,
+        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis(), obj,
                 countFunction);
     }
 
@@ -103,9 +103,8 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
                 .merge(DistributionStatisticConfig.DEFAULT);
     }
 
-    @Override
-    protected long getRegistryStartMillis() {
-        return config.publishAtStep() ? 0 : super.getRegistryStartMillis();
+    private long getOffsetFromEpochStepMillis() {
+        return config.alignToEpoch() ? 0 : getRegistryCreationOffsetFromEpochStepMillis();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -103,4 +103,9 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
                 .merge(DistributionStatisticConfig.DEFAULT);
     }
 
+    @Override
+    protected long getRegistryStartMillis() {
+        return config.publishAtStep() ? 0 : super.getRegistryStartMillis();
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -103,8 +103,4 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
                 .merge(DistributionStatisticConfig.DEFAULT);
     }
 
-    private long getOffsetFromEpochStepMillis() {
-        return config.alignToEpoch() ? 0 : getRegistryCreationOffsetFromEpochStepMillis();
-    }
-
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -51,7 +51,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected Counter newCounter(Meter.Id id) {
-        return new StepCounter(id, clock, config.step().toMillis());
+        return new StepCounter(id, clock, config.step().toMillis(), this.getRegistryStartMillis());
     }
 
     @Override
@@ -65,7 +65,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector) {
         Timer timer = new StepTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                this.config.step().toMillis(), false);
+                this.config.step().toMillis(), this.getRegistryStartMillis(), false);
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -74,7 +74,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected DistributionSummary newDistributionSummary(Meter.Id id,
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         DistributionSummary summary = new StepDistributionSummary(id, clock, distributionStatisticConfig, scale,
-                config.step().toMillis(), false);
+                config.step().toMillis(), this.getRegistryStartMillis(), false);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }
@@ -82,13 +82,14 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction,
             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
-        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), obj, countFunction, totalTimeFunction,
-                totalTimeFunctionUnit, getBaseTimeUnit());
+        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), this.getRegistryStartMillis(), obj,
+                countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
     }
 
     @Override
     protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
-        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), obj, countFunction);
+        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), this.getRegistryStartMillis(), obj,
+                countFunction);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -51,7 +51,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected Counter newCounter(Meter.Id id) {
-        return new StepCounter(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis());
+        return new StepCounter(id, clock, config.step().toMillis(), getPushOffsetFromEpochStepMillis());
     }
 
     @Override
@@ -65,7 +65,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector) {
         Timer timer = new StepTimer(id, clock, distributionStatisticConfig, pauseDetector, getBaseTimeUnit(),
-                this.config.step().toMillis(), getOffsetFromEpochStepMillis(), false);
+                this.config.step().toMillis(), getPushOffsetFromEpochStepMillis(), false);
         HistogramGauges.registerWithCommonFormat(timer, this);
         return timer;
     }
@@ -74,7 +74,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     protected DistributionSummary newDistributionSummary(Meter.Id id,
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         DistributionSummary summary = new StepDistributionSummary(id, clock, distributionStatisticConfig, scale,
-                config.step().toMillis(), getOffsetFromEpochStepMillis(), false);
+                config.step().toMillis(), getPushOffsetFromEpochStepMillis(), false);
         HistogramGauges.registerWithCommonFormat(summary, this);
         return summary;
     }
@@ -82,13 +82,13 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     @Override
     protected <T> FunctionTimer newFunctionTimer(Meter.Id id, T obj, ToLongFunction<T> countFunction,
             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
-        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis(), obj,
+        return new StepFunctionTimer<>(id, clock, config.step().toMillis(), getPushOffsetFromEpochStepMillis(), obj,
                 countFunction, totalTimeFunction, totalTimeFunctionUnit, getBaseTimeUnit());
     }
 
     @Override
     protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
-        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), getOffsetFromEpochStepMillis(), obj,
+        return new StepFunctionCounter<>(id, clock, config.step().toMillis(), getPushOffsetFromEpochStepMillis(), obj,
                 countFunction);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -50,10 +50,10 @@ public class StepTimer extends AbstractTimer {
      */
     public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
             final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
-            final long offsetFromEpochStepMillis, final boolean supportsAggregablePercentiles) {
+            final long pushOffsetFromEpochStepMillis, final boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
-        countTotal = new StepTuple2<>(clock, stepDurationMillis, offsetFromEpochStepMillis, 0L, 0L, count::sumThenReset,
-                total::sumThenReset);
+        countTotal = new StepTuple2<>(clock, stepDurationMillis, pushOffsetFromEpochStepMillis, 0L, 0L,
+                count::sumThenReset, total::sumThenReset);
         max = new TimeWindowMax(clock, distributionStatisticConfig);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -50,9 +50,9 @@ public class StepTimer extends AbstractTimer {
      */
     public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
             final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
-            final long registryStartMillis, final boolean supportsAggregablePercentiles) {
+            final long offsetFromEpochStepMillis, final boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
-        countTotal = new StepTuple2<>(clock, stepDurationMillis, registryStartMillis, 0L, 0L, count::sumThenReset,
+        countTotal = new StepTuple2<>(clock, stepDurationMillis, offsetFromEpochStepMillis, 0L, 0L, count::sumThenReset,
                 total::sumThenReset);
         max = new TimeWindowMax(clock, distributionStatisticConfig);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -50,10 +50,18 @@ public class StepTimer extends AbstractTimer {
      */
     public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
             final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
-            final boolean supportsAggregablePercentiles) {
+            final long registryStartMillis, final boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
-        countTotal = new StepTuple2<>(clock, stepDurationMillis, 0L, 0L, count::sumThenReset, total::sumThenReset);
+        countTotal = new StepTuple2<>(clock, stepDurationMillis, registryStartMillis, 0L, 0L, count::sumThenReset,
+                total::sumThenReset);
         max = new TimeWindowMax(clock, distributionStatisticConfig);
+    }
+
+    public StepTimer(final Id id, final Clock clock, final DistributionStatisticConfig distributionStatisticConfig,
+            final PauseDetector pauseDetector, final TimeUnit baseTimeUnit, final long stepDurationMillis,
+            final boolean supportsAggregablePercentiles) {
+        this(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis, 0,
+                supportsAggregablePercentiles);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
@@ -33,7 +33,7 @@ public class StepTuple2<T1, T2> {
 
     private final long stepMillis;
 
-    private final long registryStartMillis;
+    private final long offsetFromEpochStepMillis;
 
     private AtomicLong lastInitPos;
 
@@ -49,18 +49,18 @@ public class StepTuple2<T1, T2> {
 
     private volatile T2 t2Previous;
 
-    public StepTuple2(Clock clock, long stepMillis, long registryStartMillis, T1 t1NoValue, T2 t2NoValue,
+    public StepTuple2(Clock clock, long stepMillis, long offsetFromEpochStepMillis, T1 t1NoValue, T2 t2NoValue,
             Supplier<T1> t1Supplier, Supplier<T2> t2Supplier) {
         this.clock = clock;
         this.stepMillis = stepMillis;
-        this.registryStartMillis = registryStartMillis;
+        this.offsetFromEpochStepMillis = offsetFromEpochStepMillis;
         this.t1NoValue = t1NoValue;
         this.t2NoValue = t2NoValue;
         this.t1Supplier = t1Supplier;
         this.t2Supplier = t2Supplier;
         this.t1Previous = t1NoValue;
         this.t2Previous = t2NoValue;
-        lastInitPos = new AtomicLong((clock.wallTime() - registryStartMillis) / stepMillis);
+        lastInitPos = new AtomicLong((clock.wallTime() - offsetFromEpochStepMillis) / stepMillis);
     }
 
     public StepTuple2(Clock clock, long stepMillis, T1 t1NoValue, T2 t2NoValue, Supplier<T1> t1Supplier,
@@ -69,7 +69,7 @@ public class StepTuple2<T1, T2> {
     }
 
     private void rollCount(long now) {
-        long stepTime = (now - registryStartMillis) / stepMillis;
+        long stepTime = (now - offsetFromEpochStepMillis) / stepMillis;
         long lastInit = lastInitPos.get();
         if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
             // Need to check if there was any activity during the previous step interval.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
@@ -33,7 +33,7 @@ public class StepTuple2<T1, T2> {
 
     private final long stepMillis;
 
-    private final long offsetFromEpochStepMillis;
+    private final long pushOffsetFromEpochStepMillis;
 
     private AtomicLong lastInitPos;
 
@@ -49,18 +49,18 @@ public class StepTuple2<T1, T2> {
 
     private volatile T2 t2Previous;
 
-    public StepTuple2(Clock clock, long stepMillis, long offsetFromEpochStepMillis, T1 t1NoValue, T2 t2NoValue,
+    public StepTuple2(Clock clock, long stepMillis, long pushOffsetFromEpochStepMillis, T1 t1NoValue, T2 t2NoValue,
             Supplier<T1> t1Supplier, Supplier<T2> t2Supplier) {
         this.clock = clock;
         this.stepMillis = stepMillis;
-        this.offsetFromEpochStepMillis = offsetFromEpochStepMillis;
+        this.pushOffsetFromEpochStepMillis = pushOffsetFromEpochStepMillis;
         this.t1NoValue = t1NoValue;
         this.t2NoValue = t2NoValue;
         this.t1Supplier = t1Supplier;
         this.t2Supplier = t2Supplier;
         this.t1Previous = t1NoValue;
         this.t2Previous = t2NoValue;
-        lastInitPos = new AtomicLong((clock.wallTime() - offsetFromEpochStepMillis) / stepMillis);
+        lastInitPos = new AtomicLong((clock.wallTime() - pushOffsetFromEpochStepMillis) / stepMillis);
     }
 
     public StepTuple2(Clock clock, long stepMillis, T1 t1NoValue, T2 t2NoValue, Supplier<T1> t1Supplier,
@@ -69,7 +69,7 @@ public class StepTuple2<T1, T2> {
     }
 
     private void rollCount(long now) {
-        long stepTime = (now - offsetFromEpochStepMillis) / stepMillis;
+        long stepTime = (now - pushOffsetFromEpochStepMillis) / stepMillis;
         long lastInit = lastInitPos.get();
         if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
             // Need to check if there was any activity during the previous step interval.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -34,7 +34,7 @@ public abstract class StepValue<V> {
 
     private final long stepMillis;
 
-    private final long offsetFromEpochStepMillis;
+    private final long pushOffsetFromEpochStepMillis;
 
     private AtomicLong lastInitPos;
 
@@ -44,11 +44,11 @@ public abstract class StepValue<V> {
         this(clock, stepMillis, 0);
     }
 
-    public StepValue(final Clock clock, final long stepMillis, final long offsetFromEpochStepMillis) {
+    public StepValue(final Clock clock, final long stepMillis, final long pushOffsetFromEpochStepMillis) {
         this.clock = clock;
         this.stepMillis = stepMillis;
-        this.offsetFromEpochStepMillis = offsetFromEpochStepMillis;
-        lastInitPos = new AtomicLong((clock.wallTime() - offsetFromEpochStepMillis) / stepMillis);
+        this.pushOffsetFromEpochStepMillis = pushOffsetFromEpochStepMillis;
+        lastInitPos = new AtomicLong((clock.wallTime() - pushOffsetFromEpochStepMillis) / stepMillis);
     }
 
     protected abstract Supplier<V> valueSupplier();
@@ -60,7 +60,7 @@ public abstract class StepValue<V> {
     protected abstract V noValue();
 
     private void rollCount(long now) {
-        final long stepTime = (now - offsetFromEpochStepMillis) / stepMillis;
+        final long stepTime = (now - pushOffsetFromEpochStepMillis) / stepMillis;
         final long lastInit = lastInitPos.get();
         if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
             final V v = valueSupplier().get();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -34,7 +34,7 @@ public abstract class StepValue<V> {
 
     private final long stepMillis;
 
-    private final long registryStartMillis;
+    private final long offsetFromEpochStepMillis;
 
     private AtomicLong lastInitPos;
 
@@ -44,11 +44,11 @@ public abstract class StepValue<V> {
         this(clock, stepMillis, 0);
     }
 
-    public StepValue(final Clock clock, final long stepMillis, final long registryStartMillis) {
+    public StepValue(final Clock clock, final long stepMillis, final long offsetFromEpochStepMillis) {
         this.clock = clock;
         this.stepMillis = stepMillis;
-        this.registryStartMillis = registryStartMillis;
-        lastInitPos = new AtomicLong((clock.wallTime() - registryStartMillis) / stepMillis);
+        this.offsetFromEpochStepMillis = offsetFromEpochStepMillis;
+        lastInitPos = new AtomicLong((clock.wallTime() - offsetFromEpochStepMillis) / stepMillis);
     }
 
     protected abstract Supplier<V> valueSupplier();
@@ -60,7 +60,7 @@ public abstract class StepValue<V> {
     protected abstract V noValue();
 
     private void rollCount(long now) {
-        final long stepTime = (now - registryStartMillis) / stepMillis;
+        final long stepTime = (now - offsetFromEpochStepMillis) / stepMillis;
         final long lastInit = lastInitPos.get();
         if (lastInit < stepTime && lastInitPos.compareAndSet(lastInit, stepTime)) {
             final V v = valueSupplier().get();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -55,7 +55,7 @@ class PushMeterRegistryTest {
         }
 
         @Override
-        public boolean alignToEpoch() {
+        public boolean isPushAlignedGlobally() {
             return false;
         }
     };

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -59,7 +59,7 @@ class PushMeterRegistryTest {
         }
 
         @Override
-        public boolean publishAtStep() {
+        public boolean alignToEpoch() {
             return false;
         }
     };
@@ -186,8 +186,8 @@ class PushMeterRegistryTest {
         }
 
         @Override
-        protected long getRegistryStartMillis() {
-            return super.getRegistryStartMillis();
+        protected long getRegistryCreationOffsetFromEpochStepMillis() {
+            return super.getRegistryCreationOffsetFromEpochStepMillis();
         }
 
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -15,11 +15,16 @@
  */
 package io.micrometer.core.instrument.push;
 
+import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -40,7 +45,7 @@ class PushMeterRegistryTest {
     StepRegistryConfig config = new StepRegistryConfig() {
         @Override
         public Duration step() {
-            return Duration.ofMillis(10);
+            return Duration.ofMillis(100);
         }
 
         @Override
@@ -52,11 +57,14 @@ class PushMeterRegistryTest {
         public String get(String key) {
             return null;
         }
+
+        @Override
+        public boolean publishAtStep() {
+            return false;
+        }
     };
 
-    CountDownLatch latch = new CountDownLatch(2);
-
-    PushMeterRegistry pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
+    PushMeterRegistry pushMeterRegistry;
 
     @AfterEach
     void cleanUp() {
@@ -65,14 +73,57 @@ class PushMeterRegistryTest {
 
     @Test
     void whenUncaughtExceptionInPublish_taskStillScheduled() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(2);
+        pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
         pushMeterRegistry.start(threadFactory);
-        assertThat(latch.await(500, TimeUnit.MILLISECONDS))
+        assertThat(latch.await(config.step().toMillis() * 3, TimeUnit.MILLISECONDS))
                 .as("publish should continue to be scheduled even if an uncaught exception is thrown").isTrue();
     }
 
     @Test
     void whenUncaughtExceptionInPublish_closeRegistrySuccessful() {
+        CountDownLatch latch = new CountDownLatch(1);
+        pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
         assertThatCode(() -> pushMeterRegistry.close()).doesNotThrowAnyException();
+    }
+
+    // This test asserts timing based on system clock. Code execution will be
+    // significantly slower when debugging, causing assertions to fail.
+    // Repeated to get different times relative to the epoch steps
+    @Issue("#2818")
+    @RepeatedTest(6)
+    void publishTiming(RepetitionInfo info) throws InterruptedException {
+        TimeRecordingPushMeterRegistry timeRecordingPushMeterRegistry = new TimeRecordingPushMeterRegistry(config,
+                Clock.SYSTEM);
+        pushMeterRegistry = timeRecordingPushMeterRegistry;
+        if (info.getCurrentRepetition() == 1) {
+            // first iteration has too much delay in execution to reliably assert
+            return;
+        }
+
+        assertPublishTiming(timeRecordingPushMeterRegistry, timeRecordingPushMeterRegistry.firstPublishLatch, 0);
+
+        // stop and start with a little delay
+        timeRecordingPushMeterRegistry.stop();
+        long sleepTime = config.step().toMillis() / 5;
+        Thread.sleep(sleepTime);
+        timeRecordingPushMeterRegistry.start(threadFactory);
+
+        assertPublishTiming(timeRecordingPushMeterRegistry, timeRecordingPushMeterRegistry.secondPublishLatch,
+                sleepTime + 5 // takes some time to run other code
+        );
+    }
+
+    private void assertPublishTiming(TimeRecordingPushMeterRegistry timeRecordingPushMeterRegistry,
+            CountDownLatch publishLatch, long sleep) throws InterruptedException {
+        long startTimeMillis = timeRecordingPushMeterRegistry.lastStartTimeMillis;
+
+        long expectedPublishTime = startTimeMillis + config.step().toMillis() + 1 - sleep;
+        assertThat(publishLatch.await(config.step().toMillis() * 2, TimeUnit.MILLISECONDS)).isTrue();
+        // scheduler timing and execution time of code make asserting expected elapsed
+        // time imprecise
+        assertThat(timeRecordingPushMeterRegistry.lastPublishTimeMillis).isCloseTo(expectedPublishTime,
+                Offset.offset(7L));
     }
 
     static class ThrowingPushMeterRegistry extends StepMeterRegistry {
@@ -93,6 +144,50 @@ class PushMeterRegistryTest {
         @Override
         protected TimeUnit getBaseTimeUnit() {
             return TimeUnit.MICROSECONDS;
+        }
+
+    }
+
+    static class TimeRecordingPushMeterRegistry extends StepMeterRegistry {
+
+        long lastPublishTimeMillis;
+
+        long lastStartTimeMillis;
+
+        CountDownLatch firstPublishLatch = new CountDownLatch(1);
+
+        CountDownLatch secondPublishLatch = new CountDownLatch(1);
+
+        public TimeRecordingPushMeterRegistry(StepRegistryConfig config, Clock clock) {
+            super(config, clock);
+            start(threadFactory);
+        }
+
+        @Override
+        protected TimeUnit getBaseTimeUnit() {
+            return TimeUnit.MILLISECONDS;
+        }
+
+        @Override
+        protected void publish() {
+            lastPublishTimeMillis = clock.wallTime();
+            if (firstPublishLatch.getCount() != 0) {
+                firstPublishLatch.countDown();
+            }
+            else {
+                secondPublishLatch.countDown();
+            }
+        }
+
+        @Override
+        public void start(ThreadFactory threadFactory) {
+            super.start(threadFactory);
+            lastStartTimeMillis = clock.wallTime();
+        }
+
+        @Override
+        protected long getRegistryStartMillis() {
+            return super.getRegistryStartMillis();
         }
 
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -185,11 +185,6 @@ class PushMeterRegistryTest {
             lastStartTimeMillis = clock.wallTime();
         }
 
-        @Override
-        protected long getRegistryCreationOffsetFromEpochStepMillis() {
-            return super.getRegistryCreationOffsetFromEpochStepMillis();
-        }
-
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
@@ -51,7 +51,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1w");
         props.put("push.batchSize", "Z");
         props.put("push.step", "up");
-        props.put("push.alignToEpoch", "oops");
+        props.put("push.isPushAlignedGlobally", "oops");
 
         // overall not valid
         assertThat(config.validate().isValid()).isFalse();
@@ -73,7 +73,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1s");
         props.put("push.batchSize", "3");
         props.put("push.step", "1s");
-        props.put("push.alignToEpoch", "false");
+        props.put("push.isPushAlignedGlobally", "false");
 
         assertThat(config.validate().isValid()).isTrue();
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
@@ -51,6 +51,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1w");
         props.put("push.batchSize", "Z");
         props.put("push.step", "up");
+        props.put("push.publishAtStep", "oops");
 
         // overall not valid
         assertThat(config.validate().isValid()).isFalse();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushRegistryConfigTest.java
@@ -51,7 +51,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1w");
         props.put("push.batchSize", "Z");
         props.put("push.step", "up");
-        props.put("push.publishAtStep", "oops");
+        props.put("push.alignToEpoch", "oops");
 
         // overall not valid
         assertThat(config.validate().isValid()).isFalse();
@@ -73,6 +73,7 @@ class PushRegistryConfigTest {
         props.put("push.readTimeout", "1s");
         props.put("push.batchSize", "3");
         props.put("push.step", "1s");
+        props.put("push.alignToEpoch", "false");
 
         assertThat(config.validate().isValid()).isTrue();
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
@@ -72,9 +72,9 @@ class StepValueTest {
         final MockClock mockClock = new MockClock();
         mockClock.add(Duration.ofMillis(30));
 
-        final long registryStartTime = 18;
+        final long offsetFromEpochStepMillis = 18;
         final AtomicLong aLong = new AtomicLong(12);
-        final StepValue<Long> stepValue = new StepValue<Long>(mockClock, 60, registryStartTime) {
+        final StepValue<Long> stepValue = new StepValue<Long>(mockClock, 60, offsetFromEpochStepMillis) {
             @Override
             protected Supplier<Long> valueSupplier() {
                 return () -> aLong.getAndSet(0);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
@@ -69,12 +69,12 @@ class StepValueTest {
 
     @Test
     void testWithRegistryStart() {
-        final MockClock mockClock = new MockClock();
-        mockClock.add(Duration.ofMillis(30));
-
         final long offsetFromEpochStepMillis = 18;
+        final MockClock mockClock = new MockClock();
+        mockClock.add(Duration.ofMillis(offsetFromEpochStepMillis));
+
         final AtomicLong aLong = new AtomicLong(12);
-        final StepValue<Long> stepValue = new StepValue<Long>(mockClock, 60, offsetFromEpochStepMillis) {
+        final StepValue<Long> stepValue = new StepValue<Long>(mockClock, stepTime, offsetFromEpochStepMillis) {
             @Override
             protected Supplier<Long> valueSupplier() {
                 return () -> aLong.getAndSet(0);
@@ -91,7 +91,7 @@ class StepValueTest {
         mockClock.add(Duration.ofMillis(30));
         assertThat(stepValue.poll()).isEqualTo(0L);
 
-        mockClock.add(Duration.ofMillis(18));
+        mockClock.add(Duration.ofMillis(30));
         assertThat(stepValue.poll()).isEqualTo(12L);
 
         mockClock.add(Duration.ofMillis(42));
@@ -101,7 +101,7 @@ class StepValueTest {
         assertThat(stepValue.poll()).isEqualTo(0L);
 
         aLong.set(25);
-        mockClock.add(Duration.ofMillis(60));
+        mockClock.add(Duration.ofMillis(stepTime));
         assertThat(stepValue.poll()).isEqualTo(25L);
     }
 


### PR DESCRIPTION
This PR tries to solve this issue (https://github.com/micrometer-metrics/micrometer/issues/2818). The start time is captured when the push meter registry is initialized. For Step based meters, this is passed to the Step Value and StepTupple to align them to the registry start time and not the step start time (see - https://github.com/micrometer-metrics/micrometer/issues/1218).

TODO:

- [ ] rebase and target `1.8.x`
- [x] investigate test failures with the `alignToEpoch` config flipped