### PR TITLE
Add supplier variant for Observation.Context.getOrDefault()

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1295,6 +1295,18 @@ public interface Observation extends ObservationView {
         <T> T getOrDefault(Object key, T defaultObject);
 
         /**
+         * Returns an element or default if not present.
+         * @param key key
+         * @param defaultObjectSupplier supplier for default object to return
+         * @param <T> value type
+         * @return object or default if not present
+         */
+        default <T> T getOrDefault(Object key, Supplier<T> defaultObjectSupplier) {
+            T value = get(key);
+            return value != null ? value : defaultObjectSupplier.get();
+        }
+
+        /**
          * Returns low cardinality key values.
          * @return low cardinality key values
          */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1300,6 +1300,7 @@ public interface Observation extends ObservationView {
          * @param defaultObjectSupplier supplier for default object to return
          * @param <T> value type
          * @return object or default if not present
+         * @since 1.11.0
          */
         default <T> T getOrDefault(Object key, Supplier<T> defaultObjectSupplier) {
             T value = get(key);

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationContextTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationContextTest.java
@@ -21,7 +21,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.function.Supplier;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link Observation.Context}.
@@ -66,6 +69,30 @@ class ObservationContextTest {
         context.put(String.class, "42");
         assertThat(context.getOrDefault(String.class, "abc")).isEqualTo("42");
         assertThat(context.getOrDefault(Integer.class, 123)).isEqualTo(123);
+    }
+
+    @Test
+    void getOrDefaultSupplierWhenKeyIsPresent() {
+        context.put(String.class, "42");
+
+        @SuppressWarnings("unchecked")
+        Supplier<String> defaultSupplier = mock(Supplier.class);
+        when(defaultSupplier.get()).thenReturn("abc");
+
+        assertThat(context.getOrDefault(String.class, defaultSupplier)).isEqualTo("42");
+        verifyNoInteractions(defaultSupplier);
+    }
+
+    @Test
+    void getOrDefaultSupplierWhenKeyIsMissing() {
+        context.put(String.class, "42");
+
+        @SuppressWarnings("unchecked")
+        Supplier<Integer> defaultSupplier = mock(Supplier.class);
+        when(defaultSupplier.get()).thenReturn(123);
+
+        assertThat(context.getOrDefault(Integer.class, defaultSupplier)).isEqualTo(123);
+        verify(defaultSupplier, times(1)).get();
     }
 
     @Test


### PR DESCRIPTION
This PR adds a supplier variant for `Observation.Context.getOrDefault()` to avoid default object creation where unnecessary.