### PR TITLE
Configurable headers for OTLP registry

### DIFF
--- a/implementations/micrometer-registry-otlp/build.gradle
+++ b/implementations/micrometer-registry-otlp/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     implementation 'io.opentelemetry.proto:opentelemetry-proto:latest.release'
 
     testImplementation project(':micrometer-test')
+    testImplementation 'uk.org.webcompere:system-stubs-jupiter:latest.release'
 }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -113,7 +113,7 @@ public interface OtlpConfig extends PushRegistryConfig {
             headersString = "".equals(headersString) ? metricsHeaders : headersString + "," + metricsHeaders;
         }
 
-        String[] keyvalues = "".equals(headersString) ? new String[] {} : headersString.split(",");
+        String[] keyvalues = Objects.equals(headersString, "") ? new String[] {} : headersString.split(",");
 
         return Arrays.stream(keyvalues).map(String::trim)
                 .filter(keyvalue -> keyvalue.length() > 2 && keyvalue.indexOf('=') > 0)

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -86,6 +86,41 @@ public interface OtlpConfig extends PushRegistryConfig {
         return resourceAttributes;
     }
 
+    /**
+     * Additional headers to send with exported metrics. This may be needed for
+     * authorization headers, for example.
+     * <p>
+     * By default, headers will be loaded from {@link #get(String)}. If that is not set,
+     * they will be taken from the environment variables
+     * {@code OTEL_EXPORTER_OTLP_HEADERS} and {@code OTEL_EXPORTER_OTLP_METRICS_HEADERS}.
+     * The header key-value pairs are expected to be in a comma-separated list in the
+     * format {@code key1=value1,key2=value2}. If a header is set in both
+     * {@code OTEL_EXPORTER_OTLP_HEADERS} and {@code OTEL_EXPORTER_OTLP_METRICS_HEADERS},
+     * the header in the latter will overwrite the former.
+     * @return a map of the headers' key-value pairs
+     * @see <a href=
+     * "https://opentelemetry.io/docs/reference/specification/protocol/exporter/#specifying-headers-via-environment-variables">OTLP
+     * Exporer headers configuration</a>
+     */
+    default Map<String, String> headers() {
+        Map<String, String> env = System.getenv();
+        String headersString = getString(this, "headers").orElse(null);
+
+        if (headersString == null) {
+            headersString = env.getOrDefault("OTEL_EXPORTER_OTLP_HEADERS", "").trim(); // common
+                                                                                       // headers
+            String metricsHeaders = env.getOrDefault("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "").trim();
+            headersString = "".equals(headersString) ? metricsHeaders : headersString + "," + metricsHeaders;
+        }
+
+        String[] keyvalues = "".equals(headersString) ? new String[] {} : headersString.split(",");
+
+        return Arrays.stream(keyvalues).map(String::trim)
+                .filter(keyvalue -> keyvalue.length() > 2 && keyvalue.indexOf('=') > 0)
+                .collect(Collectors.toMap(keyvalue -> keyvalue.substring(0, keyvalue.indexOf('=')).trim(),
+                        keyvalue -> keyvalue.substring(keyvalue.indexOf('=') + 1).trim(), (l, r) -> r));
+    }
+
     @Override
     default Validated<?> validate() {
         return checkAll(this, c -> PushRegistryConfig.validate(c), checkRequired("url", OtlpConfig::url),

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -110,7 +110,7 @@ public interface OtlpConfig extends PushRegistryConfig {
             headersString = env.getOrDefault("OTEL_EXPORTER_OTLP_HEADERS", "").trim(); // common
                                                                                        // headers
             String metricsHeaders = env.getOrDefault("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "").trim();
-            headersString = "".equals(headersString) ? metricsHeaders : headersString + "," + metricsHeaders;
+            headersString = Objects.equals(headersString, "") ? metricsHeaders : headersString + "," + metricsHeaders;
         }
 
         String[] keyvalues = Objects.equals(headersString, "") ? new String[] {} : headersString.split(",");

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.push.PushRegistryConfig;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -105,8 +105,10 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                                         .addAllMetrics(metrics).build())
                                 .build())
                         .build();
-                this.httpSender.post(this.config.url()).withContent("application/x-protobuf", request.toByteArray())
-                        .send();
+                HttpSender.Request.Builder httpRequest = this.httpSender.post(this.config.url())
+                        .withContent("application/x-protobuf", request.toByteArray());
+                this.config.headers().forEach(httpRequest::withHeader);
+                httpRequest.send();
             }
             catch (Throwable e) {
                 logger.warn("Failed to publish metrics to OTLP receiver", e);

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
@@ -17,8 +17,15 @@ package io.micrometer.registry.otlp;
 
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
+
+/**
+ * Tests for {@link OtlpConfig}
+ */
 class OtlpConfigTest {
 
     @Test
@@ -31,6 +38,42 @@ class OtlpConfigTest {
         assertThat(config.resourceAttributes()).containsEntry("k", "v").containsEntry("a", "=").hasSize(2);
         config = k -> " k = v, a= b ";
         assertThat(config.resourceAttributes()).containsEntry("k", "v").containsEntry("a", "b").hasSize(2);
+    }
+
+    @Test
+    void headersEmptyishInputParsing() {
+        Stream<OtlpConfig> configs = Stream.of(k -> null, k -> "", k -> "  ", k -> " ,");
+        configs.forEach(config -> assertThat(config.headers()).isEmpty());
+    }
+
+    @Test
+    void headersConfigTakesPrecedenceOverEnvVars() throws Exception {
+        OtlpConfig config = k -> "header1=value1";
+        withEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS", "header2=value")
+                .execute(() -> assertThat(config.headers()).containsEntry("header1", "value1").hasSize(1));
+    }
+
+    @Test
+    void headersUseEnvVarWhenConfigNotSet() throws Exception {
+        OtlpConfig config = k -> null;
+        withEnvironmentVariable("OTEL_EXPORTER_OTLP_HEADERS", "header2=value")
+                .execute(() -> assertThat(config.headers()).containsEntry("header2", "value").hasSize(1));
+    }
+
+    @Test
+    void combineHeadersFromEnvVars() throws Exception {
+        OtlpConfig config = k -> null;
+        withEnvironmentVariables().set("OTEL_EXPORTER_OTLP_HEADERS", "common=v")
+                .set("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "metrics=m").execute(() -> assertThat(config.headers())
+                        .containsEntry("common", "v").containsEntry("metrics", "m").hasSize(2));
+    }
+
+    @Test
+    void metricsHeadersEnvVarOverwritesGenericHeadersEnvVar() throws Exception {
+        OtlpConfig config = k -> null;
+        withEnvironmentVariables().set("OTEL_EXPORTER_OTLP_HEADERS", "metrics=m,auth=token")
+                .set("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "metrics=t").execute(() -> assertThat(config.headers())
+                        .containsEntry("auth", "token").containsEntry("metrics", "t").hasSize(2));
     }
 
 }

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryExportTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryExportTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.registry.otlp;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.micrometer.core.instrument.Clock;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+@WireMockTest
+class OtlpMeterRegistryExportTest {
+
+    @Test
+    void checkHttpRequest(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(post("/v1/metrics").willReturn(ok()));
+        OtlpMeterRegistry registry = new OtlpMeterRegistry(new OtlpConfig() {
+            @Override
+            public String get(String key) {
+                return null;
+            }
+
+            @Override
+            public String url() {
+                return wmRuntimeInfo.getHttpBaseUrl() + "/v1/metrics";
+            }
+
+            @Override
+            public Map<String, String> headers() {
+                return Collections.singletonMap("API-Key", "super-secret-token");
+            }
+        }, Clock.SYSTEM);
+        registry.counter("publish").increment();
+        registry.publish();
+
+        verify(postRequestedFor(urlEqualTo("/v1/metrics")).withHeader("API-Key", equalTo("super-secret-token")));
+    }
+
+}


### PR DESCRIPTION
OTLP collectors may require arbitrary headers, for example for authentication. This allows configuring headers to send with metrics via `OtlpConfig` or environment variables [standard to the OTLP exporter](https://opentelemetry.io/docs/reference/specification/protocol/exporter/#specifying-headers-via-environment-variables).

Resolves gh-3546