### PR TITLE
Add peer name and port to gRPC observation contexts

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcClientObservationConvention.java
@@ -15,12 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.grpc;
 
-import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.binder.grpc.GrpcObservationDocumentation.LowCardinalityKeyNames;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Default convention for gRPC client. This class defines how to extract values from
@@ -43,14 +39,14 @@ public class DefaultGrpcClientObservationConvention implements GrpcClientObserva
 
     @Override
     public KeyValues getLowCardinalityKeyValues(GrpcClientObservationContext context) {
-        List<KeyValue> keyValues = new ArrayList<>();
-        keyValues.add(LowCardinalityKeyNames.METHOD.withValue(context.getMethodName()));
-        keyValues.add(LowCardinalityKeyNames.SERVICE.withValue(context.getServiceName()));
-        keyValues.add(LowCardinalityKeyNames.METHOD_TYPE.withValue(context.getMethodType().name()));
-        if (context.getStatusCode() != null) {
-            keyValues.add(LowCardinalityKeyNames.STATUS_CODE.withValue(context.getStatusCode().name()));
-        }
-        return KeyValues.of(keyValues);
+        String statusCode = context.getStatusCode() != null ? context.getStatusCode().name() : UNKNOWN;
+        String peerPort = context.getPeerPort() != null ? context.getPeerPort().toString() : UNKNOWN;
+        return KeyValues.of(LowCardinalityKeyNames.METHOD.withValue(context.getMethodName()),
+                LowCardinalityKeyNames.SERVICE.withValue(context.getServiceName()),
+                LowCardinalityKeyNames.METHOD_TYPE.withValue(context.getMethodType().name()),
+                LowCardinalityKeyNames.STATUS_CODE.withValue(statusCode),
+                LowCardinalityKeyNames.PEER_NAME.withValue(context.getPeerName()),
+                LowCardinalityKeyNames.PEER_PORT.withValue(peerPort));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcServerObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcServerObservationConvention.java
@@ -15,12 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.grpc;
 
-import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.instrument.binder.grpc.GrpcObservationDocumentation.LowCardinalityKeyNames;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Default convention for gRPC server. This class defines how to extract values from
@@ -43,14 +39,15 @@ public class DefaultGrpcServerObservationConvention implements GrpcServerObserva
 
     @Override
     public KeyValues getLowCardinalityKeyValues(GrpcServerObservationContext context) {
-        List<KeyValue> keyValues = new ArrayList<>();
-        keyValues.add(LowCardinalityKeyNames.METHOD.withValue(context.getMethodName()));
-        keyValues.add(LowCardinalityKeyNames.SERVICE.withValue(context.getServiceName()));
-        keyValues.add(LowCardinalityKeyNames.METHOD_TYPE.withValue(context.getMethodType().name()));
-        if (context.getStatusCode() != null) {
-            keyValues.add(LowCardinalityKeyNames.STATUS_CODE.withValue(context.getStatusCode().name()));
-        }
-        return KeyValues.of(keyValues);
+        String statusCode = context.getStatusCode() != null ? context.getStatusCode().name() : UNKNOWN;
+        String peerName = context.getPeerName() != null ? context.getPeerName() : UNKNOWN;
+        String peerPort = context.getPeerPort() != null ? context.getPeerPort().toString() : UNKNOWN;
+        return KeyValues.of(LowCardinalityKeyNames.METHOD.withValue(context.getMethodName()),
+                LowCardinalityKeyNames.SERVICE.withValue(context.getServiceName()),
+                LowCardinalityKeyNames.METHOD_TYPE.withValue(context.getMethodType().name()),
+                LowCardinalityKeyNames.STATUS_CODE.withValue(statusCode),
+                LowCardinalityKeyNames.PEER_NAME.withValue(peerName),
+                LowCardinalityKeyNames.PEER_PORT.withValue(peerPort));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationContext.java
@@ -49,6 +49,11 @@ public class GrpcClientObservationContext extends RequestReplySenderContext<Meta
 
     private Metadata trailers;
 
+    private String peerName;
+
+    @Nullable
+    private Integer peerPort;
+
     public GrpcClientObservationContext(Setter<Metadata> setter) {
         super(setter);
     }
@@ -136,6 +141,23 @@ public class GrpcClientObservationContext extends RequestReplySenderContext<Meta
      */
     public void setTrailers(Metadata trailers) {
         this.trailers = trailers;
+    }
+
+    public String getPeerName() {
+        return this.peerName;
+    }
+
+    public void setPeerName(String peerName) {
+        this.peerName = peerName;
+    }
+
+    @Nullable
+    public Integer getPeerPort() {
+        return this.peerPort;
+    }
+
+    public void setPeerPort(@Nullable Integer peerPort) {
+        this.peerPort = peerPort;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcClientObservationConvention.java
@@ -26,6 +26,8 @@ import io.micrometer.observation.ObservationConvention;
  */
 public interface GrpcClientObservationConvention extends ObservationConvention<GrpcClientObservationContext> {
 
+    String UNKNOWN = "UNKNOWN";
+
     @Override
     default boolean supportsContext(Context context) {
         return context instanceof GrpcClientObservationContext;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
@@ -83,6 +83,19 @@ public enum GrpcObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "grpc.status_code";
             }
+        },
+        PEER_NAME {
+            @Override
+            public String asString() {
+                return "net.peer.name";
+            }
+        },
+        PEER_PORT {
+            @Override
+            public String asString() {
+                return "net.peer.port";
+            }
+
         }
 
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
@@ -52,6 +52,12 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
 
     private boolean cancelled;
 
+    @Nullable
+    private String peerName;
+
+    @Nullable
+    private Integer peerPort;
+
     public GrpcServerObservationContext(Getter<Metadata> getter) {
         super(getter);
     }
@@ -157,6 +163,24 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
      */
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+
+    @Nullable
+    public String getPeerName() {
+        return this.peerName;
+    }
+
+    public void setPeerName(@Nullable String peerName) {
+        this.peerName = peerName;
+    }
+
+    @Nullable
+    public Integer getPeerPort() {
+        return this.peerPort;
+    }
+
+    public void setPeerPort(@Nullable Integer peerPort) {
+        this.peerPort = peerPort;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationConvention.java
@@ -26,6 +26,8 @@ import io.micrometer.observation.ObservationConvention;
  */
 public interface GrpcServerObservationConvention extends ObservationConvention<GrpcServerObservationContext> {
 
+    String UNKNOWN = "UNKNOWN";
+
     @Override
     default boolean supportsContext(Context context) {
         return context instanceof GrpcServerObservationContext;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientInterceptor.java
@@ -23,6 +23,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -80,7 +81,15 @@ public class ObservationGrpcClientInterceptor implements ClientInterceptor {
             }
             context.setFullMethodName(fullMethodName);
             context.setMethodType(methodType);
-            context.setAuthority(next.authority());
+            String authority = next.authority();
+            context.setAuthority(authority);
+            try {
+                URI uri = new URI(null, authority, null, null, null);
+                context.setPeerName(uri.getHost());
+                context.setPeerPort(uri.getPort());
+            }
+            catch (Exception ex) {
+            }
             return context;
         };
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerInterceptor.java
@@ -24,6 +24,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -82,8 +83,17 @@ public class ObservationGrpcServerInterceptor implements ServerInterceptor {
             }
             context.setFullMethodName(fullMethodName);
             context.setMethodType(methodType);
-            context.setAuthority(call.getAuthority());
-
+            String authority = call.getAuthority();
+            if (authority != null) {
+                context.setAuthority(authority);
+                try {
+                    URI uri = new URI(null, authority, null, null, null);
+                    context.setPeerName(uri.getHost());
+                    context.setPeerPort(uri.getPort());
+                }
+                catch (Exception ex) {
+                }
+            }
             return context;
         };
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -605,6 +605,8 @@ class GrpcObservationTest {
             assertThat(serverContext.getFullMethodName()).isEqualTo(contextualName);
             assertThat(serverContext.getMethodType()).isEqualTo(methodType);
             assertThat(serverContext.getAuthority()).isEqualTo("localhost");
+            assertThat(serverContext.getPeerName()).isEqualTo("localhost");
+            assertThat(serverContext.getPeerPort()).isEqualTo(-1);
         });
     }
 
@@ -617,6 +619,8 @@ class GrpcObservationTest {
             assertThat(clientContext.getFullMethodName()).isEqualTo(contextualName);
             assertThat(clientContext.getMethodType()).isEqualTo(methodType);
             assertThat(clientContext.getAuthority()).isEqualTo("localhost");
+            assertThat(clientContext.getPeerName()).isEqualTo("localhost");
+            assertThat(clientContext.getPeerPort()).isEqualTo(-1);
         });
     }
 


### PR DESCRIPTION
For gRPC instrumentation:
- Add peer name and port
- Use `UNKNOWN` for unknown tag values
