### PR TITLE
[Dynatrace registry v1] Use header instead of query parameter

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
@@ -194,14 +194,13 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
     void putCustomMetric(final DynatraceMetricDefinition customMetric) {
         HttpSender.Request.Builder requestBuilder;
         try {
-            requestBuilder = httpClient
-                    .put(customMetricEndpointTemplate + customMetric.getMetricId())
+            requestBuilder = httpClient.put(customMetricEndpointTemplate + customMetric.getMetricId())
                     .withHeader(AUTHORIZATION_HEADER_KEY, authorizationHeaderValue)
                     .withJsonContent(customMetric.asJson());
         }
         catch (Exception ex) {
             if (logger.isErrorEnabled()) {
-                logger.error("failed to build request: {}", redactToken(ex.getMessage()));
+                logger.error("failed to build request", ex);
             }
             return; // don't try to export data points, the request can't be built
         }
@@ -223,13 +222,12 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
         for (DynatraceBatchedPayload postMessage : createPostMessages(type, group, timeSeries)) {
             HttpSender.Request.Builder requestBuilder;
             try {
-                requestBuilder = httpClient
-                        .post(customDeviceMetricEndpoint).withJsonContent(postMessage.payload)
+                requestBuilder = httpClient.post(customDeviceMetricEndpoint).withJsonContent(postMessage.payload)
                         .withHeader(AUTHORIZATION_HEADER_KEY, authorizationHeaderValue);
             }
             catch (Exception ex) {
                 if (logger.isErrorEnabled()) {
-                    logger.error("failed to build request: {}", redactToken(ex.getMessage()));
+                    logger.error("failed to build request", ex);
                 }
 
                 return; // don't try to export data points, the request can't be built
@@ -259,7 +257,7 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
         }
         catch (Throwable e) {
             if (logger.isErrorEnabled()) {
-                logger.error("failed to send metrics to Dynatrace: {}", redactToken(e.getMessage()));
+                logger.error("failed to send metrics to Dynatrace", e);
             }
             return null;
         }
@@ -315,10 +313,6 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
 
     private Meter.Id idWithSuffix(Meter.Id id, String suffix) {
         return id.withName(id.getName() + "." + suffix);
-    }
-
-    private String redactToken(String message) {
-        return message.replace(config.apiToken(), "<redacted>");
     }
 
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceExporterV1.java
@@ -69,15 +69,13 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
 
     private static final String AUTHORIZATION_HEADER_KEY = "Authorization";
 
-    private final String authorizationHeaderValue;
+    private static final String AUTHORIZATION_HEADER_VALUE_TEMPLATE = "Api-Token %s";
 
     public DynatraceExporterV1(DynatraceConfig config, Clock clock, HttpSender httpClient) {
         super(config, clock, httpClient);
 
         this.customMetricEndpointTemplate = config.uri() + "/api/v1/timeseries/";
         this.namingConvention = new DynatraceNamingConvention(NamingConvention.dot, DynatraceApiVersion.V1);
-
-        this.authorizationHeaderValue = String.format("Api-Token %s", config.apiToken());
     }
 
     @Override
@@ -195,7 +193,8 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
         HttpSender.Request.Builder requestBuilder;
         try {
             requestBuilder = httpClient.put(customMetricEndpointTemplate + customMetric.getMetricId())
-                    .withHeader(AUTHORIZATION_HEADER_KEY, authorizationHeaderValue)
+                    .withHeader(AUTHORIZATION_HEADER_KEY,
+                            String.format(AUTHORIZATION_HEADER_VALUE_TEMPLATE, config.apiToken()))
                     .withJsonContent(customMetric.asJson());
         }
         catch (Exception ex) {
@@ -223,7 +222,8 @@ public class DynatraceExporterV1 extends AbstractDynatraceExporter {
             HttpSender.Request.Builder requestBuilder;
             try {
                 requestBuilder = httpClient.post(customDeviceMetricEndpoint).withJsonContent(postMessage.payload)
-                        .withHeader(AUTHORIZATION_HEADER_KEY, authorizationHeaderValue);
+                        .withHeader(AUTHORIZATION_HEADER_KEY,
+                                String.format(AUTHORIZATION_HEADER_VALUE_TEMPLATE, config.apiToken()));
             }
             catch (Exception ex) {
                 if (logger.isErrorEnabled()) {


### PR DESCRIPTION
In the Dynatrace v1 exporter, the API token is passed as a query parameter in the URL. On certain occasions, a misconfiguration can lead to the URL being printed in error logs. In the case where the API token is part of the URL as a query parameter, it can be leaked to the logs. We addressed that in the past (https://github.com/micrometer-metrics/micrometer/pull/3484) by redacting the token in the logs. However, we decided to update it now to use the API token in an Authorization header instead. This way, the token is no longer part of the URL, and can therefore not be leaked that way.
