### PR TITLE
Avoid using streams in observations

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -20,7 +20,6 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -367,7 +366,9 @@ public interface Observation extends ObservationView {
      * @return this
      */
     default Observation lowCardinalityKeyValues(KeyValues keyValues) {
-        keyValues.stream().forEach(this::lowCardinalityKeyValue);
+        for (KeyValue keyValue : keyValues) {
+            lowCardinalityKeyValue(keyValue);
+        }
         return this;
     }
 
@@ -400,7 +401,9 @@ public interface Observation extends ObservationView {
      * @return this
      */
     default Observation highCardinalityKeyValues(KeyValues keyValues) {
-        keyValues.stream().forEach(this::highCardinalityKeyValue);
+        for (KeyValue keyValue : keyValues) {
+            highCardinalityKeyValue(keyValue);
+        }
         return this;
     }
 
@@ -1026,7 +1029,9 @@ public interface Observation extends ObservationView {
          * @return this context
          */
         public Context addLowCardinalityKeyValues(KeyValues keyValues) {
-            keyValues.stream().forEach(this::addLowCardinalityKeyValue);
+            for (KeyValue keyValue : keyValues) {
+                addLowCardinalityKeyValue(keyValue);
+            }
             return this;
         }
 
@@ -1036,7 +1041,9 @@ public interface Observation extends ObservationView {
          * @return this context
          */
         public Context addHighCardinalityKeyValues(KeyValues keyValues) {
-            keyValues.stream().forEach(this::addHighCardinalityKeyValue);
+            for (KeyValue keyValue : keyValues) {
+                addHighCardinalityKeyValue(keyValue);
+            }
             return this;
         }
 
@@ -1047,7 +1054,9 @@ public interface Observation extends ObservationView {
          * @since 1.10.1
          */
         public Context removeLowCardinalityKeyValues(String... keyNames) {
-            Arrays.stream(keyNames).forEach(this::removeLowCardinalityKeyValue);
+            for (String keyName : keyNames) {
+                removeLowCardinalityKeyValue(keyName);
+            }
             return this;
         }
 
@@ -1058,7 +1067,9 @@ public interface Observation extends ObservationView {
          * @since 1.10.1
          */
         public Context removeHighCardinalityKeyValues(String... keyNames) {
-            Arrays.stream(keyNames).forEach(this::removeHighCardinalityKeyValue);
+            for (String keyName : keyNames) {
+                removeHighCardinalityKeyValue(keyName);
+            }
             return this;
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -160,10 +160,12 @@ public interface ObservationRegistry {
         @SuppressWarnings("unchecked")
         <T extends Observation.Context> ObservationConvention<T> getObservationConvention(T context,
                 ObservationConvention<T> defaultConvention) {
-            return (ObservationConvention<T>) this.observationConventions.stream()
-                .filter(convention -> convention.supportsContext(context))
-                .findFirst()
-                .orElse(Objects.requireNonNull(defaultConvention, "Default ObservationConvention must not be null"));
+            for (ObservationConvention<?> convention : this.observationConventions) {
+                if (convention.supportsContext(context)) {
+                    return (ObservationConvention<T>) convention;
+                }
+            }
+            return Objects.requireNonNull(defaultConvention, "Default ObservationConvention must not be null");
         }
 
         /**
@@ -174,7 +176,12 @@ public interface ObservationRegistry {
          * @return {@code true} when observation is enabled
          */
         boolean isObservationEnabled(String name, @Nullable Observation.Context context) {
-            return this.observationPredicates.stream().allMatch(predicate -> predicate.test(name, context));
+            for (ObservationPredicate predicate : this.observationPredicates) {
+                if (!predicate.test(name, context)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         // package-private for minimal visibility


### PR DESCRIPTION
I was running [my spring stress test with actuator](https://gist.github.com/yuzawa-san/5102be26fb9e4472419c23b39c4524b2) for [some recent performance work](https://github.com/spring-projects/spring-framework/pull/30136) and I found room for some minor optimizations in here around streams usage. Using the plain iteration for single operator cases uses less CPU and memory (in these cases, not while costing readability).

I have some CPU and memory icicle graphs for SimpleObservation's start and stop. Ignore the spring observation conventions typically located on the left. however this should be considered the constant in this experiment so its apparent proportional share growing means that the micrometer's share has decreased. note the overhead of the ReferencePipeline (the stream implementations).

before start() memory:
<img width="1471" alt="image" src="https://user-images.githubusercontent.com/1082334/228536768-c97518a5-3d96-4072-9554-38fd7aa11386.png">


after start() memory:
<img width="1477" alt="image" src="https://user-images.githubusercontent.com/1082334/228536429-5ef7773e-a8a5-496a-afe3-9e085fbb2987.png">


before start() cpu:
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/1082334/228536596-5565c678-6410-4749-9fb1-53ea52f16121.png">


after start() cpu:
<img width="1461" alt="image" src="https://user-images.githubusercontent.com/1082334/228536218-d60b0fcc-e313-4aaa-ac4d-127c374cd97d.png">




before stop() memory:
<img width="1466" alt="image" src="https://user-images.githubusercontent.com/1082334/228536836-9ede1184-7a9b-4d43-9bfd-13a16a209c88.png">


after stop() memory:
<img width="1477" alt="image" src="https://user-images.githubusercontent.com/1082334/228536492-082154fc-9d0d-40f5-8914-6f83eeab1d12.png">


before stop() cpu:
<img width="1476" alt="image" src="https://user-images.githubusercontent.com/1082334/228536664-8b0a65fa-1ecc-49ea-ada7-87686ba036d8.png">


after stop() cpu:
<img width="1458" alt="image" src="https://user-images.githubusercontent.com/1082334/228536298-ed8f03cb-ad67-464a-bbc7-2bd8a9cda606.png">

I tried to avoid multiple re-sort operations done in Tags in the changes done in DefaultMeterObservationHandler.java. However going from KeyValues to Tags was a bit annoying since I could not presize the intermediate collection, but that is only a minor issue.

Aside: should Tag extend KeyValue?

edit: make graphs easier to compare