### PR TITLE
Polish 'Support "_index_template" for Elasticsearch 7.8+'

### DIFF
--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -165,7 +165,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         switch (indexTemplateStatus) {
             case MISSING:
                 try {
-                    creator.createIndex(this.config);
+                    creator.createIndexTemplate(this.config);
                     this.checkedForIndexTemplate = true;
                 }
                 catch (Throwable exc) {

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/IndexTemplateCreator.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/IndexTemplateCreator.java
@@ -19,7 +19,7 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 
 /**
- * Internal strategy for create Elasticsearch index templates for metrics indices.
+ * Internal strategy to create Elasticsearch index templates for metrics indices.
  *
  * @author Brian Clozel
  */
@@ -37,7 +37,7 @@ interface IndexTemplateCreator {
      * Create the index template.
      * @param configuration the elastic configuration
      */
-    void createIndex(ElasticConfig configuration) throws Throwable;
+    void createIndexTemplate(ElasticConfig configuration) throws Throwable;
 
     /**
      * Configure the authentication information on the HTTP request.


### PR DESCRIPTION
This PR polishes the 'Support "_index_template" for Elasticsearch 7.8+' changes a bit.

See gh-3671