### PR TITLE
Resolved the bugs and added 1 line of code for unit testing, in order…

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -41,7 +41,7 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.daemon").gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.peak").gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.states").tag("state", "runnable").gauge().value()).isPositive();
-
+        assertThat(registry.get("jvm.threads.states").tag("state", "blocked").gauge().value()).isZero();
         createBlockedThread();
         assertThat(registry.get("jvm.threads.states").tag("state", "blocked").gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.states").tag("state", "waiting").gauge().value()).isPositive();


### PR DESCRIPTION
https://github.com/micrometer-metrics/micrometer/issues/3658 

Resolved the bugs mentioned here, and re-submitted 1 PR and added 1 line of single test, in order to pass the test.

I think during the same request to get ThreadMetrics, if the state of the thread has changed, it is not necessary to be real-time, just make sure that the next time you get it, you can get the latest one. So this modification meets that goal.