### PR TITLE
Disable downloadBaseline task for micrometer-jetty11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-commons', 'micrometer-observation', 'micrometer-observation-conventions', 'micrometer-observation-test'])) {
+            if (!(project.name in ['micrometer-commons', 'micrometer-observation', 'micrometer-observation-conventions', 'micrometer-observation-test', 'micrometer-jetty11'])) {
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/micrometer-jetty11/build.gradle
+++ b/micrometer-jetty11/build.gradle
@@ -13,9 +13,3 @@ compileJava {
     targetCompatibility = JavaVersion.VERSION_11
     options.release = 11
 }
-
-// this module was introduced in 1.10; the following can be removed in later branches
-if ("$project.version".startsWith("1.10.")) {
-    japicmp.enabled = false
-    downloadBaseline.enabled = false
-}


### PR DESCRIPTION
This PR disables the `downloadBaseline` task for the `micrometer-jetty11` module.