### PR TITLE
Pin spring-cloud-dependencies to 2021.0.5

### DIFF
--- a/samples/micrometer-samples-boot2/build.gradle
+++ b/samples/micrometer-samples-boot2/build.gradle
@@ -27,7 +27,7 @@ dependencies {
         exclude group: 'io.micrometer', module: 'micrometer-core'
     }
 
-    implementation platform('org.springframework.cloud:spring-cloud-dependencies:latest.release')
+    implementation platform('org.springframework.cloud:spring-cloud-dependencies:2021.0.5')
     implementation 'org.springframework.cloud:spring-cloud-starter-sleuth'
     implementation 'org.springframework.cloud:spring-cloud-sleuth-zipkin'
 


### PR DESCRIPTION
This PR pins `org.springframework.cloud:spring-cloud-dependencies` to `2021.0.5` as builds are failing now as follows:

```
% ./gradlew clean check --no-build-cache
...
Execution failed for task ':micrometer-samples-boot2:compileJava'.
> Could not resolve all files for configuration ':micrometer-samples-boot2:compileClasspath'.
   > Could not find org.springframework.cloud:spring-cloud-starter-sleuth:.
     Required by:
         project :micrometer-samples-boot2
   > Could not find org.springframework.cloud:spring-cloud-sleuth-zipkin:.
     Required by:
         project :micrometer-samples-boot2
...
%
```

`2022.0.0` seems to be broken at the moment as follows:

```
% ./gradlew :micrometer-samples-boot2:dependencies
...
+--- org.springframework.cloud:spring-cloud-dependencies:latest.release -> 2022.0.0
+--- org.springframework.cloud:spring-cloud-starter-sleuth FAILED
+--- org.springframework.cloud:spring-cloud-sleuth-zipkin FAILED
...
%
```