### PR TITLE
Add Bnd-LastModified attribute to runtime normalization ignore list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ subprojects {
             runtimeClasspath {
                 metaInf {
                     [
+                            'Bnd-LastModified',
                             'Build-Date',
                             'Build-Date-UTC',
                             'Built-By',


### PR DESCRIPTION
This PR fixes build cache misses which started while introducing [bnd Gradle plugin](https://github.com/micrometer-metrics/micrometer/commit/7c7ed9968e7815232bdf1d8ae37e059463030bb3).

Since then, a new property `Bnd-LastModified` has appeared in the `Manifest` file. This property is changing between each build, meaning all Gradle task using a Jar containing this `Manifest` file will be impacted.

Running 2 `gradlew clean assemble` in sequence leads to build cache misses on:
- `compileKotlin`
- `javadoc`
- `testingBundle`

<img width="936" alt="Screenshot 2023-03-16 at 12 23 02 PM" src="https://user-images.githubusercontent.com/10243934/225602460-5cbee1a3-e767-4e1f-9d2d-0783452ac0cd.png">

