### PR TITLE
Make cumulative count computations in `takeCountSnapshot` more efficient

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
@@ -152,11 +152,7 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
 
     abstract double valueAtPercentile(double percentile);
 
-    abstract double countAtValue(double value);
-
-    double countAtValue(long value) {
-        return countAtValue((double) value);
-    }
+    abstract Iterator<CountAtBucket> countsAtValues(Iterator<Double> values);
 
     void outputSummary(PrintStream out, double bucketScaling) {
     }
@@ -209,10 +205,9 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
         }
 
         final CountAtBucket[] counts = new CountAtBucket[monitoredValues.size()];
-        final Iterator<Double> iterator = monitoredValues.iterator();
+        final Iterator<CountAtBucket> iterator = countsAtValues(monitoredValues.iterator());
         for (int i = 0; i < counts.length; i++) {
-            final double v = iterator.next();
-            counts[i] = new CountAtBucket(v, countAtValue(v));
+            counts[i] = iterator.next();
         }
         return counts;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
@@ -19,6 +19,7 @@ import io.micrometer.core.instrument.Clock;
 
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.NavigableSet;
 import java.util.Objects;
@@ -111,9 +112,28 @@ public class TimeWindowFixedBoundaryHistogram
     }
 
     @Override
-    double countAtValue(double value) {
-        return this.cumulativeBucketCounts ? currentHistogram().countAtValueCumulative(value)
-                : currentHistogram().countAtValue(value);
+    Iterator<CountAtBucket> countsAtValues(Iterator<Double> values) {
+        return new Iterator<CountAtBucket>() {
+            private double cumulativeCount = 0.0;
+
+            @Override
+            public boolean hasNext() {
+                return values.hasNext();
+            }
+
+            @Override
+            public CountAtBucket next() {
+                double value = values.next();
+                double count = currentHistogram().countAtValue(value);
+                if (cumulativeBucketCounts) {
+                    cumulativeCount += count;
+                    return new CountAtBucket(value, cumulativeCount);
+                }
+                else {
+                    return new CountAtBucket(value, count);
+                }
+            }
+        };
     }
 
     @Override
@@ -143,22 +163,12 @@ public class TimeWindowFixedBoundaryHistogram
 
         /**
          * For recording efficiency, this is a normal histogram. We turn these values into
-         * cumulative counts only on calls to {@link #countAtValueCumulative(double)}.
+         * cumulative counts only on calls to {@link #countsAtValues(Iterator<Double>)}.
          */
         final AtomicLongArray values;
 
         FixedBoundaryHistogram() {
             this.values = new AtomicLongArray(buckets.length);
-        }
-
-        long countAtValueCumulative(double value) {
-            int index = Arrays.binarySearch(buckets, value);
-            if (index < 0)
-                return 0;
-            long count = 0;
-            for (int i = 0; i <= index; i++)
-                count += values.get(i);
-            return count;
         }
 
         long countAtValue(double value) {


### PR DESCRIPTION
Instead of recomputing the cumulative sum again for each `CountAtBucket`, keep a running tally during iteration