### PR TITLE
Fixing Scope setting and resetting via ObservationThreadLocalAccessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -388,7 +388,6 @@ subprojects {
     description = 'Application monitoring instrumentation facade'
 
     repositories {
-//        mavenLocal()
         mavenCentral()
         maven { url "https://repo.spring.io/snapshot/" } // for context-propagation snapshots
     }

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
@@ -19,15 +19,24 @@ package io.micrometer.core.instrument.kotlin
 import io.micrometer.context.ContextRegistry
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor
 import kotlinx.coroutines.*
 import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 internal class AsContextElementKtTests {
 
+    val observationRegistry = ObservationRegistry.create()
+
+    @BeforeEach
+    fun before() {
+        ContextRegistry.getInstance()
+        ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry)
+    }
+
     @Test
     fun `should return current observation from context`(): Unit = runBlocking {
-        val observationRegistry = ObservationRegistry.create()
         observationRegistry.observationConfig().observationHandler { true }
         val nextObservation = Observation.start("name", observationRegistry)
         val inScope = nextObservation.openScope()

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
@@ -31,7 +31,6 @@ internal class AsContextElementKtTests {
 
     @BeforeEach
     fun before() {
-        ContextRegistry.getInstance()
         ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry)
     }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKit.java
@@ -44,6 +44,8 @@ public abstract class AnyContextObservationHandlerCompatibilityKit
         assertThatCode(() -> handler.onEvent(Observation.Event.of("testEvent"), testContext))
                 .doesNotThrowAnyException();
         assertThatCode(() -> handler.onScopeOpened(testContext)).doesNotThrowAnyException();
+        assertThatCode(() -> handler.onScopeClosed(testContext)).doesNotThrowAnyException();
+        assertThatCode(() -> handler.onScopeReset()).doesNotThrowAnyException();
         assertThatCode(() -> handler.supportsContext(testContext)).doesNotThrowAnyException();
         assertThat(handler.supportsContext(testContext)).as("Handler supports any context").isTrue();
     }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ConcreteContextObservationHandlerCompatibilityKit.java
@@ -60,6 +60,7 @@ public abstract class ConcreteContextObservationHandlerCompatibilityKit<T extend
         assertThatCode(() -> handler.onError(context())).doesNotThrowAnyException();
         assertThatCode(() -> handler.onEvent(Observation.Event.of("testEvent"), context())).doesNotThrowAnyException();
         assertThatCode(() -> handler.onScopeOpened(context())).doesNotThrowAnyException();
+        assertThatCode(() -> handler.onScopeClosed(context())).doesNotThrowAnyException();
     }
 
     @Test

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/NullContextObservationHandlerCompatibilityKit.java
@@ -58,6 +58,7 @@ public abstract class NullContextObservationHandlerCompatibilityKit {
         assertThatCode(() -> handler.onError(null)).doesNotThrowAnyException();
         assertThatCode(() -> handler.onEvent(null, null)).doesNotThrowAnyException();
         assertThatCode(() -> handler.onScopeOpened(null)).doesNotThrowAnyException();
+        assertThatCode(() -> handler.onScopeClosed(null)).doesNotThrowAnyException();
         assertThatCode(() -> handler.supportsContext(null)).doesNotThrowAnyException();
         assertThat(handler.supportsContext(null)).as("Handler supports null context").isTrue();
     }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKitTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/AnyContextObservationHandlerCompatibilityKitTests.java
@@ -40,6 +40,15 @@ class AnyContextObservationHandlerCompatibilityKitTests extends AnyContextObserv
             }
 
             @Override
+            public void onScopeReset() {
+
+            }
+
+            @Override
+            public void onScopeClosed(Observation.Context context) {
+            }
+
+            @Override
             public void onStop(Observation.Context context) {
             }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -56,7 +56,9 @@ public interface ObservationHandler<T extends Observation.Context> {
     }
 
     /**
-     * Reacts to resetting of an {@link Observation.Scope}.
+     * Reacts to resetting of scopes. If your handler uses a
+     * {@link ThreadLocal} value, this method should clear that
+     * {@link ThreadLocal}.
      */
     default void onScopeReset() {
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -56,9 +56,8 @@ public interface ObservationHandler<T extends Observation.Context> {
     }
 
     /**
-     * Reacts to resetting of scopes. If your handler uses a
-     * {@link ThreadLocal} value, this method should clear that
-     * {@link ThreadLocal}.
+     * Reacts to resetting of scopes. If your handler uses a {@link ThreadLocal} value,
+     * this method should clear that {@link ThreadLocal}.
      */
     default void onScopeReset() {
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -56,6 +56,12 @@ public interface ObservationHandler<T extends Observation.Context> {
     }
 
     /**
+     * Reacts to resetting of an {@link Observation.Scope}.
+     */
+    default void onScopeReset() {
+    }
+
+    /**
      * Reacts to opening of an {@link Observation.Scope}.
      * @param context an {@link Observation.Context}
      */
@@ -145,6 +151,11 @@ public interface ObservationHandler<T extends Observation.Context> {
         }
 
         @Override
+        public void onScopeReset() {
+            this.handlers.forEach(ObservationHandler::onScopeReset);
+        }
+
+        @Override
         public void onScopeOpened(Observation.Context context) {
             getFirstApplicableHandler(context).ifPresent(handler -> handler.onScopeOpened(context));
         }
@@ -216,6 +227,11 @@ public interface ObservationHandler<T extends Observation.Context> {
         @Override
         public void onEvent(Observation.Event event, Observation.Context context) {
             getAllApplicableHandlers(context).forEach(handler -> handler.onEvent(event, context));
+        }
+
+        @Override
+        public void onScopeReset() {
+            this.handlers.forEach(ObservationHandler::onScopeReset);
         }
 
         @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -90,6 +90,14 @@ public interface ObservationRegistry {
     }
 
     /**
+     * Clear all thread local entries for {@link ObservationHandler}s and {@link ObservationRegistry}.
+     */
+    default void resetScope() {
+        observationConfig().getObservationHandlers().forEach(ObservationHandler::onScopeReset);
+        setCurrentObservationScope(null);
+    }
+
+    /**
      * Access to configuration options for this registry.
      */
     class ObservationConfig {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -90,7 +90,8 @@ public interface ObservationRegistry {
     }
 
     /**
-     * Clear all thread local entries for {@link ObservationHandler}s and {@link ObservationRegistry}.
+     * Clear all thread local entries for {@link ObservationHandler}s and
+     * {@link ObservationRegistry}.
      */
     default void resetScope() {
         observationConfig().getObservationHandlers().forEach(ObservationHandler::onScopeReset);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.observation.contextpropagation;
 
+import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ThreadLocalAccessor;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -93,8 +94,9 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
      * @return instance
      */
     public static ObservationThreadLocalAccessor getInstance() {
-        return Objects.requireNonNull(instance,
-                "Instance was not set - please ensure that ContextRegistry methods were called (e.g. <ContextRegistry.getInstance()>) so that this class gets instantiated via the SPI mechanism.");
+        ContextRegistry.getInstance(); // we're ensuring that the SPI mechanism got called
+                                       // and an instance of OTLA was created
+        return instance;
     }
 
     public void setObservationRegistry(ObservationRegistry observationRegistry) {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
@@ -96,6 +96,17 @@ class AllMatchingCompositeObservationHandlerTests {
     }
 
     @Test
+    void should_run_on_scope_reset_for_handlers() {
+        AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
+                this.matchingHandler, this.matchingHandler2);
+
+        allMatchingHandler.onScopeReset();
+
+        assertThat(this.matchingHandler.scopeReset).isTrue();
+        assertThat(this.matchingHandler2.scopeReset).isTrue();
+    }
+
+    @Test
     void should_support_the_context_if_any_handler_supports_it() {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
@@ -138,6 +149,8 @@ class AllMatchingCompositeObservationHandlerTests {
 
         boolean scopeClosed;
 
+        boolean scopeReset;
+
         @Override
         public void onStart(Observation.Context context) {
             this.started = true;
@@ -161,6 +174,11 @@ class AllMatchingCompositeObservationHandlerTests {
         @Override
         public void onScopeClosed(Observation.Context context) {
             this.scopeClosed = true;
+        }
+
+        @Override
+        public void onScopeReset() {
+            this.scopeReset = true;
         }
 
         @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
@@ -88,6 +88,16 @@ class FirstMatchingCompositeObservationHandlerTests {
     }
 
     @Test
+    void should_run_on_scope_reset_for_handlers() {
+        FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
+                new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
+
+        firstMatchingHandler.onScopeReset();
+
+        assertThat(this.matchingHandler.scopeReset).isTrue();
+    }
+
+    @Test
     void should_support_the_context_if_any_handler_supports_it() {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
@@ -129,6 +139,8 @@ class FirstMatchingCompositeObservationHandlerTests {
 
         boolean scopeClosed;
 
+        boolean scopeReset;
+
         @Override
         public void onStart(Observation.Context context) {
             this.started = true;
@@ -152,6 +164,11 @@ class FirstMatchingCompositeObservationHandlerTests {
         @Override
         public void onScopeClosed(Observation.Context context) {
             this.scopeClosed = true;
+        }
+
+        @Override
+        public void onScopeReset() {
+            this.scopeReset = true;
         }
 
         @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -21,12 +21,14 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshot;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.ObservationTextPublisher;
 import io.micrometer.observation.annotation.Observed;
-import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
@@ -44,9 +46,16 @@ import static org.awaitility.Awaitility.await;
  */
 class ObservedAspectTests {
 
+    TestObservationRegistry registry = TestObservationRegistry.create();
+
+    @BeforeEach
+    void setup() {
+        ContextRegistry.getInstance();
+        ObservationThreadLocalAccessor.getInstance().setObservationRegistry(registry);
+    }
+
     @Test
     void annotatedCallShouldBeObserved() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -65,7 +74,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedCallShouldBeObservedAndErrorRecorded() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -84,7 +92,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedAsyncCallShouldBeObserved() throws ExecutionException, InterruptedException {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -109,7 +116,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedAsyncCallShouldBeObservedAndErrorRecorded() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -135,7 +141,6 @@ class ObservedAspectTests {
 
     @Test
     void customObservationConventionShouldBeUsed() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -153,7 +158,6 @@ class ObservedAspectTests {
 
     @Test
     void skipPredicateShouldTakeEffect() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedService());
@@ -166,7 +170,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedClassShouldBeObserved() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
@@ -185,7 +188,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedClassShouldBeObservedAndErrorRecorded() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
@@ -205,7 +207,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedAsyncClassCallShouldBeObserved() throws ExecutionException, InterruptedException {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
@@ -230,7 +231,6 @@ class ObservedAspectTests {
 
     @Test
     void annotatedAsyncClassCallShouldBeObservedAndErrorRecorded() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
@@ -256,7 +256,6 @@ class ObservedAspectTests {
 
     @Test
     void customObservationConventionShouldBeUsedForClass() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
@@ -274,7 +273,6 @@ class ObservedAspectTests {
 
     @Test
     void skipPredicateShouldTakeEffectForClass() {
-        TestObservationRegistry registry = TestObservationRegistry.create();
         registry.observationConfig().observationHandler(new ObservationTextPublisher());
 
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -50,7 +50,7 @@ class ObservedAspectTests {
 
     @BeforeEach
     void setup() {
-        ContextRegistry.getInstance();
+        ;
         ObservationThreadLocalAccessor.getInstance().setObservationRegistry(registry);
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -50,7 +50,6 @@ class ObservedAspectTests {
 
     @BeforeEach
     void setup() {
-        ;
         ObservationThreadLocalAccessor.getInstance().setObservationRegistry(registry);
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -42,6 +42,8 @@ class ObservationThreadLocalAccessorTests {
     void setup() {
         observationRegistry.observationConfig().observationHandler(new TracingHandler());
         registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
+        ContextRegistry.getInstance();
+        ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry);
     }
 
     @AfterEach
@@ -52,6 +54,7 @@ class ObservationThreadLocalAccessorTests {
     @Test
     void capturedThreadLocalValuesShouldBeCapturedRestoredAndCleared()
             throws InterruptedException, ExecutionException, TimeoutException {
+
         // given
         Observation parent = Observation.start("parent", observationRegistry);
         Observation child = Observation.createNotStarted("foo", observationRegistry).parentObservation(parent).start();
@@ -142,6 +145,11 @@ class ObservationThreadLocalAccessorTests {
         public void onStop(Observation.Context context) {
             context.put("state", "stopped");
             System.out.println("on stop [" + context.getName() + "]");
+        }
+
+        @Override
+        public void onScopeReset() {
+            value.remove();
         }
 
         @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -43,7 +43,7 @@ class ObservationThreadLocalAccessorTests {
     void setup() {
         observationRegistry.observationConfig().observationHandler(new TracingHandler());
         registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
-        ContextRegistry.getInstance();
+        ;
         ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry);
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.util.concurrent.*;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 class ObservationThreadLocalAccessorTests {
 
@@ -95,6 +96,16 @@ class ObservationThreadLocalAccessorTests {
 
         child.stop();
         parent.stop();
+    }
+
+    @Test
+    void exceptionShouldBeThrownWhenObservationRegistryNotSet() {
+        ObservationThreadLocalAccessor accessor = new ObservationThreadLocalAccessor();
+
+        thenThrownBy(accessor::getValue).hasMessageContaining("You must override the default ObservationRegistry");
+        thenThrownBy(accessor::reset).hasMessageContaining("You must override the default ObservationRegistry");
+        thenThrownBy(() -> accessor.restore(Observation.NOOP))
+                .hasMessageContaining("You must override the default ObservationRegistry");
     }
 
     private void thenCurrentObservationHasParent(Observation parent, Observation observation) {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -43,7 +43,6 @@ class ObservationThreadLocalAccessorTests {
     void setup() {
         observationRegistry.observationConfig().observationHandler(new TracingHandler());
         registry.registerThreadLocalAccessor(new ObservationThreadLocalAccessor());
-        ;
         ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry);
     }
 


### PR DESCRIPTION
# Required Changes

* Earlier behaviour of `ObservationThreadLocalAccessor` didn't require setting of `ObservationRegistry`, however it was buggy
** In order to fix the bug we need to require the user to set the `OR` on `OTLA` in this way `ObservationThreadLocalAccessor.getInstance().setObservationRegistry(observationRegistry)`
* All `ObservationHandler` implementations that rely on `ThreadLocal`s must implement the new `onScopeReset` method to tell `ObservationRegistry` how to reset scopes