### PR TITLE
Polish "Fixing Scope setting and resetting via ObservationThreadLocalAccessor"

### DIFF
--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
@@ -53,7 +53,6 @@ internal class AsContextElementKtTests {
 
     @Test
     fun `should return observation from coroutine context when KotlinContextElement present`(): Unit = runBlocking {
-        val observationRegistry = ObservationRegistry.create()
         observationRegistry.observationConfig().observationHandler { true }
         val nextObservation = Observation.start("name", observationRegistry)
         val inScope = nextObservation.openScope()

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -757,7 +757,7 @@ public interface Observation extends ObservationView {
 
         /**
          * Clears the current scope and notifies the handlers that the scope was closed.
-         * You don't need to call this method manually, if you use try-with-resource, it
+         * You don't need to call this method manually. If you use try-with-resource, it
          * will call this for you. Please only call this method if you know what you are
          * doing and your use-case demands the usage of it.
          */
@@ -766,9 +766,10 @@ public interface Observation extends ObservationView {
 
         /**
          * Clears the current scope and notifies the handlers that the scope was reset.
-         * You don't need to call this method in most of the cases, please only call this
+         * You don't need to call this method in most of the cases. Please only call this
          * method if you know what you are doing and your use-case demands the usage of
          * it.
+         * @since 1.10.4
          */
         void reset();
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -73,6 +73,7 @@ public interface ObservationHandler<T extends Observation.Context> {
      * Reacts to resetting of scopes. If your handler uses a {@link ThreadLocal} value,
      * this method should clear that {@link ThreadLocal}.
      * @param context an {@link Observation.Context}
+     * @since 1.10.4
      */
     default void onScopeReset(T context) {
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
@@ -74,11 +74,13 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
         reset();
         Observation.Scope observationScope = value.getContext().get(SCOPE_KEY);
         if (observationScope != null) {
-            observationScope.close(); // We close the previous scope -
-            // it will put its parent as current and call all handlers
+            // We close the previous scope - it will put its parent as current and call
+            // all handlers.
+            observationScope.close();
         }
-        setValue(value); // We open the previous scope again, however this time in TL
-        // we have the whole hierarchy of scopes re-attached via handlers
+        // We open the previous scope again, however this time in TL we have the whole
+        // hierarchy of scopes re-attached via handlers.
+        setValue(value);
     }
 
 }


### PR DESCRIPTION
This PR polishes "Fixing Scope setting and resetting via ObservationThreadLocalAccessor" changes a bit.

See gh-3613