### PR TITLE
Remove sourceSets java11Test configuration in micrometer-core

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -9,14 +9,6 @@ multiRelease {
     targetVersions 8, 11
 }
 
-// Otherwise java11 tests will not see java11 code
-sourceSets {
-    java11Test {
-        compileClasspath += sourceSets.java11.output
-        runtimeClasspath += sourceSets.java11.output
-    }
-}
-
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = javaTargetVersion


### PR DESCRIPTION
This PR removes `sourceSets` `java11Test` configuration in `micrometer-core` as it seems to be unnecessary now somehow.