### PR TITLE
Optimize getting ThreadMetrics where getThreadInfo is repeatedly called

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -29,8 +29,6 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -74,7 +74,8 @@ public class JvmThreadMetrics implements MeterBinder {
         try {
             long[] allThreadIds = threadBean.getAllThreadIds();
             EnumMap<Thread.State, Long> stateCountGroup = Arrays.stream(threadBean.getThreadInfo(allThreadIds))
-                    .collect(Collectors.groupingBy(ThreadInfo::getThreadState, () -> new EnumMap<>(Thread.State.class),Collectors.counting()));
+                    .collect(Collectors.groupingBy(ThreadInfo::getThreadState, () -> new EnumMap<>(Thread.State.class),
+                            Collectors.counting()));
             for (Thread.State state : Thread.State.values()) {
                 Gauge.builder("jvm.threads.states", () -> stateCountGroup.get(state))
                         .tags(Tags.concat(tags, "state", getStateTagValue(state)))

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -15,17 +15,13 @@
  */
 package io.micrometer.core.instrument.binder.jvm;
 
+import java.util.concurrent.TimeUnit;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
-import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link JvmThreadMetrics}.
@@ -51,17 +47,6 @@ class JvmThreadMetricsTest {
 
         createTimedWaitingThread();
         assertThat(registry.get("jvm.threads.states").tag("state", "timed-waiting").gauge().value()).isGreaterThan(0);
-    }
-
-    @Test
-    void getThreadStateCountWhenThreadInfoIsNullShouldWork() {
-        ThreadMXBean threadBean = mock(ThreadMXBean.class);
-        long[] threadIds = { 1L, 2L };
-        when(threadBean.getAllThreadIds()).thenReturn(threadIds);
-        ThreadInfo threadInfo = mock(ThreadInfo.class);
-        when(threadInfo.getThreadState()).thenReturn(Thread.State.RUNNABLE);
-        when(threadBean.getThreadInfo(threadIds)).thenReturn(new ThreadInfo[] { threadInfo, null });
-        assertThat(JvmThreadMetrics.getThreadStateCount(threadBean, Thread.State.RUNNABLE)).isEqualTo(1);
     }
 
     private void createTimedWaitingThread() {


### PR DESCRIPTION
I accidentally discovered that the JvmThreadMetrics class repeatedly calls getThreadInfo and getAllThreadIds when getting the Metrics related to jvm.threads.states, resulting in a relatively wasteful CPU, so I proposed a PR to do some optimization

Here are the problems I found with the flame chart： 

<img width="2483" alt="image" src="https://user-images.githubusercontent.com/4795442/219629731-c22c7389-53a7-4c37-aa8a-cbb2562a0e53.png">

You can see that the width of the position in my circle is not a short percentage of the entire figure.

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/4795442/219630096-e154d68d-1bc9-4feb-a558-24ddc01c1986.png">

The above is the problematic part of the code, it loops through all the thread states, calling getAllThreadIds and getThreadInfo once in each loop.

My optimization idea is to call getAllThreadIds and getThreadInfo only once, and group the results by State, and finally just set the Metrics based on the grouped results.