### PR TITLE
Pin software.amazon.awssdk:cloudwatch to 2.20.33 temporarily

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -88,7 +88,7 @@ def VERSIONS = [
         'org.testcontainers:mongodb:latest.release',
         'org.testcontainers:testcontainers:latest.release',
         'ru.lanwen.wiremock:wiremock-junit5:latest.release',
-        'software.amazon.awssdk:cloudwatch:latest.release'
+        'software.amazon.awssdk:cloudwatch:2.20.33' // FIXME: Use latest.release when a proper version is available.
 ]
 
 def PLATFORM_BOMS = [


### PR DESCRIPTION
This PR pins `software.amazon.awssdk:cloudwatch` to 2.20.33 temporarily as it seems to be broken as follows:

```
* What went wrong:
Execution failed for task ':micrometer-registry-cloudwatch2:compileJava'.
> Could not resolve all files for configuration ':micrometer-registry-cloudwatch2:compileClasspath'.
   > Could not find sdk-core-2.20.34.jar (software.amazon.awssdk:sdk-core:2.20.34).
     Searched in the following locations:
         https://repo.maven.apache.org/maven2/software/amazon/awssdk/sdk-core/2.20.34/sdk-core-2.20.34.jar
```

See https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/4021/workflows/ef196d14-ffee-4e72-b9a8-894175036498/jobs/21250