### PR TITLE
Upgrade machine executor to ubuntu-2204:2023.02.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ executors:
   machine-executor:
     working_directory: ~/micrometer
     machine:
-      image: ubuntu-2004:2022.10.1
+      image: ubuntu-2204:2023.02.1
 
 commands:
   gradlew-build:


### PR DESCRIPTION
In addition to bumping the latest patch release (`2023.02.1`), this upgrades from Ubuntu 20.04 to 22.04, which is the latest LTS version.