### PR TITLE
Add Javadoc since to new constructors in LoggingMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -78,6 +78,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
     /**
      * Constructor allowing custom sink instead of a default {@code log::info}.
      * @param loggingSink the custom sink that will be called for each time series.
+     * @since 1.11.0
      */
     public LoggingMeterRegistry(Consumer<String> loggingSink) {
         this(LoggingRegistryConfig.DEFAULT, Clock.SYSTEM, loggingSink);
@@ -88,6 +89,7 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
      * @param config the LoggingRegistryConfig
      * @param clock the Clock
      * @param loggingSink the custom sink that will be called for each time series.
+     * @since 1.11.0
      */
     public LoggingMeterRegistry(LoggingRegistryConfig config, Clock clock, Consumer<String> loggingSink) {
         this(config, clock, new NamedThreadFactory("logging-metrics-publisher"), loggingSink, null);


### PR DESCRIPTION
This PR adds Javadoc `@since` tags to the new constructors in the `LoggingMeterRegistry`.

See gh-3685