### PR TITLE
Clean up compile warnings in micrometer-core

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsNoSecondLevelCacheTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsNoSecondLevelCacheTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.*;
  * part of the Hibernate project as of version 5.4.26. See
  * https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 class HibernateMetricsNoSecondLevelCacheTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.*;
  * part of the Hibernate project as of version 5.4.26. See
  * https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 class HibernateMetricsTest {
 
     private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
  * part of the Hibernate project as of version 5.4.26. See
  * https://mvnrepository.com/artifact/org.hibernate/hibernate-micrometer/
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 class HibernateQueryMetricsTest {
 
     private MeterRegistry registry = new SimpleMeterRegistry();


### PR DESCRIPTION
Running the `:micrometer-core:compileTestJava` task produces the following warnings:

```
> Task :micrometer-core:compileTestJava
/Users/izeye/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateQueryMetricsTest.java:42: warning: [dep-ann] deprecated item is not annotated with @Deprecated
class HibernateQueryMetricsTest {
^
/Users/izeye/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsNoSecondLevelCacheTest.java:41: warning: [dep-ann] deprecated item is not annotated with @Deprecated
class HibernateMetricsNoSecondLevelCacheTest {
^
/Users/izeye/IdeaProjects/micrometer/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jpa/HibernateMetricsTest.java:45: warning: [dep-ann] deprecated item is not annotated with @Deprecated
class HibernateMetricsTest {
^
3 warnings
```

I'm not sure why `@SuppressWarnings("deprecation")` is not sufficient there, but annotating them with `@Deprecated` seems to clean up the warnings.