### PR TITLE
Bump to a medium+ resource class for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,18 +5,21 @@ executors:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+    resource_class: medium+
     docker:
       - image: cimg/openjdk:18.0.2
   circle-jdk17-executor:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+    resource_class: medium+
     docker:
       - image: cimg/openjdk:17.0.4
   circle-jdk11-executor:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
+    resource_class: medium+
     docker:
       - image: cimg/openjdk:11.0.13
   machine-executor:


### PR DESCRIPTION
Our builds are running at max CPU and RAM for most of the CI build on the default `medium` resource class for docker executors. We could probably get some improvement from more resources. This bumps up one level to `medium+` and makes the resource class choice explicit in the build, instead of the implicit default.