### PR TITLE
Polish "Jetty Client instrumentation with Observation API"

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/DefaultJettyClientObservationConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2023 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2023 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientKeyValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2023 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public final class JettyClientKeyValues {
 
     private static final KeyValue HOST_UNKNOWN = KeyValue.of("host", "UNKNOWN");
 
-    public static final KeyValue STATUS_UNKNOWN = KeyValue.of("status", "UNKNOWN");
+    private static final KeyValue STATUS_UNKNOWN = KeyValue.of("status", "UNKNOWN");
 
     private static final Pattern TRAILING_SLASH_PATTERN = Pattern.compile("/$");
 
@@ -75,7 +75,6 @@ public final class JettyClientKeyValues {
      * {@code request}.
      * @param request the request
      * @return the host KeyValue derived from request
-     * @since 1.7.0
      */
     public static KeyValue host(Request request) {
         return (request != null) ? KeyValue.of("host", request.getHost()) : HOST_UNKNOWN;
@@ -94,9 +93,10 @@ public final class JettyClientKeyValues {
     /**
      * Creates a {@code uri} KeyValue based on the URI of the given {@code result}.
      * {@code REDIRECTION} for 3xx responses, {@code NOT_FOUND} for 404 responses.
+     * @param request the request
      * @param result the request result
      * @param successfulUriPattern successful URI pattern
-     * @return the uri KeyValue derived from the request result
+     * @return the uri KeyValue derived from the request and its result
      */
     public static KeyValue uri(Request request, @Nullable Result result,
             BiFunction<Request, Result, String> successfulUriPattern) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
@@ -62,8 +62,8 @@ public class JettyClientMetrics implements Request.Listener {
     private final BiFunction<Request, Result, String> uriPatternFunction;
 
     /**
-     * @deprecated use {@link JettyClientMetrics#builder(MeterRegistry, BiFunction)}
-     * instead.
+     * @deprecated since 1.11.0 in favor of
+     * {@link JettyClientMetrics#builder(MeterRegistry, BiFunction)}
      */
     @Deprecated
     protected JettyClientMetrics(MeterRegistry registry, JettyClientTagsProvider tagsProvider, String timingMetricName,
@@ -121,7 +121,7 @@ public class JettyClientMetrics implements Request.Listener {
      * @param registry meter registry to use
      * @param tagsProvider tags provider for customizing tagging
      * @return builder
-     * @deprecated use {@link #builder(MeterRegistry, BiFunction)} instead;
+     * @deprecated since 1.11.0 in favor of {@link #builder(MeterRegistry, BiFunction)};
      * {@link Builder#tagsProvider(JettyClientTagsProvider)} can be used to provide a
      * custom tags provider
      */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientObservationConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2023 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientTagsProvider.java
@@ -50,8 +50,9 @@ public interface JettyClientTagsProvider {
      * that goes to a certain endpoint, regardless of the parameters to that endpoint.
      * @param result The result which also contains the original request.
      * @return A URI pattern with path variables and query parameter unsubstituted.
-     * @deprecated use {@link JettyClientMetrics#builder(MeterRegistry, BiFunction)}
-     * instead to configure the uri pattern function
+     * @deprecated since 1.11.0 in favor of
+     * {@link JettyClientMetrics#builder(MeterRegistry, BiFunction)} to configure the uri
+     * pattern function
      */
     @Deprecated
     String uriPattern(Result result);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2023 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR polishes "Jetty Client instrumentation with Observation API" changes a bit.

See gh-3416