### PR TITLE
Added ability to define percentiles for OkHttpMetricsEventListener

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -180,11 +180,8 @@ public class OkHttpMetricsEventListener extends EventListener {
             tags = Tags.of(tags).and("host", requestAvailable ? request.url().host() : TAG_VALUE_UNKNOWN);
         }
 
-        Timer.builder(this.requestsMetricName)
-                .tags(tags)
-                .description("Timer of OkHttp operation")
-                .publishPercentiles(timerPercentiles)
-                .register(registry)
+        Timer.builder(this.requestsMetricName).tags(tags).description("Timer of OkHttp operation")
+                .publishPercentiles(timerPercentiles).register(registry)
                 .record(registry.config().clock().monotonicTime() - state.startTime, TimeUnit.NANOSECONDS);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
@@ -223,21 +223,16 @@ class OkHttpMetricsEventListenerTest {
     void timerPercentilesCanBeDefined(@WiremockResolver.Wiremock WireMockServer server) throws IOException {
         server.stubFor(any(anyUrl()));
         OkHttpMetricsEventListener eventListener = OkHttpMetricsEventListener.builder(registry, "okhttp.requests")
-                .timerPercentiles(0.9, 0.99)
-                .build();
-        OkHttpClient client = new OkHttpClient.Builder()
-                .eventListener(eventListener)
-                .build();
+                .timerPercentiles(0.9, 0.99).build();
+        OkHttpClient client = new OkHttpClient.Builder().eventListener(eventListener).build();
         Request request = new Request.Builder().url(server.baseUrl()).build();
 
         client.newCall(request).execute().close();
 
-        ValueAtPercentile[] percentiles = registry.get("okhttp.requests")
-                .tags("status", "200", "target.host", "localhost", "target.port", String.valueOf(server.port()),
-                        "target.scheme", "http")
-                .timer()
-                .takeSnapshot()
-                .percentileValues();
+        ValueAtPercentile[] percentiles = registry
+                .get("okhttp.requests").tags("status", "200", "target.host", "localhost", "target.port",
+                        String.valueOf(server.port()), "target.scheme", "http")
+                .timer().takeSnapshot().percentileValues();
         assertThat(Arrays.stream(percentiles).map(ValueAtPercentile::percentile)).contains(0.9, 0.99);
     }
 


### PR DESCRIPTION
The default behavior seems to be to only create the 95 percentile

At Toast we mostly use 95 & 99 percentiles but I figured others may want this feature as well

Issue: https://github.com/micrometer-metrics/micrometer/issues/3620