### PR TITLE
Kafka metrics ending in "-count" are gauges

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -249,7 +249,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
     }
 
     private Meter registerMeter(MeterRegistry registry, MetricName metricName, String meterName, Iterable<Tag> tags) {
-        if (meterName.endsWith("total") || meterName.endsWith("count")) {
+        if (meterName.endsWith("total")) {
             return registerCounter(registry, metricName, meterName, tags);
         }
         else {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetricsIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.kafka;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -107,6 +108,10 @@ class KafkaClientMetricsIntegrationTest {
 
         assertThat(registry.getMeters()).hasSizeGreaterThan(producerAndConsumerMetricsAfterSend);
         assertThat(registry.getMeters()).extracting(m -> m.getId().getTag("kafka.version")).allMatch(v -> !v.isEmpty());
+
+        // see gh-3300
+        assertThat(registry.getMeters().stream().filter(meter -> meter.getId().getName().endsWith(".count")))
+                .allMatch(meter -> meter instanceof Gauge);
 
         // Printing out for discovery purposes
         out.println("All meters from producer and consumer:");


### PR DESCRIPTION
I am using the kafka metrics module from mirometer. There are just 2 matrics in the set that end in count, and they're both gauges.

This is the output from the SimpleMeterRegistry
```
kafka.consumer.connection.count(COUNTER)[client.id='FOO', kafka.version='5.5.8-ccs']; count=3.0
kafka.producer.connection.count(COUNTER)[client.id='FOO', kafka.version='5.5.8-ccs']; count=2.0
```

The endsWith("total") is correct.

If you check confluent's docs here: https://docs.confluent.io/platform/current/kafka/monitoring.html#global-connection-metrics

you can see that anything ending in `-count` is a gauge style metric