### PR TITLE
Avoid duplicate publishing of data.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -71,7 +71,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     }
 
     /**
-     * @return - true if registry is publishing metrics
+     * Returns - true if registry is publishing metrics.
      */
     public boolean isPublishing() {
         return publishing.get();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -52,7 +52,8 @@ public abstract class PushMeterRegistry extends MeterRegistry {
     /**
      * Catch uncaught exceptions thrown from {@link #publish()}.
      */
-    private void publishSafely() {
+    // VisibleForTesting
+    void publishSafely() {
         if (this.publishing.compareAndSet(false, true)) {
             try {
                 publish();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -67,14 +67,14 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             }
         }
         else {
-            logger.warn("Publishing is already in progress.");
+            logger.warn("Publishing is already in progress. Skipping duplicate call to publishSafely().");
         }
     }
 
     /**
-     * Returns - true if registry is publishing metrics.
+     * Returns - true if scheduled publishing of metrics is in progress.
      */
-    public boolean isPublishing() {
+    protected boolean isPublishing() {
         return publishing.get();
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -107,10 +107,12 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     @Override
     public void close() {
         stop();
-        getMeters().stream()
-            .filter(meter -> meter instanceof StepMeter)
-            .map(meter -> (StepMeter) meter)
-            .forEach(StepMeter::_manualRollover);
+        if (!isPublishing()) {
+            getMeters().stream()
+                .filter(StepMeter.class::isInstance)
+                .map(StepMeter.class::cast)
+                .forEach(StepMeter::_manualRollover);
+        }
         super.close();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -22,17 +22,21 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -62,15 +66,9 @@ class PushMeterRegistryTest {
 
     CountDownLatch latch = new CountDownLatch(2);
 
-    PushMeterRegistry pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
-
-    @AfterEach
-    void cleanUp() {
-        pushMeterRegistry.close();
-    }
-
     @Test
     void whenUncaughtExceptionInPublish_taskStillScheduled() throws InterruptedException {
+        PushMeterRegistry pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
         pushMeterRegistry.start(threadFactory);
         assertThat(latch.await(500, TimeUnit.MILLISECONDS))
             .as("publish should continue to be scheduled even if an uncaught exception is thrown")
@@ -79,17 +77,99 @@ class PushMeterRegistryTest {
 
     @Test
     void whenUncaughtExceptionInPublish_closeRegistrySuccessful() {
+        PushMeterRegistry pushMeterRegistry = new ThrowingPushMeterRegistry(config, latch);
         assertThatCode(() -> pushMeterRegistry.close()).doesNotThrowAnyException();
     }
 
     @Test
     @Issue("#3712")
     void publishOnlyHappensOnceWithMultipleClose() {
-        pushMeterRegistry = new CountingPushMeterRegistry(config, Clock.SYSTEM);
+        CountingPushMeterRegistry pushMeterRegistry = new CountingPushMeterRegistry(config, Clock.SYSTEM);
         pushMeterRegistry.close();
-        assertThat(((CountingPushMeterRegistry) pushMeterRegistry).publishCount.get()).isOne();
+        assertThat(pushMeterRegistry.publishCount.get()).isOne();
         pushMeterRegistry.close();
-        assertThat(((CountingPushMeterRegistry) pushMeterRegistry).publishCount.get()).isOne();
+        assertThat(pushMeterRegistry.publishCount.get()).isOne();
+    }
+
+    @Test
+    @Issue("#3711")
+    void scheduledPublishOverlapWithPublishOnClose() throws InterruptedException {
+        MockClock clock = new MockClock();
+        CyclicBarrier barrier = new CyclicBarrier(2);
+        OverlappingStepMeterRegistry overlappingStepMeterRegistry = new OverlappingStepMeterRegistry(config, clock,
+                barrier);
+        Counter c1 = overlappingStepMeterRegistry.counter("c1");
+        Counter c2 = overlappingStepMeterRegistry.counter("c2");
+        c1.increment();
+        c2.increment(2.5);
+        clock.add(config.step());
+
+        // simulated scheduled publish
+        Thread scheduledPublishingThread = new Thread(
+                () -> ((PushMeterRegistry) overlappingStepMeterRegistry).publishSafely(),
+                "scheduledMetricsPublisherThread");
+        scheduledPublishingThread.start();
+        // publish on shutdown
+        Thread onClosePublishThread = new Thread(overlappingStepMeterRegistry::close, "shutdownHookThread");
+        onClosePublishThread.start();
+        scheduledPublishingThread.join();
+        onClosePublishThread.join();
+
+        assertThat(overlappingStepMeterRegistry.publishes).as("only one publish happened").hasSize(1);
+        Deque<Double> firstPublishValues = overlappingStepMeterRegistry.publishes.get(0);
+        assertThat(firstPublishValues.pop()).isEqualTo(1);
+        assertThat(firstPublishValues.pop()).isEqualTo(2.5);
+    }
+
+    private static class OverlappingStepMeterRegistry extends StepMeterRegistry {
+
+        private final AtomicInteger numberOfPublish = new AtomicInteger();
+
+        private final Map<Integer, Deque<Double>> publishes = new ConcurrentHashMap<>();
+
+        private final CyclicBarrier barrier;
+
+        public OverlappingStepMeterRegistry(StepRegistryConfig config, Clock clock, CyclicBarrier barrier) {
+            super(config, clock);
+            this.barrier = barrier;
+        }
+
+        @Override
+        protected TimeUnit getBaseTimeUnit() {
+            return SECONDS;
+        }
+
+        @Override
+        protected void publish() {
+            try {
+                barrier.await(100, MILLISECONDS);
+            }
+            catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+            int publishIndex = numberOfPublish.getAndIncrement();
+            for (Counter counter : getMeters().stream()
+                .filter(meter -> meter instanceof Counter)
+                .map(meter -> (Counter) meter)
+                .collect(Collectors.toSet())) {
+                publishes.merge(publishIndex, new ArrayDeque<>(Arrays.asList(counter.count())), (l1, l2) -> {
+                    l1.addAll(l2);
+                    return l1;
+                });
+            }
+        }
+
+        @Override
+        public void close() {
+            try {
+                barrier.await(100, MILLISECONDS);
+            }
+            catch (InterruptedException | BrokenBarrierException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+            super.close();
+        }
+
     }
 
     static class CountingPushMeterRegistry extends PushMeterRegistry {


### PR DESCRIPTION
This PR tries to address the issue mentioned in [3711](https://github.com/micrometer-metrics/micrometer/issues/3711). This adds a boolean `publishing` and exposes a public method `isPublishing()` to PushMeterRegistry to check if the registry is publishing data or not. 
Well, this restricts the publishing of data if there is already a publish operation in place. This can be true for StepRegistries but not sure about the desired behavior for Cumulative Registries. Since, `publishSafely()` is private to PushMeterRegistry, adding this as the default behavior for all the PushRegistries.

TODO:
- [x] Add Unit tests.