### PR TITLE
Polish "Add BND plugin and OSGi export core package"

### DIFF
--- a/micrometer-osgi-test/src/test/java/io/micrometer/osgi/test/OsgiTest.java
+++ b/micrometer-osgi-test/src/test/java/io/micrometer/osgi/test/OsgiTest.java
@@ -30,19 +30,15 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.test.junit5.context.BundleContextExtension;
 import org.osgi.test.junit5.service.ServiceExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith({ ServiceExtension.class, BundleContextExtension.class })
-public class OsgiTest {
+class OsgiTest {
 
     private final BundleContext context = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
-
-    private final Logger logger = LoggerFactory.getLogger(OsgiTest.class);
 
     private final MockClock clock = new MockClock();
 
@@ -58,15 +54,13 @@ public class OsgiTest {
     @Test
     void testPrometheusMeterRegistryResolves() {
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        assertThat(registry).isNotNull();
         testMetrics(registry);
-        logger.info(registry.scrape());
+        assertThat(registry.scrape()).contains("micrometer_test_counter").contains(" micrometer_test_timer");
     }
 
     @Test
     void testJmxMeterRegistryResolves() {
         JmxMeterRegistry registry = new JmxMeterRegistry(JmxConfig.DEFAULT, clock);
-        assertThat(registry).isNotNull();
         testMetrics(registry);
     }
 

--- a/micrometer-osgi-test/test.bndrun
+++ b/micrometer-osgi-test/test.bndrun
@@ -1,7 +1,7 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework;
 -runee: ${project.osgiRunee}
--runtrace: true
+-runtrace: false
 
 #uncomment to remote debug
 # -runjdb: 5005


### PR DESCRIPTION
This PR polishes the "Add BND plugin and OSGi export core package" changes from https://github.com/micrometer-metrics/micrometer/pull/3457 a bit.

With this PR, I thought that `testImplementation 'org.slf4j:slf4j-api'` and `testRuntimeOnly 'org.slf4j:slf4j-simple'` could be removed from the `micrometer-osgi-test` module, but it doesn't seem to be the case as the following failure occurs:

```
> Task :micrometer-osgi-test:resolve FAILED
Resolution failed. Capabilities satisfying the following requirements could not be found:
    [<<INITIAL>>]
      ⇒ osgi.identity: (osgi.identity=micrometer-osgi-test-tests)
          ⇒ [micrometer-osgi-test-tests version=1.11.0.SNAPSHOT]
              ⇒ osgi.wiring.package: (osgi.wiring.package=io.micrometer.core.instrument.composite)
                  ⇒ [micrometer-core version=1.11.0.SNAPSHOT]
                      ⇒ osgi.wiring.package: (&(osgi.wiring.package=io.micrometer.common.docs)(version>=1.11.0)(!(version>=2.0.0)))
                          ⇒ [micrometer-commons version=1.11.0.SNAPSHOT]
                              ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.slf4j.helpers)(version>=1.7.0)(!(version>=2.0.0)))
                                  ⇒ [slf4j.api version=1.7.36]
                                      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.slf4j.impl)(version>=1.6.0))
The following requirements are optional:
    [junit-jupiter-engine version=5.9.2]
      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.apiguardian.api)(version>=1.1.0)(!(version>=2.0.0)))
    [junit-platform-launcher version=1.9.2]
      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.apiguardian.api)(version>=1.1.0)(!(version>=2.0.0)))
    [junit-jupiter-api version=5.9.2]
      ⇒ osgi.wiring.package: (osgi.wiring.package=kotlin.collections)
      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.apiguardian.api)(version>=1.1.0)(!(version>=2.0.0)))
      ⇒ osgi.wiring.package: (osgi.wiring.package=kotlin)
      ⇒ osgi.wiring.package: (osgi.wiring.package=kotlin.jvm.internal)
      ⇒ osgi.wiring.package: (osgi.wiring.package=kotlin.jvm.functions)
    [junit-platform-commons version=1.9.2]
      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.apiguardian.api)(version>=1.1.0)(!(version>=2.0.0)))
    [junit-platform-engine version=1.9.2]
      ⇒ osgi.wiring.package: (&(osgi.wiring.package=org.apiguardian.api)(version>=1.1.0)(!(version>=2.0.0)))

FAILURE: Build failed with an exception.
```

I'm not familiar with OSGi, so I might miss something.