### PR TITLE
Support Apache HttpClient 5

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,6 +49,7 @@ def VERSIONS = [
         'net.sf.ehcache:ehcache:latest.release',
         'org.apache.httpcomponents:httpasyncclient:latest.release',
         'org.apache.httpcomponents:httpclient:latest.release',
+        'org.apache.httpcomponents.client5:httpclient5:latest.release',
         'org.apache.kafka:kafka-clients:2.+',
         'org.apache.kafka:kafka-streams:2.+',
         'org.apache.logging.log4j:log4j-core:2.+',

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     // apache httpcomponents monitoring
     optionalApi 'org.apache.httpcomponents:httpclient'
     optionalApi 'org.apache.httpcomponents:httpasyncclient'
+    optionalApi 'org.apache.httpcomponents.client5:httpclient5'
 
     // hystrix monitoring
     optionalApi 'com.netflix.hystrix:hystrix-core'

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.observation.transport.RequestReplySenderContext;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.util.function.Function;
+
+/**
+ * {@link io.micrometer.observation.Observation.Context} for use with Apache HTTP Client 5
+ * {@link io.micrometer.observation.Observation} instrumentation.
+ *
+ * @since 1.11.0
+ */
+public class ApacheHttpClientContext extends RequestReplySenderContext<HttpRequest, HttpResponse> {
+
+    private final HttpContext apacheHttpContext;
+
+    private final Function<HttpRequest, String> uriMapper;
+
+    private final boolean exportTagsForRoute;
+
+    public ApacheHttpClientContext(HttpRequest request, HttpContext apacheHttpContext,
+            Function<HttpRequest, String> uriMapper, boolean exportTagsForRoute) {
+        super((httpRequest, key, value) -> {
+            if (httpRequest != null) {
+                httpRequest.addHeader(key, value);
+            }
+        });
+        this.uriMapper = uriMapper;
+        this.exportTagsForRoute = exportTagsForRoute;
+        setCarrier(request);
+        this.apacheHttpContext = apacheHttpContext;
+    }
+
+    public HttpContext getApacheHttpContext() {
+        return apacheHttpContext;
+    }
+
+    public Function<HttpRequest, String> getUriMapper() {
+        return uriMapper;
+    }
+
+    public boolean shouldExportTagsForRoute() {
+        return exportTagsForRoute;
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationConvention.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+
+/**
+ * {@link ObservationConvention} for Apache HTTP client instrumentation.
+ *
+ * @since 1.11.0
+ * @see DefaultApacheHttpClientObservationConvention
+ */
+public interface ApacheHttpClientObservationConvention extends ObservationConvention<ApacheHttpClientContext> {
+
+    @Override
+    default boolean supportsContext(Observation.Context context) {
+        return context instanceof ApacheHttpClientContext;
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationConvention.java
@@ -19,7 +19,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 
 /**
- * {@link ObservationConvention} for Apache HTTP client instrumentation.
+ * {@link ObservationConvention} for Apache HTTP Client 5 instrumentation.
  *
  * @since 1.11.0
  * @see DefaultApacheHttpClientObservationConvention

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+/**
+ * {@link ObservationDocumentation} for Apache HTTP Client 5 instrumentation.
+ * @since 1.11.0
+ * @see MicrometerHttpRequestExecutor
+ */
+public enum ApacheHttpClientObservationDocumentation implements ObservationDocumentation {
+
+    DEFAULT {
+        @Override
+        public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+            return DefaultApacheHttpClientObservationConvention.class;
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return ApacheHttpClientKeyNames.values();
+        }
+    };
+
+    enum ApacheHttpClientKeyNames implements KeyName {
+
+        STATUS {
+            @Override
+            public String asString() {
+                return "status";
+            }
+        },
+        METHOD {
+            @Override
+            public String asString() {
+                return "method";
+            }
+        },
+        URI {
+            @Override
+            public String asString() {
+                return "uri";
+            }
+        },
+        TARGET_SCHEME {
+            @Override
+            public String asString() {
+                return "target.scheme";
+            }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        },
+        TARGET_HOST {
+            @Override
+            public String asString() {
+                return "target.host";
+            }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        },
+        TARGET_PORT {
+            @Override
+            public String asString() {
+                return "target.port";
+            }
+
+            @Override
+            public boolean isRequired() {
+                return false;
+            }
+        }
+
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.lang.Nullable;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+
+import java.io.IOException;
+
+/**
+ * Default implementation of {@link ApacheHttpClientObservationConvention}.
+ *
+ * @since 1.11.0
+ * @see ApacheHttpClientObservationDocumentation
+ */
+public class DefaultApacheHttpClientObservationConvention implements ApacheHttpClientObservationConvention {
+
+    /**
+     * Singleton instance of this convention.
+     */
+    public static final DefaultApacheHttpClientObservationConvention INSTANCE = new DefaultApacheHttpClientObservationConvention();
+
+    // There is no need to instantiate this class multiple times, but it may be extended,
+    // hence protected visibility.
+    protected DefaultApacheHttpClientObservationConvention() {
+    }
+
+    @Override
+    public String getName() {
+        return MicrometerHttpRequestExecutor.METER_NAME;
+    }
+
+    @Override
+    public String getContextualName(ApacheHttpClientContext context) {
+        return "HTTP " + getMethodString(context.getCarrier());
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(ApacheHttpClientContext context) {
+        KeyValues keyValues = KeyValues.of(
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.METHOD
+                        .withValue(getMethodString(context.getCarrier())),
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.URI
+                        .withValue(context.getUriMapper().apply(context.getCarrier())),
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.STATUS
+                        .withValue(getStatusValue(context.getResponse(), context.getError())));
+        if (context.shouldExportTagsForRoute()) {
+            keyValues = keyValues.and(HttpContextUtils.generateTagStringsForRoute(context.getApacheHttpContext()));
+        }
+        return keyValues;
+    }
+
+    String getStatusValue(@Nullable HttpResponse response, Throwable error) {
+        if (error instanceof IOException || error instanceof HttpException || error instanceof RuntimeException) {
+            return "IO_ERROR";
+        }
+
+        return response != null ? Integer.toString(response.getCode()) : "CLIENT_ERROR";
+    }
+
+    String getMethodString(@Nullable HttpRequest request) {
+        return request != null && request.getMethod() != null ? request.getMethod() : "UNKNOWN";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultUriMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultUriMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpRequest;
+
+import java.util.function.Function;
+
+/**
+ * Extracts the URI pattern from the predefined request header,
+ * {@value DefaultUriMapper#URI_PATTERN_HEADER} if available.
+ *
+ * @author Benjamin Hubert
+ * @since 1.11.0
+ */
+public class DefaultUriMapper implements Function<HttpRequest, String> {
+
+    /**
+     * Header name for URI pattern.
+     */
+    public static final String URI_PATTERN_HEADER = "URI_PATTERN";
+
+    @Override
+    public String apply(HttpRequest httpRequest) {
+        Header uriPattern = httpRequest.getLastHeader(URI_PATTERN_HEADER);
+        if (uriPattern != null && uriPattern.getValue() != null) {
+            return uriPattern.getValue();
+        }
+        return "UNKNOWN";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/HttpContextUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/HttpContextUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.Tags;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+class HttpContextUtils {
+
+    static Tags generateTagsForRoute(HttpContext context) {
+        return Tags.of(generateTagStringsForRoute(context));
+    }
+
+    static String[] generateTagStringsForRoute(HttpContext context) {
+        String targetScheme = "UNKNOWN";
+        String targetHost = "UNKNOWN";
+        String targetPort = "UNKNOWN";
+        Object routeAttribute = context.getAttribute("http.route");
+        if (routeAttribute instanceof HttpRoute) {
+            HttpHost host = ((HttpRoute) routeAttribute).getTargetHost();
+            targetScheme = host.getSchemeName();
+            targetHost = host.getHostName();
+            targetPort = String.valueOf(host.getPort());
+        }
+        return new String[] {
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_SCHEME.asString(),
+                targetScheme, ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_HOST.asString(),
+                targetHost, ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.TARGET_PORT.asString(),
+                targetPort };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.HttpResponseInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Provides {@link HttpRequestInterceptor} and {@link HttpResponseInterceptor} for
+ * configuring with an {@link org.apache.hc.client5.http.async.HttpAsyncClient}. Usage
+ * example: <pre>{@code
+ *     MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
+ *             request -> request.getRequestLine().getUri(),
+ *             Tags.empty(),
+ *             true);
+ *
+ *     CloseableHttpAsyncClient httpAsyncClient = HttpAsyncClients.custom()
+ *             .addInterceptorFirst(interceptor.getRequestInterceptor())
+ *             .addInterceptorLast(interceptor.getResponseInterceptor())
+ *             .build();
+ * }</pre>
+ *
+ * @author Jon Schneider
+ * @since 1.11.0
+ */
+public class MicrometerHttpClientInterceptor {
+
+    private static final String METER_NAME = "httpcomponents.httpclient.request";
+
+    private final Map<HttpContext, Timer.ResourceSample> timerByHttpContext = new ConcurrentHashMap<>();
+
+    private final HttpRequestInterceptor requestInterceptor;
+
+    private final HttpResponseInterceptor responseInterceptor;
+
+    /**
+     * Create a {@code MicrometerHttpClientInterceptor} instance.
+     * @param meterRegistry meter registry to bind
+     * @param uriMapper URI mapper to create {@code uri} tag
+     * @param extraTags extra tags
+     * @param exportTagsForRoute whether to export tags for route
+     */
+    public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry, Function<HttpRequest, String> uriMapper,
+            Iterable<Tag> extraTags, boolean exportTagsForRoute) {
+        this.requestInterceptor = (request, entityDetails, context) -> timerByHttpContext.put(context,
+                Timer.resource(meterRegistry, METER_NAME).tags("method", request.getMethod(), "uri",
+                        uriMapper.apply(request)));
+
+        this.responseInterceptor = (response, entityDetails, context) -> {
+            timerByHttpContext.remove(context).tag("status", Integer.toString(response.getCode()))
+                    .tags(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
+                    .tags(extraTags).close();
+        };
+    }
+
+    /**
+     * Create a {@code MicrometerHttpClientInterceptor} instance with
+     * {@link DefaultUriMapper}.
+     * @param meterRegistry meter registry to bind
+     * @param extraTags extra tags
+     * @param exportTagsForRoute whether to export tags for route
+     */
+    public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry, Iterable<Tag> extraTags,
+            boolean exportTagsForRoute) {
+        this(meterRegistry, new DefaultUriMapper(), extraTags, exportTagsForRoute);
+    }
+
+    public HttpRequestInterceptor getRequestInterceptor() {
+        return requestInterceptor;
+    }
+
+    public HttpResponseInterceptor getResponseInterceptor() {
+        return responseInterceptor;
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
@@ -33,14 +33,14 @@ import java.util.function.Function;
  * configuring with an {@link org.apache.hc.client5.http.async.HttpAsyncClient}. Usage
  * example: <pre>{@code
  *     MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
- *             request -> request.getRequestLine().getUri(),
+ *             HttpRequest::getRequestUri,
  *             Tags.empty(),
  *             true);
  *
  *     CloseableHttpAsyncClient httpAsyncClient = HttpAsyncClients.custom()
- *             .addInterceptorFirst(interceptor.getRequestInterceptor())
- *             .addInterceptorLast(interceptor.getResponseInterceptor())
- *             .build();
+ *                 .addRequestInterceptorFirst(interceptor.getRequestInterceptor())
+ *                 .addResponseInterceptorLast(interceptor.getResponseInterceptor())
+ *                 .build();
  * }</pre>
  *
  * @author Jon Schneider

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
@@ -30,8 +30,8 @@ import java.util.function.Function;
 
 /**
  * Provides {@link HttpRequestInterceptor} and {@link HttpResponseInterceptor} for
- * configuring with an {@link org.apache.hc.client5.http.async.HttpAsyncClient}. Usage
- * example: <pre>{@code
+ * instrumenting async Apache HTTP Client 5. Configure the interceptors on an
+ * {@link org.apache.hc.client5.http.async.HttpAsyncClient}. Usage example: <pre>{@code
  *     MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
  *             HttpRequest::getRequestUri,
  *             Tags.empty(),

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -34,9 +34,10 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * This instruments the execution of every request that goes
- * through an {@link org.apache.hc.client5.http.classic.HttpClient} on which it is configured. It must be registered
- * as request executor when creating the HttpClient instance. For example:
+ * This instruments the execution of every request that goes through an
+ * {@link org.apache.hc.client5.http.classic.HttpClient} on which it is configured. It
+ * must be registered as request executor when creating the HttpClient instance. For
+ * example:
  *
  * <pre>
  *     HttpClientBuilder.create()

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * This HttpRequestExecutor tracks the request duration of every request, that goes
- * through an {@link org.apache.hc.client5.http.classic.HttpClient}. It must be registered
+ * This instruments the execution of every request that goes
+ * through an {@link org.apache.hc.client5.http.classic.HttpClient} on which it is configured. It must be registered
  * as request executor when creating the HttpClient instance. For example:
  *
  * <pre>

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2019 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.ObservationOrTimerCompatibleInstrumentation;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.HttpClientConnection;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * This HttpRequestExecutor tracks the request duration of every request, that goes
+ * through an {@link org.apache.hc.client5.http.classic.HttpClient}. It must be registered
+ * as request executor when creating the HttpClient instance. For example:
+ *
+ * <pre>
+ *     HttpClientBuilder.create()
+ *         .setRequestExecutor(MicrometerHttpRequestExecutor
+ *                 .builder(meterRegistry)
+ *                 .build())
+ *         .build();
+ * </pre>
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @author Tommy Ludwig
+ * @since 1.11.0
+ */
+public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
+
+    static final String METER_NAME = "httpcomponents.httpclient.request";
+
+    private final MeterRegistry registry;
+
+    private final ObservationRegistry observationRegistry;
+
+    @Nullable
+    private final ApacheHttpClientObservationConvention convention;
+
+    private final Function<HttpRequest, String> uriMapper;
+
+    private final Iterable<Tag> extraTags;
+
+    private final boolean exportTagsForRoute;
+
+    /**
+     * Use {@link #builder(MeterRegistry)} to create an instance of this class.
+     */
+    private MicrometerHttpRequestExecutor(MeterRegistry registry, Function<HttpRequest, String> uriMapper,
+            Iterable<Tag> extraTags, boolean exportTagsForRoute, ObservationRegistry observationRegistry,
+            @Nullable ApacheHttpClientObservationConvention convention) {
+        super();
+        this.registry = Optional.ofNullable(registry).orElseThrow(
+                () -> new IllegalArgumentException("registry is required but has been initialized with null"));
+        this.uriMapper = Optional.ofNullable(uriMapper).orElseThrow(
+                () -> new IllegalArgumentException("uriMapper is required but has been initialized with null"));
+        this.extraTags = Optional.ofNullable(extraTags).orElse(Collections.emptyList());
+        this.exportTagsForRoute = exportTagsForRoute;
+        this.observationRegistry = observationRegistry;
+        this.convention = convention;
+    }
+
+    /**
+     * Use this method to create an instance of {@link MicrometerHttpRequestExecutor}.
+     * @param registry The registry to register the metrics to.
+     * @return An instance of the builder, which allows further configuration of the
+     * request executor.
+     */
+    public static Builder builder(MeterRegistry registry) {
+        return new Builder(registry);
+    }
+
+    @Override
+    public ClassicHttpResponse execute(ClassicHttpRequest request, HttpClientConnection conn, HttpContext context)
+            throws IOException, HttpException {
+        ObservationOrTimerCompatibleInstrumentation<ApacheHttpClientContext> sample = ObservationOrTimerCompatibleInstrumentation
+                .start(registry, observationRegistry,
+                        () -> new ApacheHttpClientContext(request, context, uriMapper, exportTagsForRoute), convention,
+                        DefaultApacheHttpClientObservationConvention.INSTANCE);
+        String statusCodeOrError = "UNKNOWN";
+
+        try {
+            ClassicHttpResponse response = super.execute(request, conn, context);
+            sample.setResponse(response);
+            statusCodeOrError = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusValue(response, null);
+            return response;
+        }
+        catch (IOException | HttpException | RuntimeException e) {
+            statusCodeOrError = "IO_ERROR";
+            sample.setThrowable(e);
+            throw e;
+        }
+        finally {
+            String status = statusCodeOrError;
+            sample.stop(METER_NAME, "Duration of Apache HttpClient request execution", () -> Tags
+                    .of("method", DefaultApacheHttpClientObservationConvention.INSTANCE.getMethodString(request), "uri",
+                            uriMapper.apply(request), "status", status)
+                    .and(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
+                    .and(extraTags));
+        }
+    }
+
+    public static class Builder {
+
+        private final MeterRegistry registry;
+
+        private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+
+        private Iterable<Tag> extraTags = Collections.emptyList();
+
+        private Function<HttpRequest, String> uriMapper = new DefaultUriMapper();
+
+        private boolean exportTagsForRoute = false;
+
+        @Nullable
+        private ApacheHttpClientObservationConvention observationConvention;
+
+        Builder(MeterRegistry registry) {
+            this.registry = registry;
+        }
+
+        /**
+         * These tags will not be applied when instrumentation is performed with the
+         * {@link Observation} API. Configure an
+         * {@link ApacheHttpClientObservationConvention} instead with the extra key
+         * values.
+         * @param tags Additional tags which should be exposed with every value.
+         * @return This builder instance.
+         * @see #observationConvention(ApacheHttpClientObservationConvention)
+         * @see #observationRegistry(ObservationRegistry)
+         * @see DefaultApacheHttpClientObservationConvention
+         */
+        public Builder tags(Iterable<Tag> tags) {
+            this.extraTags = tags;
+            return this;
+        }
+
+        /**
+         * Allows to register a mapping function for exposing request URIs. Be careful,
+         * exposing request URIs could result in a huge number of tag values, which could
+         * cause problems in your meter registry.
+         *
+         * By default, this feature is almost disabled. It only exposes values of the
+         * {@value DefaultUriMapper#URI_PATTERN_HEADER} HTTP header.
+         * @param uriMapper A mapper that allows mapping and exposing request paths.
+         * @return This builder instance.
+         * @see DefaultUriMapper
+         */
+        public Builder uriMapper(Function<HttpRequest, String> uriMapper) {
+            this.uriMapper = uriMapper;
+            return this;
+        }
+
+        /**
+         * Allows to expose the target scheme, host and port with every metric. Be careful
+         * with enabling this feature: If your client accesses a huge number of remote
+         * servers, this would result in a huge number of tag values, which could cause
+         * cardinality problems.
+         *
+         * By default, this feature is disabled.
+         * @param exportTagsForRoute Set this to true, if the metrics should be tagged
+         * with the target route.
+         * @return This builder instance.
+         */
+        public Builder exportTagsForRoute(boolean exportTagsForRoute) {
+            this.exportTagsForRoute = exportTagsForRoute;
+            return this;
+        }
+
+        /**
+         * Configure an observation registry to instrument using the {@link Observation}
+         * API instead of directly with a {@link Timer}.
+         * @param observationRegistry registry with which to instrument
+         * @return This builder instance.
+         */
+        public Builder observationRegistry(ObservationRegistry observationRegistry) {
+            this.observationRegistry = observationRegistry;
+            return this;
+        }
+
+        /**
+         * Provide a custom convention to override the default convention used when
+         * instrumenting with the {@link Observation} API. This only takes effect when an
+         * {@link #observationRegistry(ObservationRegistry)} is configured.
+         * @param convention semantic convention to use
+         * @return This builder instance.
+         * @see #observationRegistry(ObservationRegistry)
+         */
+        public Builder observationConvention(ApacheHttpClientObservationConvention convention) {
+            this.observationConvention = convention;
+            return this;
+        }
+
+        /**
+         * @return Creates an instance of {@link MicrometerHttpRequestExecutor} with all
+         * the configured properties.
+         */
+        public MicrometerHttpRequestExecutor build() {
+            return new MicrometerHttpRequestExecutor(registry, uriMapper, extraTags, exportTagsForRoute,
+                    observationRegistry, observationConvention);
+        }
+
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.lang.NonNull;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.core5.pool.ConnPoolControl;
+
+/**
+ * Collects metrics from a {@link ConnPoolControl}, for example
+ * {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager} for synchronous
+ * HTTP clients or
+ * {@link org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager} for
+ * asynchronous HTTP clients.
+ * <p>
+ * It monitors the overall connection pool state. Usage example: <pre>{@code
+ *      PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+ *      HttpClient httpClient = HttpClientBuilder.create().setConnectionManager(connectionManager).build();
+ *      new PoolingHttpClientConnectionManagerMetricsBinder(connectionManager, "my-pool").bindTo(registry);
+ * }</pre>
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ * @since 1.11.0
+ */
+public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
+
+    private final ConnPoolControl<HttpRoute> connPoolControl;
+
+    private final Iterable<Tag> tags;
+
+    /**
+     * Creates a metrics binder for the given pooling connection pool control.
+     * @param connPoolControl The connection pool control to monitor.
+     * @param name Name of the connection pool control. Will be added as tag with the key
+     * "httpclient".
+     * @param tags Tags to apply to all recorded metrics. Must be an even number of
+     * arguments representing key/value pairs of tags.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name,
+            String... tags) {
+        this(connPoolControl, name, Tags.of(tags));
+    }
+
+    /**
+     * Creates a metrics binder for the given connection pool control.
+     * @param connPoolControl The connection pool control to monitor.
+     * @param name Name of the connection pool control. Will be added as tag with the key
+     * "httpclient".
+     * @param tags Tags to apply to all recorded metrics.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public PoolingHttpClientConnectionManagerMetricsBinder(ConnPoolControl<HttpRoute> connPoolControl, String name,
+            Iterable<Tag> tags) {
+        this.connPoolControl = connPoolControl;
+        this.tags = Tags.concat(tags, "httpclient", name);
+    }
+
+    @Override
+    public void bindTo(@NonNull MeterRegistry registry) {
+        registerTotalMetrics(registry);
+    }
+
+    private void registerTotalMetrics(MeterRegistry registry) {
+        Gauge.builder("httpcomponents.httpclient.pool.total.max", connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getMax())
+                .description("The configured maximum number of allowed persistent connections for all routes.")
+                .tags(tags).register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.connections", connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getAvailable())
+                .description("The number of persistent and available connections for all routes.").tags(tags)
+                .tag("state", "available").register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.connections", connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getLeased())
+                .description("The number of persistent and leased connections for all routes.").tags(tags)
+                .tag("state", "leased").register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.total.pending", connPoolControl,
+                (connPoolControl) -> connPoolControl.getTotalStats().getPending())
+                .description(
+                        "The number of connection requests being blocked awaiting a free connection for all routes.")
+                .tags(tags).register(registry);
+        Gauge.builder("httpcomponents.httpclient.pool.route.max.default", connPoolControl,
+                ConnPoolControl::getDefaultMaxPerRoute)
+                .description("The configured default maximum number of allowed persistent connections per route.")
+                .tags(tags).register(registry);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -28,10 +28,8 @@ import org.apache.hc.core5.pool.ConnPoolControl;
 
 /**
  * Collects metrics from a {@link ConnPoolControl}, for example
- * {@link PoolingHttpClientConnectionManager} for synchronous
- * HTTP clients or
- * {@link PoolingAsyncClientConnectionManager} for
- * asynchronous HTTP clients.
+ * {@link PoolingHttpClientConnectionManager} for synchronous HTTP clients or
+ * {@link PoolingAsyncClientConnectionManager} for asynchronous HTTP clients.
  * <p>
  * It monitors the overall connection pool state. Usage example: <pre>{@code
  *      PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -22,13 +22,15 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.core5.pool.ConnPoolControl;
 
 /**
  * Collects metrics from a {@link ConnPoolControl}, for example
- * {@link org.apache.http.impl.conn.PoolingHttpClientConnectionManager} for synchronous
+ * {@link PoolingHttpClientConnectionManager} for synchronous
  * HTTP clients or
- * {@link org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager} for
+ * {@link PoolingAsyncClientConnectionManager} for
  * asynchronous HTTP clients.
  * <p>
  * It monitors the overall connection pool state. Usage example: <pre>{@code

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Meter binders for Apache HttpComponents 5.
+ */
+@NonNullFields
+@NonNullApi
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.client5.http.async.methods.SimpleRequestBuilder;
+import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClients;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import java.util.concurrent.Future;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.any;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MicrometerHttpClientInterceptor}.
+ *
+ * @author Jon Schneider
+ * @author Johnny Lim
+ */
+@ExtendWith(WiremockResolver.class)
+class MicrometerHttpClientInterceptorTest {
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setup() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    }
+
+    @Test
+    void asyncRequest(@WiremockResolver.Wiremock WireMockServer server) throws Exception {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpAsyncClient client = asyncClient();
+        client.start();
+        SimpleHttpRequest request = SimpleRequestBuilder.get(server.baseUrl()).build();
+
+        Future<SimpleHttpResponse> future = client.execute(request, null);
+        HttpResponse response = future.get();
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(registry.get("httpcomponents.httpclient.request").timer().count()).isEqualTo(1);
+
+        client.close();
+    }
+
+    @Test
+    void uriIsReadFromHttpHeader(@WiremockResolver.Wiremock WireMockServer server) throws Exception {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry, Tags.empty(), true);
+        CloseableHttpAsyncClient client = asyncClient(interceptor);
+        client.start();
+        SimpleHttpRequest request = SimpleRequestBuilder.get(server.baseUrl()).build();
+        request.addHeader(DefaultUriMapper.URI_PATTERN_HEADER, "/some/pattern");
+
+        Future<SimpleHttpResponse> future = client.execute(request, null);
+        HttpResponse response = future.get();
+
+        assertThat(response.getCode()).isEqualTo(200);
+        assertThat(registry.get("httpcomponents.httpclient.request").tag("uri", "/some/pattern").tag("status", "200")
+                .timer().count()).isEqualTo(1);
+
+        client.close();
+    }
+
+    private CloseableHttpAsyncClient asyncClient() {
+        MicrometerHttpClientInterceptor interceptor = new MicrometerHttpClientInterceptor(registry,
+                HttpRequest::getRequestUri, Tags.empty(), true);
+        return asyncClient(interceptor);
+    }
+
+    private CloseableHttpAsyncClient asyncClient(MicrometerHttpClientInterceptor interceptor) {
+        return HttpAsyncClients.custom().addRequestInterceptorFirst(interceptor.getRequestInterceptor())
+                .addResponseInterceptorLast(interceptor.getResponseInterceptor()).build();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.GlobalObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for {@link MicrometerHttpRequestExecutor}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+@ExtendWith(WiremockResolver.class)
+class MicrometerHttpRequestExecutorTest {
+
+    private static final String EXPECTED_METER_NAME = "httpcomponents.httpclient.request";
+
+    private final MeterRegistry registry = new SimpleMeterRegistry();
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void timeSuccessful(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).timer().count()).isEqualTo(1L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void httpMethodIsTagged(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpPost(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET").timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "POST").timer().count()).isEqualTo(1L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void httpStatusCodeIsTagged(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(urlEqualTo("/ok")).willReturn(aResponse().withStatus(200)));
+        server.stubFor(any(urlEqualTo("/notfound")).willReturn(aResponse().withStatus(404)));
+        server.stubFor(any(urlEqualTo("/error")).willReturn(aResponse().withStatus(500)));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/ok")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/ok")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/notfound")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/error")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "200").timer().count())
+                .isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "404").timer().count())
+                .isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "500").timer().count())
+                .isEqualTo(1L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void uriIsUnknownByDefault(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/someuri")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/otheruri")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("uri", "UNKNOWN").timer().count()).isEqualTo(3L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void uriIsReadFromHttpHeader(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        HttpGet getWithHeader = new HttpGet(server.baseUrl());
+        getWithHeader.addHeader(DefaultUriMapper.URI_PATTERN_HEADER, "/some/pattern");
+        EntityUtils.consume(client.execute(getWithHeader).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("uri", "/some/pattern").timer().count()).isEqualTo(1L);
+        assertThrows(MeterNotFoundException.class,
+                () -> registry.get(EXPECTED_METER_NAME).tags("uri", "UNKNOWN").timer());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void routeNotTaggedByDefault(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME).timer().getId().getTags().stream().map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).doesNotContain("target.scheme", "target.host", "target.port");
+        assertThat(tagKeys).contains("status", "method");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void routeTaggedIfEnabled(boolean configureObservationRegistry, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        CloseableHttpClient client = client(executor(true, configureObservationRegistry));
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        List<String> tagKeys = registry.get(EXPECTED_METER_NAME).timer().getId().getTags().stream().map(Tag::getKey)
+                .collect(Collectors.toList());
+        assertThat(tagKeys).contains("target.scheme", "target.host", "target.port");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void uriMapperWorksAsExpected(boolean configureObservationRegistry,
+            @WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor.Builder executorBuilder = MicrometerHttpRequestExecutor.builder(registry)
+                .uriMapper(request -> request.getRequestUri());
+        if (configureObservationRegistry) {
+            executorBuilder.observationRegistry(createObservationRegistry());
+        }
+        MicrometerHttpRequestExecutor executor = executorBuilder.build();
+        CloseableHttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/foo")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/bar")).getEntity());
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/foo")).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("uri", "/").timer().count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("uri", "/foo").timer().count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("uri", "/bar").timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void additionalTagsAreExposed(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry)
+                .tags(Tags.of("foo", "bar", "some.key", "value")).exportTagsForRoute(true).build();
+        CloseableHttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("foo", "bar", "some.key", "value", "target.host", "localhost")
+                .timer().count()).isEqualTo(1L);
+    }
+
+    @Test
+    void settingNullRegistryThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> MicrometerHttpRequestExecutor.builder(null).build());
+    }
+
+    @Test
+    void overridingUriMapperWithNullThrowsException() {
+        assertThrows(IllegalArgumentException.class,
+                () -> MicrometerHttpRequestExecutor.builder(registry).uriMapper(null).build());
+    }
+
+    @Test
+    void overrideExtraTagsDoesNotThrowAnException(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        MicrometerHttpRequestExecutor executor = MicrometerHttpRequestExecutor.builder(registry).tags(null).build();
+        CloseableHttpClient client = client(executor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get(EXPECTED_METER_NAME)).isNotNull();
+    }
+
+    @Test
+    void globalConventionUsedWhenCustomConventionNotConfigured(@WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        ObservationRegistry observationRegistry = createObservationRegistry();
+        observationRegistry.observationConfig().observationConvention(new CustomGlobalApacheHttpConvention());
+        MicrometerHttpRequestExecutor micrometerHttpRequestExecutor = MicrometerHttpRequestExecutor.builder(registry)
+                .observationRegistry(observationRegistry).build();
+        CloseableHttpClient client = client(micrometerHttpRequestExecutor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get("custom.apache.http.client.requests")).isNotNull();
+    }
+
+    @Test
+    void localConventionTakesPrecedentOverGlobalConvention(@WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        ObservationRegistry observationRegistry = createObservationRegistry();
+        observationRegistry.observationConfig().observationConvention(new CustomGlobalApacheHttpConvention());
+        MicrometerHttpRequestExecutor micrometerHttpRequestExecutor = MicrometerHttpRequestExecutor.builder(registry)
+                .observationRegistry(observationRegistry).observationConvention(new CustomGlobalApacheHttpConvention() {
+                    @Override
+                    public String getName() {
+                        return "local." + super.getName();
+                    }
+                }).build();
+        CloseableHttpClient client = client(micrometerHttpRequestExecutor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get("local.custom.apache.http.client.requests")).isNotNull();
+    }
+
+    @Test
+    void localConventionConfigured(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
+        server.stubFor(any(anyUrl()));
+        ObservationRegistry observationRegistry = createObservationRegistry();
+        MicrometerHttpRequestExecutor micrometerHttpRequestExecutor = MicrometerHttpRequestExecutor.builder(registry)
+                .observationRegistry(observationRegistry).observationConvention(new CustomGlobalApacheHttpConvention())
+                .build();
+        CloseableHttpClient client = client(micrometerHttpRequestExecutor);
+        EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+        assertThat(registry.get("custom.apache.http.client.requests")).isNotNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "get", "post", "custom" })
+    void contextualNameContainsRequestMethod(String method, @WiremockResolver.Wiremock WireMockServer server)
+            throws IOException {
+        server.stubFor(any(anyUrl()));
+        TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+        MicrometerHttpRequestExecutor micrometerHttpRequestExecutor = MicrometerHttpRequestExecutor.builder(registry)
+                .observationRegistry(observationRegistry).build();
+        CloseableHttpClient client = client(micrometerHttpRequestExecutor);
+        switch (method) {
+            case "get":
+                EntityUtils.consume(client.execute(new HttpGet(server.baseUrl())).getEntity());
+                break;
+
+            case "post":
+                EntityUtils.consume(client.execute(new HttpPost(server.baseUrl())).getEntity());
+                break;
+
+            default:
+                EntityUtils.consume(
+                        client.execute(new HttpUriRequestBase(method, URI.create(server.baseUrl()))).getEntity());
+                break;
+        }
+        TestObservationRegistryAssert.assertThat(observationRegistry).hasSingleObservationThat()
+                .hasContextualNameEqualToIgnoringCase("http " + method);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { false, true })
+    void httpStatusCodeIsTaggedWithIoError(boolean configureObservationRegistry,
+            @WiremockResolver.Wiremock WireMockServer server) {
+        server.stubFor(any(urlEqualTo("/error")).willReturn(aResponse().withStatus(1)));
+        CloseableHttpClient client = client(executor(false, configureObservationRegistry));
+        assertThatThrownBy(
+                () -> EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/error")).getEntity()))
+                        .isInstanceOf(ClientProtocolException.class);
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "IO_ERROR").timer().count())
+                .isEqualTo(1L);
+    }
+
+    static class CustomGlobalApacheHttpConvention extends DefaultApacheHttpClientObservationConvention
+            implements GlobalObservationConvention<ApacheHttpClientContext> {
+
+        @Override
+        public String getName() {
+            return "custom.apache.http.client.requests";
+        }
+
+    }
+
+    private CloseableHttpClient client(HttpRequestExecutor executor) {
+        return HttpClientBuilder.create().setRequestExecutor(executor).build();
+    }
+
+    private HttpRequestExecutor executor(boolean exportRoutes, boolean configureObservationRegistry) {
+        MicrometerHttpRequestExecutor.Builder builder = MicrometerHttpRequestExecutor.builder(registry);
+        if (configureObservationRegistry) {
+            builder.observationRegistry(createObservationRegistry());
+        }
+        return builder.exportTagsForRoute(exportRoutes).build();
+    }
+
+    private ObservationRegistry createObservationRegistry() {
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        return observationRegistry;
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.core5.pool.ConnPoolControl;
+import org.apache.hc.core5.pool.PoolStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PoolingHttpClientConnectionManagerMetricsBinder}.
+ *
+ * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
+ */
+class PoolingHttpClientConnectionManagerMetricsBinderTest {
+
+    private MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+    private ConnPoolControl<HttpRoute> connPoolControl;
+
+    private PoolingHttpClientConnectionManagerMetricsBinder binder;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        connPoolControl = (ConnPoolControl<HttpRoute>) mock(ConnPoolControl.class);
+        binder = new PoolingHttpClientConnectionManagerMetricsBinder(connPoolControl, "test");
+        binder.bindTo(registry);
+    }
+
+    @Test
+    void totalMax() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getMax()).thenReturn(13);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.max").tags("httpclient", "test").gauge().value())
+                .isEqualTo(13.0);
+    }
+
+    @Test
+    void totalAvailable() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getAvailable()).thenReturn(17);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+                .tags("httpclient", "test", "state", "available").gauge().value()).isEqualTo(17.0);
+    }
+
+    @Test
+    void totalLeased() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getLeased()).thenReturn(23);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+                .tags("httpclient", "test", "state", "leased").gauge().value()).isEqualTo(23.0);
+    }
+
+    @Test
+    void totalPending() {
+        PoolStats poolStats = mock(PoolStats.class);
+        when(poolStats.getPending()).thenReturn(37);
+        when(connPoolControl.getTotalStats()).thenReturn(poolStats);
+        assertThat(
+                registry.get("httpcomponents.httpclient.pool.total.pending").tags("httpclient", "test").gauge().value())
+                        .isEqualTo(37.0);
+    }
+
+    @Test
+    void routeMaxDefault() {
+        when(connPoolControl.getDefaultMaxPerRoute()).thenReturn(7);
+        assertThat(registry.get("httpcomponents.httpclient.pool.route.max.default").tags("httpclient", "test").gauge()
+                .value()).isEqualTo(7.0);
+    }
+
+}

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation 'com.hazelcast:hazelcast'
     testImplementation 'com.squareup.okhttp3:okhttp'
     testImplementation 'org.apache.httpcomponents:httpclient'
+    testImplementation 'org.apache.httpcomponents.client5:httpclient5'
     testImplementation 'org.eclipse.jetty:jetty-client'
     testImplementation 'org.eclipse.jetty:jetty-server'
     testImplementation 'org.eclipse.jetty:jetty-servlet'

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/ApacheHttpClient5TimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/ApacheHttpClient5TimingInstrumentationVerificationTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.ApacheHttpClientObservationDocumentation;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.DefaultUriMapper;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.MicrometerHttpRequestExecutor;
+import io.micrometer.observation.docs.ObservationDocumentation;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.BasicHttpEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+class ApacheHttpClient5TimingInstrumentationVerificationTests
+        extends HttpClientTimingInstrumentationVerificationTests<CloseableHttpClient> {
+
+    @Override
+    protected CloseableHttpClient clientInstrumentedWithMetrics() {
+        return HttpClientBuilder.create()
+                .setRequestExecutor(MicrometerHttpRequestExecutor.builder(getRegistry()).build()).build();
+    }
+
+    @Nullable
+    @Override
+    protected CloseableHttpClient clientInstrumentedWithObservations() {
+        return HttpClientBuilder.create().setRequestExecutor(MicrometerHttpRequestExecutor.builder(getRegistry())
+                .observationRegistry(getObservationRegistry()).build()).build();
+    }
+
+    @Override
+    protected String timerName() {
+        return "httpcomponents.httpclient.request";
+    }
+
+    @Override
+    protected ObservationDocumentation observationDocumentation() {
+        return ApacheHttpClientObservationDocumentation.DEFAULT;
+    }
+
+    @Override
+    protected void sendHttpRequest(CloseableHttpClient instrumentedClient, HttpMethod method, @Nullable byte[] body,
+            URI baseUri, String templatedPath, String... pathVariables) {
+        try {
+            EntityUtils.consume(instrumentedClient
+                    .execute(makeRequest(method, body, baseUri, templatedPath, pathVariables)).getEntity());
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpUriRequest makeRequest(HttpMethod method, @Nullable byte[] body, URI baseUri, String templatedPath,
+            String... pathVariables) {
+        HttpUriRequestBase request = new HttpUriRequestBase(method.name(),
+                URI.create(baseUri + substitutePathVariables(templatedPath, pathVariables)));
+        if (body != null) {
+            BasicHttpEntity entity = new BasicHttpEntity(new ByteArrayInputStream(body), ContentType.TEXT_PLAIN);
+            request.setEntity(entity);
+        }
+        request.setHeader(DefaultUriMapper.URI_PATTERN_HEADER, templatedPath);
+        return request;
+    }
+
+}


### PR DESCRIPTION
Copied and adapted from the existing instrumentation for Apache HttpClient 4. This is a follow-up to gh-3009 that started the work. This needed to be redone to incorporate the Observation API support that was added since then.

~TODO: Naming of copied classes: should we keep the same names or add `Hc5` (or similar) to the names to avoid confusion with the Apache HC 4 classes when choosing the import?~
We'll keep the names the same to make the parity more clear. IDEs and compilers will alert users if they try to use the wrong class (e.g. by importing the wrong one for the version they are using).