### PR TITLE
Include all subprojects in the japicmp check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -324,7 +324,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-commons', 'micrometer-observation', 'micrometer-observation-conventions', 'micrometer-observation-test', 'micrometer-jetty11'])) {
+            if (!(project.name in [])) {
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 
-compatibleVersion=1.9.3
+compatibleVersion=1.10.0
 
 kotlin.stdlib.default.dependency=false
 


### PR DESCRIPTION
This PR changes to include all subprojects in the japicmp check.

Closes gh-3486