### PR TITLE
Manual rollover of step meters for publishing partial step

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
@@ -26,7 +26,7 @@ import io.micrometer.core.instrument.Counter;
  *
  * @author Jon Schneider
  */
-public class StepCounter extends AbstractMeter implements Counter {
+public class StepCounter extends AbstractMeter implements Counter, StepMeter {
 
     private final StepDouble value;
 
@@ -43,6 +43,11 @@ public class StepCounter extends AbstractMeter implements Counter {
     @Override
     public double count() {
         return value.poll();
+    }
+
+    @Override
+    public void _manualRollover() {
+        value.manualRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.LongAdder;
  * @author Jon Schneider
  * @author Johnny Lim
  */
-public class StepDistributionSummary extends AbstractDistributionSummary {
+public class StepDistributionSummary extends AbstractDistributionSummary implements StepMeter {
 
     private final LongAdder count = new LongAdder();
 
@@ -84,6 +84,11 @@ public class StepDistributionSummary extends AbstractDistributionSummary {
     public Iterable<Measurement> measure() {
         return Arrays.asList(new Measurement(() -> (double) count(), Statistic.COUNT),
                 new Measurement(this::totalAmount, Statistic.TOTAL), new Measurement(this::max, Statistic.MAX));
+    }
+
+    @Override
+    public void _manualRollover() {
+        countTotal.manualRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -22,7 +22,7 @@ import io.micrometer.core.instrument.FunctionCounter;
 import java.lang.ref.WeakReference;
 import java.util.function.ToDoubleFunction;
 
-public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCounter {
+public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCounter, StepMeter {
 
     private final WeakReference<T> ref;
 
@@ -48,6 +48,12 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
             count.getCurrent().add(last - prevLast);
         }
         return count.poll();
+    }
+
+    @Override
+    public void _manualRollover() {
+        count(); // add any difference from last count
+        count.manualRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -32,7 +32,7 @@ import java.util.function.ToLongFunction;
  * @author Jon Schneider
  * @author Johnny Lim
  */
-public class StepFunctionTimer<T> implements FunctionTimer {
+public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
 
     private final Id id;
 
@@ -116,6 +116,12 @@ public class StepFunctionTimer<T> implements FunctionTimer {
 
     public Type type() {
         return Type.TIMER;
+    }
+
+    @Override
+    public void _manualRollover() {
+        accumulateCountAndTotal();
+        countTotal.manualRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.step;
+
+/**
+ * Internal. Intentionally package-private.
+ */
+interface StepMeter {
+
+    /**
+     * This is an internal method not meant for general use.
+     * <p>
+     * Force a rollover of the values returned by a step meter.
+     */
+    void _manualRollover();
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -104,4 +104,14 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
             .merge(DistributionStatisticConfig.DEFAULT);
     }
 
+    @Override
+    public void close() {
+        stop();
+        getMeters().stream()
+            .filter(meter -> meter instanceof StepMeter)
+            .map(meter -> (StepMeter) meter)
+            .forEach(StepMeter::_manualRollover);
+        super.close();
+    }
+
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.LongAdder;
 /**
  * @author Jon Schneider
  */
-public class StepTimer extends AbstractTimer {
+public class StepTimer extends AbstractTimer implements StepMeter {
 
     private final LongAdder count = new LongAdder();
 
@@ -77,6 +77,11 @@ public class StepTimer extends AbstractTimer {
     @Override
     public double max(final TimeUnit unit) {
         return TimeUtils.nanosToUnit(max.poll(), unit);
+    }
+
+    @Override
+    public void _manualRollover() {
+        countTotal.manualRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
@@ -74,6 +74,15 @@ public class StepTuple2<T1, T2> {
     }
 
     /**
+     * Intended for internal use. Rolls the values regardless of the clock or current
+     * time.
+     */
+    void manualRollover() {
+        t1Previous = t1Supplier.get();
+        t2Previous = t2Supplier.get();
+    }
+
+    /**
      * @return The value for the last completed interval.
      */
     public T1 poll1() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -73,4 +73,11 @@ public abstract class StepValue<V> {
         return previous;
     }
 
+    /**
+     * internal use only; intentionally left package-private
+     */
+    void manualRollover() {
+        previous = valueSupplier().get();
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepCounterTest.java
@@ -68,4 +68,14 @@ class StepCounterTest {
         assertThat(counter.count()).isEqualTo(0);
     }
 
+    @Test
+    void manualRolloverPartialStep() {
+        StepCounter counter = (StepCounter) registry.counter("my.counter");
+        counter.increment(2.5);
+
+        assertThat(counter.count()).isZero();
+        counter._manualRollover();
+        assertThat(counter.count()).isEqualTo(2.5);
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepDistributionSummaryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepDistributionSummaryTest.java
@@ -28,11 +28,12 @@ import static org.mockito.Mockito.mock;
 
 class StepDistributionSummaryTest {
 
+    MockClock clock = new MockClock();
+
     @Issue("#1814")
     @Test
     void meanShouldWorkIfTotalNotCalled() {
         Duration stepDuration = Duration.ofMillis(10);
-        MockClock clock = new MockClock();
         StepDistributionSummary summary = new StepDistributionSummary(mock(Meter.Id.class), clock,
                 DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(), 1.0,
                 stepDuration.toMillis(), false);
@@ -46,6 +47,25 @@ class StepDistributionSummaryTest {
 
         clock.add(stepDuration);
         assertThat(summary.mean()).isEqualTo(75.0);
+    }
+
+    @Test
+    void manualRolloverPartialStep() {
+        Duration stepDuration = Duration.ofMillis(10);
+        StepDistributionSummary summary = new StepDistributionSummary(mock(Meter.Id.class), clock,
+                DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(), 1.0,
+                stepDuration.toMillis(), false);
+
+        summary.record(100);
+        summary.record(200);
+
+        assertThat(summary.count()).isZero();
+
+        summary._manualRollover();
+
+        assertThat(summary.count()).isEqualTo(2);
+        assertThat(summary.totalAmount()).isEqualTo(300);
+        assertThat(summary.mean()).isEqualTo(150);
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -64,4 +64,17 @@ class StepFunctionCounterTest {
         assertThat(counter.count()).isEqualTo(1);
     }
 
+    @Test
+    void manualRolloverPartialStep() {
+        AtomicInteger n = new AtomicInteger(3);
+        StepFunctionCounter<AtomicInteger> counter = (StepFunctionCounter) registry.more()
+            .counter("my.counter", Tags.empty(), n);
+
+        assertThat(counter.count()).isZero();
+
+        counter._manualRollover();
+
+        assertThat(counter.count()).isEqualTo(3);
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -35,9 +35,10 @@ import static org.mockito.Mockito.mock;
  */
 class StepFunctionTimerTest {
 
+    MockClock clock = new MockClock();
+
     @Test
     void totalTimeWhenStateObjectChangedToNullShouldWorkWithChangedTimeUnit() {
-        MockClock clock = new MockClock();
         StepFunctionTimer<Object> functionTimer = new StepFunctionTimer<>(mock(Meter.Id.class), clock, 1000L,
                 new Object(), (o) -> 1L, (o) -> 1d, TimeUnit.SECONDS, TimeUnit.SECONDS);
         clock.add(Duration.ofSeconds(1));
@@ -63,7 +64,6 @@ class StepFunctionTimerTest {
         totalTimes.add(1000.0);
 
         Duration stepDuration = Duration.ofMillis(10);
-        MockClock clock = new MockClock();
         StepFunctionTimer<Object> ft = new StepFunctionTimer<>(mock(Meter.Id.class), clock, stepDuration.toMillis(),
                 new Object(), (o) -> counts.poll(), (o) -> totalTimes.poll(), TimeUnit.SECONDS, TimeUnit.SECONDS);
 
@@ -74,6 +74,28 @@ class StepFunctionTimerTest {
 
         clock.add(stepDuration);
         assertThat(ft.mean(TimeUnit.SECONDS)).isEqualTo(700.0 / 5L);
+    }
+
+    @Test
+    void manualRolloverPartialStep() {
+        Queue<Long> counts = new ArrayDeque<>();
+        counts.add(2L);
+        counts.add(5L);
+        counts.add(10L);
+
+        Queue<Double> totalTimes = new ArrayDeque<>();
+        totalTimes.add(150.0);
+        totalTimes.add(300.0);
+        totalTimes.add(1000.0);
+
+        Duration stepDuration = Duration.ofMillis(10);
+        StepFunctionTimer<Object> timer = new StepFunctionTimer<>(mock(Meter.Id.class), clock, stepDuration.toMillis(),
+                new Object(), (o) -> counts.poll(), (o) -> totalTimes.poll(), TimeUnit.SECONDS, TimeUnit.SECONDS);
+
+        timer._manualRollover();
+
+        assertThat(timer.count()).isEqualTo(2);
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -18,12 +18,17 @@ package io.micrometer.core.instrument.step;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.com.google.common.util.concurrent.AtomicDouble;
 
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static java.time.Duration.ofMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -55,17 +60,7 @@ class StepMeterRegistryTest {
         }
     };
 
-    private MeterRegistry registry = new StepMeterRegistry(config, clock) {
-        @Override
-        protected void publish() {
-            publishes.incrementAndGet();
-        }
-
-        @Override
-        protected TimeUnit getBaseTimeUnit() {
-            return TimeUnit.SECONDS;
-        }
-    };
+    private MyStepMeterRegistry registry = new MyStepMeterRegistry();
 
     @Issue("#370")
     @Test
@@ -162,6 +157,197 @@ class StepMeterRegistryTest {
             softly.assertThat(timerStep2Length2.max(MILLISECONDS)).isEqualTo(0L);
             softly.assertThat(timerStep1Length6.max(MILLISECONDS)).isEqualTo(0L);
         });
+    }
+
+    @Issue("#1882")
+    @Test
+    void shortLivedPublish() {
+        Counter counter = Counter.builder("counter").register(registry);
+        counter.increment();
+        Timer timer = Timer.builder("timer").register(registry);
+        timer.record(5, MILLISECONDS);
+        DistributionSummary summary = DistributionSummary.builder("summary").register(registry);
+        summary.record(7);
+        FunctionCounter functionCounter = FunctionCounter.builder("counter.function", this, obj -> 15)
+            .register(registry);
+        FunctionTimer functionTimer = FunctionTimer.builder("timer.function", this, obj -> 3, obj -> 53, MILLISECONDS)
+            .register(registry);
+
+        // before step rollover
+        assertThat(counter.count()).isZero();
+        assertThat(timer.count()).isZero();
+        assertThat(timer.totalTime(MILLISECONDS)).isZero();
+        assertThat(summary.count()).isZero();
+        assertThat(summary.totalAmount()).isZero();
+        assertThat(functionCounter.count()).isZero();
+        assertThat(functionTimer.count()).isZero();
+        assertThat(functionTimer.totalTime(MILLISECONDS)).isZero();
+
+        registry.close();
+
+        assertThat(registry.publishedCounterCounts).hasSize(1);
+        assertThat(registry.publishedCounterCounts.pop()).isOne();
+        assertThat(registry.publishedTimerCounts).hasSize(1);
+        assertThat(registry.publishedTimerCounts.pop()).isOne();
+        assertThat(registry.publishedTimerSumMilliseconds).hasSize(1);
+        assertThat(registry.publishedTimerSumMilliseconds.pop()).isEqualTo(5.0);
+        assertThat(registry.publishedSummaryCounts).hasSize(1);
+        assertThat(registry.publishedSummaryCounts.pop()).isOne();
+        assertThat(registry.publishedSummaryTotals).hasSize(1);
+        assertThat(registry.publishedSummaryTotals.pop()).isEqualTo(7);
+        assertThat(registry.publishedFunctionCounterCounts).hasSize(1);
+        assertThat(registry.publishedFunctionCounterCounts.pop()).isEqualTo(15);
+        assertThat(registry.publishedFunctionTimerCounts).hasSize(1);
+        assertThat(registry.publishedFunctionTimerCounts.pop()).isEqualTo(3);
+        assertThat(registry.publishedFunctionTimerTotals).hasSize(1);
+        assertThat(registry.publishedFunctionTimerTotals.pop()).isEqualTo(53);
+    }
+
+    @Issue("#1882")
+    @Test
+    void finalPushHasPartialStep() {
+        AtomicDouble counterCount = new AtomicDouble(15);
+        AtomicLong timerCount = new AtomicLong(3);
+        AtomicDouble timerTotalTime = new AtomicDouble(53);
+
+        Counter counter = Counter.builder("counter").register(registry);
+        counter.increment();
+        Timer timer = Timer.builder("timer").register(registry);
+        timer.record(5, MILLISECONDS);
+        DistributionSummary summary = DistributionSummary.builder("summary").register(registry);
+        summary.record(7);
+        FunctionCounter functionCounter = FunctionCounter.builder("counter.function", this, obj -> counterCount.get())
+            .register(registry);
+        FunctionTimer functionTimer = FunctionTimer
+            .builder("timer.function", this, obj -> timerCount.get(), obj -> timerTotalTime.get(), MILLISECONDS)
+            .register(registry);
+
+        // before step rollover
+        assertThat(counter.count()).isZero();
+        assertThat(timer.count()).isZero();
+        assertThat(timer.totalTime(MILLISECONDS)).isZero();
+        assertThat(summary.count()).isZero();
+        assertThat(summary.totalAmount()).isZero();
+        assertThat(functionCounter.count()).isZero();
+        assertThat(functionTimer.count()).isZero();
+        assertThat(functionTimer.totalTime(MILLISECONDS)).isZero();
+
+        clock.add(config.step());
+        registry.publish();
+
+        assertThat(registry.publishedCounterCounts).hasSize(1);
+        assertThat(registry.publishedCounterCounts.pop()).isOne();
+        assertThat(registry.publishedTimerCounts).hasSize(1);
+        assertThat(registry.publishedTimerCounts.pop()).isOne();
+        assertThat(registry.publishedTimerSumMilliseconds).hasSize(1);
+        assertThat(registry.publishedTimerSumMilliseconds.pop()).isEqualTo(5.0);
+        assertThat(registry.publishedSummaryCounts).hasSize(1);
+        assertThat(registry.publishedSummaryCounts.pop()).isOne();
+        assertThat(registry.publishedSummaryTotals).hasSize(1);
+        assertThat(registry.publishedSummaryTotals.pop()).isEqualTo(7);
+        assertThat(registry.publishedFunctionCounterCounts).hasSize(1);
+        assertThat(registry.publishedFunctionCounterCounts.pop()).isEqualTo(15);
+        assertThat(registry.publishedFunctionTimerCounts).hasSize(1);
+        assertThat(registry.publishedFunctionTimerCounts.pop()).isEqualTo(3);
+        assertThat(registry.publishedFunctionTimerTotals).hasSize(1);
+        assertThat(registry.publishedFunctionTimerTotals.pop()).isEqualTo(53);
+
+        // set clock to middle of second step
+        clock.add(config.step().dividedBy(2));
+        // record some more values in new step interval
+        counter.increment(2);
+        timer.record(6, MILLISECONDS);
+        summary.record(8);
+        counterCount.set(18);
+        timerCount.set(5);
+        timerTotalTime.set(77);
+
+        // shutdown
+        registry.close();
+
+        assertThat(registry.publishedCounterCounts).hasSize(1);
+        assertThat(registry.publishedTimerCounts).hasSize(1);
+        assertThat(registry.publishedTimerSumMilliseconds).hasSize(1);
+        assertThat(registry.publishedSummaryCounts).hasSize(1);
+        assertThat(registry.publishedSummaryTotals).hasSize(1);
+        assertThat(registry.publishedFunctionCounterCounts).hasSize(1);
+        assertThat(registry.publishedFunctionTimerCounts).hasSize(1);
+        assertThat(registry.publishedFunctionTimerTotals).hasSize(1);
+
+        assertThat(registry.publishedCounterCounts.pop()).isEqualTo(2);
+        assertThat(registry.publishedTimerCounts.pop()).isEqualTo(1);
+        assertThat(registry.publishedTimerSumMilliseconds.pop()).isEqualTo(6.0);
+        assertThat(registry.publishedSummaryCounts.pop()).isOne();
+        assertThat(registry.publishedSummaryTotals.pop()).isEqualTo(8);
+        assertThat(registry.publishedFunctionCounterCounts.pop()).isEqualTo(3);
+        assertThat(registry.publishedFunctionTimerCounts.pop()).isEqualTo(2);
+        assertThat(registry.publishedFunctionTimerTotals.pop()).isEqualTo(24);
+    }
+
+    private class MyStepMeterRegistry extends StepMeterRegistry {
+
+        Deque<Double> publishedCounterCounts = new ArrayDeque<>();
+
+        Deque<Long> publishedTimerCounts = new ArrayDeque<>();
+
+        Deque<Double> publishedTimerSumMilliseconds = new ArrayDeque<>();
+
+        Deque<Long> publishedSummaryCounts = new ArrayDeque<Long>();
+
+        Deque<Double> publishedSummaryTotals = new ArrayDeque<>();
+
+        Deque<Double> publishedFunctionCounterCounts = new ArrayDeque<>();
+
+        Deque<Double> publishedFunctionTimerCounts = new ArrayDeque<>();
+
+        Deque<Double> publishedFunctionTimerTotals = new ArrayDeque<>();
+
+        public MyStepMeterRegistry() {
+            super(StepMeterRegistryTest.this.config, StepMeterRegistryTest.this.clock);
+        }
+
+        @Override
+        protected void publish() {
+            publishes.incrementAndGet();
+            getMeters().stream()
+                .map(meter -> meter.match(null, this::publishCounter, this::publishTimer, this::publishSummary, null,
+                        null, this::publishFunctionCounter, this::publishFunctionTimer, null))
+                .collect(Collectors.toList());
+        }
+
+        private Timer publishTimer(Timer timer) {
+            publishedTimerCounts.add(timer.count());
+            publishedTimerSumMilliseconds.add(timer.totalTime(MILLISECONDS));
+            return timer;
+        }
+
+        private FunctionTimer publishFunctionTimer(FunctionTimer functionTimer) {
+            publishedFunctionTimerCounts.add(functionTimer.count());
+            publishedFunctionTimerTotals.add(functionTimer.totalTime(MILLISECONDS));
+            return functionTimer;
+        }
+
+        private Counter publishCounter(Counter counter) {
+            publishedCounterCounts.add(counter.count());
+            return counter;
+        }
+
+        private FunctionCounter publishFunctionCounter(FunctionCounter functionCounter) {
+            publishedFunctionCounterCounts.add(functionCounter.count());
+            return functionCounter;
+        }
+
+        private DistributionSummary publishSummary(DistributionSummary summary) {
+            publishedSummaryCounts.add(summary.count());
+            publishedSummaryTotals.add(summary.totalAmount());
+            return summary;
+        }
+
+        @Override
+        protected TimeUnit getBaseTimeUnit() {
+            return TimeUnit.SECONDS;
+        }
+
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepTimerTest.java
@@ -30,11 +30,12 @@ import static org.mockito.Mockito.mock;
 
 class StepTimerTest {
 
+    MockClock clock = new MockClock();
+
     @Issue("#1814")
     @Test
     void meanShouldWorkIfTotalTimeNotCalled() {
         Duration stepDuration = Duration.ofMillis(10);
-        MockClock clock = new MockClock();
         StepTimer timer = new StepTimer(mock(Meter.Id.class), clock,
                 DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(),
                 mock(PauseDetector.class), TimeUnit.MILLISECONDS, stepDuration.toMillis(), false);
@@ -48,6 +49,21 @@ class StepTimerTest {
 
         clock.add(stepDuration);
         assertThat(timer.mean(TimeUnit.MILLISECONDS)).isEqualTo(75.0);
+    }
+
+    @Test
+    void manualRolloverPartialStep() {
+        Duration stepDuration = Duration.ofMillis(10);
+        StepTimer timer = new StepTimer(mock(Meter.Id.class), clock,
+                DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(),
+                mock(PauseDetector.class), TimeUnit.MILLISECONDS, stepDuration.toMillis(), false);
+        timer.record(75, TimeUnit.MILLISECONDS);
+        timer.record(25, TimeUnit.MILLISECONDS);
+
+        timer._manualRollover();
+
+        assertThat(timer.count()).isEqualTo(2);
+        assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(100);
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
@@ -64,6 +64,13 @@ class StepValueTest {
 
         clock.add(Duration.ofMillis(60));
         assertThat(stepValue.poll()).isEqualTo(24L);
+
+        clock.add(Duration.ofMillis(stepTime / 2));
+        aLong.set(27);
+        assertThat(stepValue.poll()).isEqualTo(24L);
+
+        stepValue.manualRollover();
+        assertThat(stepValue.poll()).isEqualTo(27L);
     }
 
 }


### PR DESCRIPTION
Allows step-based meters to manually be rolled over, instead of their normal time-based rollover. This is useful in the case of publishing a partial step, such as should happen on a final publish of step meters (including when an application is shutdown before a full step interval has happened). For now, we don't see a need to expose this API publicly, so we try to keep its visibility as low as possible and mark it as internal.

This approach was chosen because it is a non-invasive option with respect to implementations of StepMeterRegistry. The changes are isolated to core code we can update. This will fix the intended problem without requiring updates to every registry implementation (possibly including custom ones we do not maintain). It avoids messing with the clock and it (hopefully) avoids making the read behavior of step meters any more complex. 

Resolves #1882
Supersedes #3533