### PR TITLE
Add metrics for the total number of application threads started in the JVM

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -180,17 +180,19 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
             CompositeData cd = (CompositeData) notification.getUserData();
             GarbageCollectionNotificationInfo notificationInfo = GarbageCollectionNotificationInfo.from(cd);
 
+            String gcName = notificationInfo.getGcName();
             String gcCause = notificationInfo.getGcCause();
             String gcAction = notificationInfo.getGcAction();
             GcInfo gcInfo = notificationInfo.getGcInfo();
             long duration = gcInfo.getDuration();
-            if (isConcurrentPhase(gcCause, notificationInfo.getGcName())) {
-                Timer.builder("jvm.gc.concurrent.phase.time").tags(tags).tags("action", gcAction, "cause", gcCause)
+            if (isConcurrentPhase(gcCause, gcName)) {
+                Timer.builder("jvm.gc.concurrent.phase.time").tags(tags)
+                        .tags("action", gcAction, "cause", gcCause, "gc_name", gcName)
                         .description("Time spent in concurrent phase").register(registry)
                         .record(duration, TimeUnit.MILLISECONDS);
             }
             else {
-                Timer.builder("jvm.gc.pause").tags(tags).tags("action", gcAction, "cause", gcCause)
+                Timer.builder("jvm.gc.pause").tags(tags).tags("action", gcAction, "cause", gcCause, "gc", gcName)
                         .description("Time spent in GC pause").register(registry)
                         .record(duration, TimeUnit.MILLISECONDS);
             }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -180,19 +180,17 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
             CompositeData cd = (CompositeData) notification.getUserData();
             GarbageCollectionNotificationInfo notificationInfo = GarbageCollectionNotificationInfo.from(cd);
 
-            String gcName = notificationInfo.getGcName();
             String gcCause = notificationInfo.getGcCause();
             String gcAction = notificationInfo.getGcAction();
             GcInfo gcInfo = notificationInfo.getGcInfo();
             long duration = gcInfo.getDuration();
-            if (isConcurrentPhase(gcCause, gcName)) {
-                Timer.builder("jvm.gc.concurrent.phase.time").tags(tags)
-                        .tags("action", gcAction, "cause", gcCause, "gc_name", gcName)
+            if (isConcurrentPhase(gcCause, notificationInfo.getGcName())) {
+                Timer.builder("jvm.gc.concurrent.phase.time").tags(tags).tags("action", gcAction, "cause", gcCause)
                         .description("Time spent in concurrent phase").register(registry)
                         .record(duration, TimeUnit.MILLISECONDS);
             }
             else {
-                Timer.builder("jvm.gc.pause").tags(tags).tags("action", gcAction, "cause", gcCause, "gc", gcName)
+                Timer.builder("jvm.gc.pause").tags(tags).tags("action", gcAction, "cause", gcCause)
                         .description("Time spent in GC pause").register(registry)
                         .record(duration, TimeUnit.MILLISECONDS);
             }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -17,7 +17,11 @@ package io.micrometer.core.instrument.binder.jvm;
 
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.NonNullFields;
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -68,8 +68,8 @@ public class JvmThreadMetrics implements MeterBinder {
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
         FunctionCounter.builder("jvm.threads.started", threadBean, ThreadMXBean::getTotalStartedThreadCount).tags(tags)
-                .description("The total number of application threads started in the JVM")
-                .baseUnit(BaseUnits.THREADS).register(registry);
+                .description("The total number of application threads started in the JVM").baseUnit(BaseUnits.THREADS)
+                .register(registry);
 
         try {
             threadBean.getAllThreadIds();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -17,10 +17,7 @@ package io.micrometer.core.instrument.binder.jvm;
 
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.NonNullFields;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 
@@ -66,9 +63,9 @@ public class JvmThreadMetrics implements MeterBinder {
                 .description("The current number of live threads including both daemon and non-daemon threads")
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
-        Gauge.builder("jvm.threads.started", threadBean, ThreadMXBean::getTotalStartedThreadCount).tags(tags)
+        FunctionCounter.builder("jvm.threads.started", threadBean, ThreadMXBean::getTotalStartedThreadCount).tags(tags)
                 .description(
-                        "The total number of threads created and also started since the Java virtual machine started")
+                        "The total number of application threads started in the JVM")
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
         try {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -66,6 +66,11 @@ public class JvmThreadMetrics implements MeterBinder {
                 .description("The current number of live threads including both daemon and non-daemon threads")
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
+        Gauge.builder("jvm.threads.started", threadBean, ThreadMXBean::getTotalStartedThreadCount).tags(tags)
+                .description(
+                        "The total number of threads created and also started since the Java virtual machine started")
+                .baseUnit(BaseUnits.THREADS).register(registry);
+
         try {
             threadBean.getAllThreadIds();
             for (Thread.State state : Thread.State.values()) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -68,8 +68,7 @@ public class JvmThreadMetrics implements MeterBinder {
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
         FunctionCounter.builder("jvm.threads.started", threadBean, ThreadMXBean::getTotalStartedThreadCount).tags(tags)
-                .description(
-                        "The total number of application threads started in the JVM")
+                .description("The total number of application threads started in the JVM")
                 .baseUnit(BaseUnits.THREADS).register(registry);
 
         try {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -39,6 +39,7 @@ class JvmThreadMetricsTest {
     void threadMetrics() {
         MeterRegistry registry = new SimpleMeterRegistry();
         new JvmThreadMetrics().bindTo(registry);
+        double initialThreadCount = registry.get("jvm.threads.started").gauge().value();
 
         assertThat(registry.get("jvm.threads.live").gauge().value()).isGreaterThan(0);
         assertThat(registry.get("jvm.threads.daemon").gauge().value()).isGreaterThan(0);
@@ -51,6 +52,7 @@ class JvmThreadMetricsTest {
 
         createTimedWaitingThread();
         assertThat(registry.get("jvm.threads.states").tag("state", "timed-waiting").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.started").gauge().value()).isGreaterThan(initialThreadCount);
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -39,20 +39,20 @@ class JvmThreadMetricsTest {
     void threadMetrics() {
         MeterRegistry registry = new SimpleMeterRegistry();
         new JvmThreadMetrics().bindTo(registry);
-        double initialThreadCount = registry.get("jvm.threads.started").gauge().value();
+        double initialThreadCount = registry.get("jvm.threads.started").functionCounter().count();
 
-        assertThat(registry.get("jvm.threads.live").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.daemon").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.peak").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.states").tag("state", "runnable").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.live").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.daemon").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.peak").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.states").tag("state", "runnable").gauge().value()).isPositive();
 
         createBlockedThread();
-        assertThat(registry.get("jvm.threads.states").tag("state", "blocked").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.states").tag("state", "waiting").gauge().value()).isGreaterThan(0);
+        assertThat(registry.get("jvm.threads.states").tag("state", "blocked").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.states").tag("state", "waiting").gauge().value()).isPositive();
 
         createTimedWaitingThread();
-        assertThat(registry.get("jvm.threads.states").tag("state", "timed-waiting").gauge().value()).isGreaterThan(0);
-        assertThat(registry.get("jvm.threads.started").gauge().value()).isGreaterThan(initialThreadCount);
+        assertThat(registry.get("jvm.threads.states").tag("state", "timed-waiting").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.started").functionCounter().count()).isGreaterThan(initialThreadCount);
     }
 
     @Test


### PR DESCRIPTION
- generate a metric for total Threads started since the JVM start time. This is extremely useful to understand how an application is doing on thread creation and also understand the creation patterns. The existing metrics give the current status of threads but nothing about whether the threads are created newly or are existing ones. This metric will aid in such scenarios by taking deltas.