### PR TITLE
Use latest.release for wavefront-sdk-java

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,7 @@ def VERSIONS = [
         'com.signalfx.public:signalfx-java:latest.release',
         'com.squareup.okhttp3:okhttp:latest.release',
         'com.tngtech.archunit:archunit-junit5:latest.release',
-        'com.wavefront:wavefront-sdk-java:3.0.+',
+        'com.wavefront:wavefront-sdk-java:latest.release',
         'io.dropwizard.metrics:metrics-core:4.+',
         'io.dropwizard.metrics:metrics-graphite:4.+',
         'io.dropwizard.metrics:metrics-jmx:4.+',


### PR DESCRIPTION
This PR changes to use `latest.release` for `com.wavefront:wavefront-sdk-java`.

It has been pinned to `3.0.+` in c11349500e41196e9b25a04364fda7b76677ba17, but I'm not sure if it's intentional also for the `main` branch. I'm just opening this just in case.