### PR TITLE
Use Meter.Id for logging in DynatraceExporterV2

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -176,7 +176,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return createMetricBuilder(meter).setDoubleGaugeValue(value).serialize();
         }
         catch (MetricException e) {
-            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId().getName(), e.getMessage());
+            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
         return null;
@@ -191,7 +191,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return createMetricBuilder(meter).setDoubleCounterValueDelta(measurement.getValue()).serialize();
         }
         catch (MetricException e) {
-            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId().getName(), e.getMessage());
+            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
         return null;
@@ -241,7 +241,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return Stream.of(line);
         }
         catch (MetricException e) {
-            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId().getName(), e.getMessage());
+            logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
         }
 
         return Stream.empty();


### PR DESCRIPTION
This PR changes to use `Meter.Id` for logging in `DynatraceExporterV2` as it might help to understand #3560 or similar a bit better.