### PR TITLE
Do not rollover again after closing

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepCounter.java
@@ -46,8 +46,8 @@ public class StepCounter extends AbstractMeter implements Counter, StepMeter {
     }
 
     @Override
-    public void _manualRollover() {
-        value.manualRollover();
+    public void _closingRollover() {
+        value.closingRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepDistributionSummary.java
@@ -87,8 +87,8 @@ public class StepDistributionSummary extends AbstractDistributionSummary impleme
     }
 
     @Override
-    public void _manualRollover() {
-        countTotal.manualRollover();
+    public void _closingRollover() {
+        countTotal.closingRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -51,9 +51,9 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
     }
 
     @Override
-    public void _manualRollover() {
+    public void _closingRollover() {
         count(); // add any difference from last count
-        count.manualRollover();
+        count.closingRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -119,9 +119,9 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
     }
 
     @Override
-    public void _manualRollover() {
+    public void _closingRollover() {
         accumulateCountAndTotal();
-        countTotal.manualRollover();
+        countTotal.closingRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeter.java
@@ -23,8 +23,9 @@ interface StepMeter {
     /**
      * This is an internal method not meant for general use.
      * <p>
-     * Force a rollover of the values returned by a step meter.
+     * Force a rollover of the values returned by a step meter and never rollover again
+     * after.
      */
-    void _manualRollover();
+    void _closingRollover();
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -111,7 +111,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
             getMeters().stream()
                 .filter(StepMeter.class::isInstance)
                 .map(StepMeter.class::cast)
-                .forEach(StepMeter::_manualRollover);
+                .forEach(StepMeter::_closingRollover);
         }
         super.close();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTimer.java
@@ -80,8 +80,8 @@ public class StepTimer extends AbstractTimer implements StepMeter {
     }
 
     @Override
-    public void _manualRollover() {
-        countTotal.manualRollover();
+    public void _closingRollover() {
+        countTotal.closingRollover();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepTuple2.java
@@ -77,7 +77,9 @@ public class StepTuple2<T1, T2> {
      * Intended for internal use. Rolls the values regardless of the clock or current
      * time.
      */
-    void manualRollover() {
+    void closingRollover() {
+        // ensure rollover does not happen again
+        lastInitPos.set(Long.MAX_VALUE);
         t1Previous = t1Supplier.get();
         t2Previous = t2Supplier.get();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -76,7 +76,9 @@ public abstract class StepValue<V> {
     /**
      * internal use only; intentionally left package-private
      */
-    void manualRollover() {
+    void closingRollover() {
+        // make sure value does not rollover again if passing a step boundary
+        lastInitPos.set(Long.MAX_VALUE);
         previous = valueSupplier().get();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepCounterTest.java
@@ -69,12 +69,15 @@ class StepCounterTest {
     }
 
     @Test
-    void manualRolloverPartialStep() {
+    void closingRolloverPartialStep() {
         StepCounter counter = (StepCounter) registry.counter("my.counter");
         counter.increment(2.5);
 
         assertThat(counter.count()).isZero();
-        counter._manualRollover();
+        counter._closingRollover();
+        assertThat(counter.count()).isEqualTo(2.5);
+
+        clock.add(config.step());
         assertThat(counter.count()).isEqualTo(2.5);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepDistributionSummaryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepDistributionSummaryTest.java
@@ -50,7 +50,7 @@ class StepDistributionSummaryTest {
     }
 
     @Test
-    void manualRolloverPartialStep() {
+    void closingRolloverPartialStep() {
         Duration stepDuration = Duration.ofMillis(10);
         StepDistributionSummary summary = new StepDistributionSummary(mock(Meter.Id.class), clock,
                 DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(), 1.0,
@@ -61,7 +61,13 @@ class StepDistributionSummaryTest {
 
         assertThat(summary.count()).isZero();
 
-        summary._manualRollover();
+        summary._closingRollover();
+
+        assertThat(summary.count()).isEqualTo(2);
+        assertThat(summary.totalAmount()).isEqualTo(300);
+        assertThat(summary.mean()).isEqualTo(150);
+
+        clock.add(stepDuration);
 
         assertThat(summary.count()).isEqualTo(2);
         assertThat(summary.totalAmount()).isEqualTo(300);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -65,7 +65,7 @@ class StepFunctionCounterTest {
     }
 
     @Test
-    void manualRolloverPartialStep() {
+    void closingRolloverPartialStep() {
         AtomicInteger n = new AtomicInteger(3);
         @SuppressWarnings({ "rawtypes", "unchecked" })
         StepFunctionCounter<AtomicInteger> counter = (StepFunctionCounter) registry.more()
@@ -73,7 +73,11 @@ class StepFunctionCounterTest {
 
         assertThat(counter.count()).isZero();
 
-        counter._manualRollover();
+        counter._closingRollover();
+
+        assertThat(counter.count()).isEqualTo(3);
+
+        clock.add(config.step());
 
         assertThat(counter.count()).isEqualTo(3);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -77,7 +77,7 @@ class StepFunctionTimerTest {
     }
 
     @Test
-    void manualRolloverPartialStep() {
+    void closingRolloverPartialStep() {
         Queue<Long> counts = new ArrayDeque<>();
         counts.add(2L);
         counts.add(5L);
@@ -95,7 +95,12 @@ class StepFunctionTimerTest {
         assertThat(timer.count()).isZero();
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isZero();
 
-        timer._manualRollover();
+        timer._closingRollover();
+
+        assertThat(timer.count()).isEqualTo(2);
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);
+
+        clock.add(stepDuration);
 
         assertThat(timer.count()).isEqualTo(2);
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepTimerTest.java
@@ -52,7 +52,7 @@ class StepTimerTest {
     }
 
     @Test
-    void manualRolloverPartialStep() {
+    void closingRolloverPartialStep() {
         Duration stepDuration = Duration.ofMillis(10);
         StepTimer timer = new StepTimer(mock(Meter.Id.class), clock,
                 DistributionStatisticConfig.builder().expiry(stepDuration).bufferLength(2).build(),
@@ -63,7 +63,12 @@ class StepTimerTest {
         assertThat(timer.count()).isZero();
         assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isZero();
 
-        timer._manualRollover();
+        timer._closingRollover();
+
+        assertThat(timer.count()).isEqualTo(2);
+        assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(100);
+
+        clock.add(stepDuration);
 
         assertThat(timer.count()).isEqualTo(2);
         assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(100);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepValueTest.java
@@ -15,10 +15,12 @@
  */
 package io.micrometer.core.instrument.step;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MockClock;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
@@ -69,8 +71,39 @@ class StepValueTest {
         aLong.set(27);
         assertThat(stepValue.poll()).isEqualTo(24L);
 
-        stepValue.manualRollover();
+        stepValue.closingRollover();
         assertThat(stepValue.poll()).isEqualTo(27L);
+    }
+
+    @Test
+    @Issue("#3720")
+    void testManualRolloverDropsDataOnStepCompletion() {
+        final MockClock clock = new MockClock();
+        final long stepTime = 60;
+        final AtomicLong aLong = new AtomicLong(10);
+        final StepValue<Long> stepValue = new StepValue<Long>(clock, stepTime) {
+            @Override
+            public Supplier<Long> valueSupplier() {
+                return () -> aLong.getAndSet(0);
+            }
+
+            @Override
+            public Long noValue() {
+                return 0L;
+            }
+        };
+        clock.add(Duration.ofMillis(1));
+        assertThat(stepValue.poll()).isZero();
+        clock.add(Duration.ofMillis(59));
+        assertThat(stepValue.poll()).isEqualTo(10);
+        clock.add(Duration.ofMillis(stepTime - 1));
+        aLong.set(5);
+        stepValue.closingRollover();
+        assertThat(stepValue.poll()).isEqualTo(5);
+        clock.add(Duration.ofMillis(1));
+        assertThat(stepValue.poll()).isEqualTo(5L);
+        clock.add(stepTime, TimeUnit.MILLISECONDS);
+        assertThat(stepValue.poll()).isEqualTo(5L);
     }
 
 }


### PR DESCRIPTION
If a registry is closed near the end of a step interval, the publish on closing may take enough time that some meters are read after the step boundary is crossed. Without this fix, that results in those meters rolling over again, which we do not want in this case.

This renames manualRollover to closingRollover to signal this difference in behavior.

Resolves gh-3720