### PR TITLE
[Dynatrace v2] Ensure synchronization when taking snapshots

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -80,14 +80,18 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
         return summary.getMin();
     }
 
+    /**
+     * @deprecated see {@link DynatraceSummarySnapshotSupport#hasValues()}.
+     */
     @Override
+    @Deprecated
     public boolean hasValues() {
         return count() > 0;
     }
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshot() {
-        return new DynatraceSummarySnapshot(min(), max(), totalAmount(), count());
+        return summary.takeSummarySnapshot();
     }
 
     @Override
@@ -98,9 +102,7 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
-        DynatraceSummarySnapshot snapshot = takeSummarySnapshot();
-        summary.reset();
-        return snapshot;
+        return summary.takeSummarySnapshotAndReset();
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummary.java
@@ -67,6 +67,20 @@ final class DynatraceSummary {
         return Double.longBitsToDouble(max.longValue());
     }
 
+    DynatraceSummarySnapshot takeSummarySnapshot() {
+        synchronized (this) {
+            return new DynatraceSummarySnapshot(getMin(), getMax(), getTotal(), getCount());
+        }
+    }
+
+    DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
+        synchronized (this) {
+            DynatraceSummarySnapshot snapshot = takeSummarySnapshot();
+            reset();
+            return snapshot;
+        }
+    }
+
     void reset() {
         synchronized (this) {
             min.set(0);

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshotSupport.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshotSupport.java
@@ -25,6 +25,12 @@ import java.util.concurrent.TimeUnit;
  */
 public interface DynatraceSummarySnapshotSupport {
 
+    /**
+     * @deprecated This method might lead to problems with a race condition if values are
+     * added to the summary after reading the number of values already recorded. Take a
+     * snapshot and use {@link DynatraceSummarySnapshot#getCount()} instead.
+     */
+    @Deprecated()
     boolean hasValues();
 
     DynatraceSummarySnapshot takeSummarySnapshot();

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -55,9 +55,13 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
         }
     }
 
+    /**
+     * @deprecated see {@link DynatraceSummarySnapshotSupport#hasValues()}.
+     */
     @Override
+    @Deprecated
     public boolean hasValues() {
-        return count() > 0;
+        return summary.getCount() > 0;
     }
 
     @Override
@@ -67,7 +71,7 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
-        return new DynatraceSummarySnapshot(min(unit), max(unit), totalTime(unit), count());
+        return convertIfNecessary(unit, summary.takeSummarySnapshot());
     }
 
     @Override
@@ -77,9 +81,17 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
-        DynatraceSummarySnapshot snapshot = takeSummarySnapshot(unit);
-        summary.reset();
-        return snapshot;
+        return convertIfNecessary(unit, summary.takeSummarySnapshotAndReset());
+    }
+
+    DynatraceSummarySnapshot convertIfNecessary(TimeUnit unit, DynatraceSummarySnapshot snapshot) {
+        if (unit == baseTimeUnit()) {
+            return snapshot;
+        }
+
+        return new DynatraceSummarySnapshot(unit.convert((long) snapshot.getMin(), baseTimeUnit()),
+                unit.convert((long) snapshot.getMax(), baseTimeUnit()),
+                unit.convert((long) snapshot.getTotal(), baseTimeUnit()), snapshot.getCount());
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -84,7 +84,7 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
         return convertIfNecessary(unit, summary.takeSummarySnapshotAndReset());
     }
 
-    DynatraceSummarySnapshot convertIfNecessary(TimeUnit unit, DynatraceSummarySnapshot snapshot) {
+    DynatraceSummarySnapshot convertIfNecessary(DynatraceSummarySnapshot snapshot, TimeUnit unit) {
         if (unit == baseTimeUnit()) {
             return snapshot;
         }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -71,7 +71,7 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
-        return convertIfNecessary(unit, summary.takeSummarySnapshot());
+        return convertIfNecessary(summary.takeSummarySnapshot(), unit);
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -81,7 +81,7 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
-        return convertIfNecessary(unit, summary.takeSummarySnapshotAndReset());
+        return convertIfNecessary(summary.takeSummarySnapshotAndReset(), unit);
     }
 
     DynatraceSummarySnapshot convertIfNecessary(DynatraceSummarySnapshot snapshot, TimeUnit unit) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -199,17 +199,16 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     Stream<String> toTimerLine(Timer meter) {
         if (!(meter instanceof DynatraceSummarySnapshotSupport)) {
-            // fall back to previous behaviour
             return toSummaryLine(meter, meter.takeSnapshot(), getBaseTimeUnit());
         }
 
-        DynatraceSummarySnapshotSupport summary = (DynatraceSummarySnapshotSupport) meter;
-        if (!summary.hasValues()) {
+        DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
+                .takeSummarySnapshotAndReset(getBaseTimeUnit());
+
+        if (snapshot.getCount() == 0) {
             return Stream.empty();
         }
 
-        // Take a snapshot and reset the Timer for the next export
-        DynatraceSummarySnapshot snapshot = summary.takeSummarySnapshotAndReset(getBaseTimeUnit());
         return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(), snapshot.getCount());
     }
 
@@ -249,18 +248,15 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     Stream<String> toDistributionSummaryLine(DistributionSummary meter) {
         if (!(meter instanceof DynatraceSummarySnapshotSupport)) {
-            // fall back to previous behaviour
             return toSummaryLine(meter, meter.takeSnapshot(), null);
         }
 
-        DynatraceSummarySnapshotSupport summary = (DynatraceSummarySnapshotSupport) meter;
+        DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter).takeSummarySnapshotAndReset();
 
-        if (!summary.hasValues()) {
+        if (snapshot.getCount() == 0) {
             return Stream.empty();
         }
 
-        // Take a snapshot and reset the DistributionSummary for the next export
-        DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter).takeSummarySnapshotAndReset();
         return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(), snapshot.getCount());
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -44,23 +44,21 @@ class DynatraceDistributionSummaryTest {
     private static final Clock CLOCK = new MockClock();
 
     @Test
-    void testHasValues() {
+    void testSummaryCount() {
         DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
-        assertThat(ds.hasValues()).isFalse();
+
+        assertThat(ds.count()).isZero();
         ds.record(3.14);
-        assertThat(ds.hasValues()).isTrue();
+        assertThat(ds.count()).isEqualTo(1);
+        ds.record(5.6);
+        assertThat(ds.count()).isEqualTo(2);
 
-        // reset, hasValues should be initially false
         ds.takeSummarySnapshotAndReset();
-        assertThat(ds.hasValues()).isFalse();
-
-        // add invalid value, hasValues stays false
-        ds.record(-1.234);
-        assertThat(ds.hasValues()).isFalse();
+        assertThat(ds.count()).isZero();
     }
 
     @Test
-    void testDynatraceDistributionSummary() {
+    void testDynatraceDistributionSummaryValuesAreRecorded() {
         DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
         ds.record(4.76);
@@ -91,6 +89,29 @@ class DynatraceDistributionSummaryTest {
     }
 
     @Test
+    void testUnitsAreIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
+
+        ds.record(100);
+        DynatraceSummarySnapshot microsecondsSnapshot = ds.takeSummarySnapshot(TimeUnit.MICROSECONDS);
+        DynatraceSummarySnapshot daysSnapshot = ds.takeSummarySnapshot(TimeUnit.DAYS);
+
+        // both the microseconds and the days snapshot return the same values.
+        assertMinMaxSumCount(microsecondsSnapshot, daysSnapshot.getMin(), daysSnapshot.getMax(),
+                daysSnapshot.getTotal(), daysSnapshot.getCount());
+    }
+
+    @Test
+    void testUnitsAreIgnoredButResetWorks() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
+
+        ds.record(100);
+        DynatraceSummarySnapshot microsecondsSnapshot = ds.takeSummarySnapshotAndReset(TimeUnit.MICROSECONDS);
+        assertMinMaxSumCount(microsecondsSnapshot, 100, 100, 100, 1);
+        assertMinMaxSumCount(ds.takeSummarySnapshot(TimeUnit.DAYS), 0, 0, 0, 0);
+    }
+
+    @Test
     void testMinMaxAreOverwritten() {
         DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
         ds.record(3.14);
@@ -108,19 +129,8 @@ class DynatraceDistributionSummaryTest {
         ds.record(4.76);
 
         assertMinMaxSumCount(ds.takeSummarySnapshot(), 3.14, 4.76, 7.9, 2);
-        // run twice to make sure it's not reset in between
-        assertMinMaxSumCount(ds.takeSummarySnapshot(), 3.14, 4.76, 7.9, 2);
-    }
-
-    @Test
-    void testGetSnapshotNoResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
-        ds.record(3.14);
-        ds.record(4.76);
-
-        assertMinMaxSumCount(ds.takeSummarySnapshot(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
-        // run twice to make sure it's not reset in between
-        assertMinMaxSumCount(ds.takeSummarySnapshot(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
+        // check the distribution summary was reset.
+        assertMinMaxSumCount(ds, 3.14, 4.76, 7.9, 2);
     }
 
     @Test
@@ -130,17 +140,7 @@ class DynatraceDistributionSummaryTest {
         ds.record(4.76);
 
         assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(), 3.14, 4.76, 7.9, 2);
-        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(), 0d, 0d, 0d, 0);
-    }
-
-    @Test
-    void testGetSnapshotAndResetWithTimeUnitIgnored() {
-        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
-        ds.record(3.14);
-        ds.record(4.76);
-
-        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(TimeUnit.MINUTES), 3.14, 4.76, 7.9, 2);
-        assertMinMaxSumCount(ds.takeSummarySnapshotAndReset(TimeUnit.MINUTES), 0d, 0d, 0d, 0);
+        assertMinMaxSumCount(ds, 0d, 0d, 0d, 0);
     }
 
     private void assertMinMaxSumCount(DynatraceDistributionSummary ds, double expMin, double expMax, double expTotal,

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
@@ -141,10 +141,10 @@ class DynatraceTimerTest {
         DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR, unit);
 
         DynatraceSummarySnapshot snapshot = new DynatraceSummarySnapshot(1000., 2000., 3000., 2);
-        DynatraceSummarySnapshot unconverted = timer.convertIfNecessary(unit, snapshot);
+        DynatraceSummarySnapshot unconverted = timer.convertIfNecessary(snapshot, unit);
         assertThat(unconverted).isEqualTo(snapshot);
 
-        DynatraceSummarySnapshot converted = timer.convertIfNecessary(TimeUnit.SECONDS, snapshot);
+        DynatraceSummarySnapshot converted = timer.convertIfNecessary(snapshot, TimeUnit.SECONDS);
         assertMinMaxSumCount(converted, 1, 2, 3, 2);
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
@@ -50,24 +50,30 @@ class DynatraceTimerTest {
     private static final PauseDetector PAUSE_DETECTOR = new NoPauseDetector();
 
     @Test
-    void testHasValues() {
+    void testTimerCount() {
         DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
                 BASE_TIME_UNIT);
-        assertThat(timer.hasValues()).isFalse();
+
+        assertThat(timer.count()).isZero();
         timer.record(Duration.ofMillis(314));
-        assertThat(timer.hasValues()).isTrue();
+        assertThat(timer.count()).isEqualTo(1);
         timer.record(Duration.ofMillis(476));
-        assertThat(timer.hasValues()).isTrue();
+        assertThat(timer.count()).isEqualTo(2);
 
-        // checks that the recorded values are returned in the TimeUnit used to set up the
-        // instrument
+        timer.takeSummarySnapshotAndReset(BASE_TIME_UNIT);
+        assertThat(timer.count()).isZero();
+
+    }
+
+    @Test
+    void testTimerValuesAreRecorded() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
+                BASE_TIME_UNIT);
+
+        timer.record(Duration.ofMillis(314));
+        timer.record(Duration.ofMillis(476));
+
         assertMinMaxSumCount(timer, 314, 476, 790, 2);
-        assertThat(timer.hasValues()).isTrue();
-        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(), 314, 476, 790, 2);
-        assertThat(timer.hasValues()).isFalse();
-
-        timer.record(-100, TimeUnit.MILLISECONDS);
-        assertThat(timer.hasValues()).isFalse();
     }
 
     @Test
@@ -100,22 +106,7 @@ class DynatraceTimerTest {
 
         assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(BASE_TIME_UNIT), 314, 476, 790, 2);
         // check that the timer was indeed reset
-        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 0d, 0d, 0d, 0);
-    }
-
-    @Test
-    void testGetSnapshotAndResetWithNoTimeUnit() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
-                BASE_TIME_UNIT);
-        // record in a time unit that is not the base time unit
-        timer.record(Duration.ofSeconds(1));
-        timer.record(Duration.ofSeconds(2));
-
-        // checks that the recorded values are returned in the TimeUnit used to set up the
-        // instrument
-        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(), 1000, 2000, 3000, 2);
-        // check that the timer was indeed reset
-        assertMinMaxSumCount(timer.takeSummarySnapshot(), 0d, 0d, 0d, 0);
+        assertMinMaxSumCount(timer, 0d, 0d, 0d, 0);
     }
 
     @Test
@@ -127,22 +118,7 @@ class DynatraceTimerTest {
 
         assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 314, 476, 790, 2);
         // check that the timer was not reset
-        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 314, 476, 790, 2);
-    }
-
-    @Test
-    void testGetSnapshotWithNoTimeUnit() {
-        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
-                BASE_TIME_UNIT);
-        // record in a time unit that is not the base time unit
-        timer.record(Duration.ofSeconds(1));
-        timer.record(Duration.ofSeconds(2));
-
-        // checks that the recorded values are returned in the TimeUnit used to set up the
-        // instrument
-        assertMinMaxSumCount(timer.takeSummarySnapshot(), 1000, 2000, 3000, 2);
-        // check that the timer was not reset
-        assertMinMaxSumCount(timer.takeSummarySnapshot(), 1000, 2000, 3000, 2);
+        assertMinMaxSumCount(timer, 314, 476, 790, 2);
     }
 
     @Test
@@ -157,6 +133,48 @@ class DynatraceTimerTest {
         // before being returned
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isCloseTo(1d, OFFSET);
         assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isCloseTo(1000, OFFSET);
+    }
+
+    @Test
+    void testConvertIfNecessary() {
+        TimeUnit unit = TimeUnit.MILLISECONDS;
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR, unit);
+
+        DynatraceSummarySnapshot snapshot = new DynatraceSummarySnapshot(1000., 2000., 3000., 2);
+        DynatraceSummarySnapshot unconverted = timer.convertIfNecessary(unit, snapshot);
+        assertThat(unconverted).isEqualTo(snapshot);
+
+        DynatraceSummarySnapshot converted = timer.convertIfNecessary(TimeUnit.SECONDS, snapshot);
+        assertMinMaxSumCount(converted, 1, 2, 3, 2);
+    }
+
+    @Test
+    void testSnapshotWithoutTimeUnitAndReset() {
+        DynatraceTimer timer = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
+                TimeUnit.MILLISECONDS);
+        timer.record(Duration.ofSeconds(1));
+
+        assertMinMaxSumCount(timer.takeSummarySnapshotAndReset(), 1000, 1000, 1000, 1);
+        assertMinMaxSumCount(timer.takeSummarySnapshot(), 0, 0, 0, 0);
+    }
+
+    @Test
+    void testSnapshotWithoutTimeUnit_shouldReturnInBaseUnit() {
+        DynatraceTimer timerMillis = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
+                TimeUnit.MILLISECONDS);
+        DynatraceTimer timerDays = new DynatraceTimer(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, PAUSE_DETECTOR,
+                TimeUnit.DAYS);
+
+        timerMillis.record(Duration.ofMillis(314));
+        // add 3000 millis as seconds
+        timerMillis.record(Duration.ofSeconds(3));
+
+        timerDays.record(Duration.ofDays(10));
+        // add 1 day as hours
+        timerDays.record(Duration.ofHours(24));
+
+        assertMinMaxSumCount(timerMillis.takeSummarySnapshot(), 314, 3000, 3314, 2);
+        assertMinMaxSumCount(timerDays.takeSummarySnapshot(), 1, 10, 11, 2);
     }
 
     @Test
@@ -183,7 +201,7 @@ class DynatraceTimerTest {
         // Amount & Unit
         timer.record(400, TimeUnit.MILLISECONDS);
 
-        assertMinMaxSumCount(timer.takeSummarySnapshot(), 100, 400, 1000, 4);
+        assertMinMaxSumCount(timer.takeSummarySnapshot(BASE_TIME_UNIT), 100, 400, 1000, 4);
     }
 
     private void assertMinMaxSumCount(DynatraceTimer timer, double expMin, double expMax, double expTotal,


### PR DESCRIPTION
We found a timing bug that can appear when using the Dynatrace v2 exporter, usually only when recording data at high volumes. In previous versions, recording a snapshot was not a synchronized operation. That means that it was possible to write data to a DynatraceSummary, while the snapshot was being created. In very rare cases this can lead to invalid data. This PR moves the synchronization while taking a snapshot to the innermost level, and ensures that no writes can happen while a Snapshot is produced. 