### PR TITLE
Upgrade to Gradle Enterprise Gradle Plugin 3.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
         classpath 'com.netflix.nebula:nebula-publishing-plugin:18.4.0'
         classpath 'com.netflix.nebula:nebula-project-plugin:9.4.0'
         classpath 'io.spring.nohttp:nohttp-gradle:0.0.10'
-        classpath 'org.gradle:test-retry-gradle-plugin:1.4.1'
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         classpath 'me.champeau.gradle:japicmp-gradle-plugin:0.4.1'
         classpath 'de.undercouch:gradle-download-task:5.2.1'
@@ -59,7 +58,6 @@ subprojects {
         apply plugin: 'com.github.hierynomus.license'
         apply plugin: 'checkstyle'
         apply plugin: 'io.spring.nohttp'
-        apply plugin: 'org.gradle.test-retry'
 
         java {
             // It is more idiomatic to define different features for different sets of optional

--- a/buildscript-gradle.lockfile
+++ b/buildscript-gradle.lockfile
@@ -76,7 +76,6 @@ org.codehaus.plexus:plexus-utils:2.0.6=classpath
 org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r=classpath
 org.glassfish.jaxb:jaxb-runtime:2.3.2=classpath
 org.glassfish.jaxb:txw2:2.3.2=classpath
-org.gradle:test-retry-gradle-plugin:1.4.1=classpath
 org.javassist:javassist:3.24.0-GA=classpath
 org.jetbrains.kotlin:kotlin-stdlib-common:1.5.30=classpath
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.5.30=classpath

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.11.4'
+    id 'com.gradle.enterprise' version '3.12'
     id 'io.spring.ge.conventions' version '0.0.11'
 }
 


### PR DESCRIPTION
This PR upgrades to Gradle Enterprise Gradle Plugin 3.12.

This PR also removes Test-Retry Gradle Plugin as it's provided by Gradle Enterprise Gradle Plugin now.

Supersedes gh-3565
See https://plugins.gradle.org/plugin/com.gradle.enterprise/3.12