### PR TITLE
Allow documenting optional keys

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/docs/KeyName.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/docs/KeyName.java
@@ -62,4 +62,13 @@ public interface KeyName {
      */
     String asString();
 
+    /**
+     * Whether this key is required to be present in the instrumentation. This can be
+     * checked in a test of the instrumentation.
+     * @return whether this key is required
+     */
+    default boolean isRequired() {
+        return true;
+    }
+
 }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -356,6 +356,19 @@ class TestObservationRegistryAssertTests {
             public String asString() {
                 return "foo";
             }
+        },
+
+        MAYBE_SOMETHING {
+
+            @Override
+            public String asString() {
+                return "maybe.something";
+            }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
         }
 
     }


### PR DESCRIPTION
There is no distinction between required and optional keys currently when using ObservationDocumentation. This introduces a new method `isRequired` that will default to true. Optional keys may be documented by overriding this method.

Future use of this can be in the docs-generator marking whether a key is required or not in the generated documentation. Also, testing the instrumentation with our TCKs can check that required keys are always present, and that undocumented keys are not present but optional keys may or may not be present.