### PR TITLE
Polish "Take Supplier<Context> instead of Context"

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -191,7 +191,7 @@ public interface Observation extends ObservationView {
      * returned.
      * @param <T> type of context
      * @param observationConvention observation convention
-     * @param contextSupplier mutable context
+     * @param contextSupplier mutable context supplier
      * @param registry observation registry
      * @return started observation
      */
@@ -215,7 +215,7 @@ public interface Observation extends ObservationView {
      * was found.
      * @param <T> type of context
      * @param registry observation registry
-     * @param contextSupplier the observation context
+     * @param contextSupplier the observation context supplier
      * @param customConvention custom convention. If {@code null}, the default one will be
      * picked.
      * @param defaultConvention default convention when no custom convention was passed,
@@ -248,7 +248,8 @@ public interface Observation extends ObservationView {
      * no-op {@link Observation} and skips the creation of the
      * {@link Observation.Context}. This check avoids unnecessary
      * {@link Observation.Context} creation, which is why it takes a {@link Supplier} for
-     * the context rather than the context directly. If the observation is not enabled(see
+     * the context rather than the context directly. If the observation is not enabled
+     * (see
      * {@link ObservationRegistry.ObservationConfig#observationPredicate(ObservationPredicate)
      * ObservationConfig#observationPredicate}), a no-op observation will also be
      * returned.
@@ -263,7 +264,7 @@ public interface Observation extends ObservationView {
      * </p>
      * @param <T> type of context
      * @param observationConvention observation convention
-     * @param contextSupplier mutable context
+     * @param contextSupplier mutable context supplier
      * @param registry observation registry
      * @return created but not started observation
      */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -166,7 +166,7 @@ public interface ObservationDocumentation {
      * @param defaultConvention default convention that will be picked if there was
      * neither custom convention nor a pre-configured one via
      * {@link ObservationRegistry.ObservationConfig#observationConvention(GlobalObservationConvention)}
-     * @param contextSupplier observation context
+     * @param contextSupplier observation context supplier
      * @param registry observation registry
      * @return observation
      */


### PR DESCRIPTION
This PR polishes "Take Supplier<Context> instead of Context" changes a bit.

See gh-3443