### PR TITLE
Update JavaDoc in RequiredSearch

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -112,7 +112,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link Timer}
+     * @return Any matching {@link Timer}
      * @throws MeterNotFoundException if there is no match.
      */
     public Timer timer() {
@@ -120,7 +120,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link Counter}.
+     * @return Any matching {@link Counter}.
      * @throws MeterNotFoundException if there is no match.
      */
     public Counter counter() {
@@ -128,7 +128,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link Gauge}.
+     * @return Any matching {@link Gauge}.
      * @throws MeterNotFoundException if there is no match.
      */
     public Gauge gauge() {
@@ -136,7 +136,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link FunctionCounter}.
+     * @return Any matching {@link FunctionCounter}.
      * @throws MeterNotFoundException if there is no match.
      */
     public FunctionCounter functionCounter() {
@@ -144,7 +144,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link TimeGauge}.
+     * @return Any matching {@link TimeGauge}.
      * @throws MeterNotFoundException if there is no match.
      */
     public TimeGauge timeGauge() {
@@ -152,7 +152,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link FunctionTimer}.
+     * @return Any matching {@link FunctionTimer}.
      * @throws MeterNotFoundException if there is no match.
      */
     public FunctionTimer functionTimer() {
@@ -160,7 +160,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link DistributionSummary}.
+     * @return Any matching {@link DistributionSummary}.
      * @throws MeterNotFoundException if there is no match.
      */
     public DistributionSummary summary() {
@@ -168,7 +168,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link LongTaskTimer}.
+     * @return Any matching {@link LongTaskTimer}.
      * @throws MeterNotFoundException if there is no match.
      */
     public LongTaskTimer longTaskTimer() {
@@ -176,7 +176,7 @@ public final class RequiredSearch {
     }
 
     /**
-     * @return The first matching {@link Meter}.
+     * @return Any matching {@link Meter}.
      * @throws MeterNotFoundException if there is no match.
      */
     public Meter meter() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -186,11 +186,7 @@ public final class RequiredSearch {
     private <M extends Meter> M getOne(Class<M> clazz) {
         Optional<M> meter = meterStream().filter(clazz::isInstance).findAny().map(clazz::cast);
 
-        if (meter.isPresent()) {
-            return meter.get();
-        }
-
-        throw MeterNotFoundException.forSearch(this, clazz);
+        return meter.orElseThrow(() -> MeterNotFoundException.forSearch(this, clazz));
     }
 
     private <M extends Meter> Collection<M> findAll(Class<M> clazz) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -116,7 +116,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public Timer timer() {
-        return findOne(Timer.class);
+        return getOne(Timer.class);
     }
 
     /**
@@ -124,7 +124,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public Counter counter() {
-        return findOne(Counter.class);
+        return getOne(Counter.class);
     }
 
     /**
@@ -132,7 +132,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public Gauge gauge() {
-        return findOne(Gauge.class);
+        return getOne(Gauge.class);
     }
 
     /**
@@ -140,7 +140,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public FunctionCounter functionCounter() {
-        return findOne(FunctionCounter.class);
+        return getOne(FunctionCounter.class);
     }
 
     /**
@@ -148,7 +148,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public TimeGauge timeGauge() {
-        return findOne(TimeGauge.class);
+        return getOne(TimeGauge.class);
     }
 
     /**
@@ -156,7 +156,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public FunctionTimer functionTimer() {
-        return findOne(FunctionTimer.class);
+        return getOne(FunctionTimer.class);
     }
 
     /**
@@ -164,7 +164,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public DistributionSummary summary() {
-        return findOne(DistributionSummary.class);
+        return getOne(DistributionSummary.class);
     }
 
     /**
@@ -172,7 +172,7 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public LongTaskTimer longTaskTimer() {
-        return findOne(LongTaskTimer.class);
+        return getOne(LongTaskTimer.class);
     }
 
     /**
@@ -180,10 +180,10 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public Meter meter() {
-        return findOne(Meter.class);
+        return getOne(Meter.class);
     }
 
-    private <M extends Meter> M findOne(Class<M> clazz) {
+    private <M extends Meter> M getOne(Class<M> clazz) {
         Optional<M> meter = meterStream().filter(clazz::isInstance).findAny().map(clazz::cast);
 
         if (meter.isPresent()) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -193,9 +193,13 @@ public final class RequiredSearch {
     }
 
     private <M extends Meter> M getOne(Class<M> clazz) {
-        Optional<M> meter = meterStream().filter(clazz::isInstance).findAny().map(clazz::cast);
-
-        return meter.orElseThrow(() -> MeterNotFoundException.forSearch(this, clazz));
+        // @formatter:off
+        return meterStream()
+                .filter(clazz::isInstance)
+                .findAny()
+                .map(clazz::cast)
+                .orElseThrow(() -> MeterNotFoundException.forSearch(this, clazz));
+        // @formatter:on
     }
 
     private <M extends Meter> Collection<M> findAll(Class<M> clazz) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -112,6 +112,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link Timer}.
      * @return Any matching {@link Timer}
      * @throws MeterNotFoundException if there is no match.
      */
@@ -120,6 +121,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link Counter}.
      * @return Any matching {@link Counter}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -128,6 +130,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link Gauge}.
      * @return Any matching {@link Gauge}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -136,6 +139,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link FunctionCounter}.
      * @return Any matching {@link FunctionCounter}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -144,6 +148,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link TimeGauge}.
      * @return Any matching {@link TimeGauge}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -152,6 +157,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link FunctionTimer}.
      * @return Any matching {@link FunctionTimer}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -160,6 +166,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link DistributionSummary}.
      * @return Any matching {@link DistributionSummary}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -168,6 +175,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link LongTaskTimer}.
      * @return Any matching {@link LongTaskTimer}.
      * @throws MeterNotFoundException if there is no match.
      */
@@ -176,6 +184,7 @@ public final class RequiredSearch {
     }
 
     /**
+     * Performs the search and returns any matching {@link Meter}.
      * @return Any matching {@link Meter}.
      * @throws MeterNotFoundException if there is no match.
      */


### PR DESCRIPTION
This PR includes three changes regarding the `RequiredSearch` class:
- The `findOne` method is calling `Stream::findAny` under the hood, which is contradicting to the JavaDoc, which is fixed in this PR;
- Meanwhile, renamed `findOne` to `getOne` because an exception is thrown when nothing is found, which conventionally would be named `get***`;
- While there, simplified one Optional API usage. 