### PR TITLE
MetricTag

### DIFF
--- a/micrometer-commons/build.gradle
+++ b/micrometer-commons/build.gradle
@@ -4,6 +4,9 @@ dependencies {
     // log monitoring
     optionalApi 'ch.qos.logback:logback-classic'
 
+    // Aspects
+    optionalApi 'org.aspectj:aspectjweaver'
+
     // JUnit 5
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.tngtech.archunit:archunit-junit5'

--- a/micrometer-commons/build.gradle
+++ b/micrometer-commons/build.gradle
@@ -16,3 +16,14 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.awaitility:awaitility'
 }
+
+jar {
+    bundle {
+
+        bnd '''\
+        Import-Package: \
+            org.aspectj.*;resolution:=dynamic,\
+            *
+        '''.stripIndent()
+    }
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotatedParameter.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotatedParameter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A container class that holds information about the parameter of the annotated method
+ * argument.
+ *
+ * Code ported from Spring Cloud Sleuth.
+ *
+ * @author Christian Schwerdtfeger
+ */
+class AnnotatedParameter {
+
+    final int parameterIndex;
+
+    final Annotation annotation;
+
+    final Object argument;
+
+    AnnotatedParameter(int parameterIndex, Annotation annotation, Object argument) {
+        this.parameterIndex = parameterIndex;
+        this.annotation = annotation;
+        this.argument = argument;
+    }
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationUtils.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class that can verify whether the method is annotated with the Micrometer
+ * Tracing annotations.
+ *
+ * Code ported from Spring Cloud Sleuth.
+ *
+ * @author Christian Schwerdtfeger
+ */
+final class AnnotationUtils {
+
+    private AnnotationUtils() {
+
+    }
+
+    static List<AnnotatedParameter> findAnnotatedParameters(Class<? extends Annotation> tagClazz, Method method,
+            Object[] args) {
+        Annotation[][] parameters = method.getParameterAnnotations();
+        List<AnnotatedParameter> result = new ArrayList<>();
+        int i = 0;
+        for (Annotation[] parameter : parameters) {
+            for (Annotation parameter2 : parameter) {
+                if (tagClazz.isAssignableFrom(parameter2.getClass())) {
+                    result.add(new AnnotatedParameter(i, parameter2, args[i]));
+                }
+            }
+            i++;
+        }
+        return result;
+    }
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/NoOpTagValueResolver.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/NoOpTagValueResolver.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+/**
+ * A no-op implementation of a {@link TagValueResolver}.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.11.0
+ */
+public class NoOpTagValueResolver implements TagValueResolver {
+
+    @Override
+    public String resolve(Object parameter) {
+        return null;
+    }
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagAnnotationHandler.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagAnnotationHandler.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * This class is able to find all methods annotated with the Micrometer annotations. All
+ * methods mean that if you have both an interface and an implementation annotated with
+ * Micrometer annotations then this class is capable of finding both of them and merging
+ * into one set of information.
+ * <p>
+ * This information is then used to add proper tags to objects such as span or timer from
+ * the method arguments that are annotated with a tag related annotation.
+ *
+ * Code ported from Spring Cloud Sleuth.
+ *
+ * @author Christian Schwerdtfeger
+ * @since 1.11.0
+ */
+public class TagAnnotationHandler<T> {
+
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(TagAnnotationHandler.class);
+
+    private final BiConsumer<KeyValue, T> tagConsumer;
+
+    private final Function<Class<? extends TagValueResolver>, ? extends TagValueResolver> resolverProvider;
+
+    private final Function<Class<? extends TagValueExpressionResolver>, ? extends TagValueExpressionResolver> expressionResolverProvider;
+
+    private final Class<? extends Annotation> tagClass;
+
+    private final BiFunction<Annotation, Object, KeyValue> toKeyValue;
+
+    public TagAnnotationHandler(BiConsumer<KeyValue, T> tagConsumer,
+            Function<Class<? extends TagValueResolver>, ? extends TagValueResolver> resolverProvider,
+            Function<Class<? extends TagValueExpressionResolver>, ? extends TagValueExpressionResolver> expressionResolverProvider,
+            Class<? extends Annotation> tagClass, BiFunction<Annotation, Object, KeyValue> toKeyValue) {
+        this.tagConsumer = tagConsumer;
+        this.resolverProvider = resolverProvider;
+        this.expressionResolverProvider = expressionResolverProvider;
+        this.tagClass = tagClass;
+        this.toKeyValue = toKeyValue;
+    }
+
+    public void addAnnotatedParameters(T objectToTag, ProceedingJoinPoint pjp) {
+        try {
+            Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+            List<AnnotatedParameter> annotatedParameters = AnnotationUtils.findAnnotatedParameters(tagClass, method,
+                    pjp.getArgs());
+            getAnnotationsFromInterfaces(pjp, method, annotatedParameters);
+            addAnnotatedArguments(objectToTag, annotatedParameters);
+        }
+        catch (SecurityException ex) {
+            log.error("Exception occurred while trying to add annotated parameters", ex);
+        }
+    }
+
+    private void getAnnotationsFromInterfaces(ProceedingJoinPoint pjp, Method mostSpecificMethod,
+            List<AnnotatedParameter> annotatedParameters) {
+        Class<?>[] implementedInterfaces = pjp.getThis().getClass().getInterfaces();
+        if (implementedInterfaces.length > 0) {
+            for (Class<?> implementedInterface : implementedInterfaces) {
+                for (Method methodFromInterface : implementedInterface.getMethods()) {
+                    if (methodsAreTheSame(mostSpecificMethod, methodFromInterface)) {
+                        List<AnnotatedParameter> annotatedParametersForActualMethod = AnnotationUtils
+                            .findAnnotatedParameters(tagClass, methodFromInterface, pjp.getArgs());
+                        mergeAnnotatedParameters(annotatedParameters, annotatedParametersForActualMethod);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean methodsAreTheSame(Method mostSpecificMethod, Method method1) {
+        return method1.getName().equals(mostSpecificMethod.getName())
+                && Arrays.equals(method1.getParameterTypes(), mostSpecificMethod.getParameterTypes());
+    }
+
+    private void mergeAnnotatedParameters(List<AnnotatedParameter> annotatedParametersIndices,
+            List<AnnotatedParameter> annotatedParametersIndicesForActualMethod) {
+        for (AnnotatedParameter container : annotatedParametersIndicesForActualMethod) {
+            final int index = container.parameterIndex;
+            boolean parameterContained = false;
+            for (AnnotatedParameter parameterContainer : annotatedParametersIndices) {
+                if (parameterContainer.parameterIndex == index) {
+                    parameterContained = true;
+                    break;
+                }
+            }
+            if (!parameterContained) {
+                annotatedParametersIndices.add(container);
+            }
+        }
+    }
+
+    private void addAnnotatedArguments(T objectToTag, List<AnnotatedParameter> toBeAdded) {
+        for (AnnotatedParameter container : toBeAdded) {
+            KeyValue keyValue = toKeyValue.apply(container.annotation, container.argument);
+            tagConsumer.accept(keyValue, objectToTag);
+        }
+    }
+
+    public Function<Class<? extends TagValueResolver>, ? extends TagValueResolver> getResolverProvider() {
+        return resolverProvider;
+    }
+
+    public Function<Class<? extends TagValueExpressionResolver>, ? extends TagValueExpressionResolver> getExpressionResolverProvider() {
+        return expressionResolverProvider;
+    }
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagValueExpressionResolver.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagValueExpressionResolver.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+/**
+ * Resolves the tag value for the given parameter and the provided expression.
+ *
+ * @author Marcin Grzejszczak
+ * @since 1.11.0
+ */
+public interface TagValueExpressionResolver {
+
+    /**
+     * Returns the tag value for the given parameter and the provided expression.
+     * @param expression the expression coming from a tag
+     * @param parameter parameter annotated with a tag related annotation
+     * @return the value of the tag
+     */
+    String resolve(String expression, Object parameter);
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagValueResolver.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/TagValueResolver.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+/**
+ * Resolves the tag value for the given parameter.
+ *
+ * @author Christian Schwerdtfeger
+ * @since 1.11.0
+ */
+public interface TagValueResolver {
+
+    /**
+     * Returns the tag value for the given parameter.
+     * @param parameter parameter annotated with a tag annotation
+     * @return the value of the tag
+     */
+    String resolve(Object parameter);
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/package-info.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.micrometer.common.annotation;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;

--- a/micrometer-commons/src/test/java/io/micrometer/common/annotation/NoOpTagValueResolverTests.java
+++ b/micrometer-commons/src/test/java/io/micrometer/common/annotation/NoOpTagValueResolverTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.common.annotation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+/**
+ * @author Marcin Grzejszczak
+ */
+class NoOpTagValueResolverTests {
+
+    @Test
+    void should_return_null() throws Exception {
+        then(new NoOpTagValueResolver().resolve("")).isNull();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/MetricTag.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/MetricTag.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.common.annotation.NoOpTagValueResolver;
+import io.micrometer.common.annotation.TagValueResolver;
+
+import java.lang.annotation.*;
+
+/**
+ * There are 3 different ways to add tags to a span. All of them are controlled by the
+ * annotation values. Precedence is:
+ * <p>
+ * try with the {@link TagValueResolver} bean if the value of the bean wasn't set, try to
+ * evaluate a SPEL expression if there’s no SPEL expression just return a
+ * {@code toString()} value of the parameter
+ *
+ * @author Christian Schwerdtfeger
+ * @since 1.11.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Target(ElementType.PARAMETER)
+public @interface MetricTag {
+
+    /**
+     * The name of the key of the tag which should be created.
+     * @return the tag key
+     */
+    String value() default "";
+
+    /**
+     * The name of the key of the tag which should be created.
+     * @return the tag value
+     */
+    String key() default "";
+
+    /**
+     * Execute this expression to calculate the tag value. Will be analyzed if no value of
+     * the {@link MetricTag#resolver()} was set.
+     * @return an expression
+     */
+    String expression() default "";
+
+    /**
+     * Use this bean to resolve the tag value. Has the highest precedence.
+     * @return {@link TagValueResolver} bean
+     */
+    Class<? extends TagValueResolver> resolver() default NoOpTagValueResolver.class;
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/MetricsTagAnnotationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/MetricsTagAnnotationHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.annotation.NoOpTagValueResolver;
+import io.micrometer.common.annotation.TagAnnotationHandler;
+import io.micrometer.common.annotation.TagValueExpressionResolver;
+import io.micrometer.common.annotation.TagValueResolver;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.function.Function;
+
+/**
+ * Annotation handler for {@link MetricTag}.
+ *
+ * @since 1.11.0
+ */
+public class MetricsTagAnnotationHandler extends TagAnnotationHandler<Timer.Builder> {
+
+    /**
+     * Creates a new instance of {@link MetricsTagAnnotationHandler}.
+     * @param resolverProvider function to retrieve a {@link TagValueResolver}
+     * @param expressionResolverProvider function to retrieve a
+     * {@link TagValueExpressionResolver}
+     */
+    public MetricsTagAnnotationHandler(
+            Function<Class<? extends TagValueResolver>, ? extends TagValueResolver> resolverProvider,
+            Function<Class<? extends TagValueExpressionResolver>, ? extends TagValueExpressionResolver> expressionResolverProvider) {
+        super((keyValue, builder) -> builder.tag(keyValue.getKey(), keyValue.getValue()), resolverProvider,
+                expressionResolverProvider, MetricTag.class, (annotation, o) -> {
+                    if (!(annotation instanceof MetricTag)) {
+                        return null;
+                    }
+                    MetricTag metricTag = (MetricTag) annotation;
+                    return KeyValue.of(resolveTagKey(metricTag),
+                            resolveTagValue(metricTag, o, resolverProvider, expressionResolverProvider));
+                });
+    }
+
+    private static String resolveTagKey(MetricTag annotation) {
+        return StringUtils.isNotBlank(annotation.value()) ? annotation.value() : annotation.key();
+    }
+
+    static String resolveTagValue(MetricTag annotation, Object argument,
+            Function<Class<? extends TagValueResolver>, ? extends TagValueResolver> resolverProvider,
+            Function<Class<? extends TagValueExpressionResolver>, ? extends TagValueExpressionResolver> expressionResolverProvider) {
+        String value = null;
+        if (annotation.resolver() != NoOpTagValueResolver.class) {
+            TagValueResolver tagValueResolver = resolverProvider.apply(annotation.resolver());
+            value = tagValueResolver.resolve(argument);
+        }
+        else if (StringUtils.isNotBlank(annotation.expression())) {
+            value = expressionResolverProvider.apply(TagValueExpressionResolver.class)
+                .resolve(annotation.expression(), argument);
+        }
+        else if (argument != null) {
+            value = argument.toString();
+        }
+        return value == null ? "" : value;
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/MetricsTagAnnotationHandlerTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/MetricsTagAnnotationHandlerTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.common.annotation.TagValueExpressionResolver;
+import io.micrometer.common.annotation.TagValueResolver;
+import io.micrometer.core.annotation.Timed;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class MetricsTagAnnotationHandlerTests {
+
+    TagValueResolver tagValueResolver = parameter -> "Value from myCustomTagValueResolver";
+
+    TagValueExpressionResolver tagValueExpressionResolver = new SpelTagValueExpressionResolver();
+
+    MetricsTagAnnotationHandler handler;
+
+    @BeforeEach
+    void setup() {
+        this.handler = new MetricsTagAnnotationHandler(aClass -> tagValueResolver,
+                aClass -> tagValueExpressionResolver);
+    }
+
+    @Test
+    void shouldUseCustomTagValueResolver() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForTagValueResolver", String.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, "test",
+                    aClass -> tagValueResolver, aClass -> tagValueExpressionResolver);
+            assertThat(resolvedValue).isEqualTo("Value from myCustomTagValueResolver");
+        }
+        else {
+            fail("Annotation was not MetricTag");
+        }
+    }
+
+    @Test
+    void shouldUseTagValueExpression() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForTagValueExpression", String.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, "test",
+                    aClass -> tagValueResolver, aClass -> tagValueExpressionResolver);
+
+            assertThat(resolvedValue).isEqualTo("hello characters");
+        }
+        else {
+            fail("Annotation was not MetricTag");
+        }
+    }
+
+    @Test
+    void shouldReturnArgumentToString() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForArgumentToString", Long.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, 15, aClass -> tagValueResolver,
+                    aClass -> tagValueExpressionResolver);
+            assertThat(resolvedValue).isEqualTo("15");
+        }
+        else {
+            fail("Annotation was not MetricTag");
+        }
+    }
+
+    protected class AnnotationMockClass {
+
+        @Timed
+        public void getAnnotationForTagValueResolver(
+                @MetricTag(key = "test", resolver = TagValueResolver.class) String test) {
+        }
+
+        @Timed
+        public void getAnnotationForTagValueExpression(
+                @MetricTag(key = "test", expression = "'hello' + ' characters'") String test) {
+        }
+
+        @Timed
+        public void getAnnotationForArgumentToString(@MetricTag("test") Long param) {
+        }
+
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/NullMetricTagAnnotationHandlerTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/NullMetricTagAnnotationHandlerTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.common.annotation.TagValueExpressionResolver;
+import io.micrometer.common.annotation.TagValueResolver;
+import io.micrometer.core.annotation.Timed;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+class NullMetricTagAnnotationHandlerTests {
+
+    TagValueResolver tagValueResolver = parameter -> null;
+
+    TagValueExpressionResolver tagValueExpressionResolver = (expression, parameter) -> "";
+
+    MetricsTagAnnotationHandler handler = new MetricsTagAnnotationHandler(aClass -> tagValueResolver,
+            aClass -> tagValueExpressionResolver);
+
+    @Test
+    void shouldUseEmptyStringWheCustomTagValueResolverReturnsNull() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForTagValueResolver", String.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, "test",
+                    aClass -> tagValueResolver, aClass -> tagValueExpressionResolver);
+            assertThat(resolvedValue).isEqualTo("");
+        }
+        else {
+            fail("Annotation was not MetricTag");
+        }
+    }
+
+    @Test
+    void shouldUseEmptyStringWhenTagValueExpressionReturnNull() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForTagValueExpression", String.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, "test",
+                    aClass -> tagValueResolver, aClass -> tagValueExpressionResolver);
+
+            assertThat(resolvedValue).isEqualTo("");
+        }
+        else {
+            fail("Annotation was not MetricTag");
+        }
+    }
+
+    @Test
+    void shouldUseEmptyStringWhenArgumentIsNull() throws NoSuchMethodException, SecurityException {
+        Method method = AnnotationMockClass.class.getMethod("getAnnotationForArgumentToString", Long.class);
+        Annotation annotation = method.getParameterAnnotations()[0][0];
+        if (annotation instanceof MetricTag) {
+            String resolvedValue = this.handler.resolveTagValue((MetricTag) annotation, null,
+                    aClass -> tagValueResolver, aClass -> tagValueExpressionResolver);
+            assertThat(resolvedValue).isEqualTo("");
+        }
+        else {
+            fail("Annotation was not SpanTag");
+        }
+    }
+
+    protected class AnnotationMockClass {
+
+        @Timed
+        public void getAnnotationForTagValueResolver(
+                @MetricTag(key = "test", resolver = TagValueResolver.class) String test) {
+        }
+
+        @Timed
+        public void getAnnotationForTagValueExpression(@MetricTag(key = "test", expression = "null") String test) {
+        }
+
+        @Timed
+        public void getAnnotationForArgumentToString(@MetricTag("test") Long param) {
+        }
+
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/SpelTagValueExpressionResolver.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/SpelTagValueExpressionResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.aop;
+
+import io.micrometer.common.annotation.TagValueExpressionResolver;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+
+class SpelTagValueExpressionResolver implements TagValueExpressionResolver {
+
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(SpelTagValueExpressionResolver.class);
+
+    @Override
+    public String resolve(String expression, Object parameter) {
+        try {
+            SimpleEvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+            ExpressionParser expressionParser = new SpelExpressionParser();
+            Expression expressionToEvaluate = expressionParser.parseExpression(expression);
+            return expressionToEvaluate.getValue(context, parameter, String.class);
+        }
+        catch (Exception ex) {
+            log.error("Exception occurred while tying to evaluate the SPEL expression [" + expression + "]", ex);
+        }
+        return parameter.toString();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.*;
 
 class TimedAspectTest {
 
-    TagValueResolver tagValueResolver = parameter -> "Value from myCustomTagValueResolver";
+    TagValueResolver tagValueResolver = parameter -> "Value from myCustomTagValueResolver [" + parameter + "]";
 
     TagValueExpressionResolver tagValueExpressionResolver = new SpelTagValueExpressionResolver();
 
@@ -407,7 +407,8 @@ class TimedAspectTest {
 
         service.getAnnotationForTagValueResolver("foo");
 
-        assertThat(registry.get("method.timed").tag("test", "Value from myCustomTagValueResolver").timer().count())
+        assertThat(
+                registry.get("method.timed").tag("test", "Value from myCustomTagValueResolver [foo]").timer().count())
             .isEqualTo(1);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.aop;
 
+import io.micrometer.common.annotation.TagValueExpressionResolver;
+import io.micrometer.common.annotation.TagValueResolver;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.LongTaskTimer;
@@ -38,6 +40,10 @@ import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.assertj.core.api.Assertions.*;
 
 class TimedAspectTest {
+
+    TagValueResolver tagValueResolver = parameter -> "Value from myCustomTagValueResolver";
+
+    TagValueExpressionResolver tagValueExpressionResolver = new SpelTagValueExpressionResolver();
 
     @Test
     void timeMethod() {
@@ -370,6 +376,58 @@ class TimedAspectTest {
         });
     }
 
+    @Test
+    void metricTagsWithText() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        TimedAspect timedAspect = new TimedAspect(registry);
+        timedAspect.setMetricsTagAnnotationHandler(
+                new MetricsTagAnnotationHandler(aClass -> tagValueResolver, aClass -> tagValueExpressionResolver));
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new MetricTagClass());
+        pf.addAspect(timedAspect);
+
+        MetricTagClass service = pf.getProxy();
+
+        service.getAnnotationForArgumentToString(15L);
+
+        assertThat(registry.get("method.timed").tag("test", "15").timer().count()).isEqualTo(1);
+    }
+
+    @Test
+    void metricTagsWithResolver() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        TimedAspect timedAspect = new TimedAspect(registry);
+        timedAspect.setMetricsTagAnnotationHandler(
+                new MetricsTagAnnotationHandler(aClass -> tagValueResolver, aClass -> tagValueExpressionResolver));
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new MetricTagClass());
+        pf.addAspect(timedAspect);
+
+        MetricTagClass service = pf.getProxy();
+
+        service.getAnnotationForTagValueResolver("foo");
+
+        assertThat(registry.get("method.timed").tag("test", "Value from myCustomTagValueResolver").timer().count())
+            .isEqualTo(1);
+    }
+
+    @Test
+    void metricTagsWithExpression() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        TimedAspect timedAspect = new TimedAspect(registry);
+        timedAspect.setMetricsTagAnnotationHandler(
+                new MetricsTagAnnotationHandler(aClass -> tagValueResolver, aClass -> tagValueExpressionResolver));
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new MetricTagClass());
+        pf.addAspect(timedAspect);
+
+        MetricTagClass service = pf.getProxy();
+
+        service.getAnnotationForTagValueExpression("15L");
+
+        assertThat(registry.get("method.timed").tag("test", "hello characters").timer().count()).isEqualTo(1);
+    }
+
     private final class FailingMeterRegistry extends SimpleMeterRegistry {
 
         private FailingMeterRegistry() {
@@ -472,6 +530,24 @@ class TimedAspectTest {
 
         @Override
         public void call() {
+        }
+
+    }
+
+    protected class MetricTagClass {
+
+        @Timed
+        public void getAnnotationForTagValueResolver(
+                @MetricTag(key = "test", resolver = TagValueResolver.class) String test) {
+        }
+
+        @Timed
+        public void getAnnotationForTagValueExpression(
+                @MetricTag(key = "test", expression = "'hello' + ' characters'") String test) {
+        }
+
+        @Timed
+        public void getAnnotationForArgumentToString(@MetricTag("test") Long param) {
         }
 
     }


### PR DESCRIPTION
- Moves the common code from Micrometer Tracing
- Adds a setter to `TimedAspect` (too many constructors already)
- This only works for the `Timer.Builder` not for the `LongTaskTimer.Builder` (code can be modified to allow that)

fixes #1732 