### PR TITLE
Support "_index_template" for Elasticsearch 7.8+

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/DefaultIndexTemplateCreator.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/DefaultIndexTemplateCreator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.elastic;
+
+import io.micrometer.core.ipc.http.HttpSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default {@link IndexTemplateCreator}, compatible with Elasticsearch 7.8+.
+ *
+ * @author Brian Clozel
+ * @see <a href=
+ * "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html">Index
+ * Templates documentation</a>.
+ */
+class DefaultIndexTemplateCreator implements IndexTemplateCreator {
+
+    private final Logger logger = LoggerFactory.getLogger(DefaultIndexTemplateCreator.class);
+
+    private final String indexTemplateRequest = "{\n" + "  \"index_patterns\": [\"%s*\"],\n" + "  \"template\": {\n"
+            + "    \"mappings\": {\n" + "      \"_source\": {\n" + "        \"enabled\": false\n" + "      },\n"
+            + "      \"properties\": {\n" + "        \"name\": { \"type\": \"keyword\" },\n"
+            + "        \"count\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"value\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"sum\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"mean\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"duration\": { \"type\": \"double\", \"index\": false},\n"
+            + "        \"max\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"total\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"unknown\": { \"type\": \"double\", \"index\": false },\n"
+            + "        \"active\": { \"type\": \"double\", \"index\": false }\n" + "      }\n" + "    }\n" + "  }\n"
+            + "}";
+
+    private final HttpSender httpClient;
+
+    DefaultIndexTemplateCreator(HttpSender httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public IndexTemplateStatus fetchIndexTemplateStatus(ElasticConfig configuration) {
+        HttpSender.Request.Builder request = this.httpClient
+            .head(configuration.host() + "/_index_template/metrics_template");
+        configureAuthentication(configuration, request);
+        try {
+            HttpSender.Response response = request.send();
+            switch (response.code()) {
+                case 200:
+                    logger.debug("Metrics index template already exists at '/_index_template/metrics_template'");
+                    return IndexTemplateStatus.EXISTS;
+                case 404:
+                    logger.debug("Metrics index template is missing from '/_index_template/metrics_template'");
+                    return IndexTemplateStatus.MISSING;
+                default:
+                    logger.error("Could not create index template in Elastic (HTTP {}): {}", response.code(),
+                            response.body());
+                    return IndexTemplateStatus.NOT_SUPPORTED;
+            }
+        }
+        catch (Throwable exc) {
+            logger.error("Could not create index template in Elastic", exc);
+        }
+        return IndexTemplateStatus.NOT_SUPPORTED;
+    }
+
+    @Override
+    public void createIndex(ElasticConfig configuration) throws Throwable {
+        String indexPattern = configuration.index() + configuration.indexDateSeparator();
+        HttpSender.Request.Builder request = this.httpClient
+            .put(configuration.host() + "/_index_template/metrics_template");
+        configureAuthentication(configuration, request);
+        request.withJsonContent(String.format(indexTemplateRequest, indexPattern))
+            .send()
+            .onError(response -> logger.error("Failed to create index template in Elastic: {}", response.body()));
+    }
+
+}

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -38,7 +38,6 @@ import java.util.Optional;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -51,6 +50,7 @@ import static java.util.stream.Collectors.joining;
  * @author Nicolas Portmann
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Brian Clozel
  * @since 1.1.0
  * @implNote This implementation requires Elasticsearch 7 or above.
  */
@@ -58,24 +58,6 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     private static final ThreadFactory DEFAULT_THREAD_FACTORY = new NamedThreadFactory("elastic-metrics-publisher");
     static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ISO_INSTANT;
-
-    private static final String ES_METRICS_TEMPLATE = "/_template/metrics_template";
-
-    private static final String TEMPLATE_PROPERTIES = "\"properties\": {\n" + "  \"name\": {\n"
-            + "    \"type\": \"keyword\"\n" + "  },\n" + "  \"count\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"value\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"sum\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"mean\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"duration\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"max\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"total\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"unknown\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  },\n" + "  \"active\": {\n" + "    \"type\": \"double\",\n"
-            + "    \"index\": false\n" + "  }\n" + "}";
-
-    private static final Function<String, String> TEMPLATE_BODY_AFTER_VERSION_7 = (indexPrefix) -> "{\n"
-            + "  \"index_patterns\": [\"" + indexPrefix + "*\"],\n" + "  \"mappings\": {\n" + "    \"_source\": {\n"
-            + "      \"enabled\": false\n" + "    },\n" + TEMPLATE_PROPERTIES + "  }\n" + "}";
 
     private static final Pattern MAJOR_VERSION_PATTERN = Pattern.compile("\"number\" *: *\"([\\d]+)");
 
@@ -114,13 +96,13 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         super(config, clock);
         config().namingConvention(new ElasticNamingConvention());
         this.config = config;
-        indexDateFormatter = DateTimeFormatter.ofPattern(config.indexDateFormat());
+        this.indexDateFormatter = DateTimeFormatter.ofPattern(config.indexDateFormat());
         this.httpClient = httpClient;
         if (StringUtils.isNotEmpty(config.pipeline())) {
-            actionLine = "{ \"create\" : {\"pipeline\":\"" + config.pipeline() + "\"} }\n";
+            this.actionLine = "{ \"create\" : {\"pipeline\":\"" + config.pipeline() + "\"} }\n";
         }
         else {
-            actionLine = "{ \"create\" : {} }\n";
+            this.actionLine = "{ \"create\" : {} }\n";
         }
 
         start(threadFactory);
@@ -128,52 +110,6 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
 
     public static Builder builder(ElasticConfig config) {
         return new Builder(config);
-    }
-
-    private void createIndexTemplateIfNeeded() {
-        if (checkedForIndexTemplate || !config.autoCreateIndex()) {
-            return;
-        }
-
-        try {
-            String uri = config.host() + ES_METRICS_TEMPLATE;
-            if (connect(HttpSender.Method.HEAD, uri).send().onError(response -> {
-                if (response.code() != 404) {
-                    logger.error("could not create index in elastic (HTTP {}): {}", response.code(), response.body());
-                }
-            }).isSuccessful()) {
-                checkedForIndexTemplate = true;
-                logger.debug("metrics template already exists");
-                return;
-            }
-
-            connect(HttpSender.Method.PUT, uri).withJsonContent(getTemplateBody())
-                .send()
-                .onError(response -> logger.error("failed to add metrics template to elastic: {}", response.body()));
-        }
-        catch (Throwable e) {
-            logger.error("could not create index in elastic", e);
-            return;
-        }
-
-        checkedForIndexTemplate = true;
-    }
-
-    private String getTemplateBody() {
-        return TEMPLATE_BODY_AFTER_VERSION_7.apply(config.index() + config.indexDateSeparator());
-    }
-
-    private HttpSender.Request.Builder connect(HttpSender.Method method, String uri) {
-        return authentication(this.httpClient.newRequest(uri).withMethod(method));
-    }
-
-    private HttpSender.Request.Builder authentication(HttpSender.Request.Builder request) {
-        if (StringUtils.isNotBlank(config.apiKeyCredentials())) {
-            return request.withAuthentication("ApiKey", config.apiKeyCredentials());
-        }
-        else {
-            return request.withBasicAuthentication(config.userName(), config.password());
-        }
     }
 
     @Override
@@ -210,6 +146,51 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
             catch (Throwable e) {
                 logger.error("failed to send metrics to elastic", e);
             }
+        }
+    }
+
+    private void createIndexTemplateIfNeeded() {
+        if (this.checkedForIndexTemplate || !this.config.autoCreateIndex()) {
+            return;
+        }
+        attemptIndexTemplateCreation(new DefaultIndexTemplateCreator(this.httpClient));
+        if (!this.checkedForIndexTemplate) {
+            logger.debug("Attempt to create index template using legacy /_template/ endpoint");
+            attemptIndexTemplateCreation(new LegacyIndexTemplateCreator(this.httpClient));
+        }
+    }
+
+    private void attemptIndexTemplateCreation(IndexTemplateCreator creator) {
+        IndexTemplateCreator.IndexTemplateStatus indexTemplateStatus = creator.fetchIndexTemplateStatus(this.config);
+        switch (indexTemplateStatus) {
+            case MISSING:
+                try {
+                    creator.createIndex(this.config);
+                    this.checkedForIndexTemplate = true;
+                }
+                catch (Throwable exc) {
+                    // in case of a network error, there will be a new creation attempt.
+                    logger.error("Could not create index template in Elastic", exc);
+                }
+                break;
+            case EXISTS:
+                this.checkedForIndexTemplate = true;
+                break;
+            case NOT_SUPPORTED:
+                break;
+        }
+    }
+
+    private HttpSender.Request.Builder connect(HttpSender.Method method, String uri) {
+        return authentication(this.httpClient.newRequest(uri).withMethod(method));
+    }
+
+    private HttpSender.Request.Builder authentication(HttpSender.Request.Builder request) {
+        if (StringUtils.isNotBlank(config.apiKeyCredentials())) {
+            return request.withAuthentication("ApiKey", config.apiKeyCredentials());
+        }
+        else {
+            return request.withBasicAuthentication(config.userName(), config.password());
         }
     }
 

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/IndexTemplateCreator.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/IndexTemplateCreator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.elastic;
+
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.core.ipc.http.HttpSender;
+
+/**
+ * Internal strategy for create Elasticsearch index templates for metrics indices.
+ *
+ * @author Brian Clozel
+ */
+interface IndexTemplateCreator {
+
+    /**
+     * Checks whether this strategy is able to create an index template on the remote
+     * Elasticsearch server.
+     * @param configuration the elastic configuration
+     * @return the index template status
+     */
+    IndexTemplateStatus fetchIndexTemplateStatus(ElasticConfig configuration);
+
+    /**
+     * Create the index template.
+     * @param configuration the elastic configuration
+     */
+    void createIndex(ElasticConfig configuration) throws Throwable;
+
+    /**
+     * Configure the authentication information on the HTTP request.
+     * @param configuration the Elasticsearch configuration
+     * @param request the new HTTP request
+     */
+    default void configureAuthentication(ElasticConfig configuration, HttpSender.Request.Builder request) {
+        if (StringUtils.isNotBlank(configuration.apiKeyCredentials())) {
+            request.withAuthentication("ApiKey", configuration.apiKeyCredentials());
+        }
+        else {
+            request.withBasicAuthentication(configuration.userName(), configuration.password());
+        }
+    }
+
+    /**
+     * The status of the metrics index template on the Elasticsearch instance.
+     */
+    enum IndexTemplateStatus {
+
+        /**
+         * This strategy cannot create an index template on the Elasticsearch instance.
+         */
+        NOT_SUPPORTED,
+        /**
+         * The index template does not exist but can be created by this strategy.
+         */
+        MISSING,
+        /**
+         * The index template already exists, nothing needs to be done.
+         */
+        EXISTS
+
+    }
+
+}

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/LegacyIndexTemplateCreator.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/LegacyIndexTemplateCreator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.elastic;
+
+import io.micrometer.core.ipc.http.HttpSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link IndexTemplateCreator} for Elasticsearch instances prior to 7.8.
+ *
+ * @author Brian Clozel
+ * @see <a href=
+ * "https://www.elastic.co/guide/en/elasticsearch/reference/7.8/indices-templates-v1.html">Legacy
+ * index templates support</a>.
+ */
+class LegacyIndexTemplateCreator implements IndexTemplateCreator {
+
+    private final Logger logger = LoggerFactory.getLogger(LegacyIndexTemplateCreator.class);
+
+    private final String indexTemplateRequest = "{\n" + "  \"index_patterns\": [\"%s*\"],\n" + "  \"mappings\": {\n"
+            + "    \"_source\": {\n" + "      \"enabled\": false\n" + "    },\n" + "    \"properties\": {\n"
+            + "      \"name\": { \"type\": \"keyword\" },\n"
+            + "      \"count\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"value\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"sum\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"mean\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"duration\": { \"type\": \"double\", \"index\": false},\n"
+            + "      \"max\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"total\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"unknown\": { \"type\": \"double\", \"index\": false },\n"
+            + "      \"active\": { \"type\": \"double\", \"index\": false }\n" + "    }\n" + "  }\n" + "}";
+
+    private final HttpSender httpClient;
+
+    LegacyIndexTemplateCreator(HttpSender httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public IndexTemplateStatus fetchIndexTemplateStatus(ElasticConfig configuration) {
+        HttpSender.Request.Builder request = this.httpClient.head(configuration.host() + "/_template/metrics_template");
+        configureAuthentication(configuration, request);
+        try {
+            HttpSender.Response response = request.send();
+            switch (response.code()) {
+                case 200:
+                    logger.debug("Metrics index template already exists at '/_template/metrics_template'");
+                    return IndexTemplateStatus.EXISTS;
+                case 404:
+                    logger.debug("Metrics index template is missing from '/_template/metrics_template'");
+                    return IndexTemplateStatus.MISSING;
+                default:
+                    logger.error("Could not create index template in Elastic (HTTP {}): {}", response.code(),
+                            response.body());
+                    return IndexTemplateStatus.NOT_SUPPORTED;
+            }
+        }
+        catch (Throwable exc) {
+            logger.error("Could not create index template in Elastic", exc);
+        }
+        return IndexTemplateStatus.NOT_SUPPORTED;
+    }
+
+    @Override
+    public void createIndex(ElasticConfig configuration) throws Throwable {
+        String indexPattern = configuration.index() + configuration.indexDateSeparator();
+        HttpSender.Request.Builder request = this.httpClient.put(configuration.host() + "/_template/metrics_template");
+        configureAuthentication(configuration, request);
+        request.withJsonContent(String.format(indexTemplateRequest, indexPattern))
+            .send()
+            .onError(response -> logger.error("Failed to create index template in Elastic: {}", response.body()));
+    }
+
+}

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/AbstractElasticsearchMeterRegistryIntegrationTest.java
@@ -40,9 +40,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Tag("docker")
 abstract class AbstractElasticsearchMeterRegistryIntegrationTest {
 
-    protected static final String VERSION_7 = "7.17.8";
+    // Testing against a pre-7.8 version to verify behavior without
+    // composable index templates support.
+    // See
+    // https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html
+    protected static final String VERSION_7 = "7.7.1";
 
-    protected static final String VERSION_8 = "8.6.0";
+    protected static final String VERSION_8 = "8.6.2";
 
     protected static final String USER = "elastic";
 


### PR DESCRIPTION
This PR addresses gh-3320, adding support for composable index templates
for Elasticsearch 7.8+.

This PR extracts the existing implementation into a strategy and adds a
new strategy that uses the new format and endpoint. The former 
`"/_template"` feature is now marked as deprecated by the Elasticsearch
team and we should phase out this behavior from Micrometer in the
future.

While this change doesn't introduce any new API, we'll need to consider
when we should schedule this change for a release:

* this introduces a behavior change because it's using a different
  endpoint
* the actual template remains the same and existing indices should not
  see any difference
* if an Elasticsearch instance already has an index template in the old
  format, this will create a new one and will supersede the former

In the future, we'll be able to phase out the legacy strategy and add
new configuration options as this variant could offer more possibilities.
We can also document the fact that developers might want to delete the
previous index template from their elasticsearch instance - this would
be probably done anyway automatically during an Elasticsearch upgrade
when the legacy endpoint is retired.

