### PR TITLE
Add a batching counter for grpc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/AbstractMetricCollectingInterceptor.java
@@ -103,6 +103,8 @@ public abstract class AbstractMetricCollectingInterceptor {
 
     protected final MeterRegistry registry;
 
+    protected final boolean batchCounter;
+
     protected final UnaryOperator<Counter.Builder> counterCustomizer;
 
     protected final UnaryOperator<Timer.Builder> timerCustomizer;
@@ -114,9 +116,10 @@ public abstract class AbstractMetricCollectingInterceptor {
      * {@link MeterRegistry}. This method won't use any customizers and will only
      * initialize the {@link Code#OK OK} status.
      * @param registry The registry to use.
+     * @param batchCounter Batch request/response counters till the end
      */
-    protected AbstractMetricCollectingInterceptor(final MeterRegistry registry) {
-        this(registry, UnaryOperator.identity(), UnaryOperator.identity(), Code.OK);
+    protected AbstractMetricCollectingInterceptor(final MeterRegistry registry, boolean batchCounter) {
+        this(registry, batchCounter, UnaryOperator.identity(), UnaryOperator.identity(), Code.OK);
     }
 
     /**
@@ -124,16 +127,18 @@ public abstract class AbstractMetricCollectingInterceptor {
      * {@link MeterRegistry} and uses the given customizers to configure the
      * {@link Counter}s and {@link Timer}s.
      * @param registry The registry to use.
+     * @param batchCounter Batch request/response counters till the end
      * @param counterCustomizer The unary function that can be used to customize the
      * created counters.
      * @param timerCustomizer The unary function that can be used to customize the created
      * timers.
      * @param eagerInitializedCodes The status codes that should be eager initialized.
      */
-    protected AbstractMetricCollectingInterceptor(final MeterRegistry registry,
+    protected AbstractMetricCollectingInterceptor(final MeterRegistry registry, boolean batchCounter,
             final UnaryOperator<Counter.Builder> counterCustomizer, final UnaryOperator<Timer.Builder> timerCustomizer,
             final Status.Code... eagerInitializedCodes) {
         this.registry = registry;
+        this.batchCounter = batchCounter;
         this.counterCustomizer = counterCustomizer;
         this.timerCustomizer = timerCustomizer;
         this.eagerInitializedCodes = eagerInitializedCodes;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -68,7 +68,17 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
      * @param registry The registry to use.
      */
     public MetricCollectingClientInterceptor(final MeterRegistry registry) {
-        super(registry);
+        super(registry, false);
+    }
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given
+     * {@link MeterRegistry}.
+     * @param registry The registry to use.
+     * @param batchCounter Batch request/response counters till the end
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry, boolean batchCounter) {
+        super(registry, batchCounter);
     }
 
     /**
@@ -85,7 +95,25 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     public MetricCollectingClientInterceptor(final MeterRegistry registry,
             final UnaryOperator<Counter.Builder> counterCustomizer, final UnaryOperator<Timer.Builder> timerCustomizer,
             final Code... eagerInitializedCodes) {
-        super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+        this(registry, false, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    }
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given
+     * {@link MeterRegistry} and uses the given customizers to configure the
+     * {@link Counter}s and {@link Timer}s.
+     * @param registry The registry to use.
+     * @param batchCounter Batch request/response counters till the end
+     * @param counterCustomizer The unary function that can be used to customize the
+     * created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created
+     * timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingClientInterceptor(final MeterRegistry registry, boolean batchCounter,
+            final UnaryOperator<Counter.Builder> counterCustomizer, final UnaryOperator<Timer.Builder> timerCustomizer,
+            final Code... eagerInitializedCodes) {
+        super(registry, batchCounter, counterCustomizer, timerCustomizer, eagerInitializedCodes);
     }
 
     @Override
@@ -116,7 +144,7 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
         final Consumer<Code> processingDurationTiming = metrics.newProcessingDurationTiming(this.registry);
 
         return new MetricCollectingClientCall<>(channel.newCall(methodDescriptor, callOptions),
-                metrics.getRequestCounter(), metrics.getResponseCounter(), processingDurationTiming);
+                metrics.getRequestCounter(), metrics.getResponseCounter(), processingDurationTiming, batchCounter);
     }
 
 }


### PR DESCRIPTION
Discovered that when you're using a statsd meterRegistry, every single request through the client/server interceptors will increment a counter, which then sends a message to statsd. This was causing some delays in our application, especially the grpc methods with large server streamed results