### PR TITLE
Add onMeterPublishedSuccess notification listener for Elastic Meter Registry

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -100,7 +100,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
     @SuppressWarnings("deprecation")
     public ElasticMeterRegistry(ElasticConfig config, Clock clock) {
         this(config, clock, DEFAULT_THREAD_FACTORY,
-             new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), Collections.emptyList());
+                new HttpUrlConnectionSender(config.connectTimeout(), config.readTimeout()), Collections.emptyList());
     }
 
     /**

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -58,6 +58,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("elastic-metrics-publisher");
     static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
     private final List<BiConsumer<ElasticMeterRegistry, List<Meter>>> meterPublishedSuccessListeners = new CopyOnWriteArrayList<>();
 
     private static final String ES_METRICS_TEMPLATE = "/_template/metrics_template";
@@ -432,7 +433,8 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             return this;
         }
 
-        public Builder onMeterPublishedSuccess(BiConsumer<ElasticMeterRegistry, List<Meter>> meterPublishedSuccessListener) {
+        public Builder onMeterPublishedSuccess(
+                BiConsumer<ElasticMeterRegistry, List<Meter>> meterPublishedSuccessListener) {
             meterPublishedSuccessListeners.add(meterPublishedSuccessListener);
             return this;
         }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
@@ -71,8 +71,7 @@ abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
         publishResult = new AtomicReference<>();
         host = "http://" + elasticsearch.getHttpHostAddress();
         registry = ElasticMeterRegistry.builder(getConfig())
-                                       .onMeterPublishedSuccess((registry, batch) -> publishResult.set(Map.entry(registry, batch)))
-                                       .build();
+                .onMeterPublishedSuccess((registry, batch) -> publishResult.set(Map.entry(registry, batch))).build();
     }
 
     @Test
@@ -99,9 +98,8 @@ abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
 
         registry.publish();
 
-        assertThat(publishResult).isNotNull()
-                                 .hasValueSatisfying(value -> assertThat(value).extracting(Map.Entry::getKey, Map.Entry::getValue)
-                                                                               .containsExactly(registry, Arrays.asList(counter)));
+        assertThat(publishResult).isNotNull().hasValueSatisfying(value -> assertThat(value)
+                .extracting(Map.Entry::getKey, Map.Entry::getValue).containsExactly(registry, Arrays.asList(counter)));
     }
 
     protected String getCountTypePath(String indexName) {


### PR DESCRIPTION
This PR adds support for elastic meter registry to notify registered listeners when a batch of meters have been successfully published to remote elastic server. 