### PR TITLE
Adds an option to allow removal of low & high cardinality key values

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -20,6 +20,7 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -942,6 +943,30 @@ public interface Observation extends ObservationView {
         }
 
         /**
+         * Removes a low cardinality key value by looking at its key - those will be
+         * removed to those fetched from the
+         * {@link ObservationConvention#getLowCardinalityKeyValues(Context)} method.
+         * @param keyName name of the key
+         * @return this context
+         */
+        public Context removeLowCardinalityKeyValue(String keyName) {
+            this.lowCardinalityKeyValues.remove(keyName);
+            return this;
+        }
+
+        /**
+         * Removes a high cardinality key value by looking at its key - those will be
+         * removed to those fetched from the
+         * {@link ObservationConvention#getHighCardinalityKeyValues(Context)} method.
+         * @param keyName name of the key
+         * @return this context
+         */
+        public Context removeHighCardinalityKeyValue(String keyName) {
+            this.highCardinalityKeyValues.remove(keyName);
+            return this;
+        }
+
+        /**
          * Adds multiple low cardinality key values at once.
          * @param keyValues collection of key values
          * @return this context
@@ -958,6 +983,26 @@ public interface Observation extends ObservationView {
          */
         public Context addHighCardinalityKeyValues(KeyValues keyValues) {
             keyValues.stream().forEach(this::addHighCardinalityKeyValue);
+            return this;
+        }
+
+        /**
+         * Removes multiple low cardinality key values at once.
+         * @param keyNames collection of key names
+         * @return this context
+         */
+        public Context removeLowCardinalityKeyValues(String... keyNames) {
+            Arrays.stream(keyNames).forEach(this::removeLowCardinalityKeyValue);
+            return this;
+        }
+
+        /**
+         * Removes multiple high cardinality key values at once.
+         * @param keyNames collection of key names
+         * @return this context
+         */
+        public Context removeHighCardinalityKeyValues(String... keyNames) {
+            Arrays.stream(keyNames).forEach(this::removeHighCardinalityKeyValue);
             return this;
         }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationContextTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationContextTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.observation;
 
 import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -129,6 +130,28 @@ class ObservationContextTest {
         assertThat(context.getHighCardinalityKeyValue("high")).isSameAs(newHigh);
         assertThat(context.getLowCardinalityKeyValues()).containsExactly(newLow);
         assertThat(context.getHighCardinalityKeyValues()).containsExactly(newHigh);
+    }
+
+    @Test
+    void removingLowCardinalityKeysShouldBePossible() {
+        context.addLowCardinalityKeyValues(KeyValues.of(KeyValue.of("key", "VALUE"), KeyValue.of("key2", "VALUE2"),
+                KeyValue.of("key3", "VALUE3"), KeyValue.of("key4", "VALUE4")));
+
+        context.removeLowCardinalityKeyValue("key");
+        context.removeLowCardinalityKeyValues("key3", "key4");
+
+        assertThat(context.getLowCardinalityKeyValues()).containsExactly(KeyValue.of("key2", "VALUE2"));
+    }
+
+    @Test
+    void removingHighCardinalityKeysShouldBePossible() {
+        context.addHighCardinalityKeyValues(KeyValues.of(KeyValue.of("key", "VALUE"), KeyValue.of("key2", "VALUE2"),
+                KeyValue.of("key3", "VALUE3"), KeyValue.of("key4", "VALUE4")));
+
+        context.removeHighCardinalityKeyValue("key");
+        context.removeHighCardinalityKeyValues("key3", "key4");
+
+        assertThat(context.getHighCardinalityKeyValues()).containsExactly(KeyValue.of("key2", "VALUE2"));
     }
 
 }


### PR DESCRIPTION
without this change it's hard to mutate a context using observationfilter because you don't have access to e.g. all properties in a map or you can't remove a key value

with this change you are allowed to completely mutate the context