### PR TITLE
[Dynatrace v2] Add missing tests to Dynatrace types

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceDistributionSummaryTest.java
@@ -67,6 +67,24 @@ class DynatraceDistributionSummaryTest {
     }
 
     @Test
+    void testDynatraceDistributionSummary_NegativeValuesAreIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
+        ds.record(-1.23);
+        ds.record(-100.3);
+
+        assertMinMaxSumCount(ds, 0., 0., 0., 0);
+    }
+
+    @Test
+    void testDynatraceDistributionSummary_NaNValuesAreIgnored() {
+        DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG, 1);
+
+        ds.record(Double.NaN);
+
+        assertMinMaxSumCount(ds, 0., 0., 0., 0);
+    }
+
+    @Test
     void testDynatraceDistributionSummaryScaled() {
         double scale = 1.5;
         DynatraceDistributionSummary ds = new DynatraceDistributionSummary(ID, CLOCK, DISTRIBUTION_STATISTIC_CONFIG,


### PR DESCRIPTION
Follow-up to https://github.com/micrometer-metrics/micrometer/pull/3615, where @jonatan-ivanov identified a missing test case. Added the case for negative values, and for `NaN`. For timers, these tests already exist (and NaN is not possible since all of the methods take `long` and not `Double`). 