### PR TITLE
Add gRPC authority info to the observation context

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationContext.java
@@ -43,6 +43,8 @@ public class GrpcClientObservationContext extends RequestReplySenderContext<Meta
     @Nullable
     private Code statusCode;
 
+    private String authority;
+
     public GrpcClientObservationContext(Setter<Metadata> setter) {
         super(setter);
     }
@@ -86,6 +88,14 @@ public class GrpcClientObservationContext extends RequestReplySenderContext<Meta
 
     public void setStatusCode(Code statusCode) {
         this.statusCode = statusCode;
+    }
+
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public void setAuthority(String authority) {
+        this.authority = authority;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
@@ -43,6 +43,9 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
     @Nullable
     private Code statusCode;
 
+    @Nullable
+    private String authority;
+
     public GrpcServerObservationContext(Getter<Metadata> getter) {
         super(getter);
     }
@@ -86,6 +89,15 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
 
     public void setStatusCode(Code statusCode) {
         this.statusCode = statusCode;
+    }
+
+    @Nullable
+    public String getAuthority() {
+        return this.authority;
+    }
+
+    public void setAuthority(@Nullable String authority) {
+        this.authority = authority;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientInterceptor.java
@@ -80,7 +80,7 @@ public class ObservationGrpcClientInterceptor implements ClientInterceptor {
             }
             context.setFullMethodName(fullMethodName);
             context.setMethodType(methodType);
-
+            context.setAuthority(next.authority());
             return context;
         };
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerInterceptor.java
@@ -83,6 +83,7 @@ public class ObservationGrpcServerInterceptor implements ServerInterceptor {
             }
             context.setFullMethodName(fullMethodName);
             context.setMethodType(methodType);
+            context.setAuthority(call.getAuthority());
 
             return context;
         };

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -400,6 +400,7 @@ class GrpcObservationTest {
             assertThat(serverContext.getMethodName()).isEqualTo(methodName);
             assertThat(serverContext.getFullMethodName()).isEqualTo(contextualName);
             assertThat(serverContext.getMethodType()).isEqualTo(methodType);
+            assertThat(serverContext.getAuthority()).isEqualTo("localhost");
         });
     }
 
@@ -411,6 +412,7 @@ class GrpcObservationTest {
             assertThat(clientContext.getMethodName()).isEqualTo(methodName);
             assertThat(clientContext.getFullMethodName()).isEqualTo(contextualName);
             assertThat(clientContext.getMethodType()).isEqualTo(methodType);
+            assertThat(clientContext.getAuthority()).isEqualTo("localhost");
         });
     }
 


### PR DESCRIPTION
Add and populate the gRPC authority information in both server and client.