### PR TITLE
Add support for creating KeyValues from any iterable

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.common;
 
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.micrometer.common.docs.KeyName;
@@ -55,6 +56,18 @@ public interface KeyValue extends Comparable<KeyValue> {
      */
     static KeyValue of(KeyName keyName, String value) {
         return KeyValue.of(keyName.asString(), value);
+    }
+
+    /**
+     * Creates a {@link KeyValue} for the given {@code element} by extracting a key and
+     * value from it.
+     * @param element the source element
+     * @param keyExtractor function to extract the key from the element
+     * @param valueExtractor function to extract the value from the element
+     * @return KeyValue
+     */
+    static <E> KeyValue of(E element, Function<E, String> keyExtractor, Function<E, String> valueExtractor) {
+        return KeyValue.of(keyExtractor.apply(element), valueExtractor.apply(element));
     }
 
     /**

--- a/micrometer-commons/src/test/java/io/micrometer/common/KeyValuesTest.java
+++ b/micrometer-commons/src/test/java/io/micrometer/common/KeyValuesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.common;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link KeyValues}.
+ */
+class KeyValuesTest {
+
+    @Test
+    void ofExtractingFromElementsReturnsKeyValues() {
+        Map<String, String> map = Map.of("micrometer", "tracing", "can", "trace");
+        KeyValues keyValues = KeyValues.of(map.entrySet(), Map.Entry::getKey, Map.Entry::getValue);
+        assertThat(keyValues).containsExactlyInAnyOrder(KeyValue.of("micrometer", "tracing"),
+                KeyValue.of("can", "trace"));
+    }
+
+    @Test
+    void andExtractingFromElementsReturnsKeyValues() {
+        Map<String, String> map = Map.of("micrometer", "tracing", "can", "trace");
+        KeyValues keyValues = KeyValues.of("no", "way").and(map.entrySet(), Map.Entry::getKey, Map.Entry::getValue);
+        assertThat(keyValues).containsExactlyInAnyOrder(KeyValue.of("no", "way"), KeyValue.of("micrometer", "tracing"),
+                KeyValue.of("can", "trace"));
+    }
+
+}


### PR DESCRIPTION
We're finding quite often that we need to adapt `Iterable<Tag>` to a `KeyValues` instance and writing code like this:

```java
Iterable<Tag> tags = this.tagsProvider.getTags(context.getUriTemplate(), context.getCarrier(),
		context.getResponse());
KeyValues keyValues = KeyValues.empty();
for (Tag tag : tags) {
	keyValues = keyValues.and(tag.getKey(), tag.getValue());
}
return keyValues;
```

It seems like this pattern might be quite common (for example you might want to adapt a `Map`). It would be nice if it could be a oneliner:

```java
return KeyValues.of(tags, Tag::getKey, Tag::getValue);
```
