### PR TITLE
Allow custom sink for LoggingMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -48,6 +48,7 @@ import static java.util.stream.Collectors.joining;
  * Logging {@link io.micrometer.core.instrument.MeterRegistry}.
  *
  * @author Jon Schneider
+ * @author Matthieu Borgraeve
  * @since 1.1.0
  */
 @Incubating(since = "1.1.0")
@@ -75,8 +76,8 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
     }
 
     /**
-     * Constructor allowing custom sink instead of a default `log::info`
-     * @param loggingSink the custom sink that will be called for each metric.
+     * Constructor allowing custom sink instead of a default {@code log::info}.
+     * @param loggingSink the custom sink that will be called for each time series.
      */
     public LoggingMeterRegistry(Consumer<String> loggingSink) {
         this(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM, loggingSink);
@@ -86,7 +87,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
      * Constructor allowing a custom sink, clock and configuration.
      * @param config the LoggingRegistryConfig
      * @param clock the Clock
-     * @param loggingSink the custom sink that will be called for each metric.
+     * @param loggingSink the custom sink that will be called for each time series.
      */
     public LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock, Consumer<String> loggingSink) {
         this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), loggingSink, null);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -65,8 +65,31 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
         this(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM);
     }
 
+    /**
+     * Constructor allowing a custom clock and configuration.
+     * @param config the LoggingRegistryConfig
+     * @param clock the Clock
+     */
     public LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock) {
-        this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), log::info, null);
+        this(config, clock, log::info);
+    }
+
+    /**
+     * Constructor allowing custom sink instead of a default `log::info`
+     * @param loggingSink the custom sink that will be called for each metric.
+     */
+    public LoggingMeterRegistry(Consumer<String> loggingSink) {
+        this(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM, loggingSink);
+    }
+
+    /**
+     * Constructor allowing a custom sink, clock and configuration.
+     * @param config the LoggingRegistryConfig
+     * @param clock the Clock
+     * @param loggingSink the custom sink that will be called for each metric.
+     */
+    public LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock, Consumer<String> loggingSink) {
+        this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), loggingSink, null);
     }
 
     private LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock, ThreadFactory threadFactory,

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -33,6 +32,7 @@ import static org.mockito.Mockito.*;
  *
  * @author Jon Schneider
  * @author Johnny Lim
+ * @author Matthieu Borgraeve
  */
 class LoggingMeterRegistryTest {
 
@@ -48,34 +48,30 @@ class LoggingMeterRegistryTest {
     }
 
     @Test
-    void publishUsesProvidedSinkFromConstructor() {
+    void providedSinkFromConstructorShouldBeUsed() {
         String expectedString = "my.gauage{tag-1=tag-2} value=1";
-
         Consumer<String> mockConsumer = mock(Consumer.class);
         doNothing().when(mockConsumer).accept(expectedString);
         AtomicInteger gaugeValue = new AtomicInteger(1);
-        {
-            LoggingMeterRegistry registry = new LoggingMeterRegistry(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM,
-                    mockConsumer);
-            registry.gauge("my.gauage", List.of(Tag.of("tag-1", "tag-2")), gaugeValue);
-            registry.publish();
-            verify(mockConsumer, times(1)).accept(expectedString);
-        }
+        LoggingMeterRegistry registry = new LoggingMeterRegistry(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM,
+                mockConsumer);
+        registry.gauge("my.gauage", Tags.of("tag-1", "tag-2"), gaugeValue);
+
+        registry.publish();
+        verify(mockConsumer, times(1)).accept(expectedString);
     }
 
     @Test
-    void publishUsesProvidedSinkFromConstructorWithDefault() {
+    void providedSinkFromConstructorShouldBeUsedWithDefaults() {
         String expectedString = "my.gauage{tag-1=tag-2} value=1";
-
         Consumer<String> mockConsumer = mock(Consumer.class);
         doNothing().when(mockConsumer).accept(expectedString);
         AtomicInteger gaugeValue = new AtomicInteger(1);
-        {
-            LoggingMeterRegistry registry = new LoggingMeterRegistry(mockConsumer);
-            registry.gauge("my.gauage", List.of(Tag.of("tag-1", "tag-2")), gaugeValue);
-            registry.publish();
-            verify(mockConsumer, times(1)).accept(expectedString);
-        }
+        LoggingMeterRegistry registry = new LoggingMeterRegistry(mockConsumer);
+        registry.gauge("my.gauage", Tags.of("tag-1", "tag-2"), gaugeValue);
+
+        registry.publish();
+        verify(mockConsumer, times(1)).accept(expectedString);
     }
 
     @Test


### PR DESCRIPTION
Hi,

My first PR here, of course feel free to let me know if I didn't do things properly !

Case I'm trying to solve: provide our own sink to the `LoggingMeterRegistry` so we can control how the metrics are logged. Specifically in our case we do not want them logged at `info` level, but rather at a `debug` level.

Does this make sense ?

I had a look at the test, and the use of the logger isn't tested yet. If you could provide me with some guidance about the tests you would expect that would be great !