### PR TITLE
Verify sender propagation for HTTP server instrumentation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/JerseyContext.java
@@ -36,7 +36,7 @@ public class JerseyContext extends RequestReplyReceiverContext<ContainerRequest,
     public JerseyContext(RequestEvent requestEvent) {
         super((carrier, key) -> {
             List<String> requestHeader = carrier.getRequestHeader(key);
-            if (requestHeader.isEmpty()) {
+            if (requestHeader == null || requestHeader.isEmpty()) {
                 return null;
             }
             return requestHeader.get(0);


### PR DESCRIPTION
This will catch issues in the implementation of instrumentation. For example, if the carrier is set after an Observation is started, this new test will not pass.

Server equivalent of #3504 