### PR TITLE
Add outcome tag to HttpClient metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
@@ -52,6 +52,12 @@ public enum ApacheHttpClientObservationDocumentation implements ObservationDocum
                 return "status";
             }
         },
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
         METHOD {
             @Override
             public String asString() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultApacheHttpClientObservationConvention.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.httpcomponents;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -63,11 +64,17 @@ public class DefaultApacheHttpClientObservationConvention implements ApacheHttpC
                 ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.URI
                     .withValue(context.getUriMapper().apply(context.getCarrier())),
                 ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.STATUS
-                    .withValue(getStatusValue(context.getResponse(), context.getError())));
+                    .withValue(getStatusValue(context.getResponse(), context.getError())),
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.OUTCOME
+                    .withValue(getStatusOutcome(context.getResponse()).name()));
         if (context.shouldExportTagsForRoute()) {
             keyValues = keyValues.and(HttpContextUtils.generateTagStringsForRoute(context.getApacheHttpContext()));
         }
         return keyValues;
+    }
+
+    Outcome getStatusOutcome(@Nullable HttpResponse response) {
+        return response != null ? Outcome.forStatus(response.getStatusLine().getStatusCode()) : Outcome.UNKNOWN;
     }
 
     String getStatusValue(@Nullable HttpResponse response, Throwable error) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.observation.ObservationOrTimerCompatibleInstrumentation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -118,11 +119,13 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
                     () -> new ApacheHttpClientContext(request, context, uriMapper, exportTagsForRoute), convention,
                     DefaultApacheHttpClientObservationConvention.INSTANCE);
         String statusCodeOrError = "UNKNOWN";
+        Outcome statusOutcome = Outcome.UNKNOWN;
 
         try {
             HttpResponse response = super.execute(request, conn, context);
             sample.setResponse(response);
             statusCodeOrError = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusValue(response, null);
+            statusOutcome = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusOutcome(response);
             return response;
         }
         catch (IOException | HttpException | RuntimeException e) {
@@ -132,10 +135,11 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
         }
         finally {
             String status = statusCodeOrError;
+            String outcome = statusOutcome.name();
             sample.stop(METER_NAME, "Duration of Apache HttpClient request execution",
                     () -> Tags
                         .of("method", DefaultApacheHttpClientObservationConvention.INSTANCE.getMethodString(request),
-                                "uri", uriMapper.apply(request), "status", status)
+                                "uri", uriMapper.apply(request), "status", status, "outcome", outcome)
                         .and(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
                         .and(extraTags));
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
@@ -48,6 +48,12 @@ public enum ApacheHttpClientObservationDocumentation implements ObservationDocum
                 return "status";
             }
         },
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
         METHOD {
             @Override
             public String asString() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.httpcomponents.hc5;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -59,11 +60,17 @@ public class DefaultApacheHttpClientObservationConvention implements ApacheHttpC
                 ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.URI
                     .withValue(context.getUriMapper().apply(context.getCarrier())),
                 ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.STATUS
-                    .withValue(getStatusValue(context.getResponse(), context.getError())));
+                    .withValue(getStatusValue(context.getResponse(), context.getError())),
+            ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.OUTCOME
+                .withValue(getStatusOutcome(context.getResponse()).name()));
         if (context.shouldExportTagsForRoute()) {
             keyValues = keyValues.and(HttpContextUtils.generateTagStringsForRoute(context.getApacheHttpContext()));
         }
         return keyValues;
+    }
+
+    Outcome getStatusOutcome(@Nullable HttpResponse response) {
+        return response != null ? Outcome.forStatus(response.getCode()) : Outcome.UNKNOWN;
     }
 
     String getStatusValue(@Nullable HttpResponse response, Throwable error) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/DefaultApacheHttpClientObservationConvention.java
@@ -61,8 +61,8 @@ public class DefaultApacheHttpClientObservationConvention implements ApacheHttpC
                     .withValue(context.getUriMapper().apply(context.getCarrier())),
                 ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.STATUS
                     .withValue(getStatusValue(context.getResponse(), context.getError())),
-            ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.OUTCOME
-                .withValue(getStatusOutcome(context.getResponse()).name()));
+                ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.OUTCOME
+                    .withValue(getStatusOutcome(context.getResponse()).name()));
         if (context.shouldExportTagsForRoute()) {
             keyValues = keyValues.and(HttpContextUtils.generateTagStringsForRoute(context.getApacheHttpContext()));
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.observation.ObservationOrTimerCompatibleInstrumentation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -105,11 +106,13 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
                     () -> new ApacheHttpClientContext(request, context, uriMapper, exportTagsForRoute), convention,
                     DefaultApacheHttpClientObservationConvention.INSTANCE);
         String statusCodeOrError = "UNKNOWN";
+        Outcome statusOutcome = Outcome.UNKNOWN;
 
         try {
             ClassicHttpResponse response = super.execute(request, conn, context);
             sample.setResponse(response);
             statusCodeOrError = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusValue(response, null);
+            statusOutcome = DefaultApacheHttpClientObservationConvention.INSTANCE.getStatusOutcome(response);
             return response;
         }
         catch (IOException | HttpException | RuntimeException e) {
@@ -119,10 +122,11 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
         }
         finally {
             String status = statusCodeOrError;
+            String outcome = statusOutcome.name();
             sample.stop(METER_NAME, "Duration of Apache HttpClient request execution",
                     () -> Tags
                         .of("method", DefaultApacheHttpClientObservationConvention.INSTANCE.getMethodString(request),
-                                "uri", uriMapper.apply(request), "status", status)
+                                "uri", uriMapper.apply(request), "status", status, "outcome", outcome)
                         .and(exportTagsForRoute ? HttpContextUtils.generateTagsForRoute(context) : Tags.empty())
                         .and(extraTags));
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
@@ -22,6 +22,7 @@ import io.micrometer.common.lang.NonNullFields;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import okhttp3.Request;
 import okhttp3.Response;
 
@@ -88,7 +89,8 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         KeyValues keyValues = KeyValues
             .of(METHOD.withValue(requestAvailable ? request.method() : TAG_VALUE_UNKNOWN),
                     URI.withValue(getUriTag(urlMapper, state, request)),
-                    STATUS.withValue(getStatusMessage(state.response, state.exception)))
+                    STATUS.withValue(getStatusMessage(state.response, state.exception)),
+                    OUTCOME.withValue(getStatusOutcome(state.response).name()))
             .and(extraTags)
             .and(stream(contextSpecificTags.spliterator(), false)
                 .map(contextTag -> contextTag.apply(request, state.response))
@@ -110,6 +112,14 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         }
         return state.response != null && (state.response.code() == 404 || state.response.code() == 301) ? "NOT_FOUND"
                 : urlMapper.apply(request);
+    }
+
+    private Outcome getStatusOutcome(@Nullable Response response) {
+        if (response == null) {
+            return Outcome.UNKNOWN;
+        }
+
+        return Outcome.forStatus(response.code());
     }
 
     private String getStatusMessage(@Nullable Response response, @Nullable IOException exception) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
@@ -95,6 +95,13 @@ public enum OkHttpObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "status";
             }
+        },
+
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
         }
 
     }

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.binder.jdk;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.binder.http.Outcome;
 
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -48,7 +49,8 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
                     .withValue(getUriTag(httpRequest, context.getResponse(), context.getUriMapper())));
         if (context.getResponse() != null) {
             keyValues = keyValues.and(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
-                .withValue(String.valueOf(context.getResponse().statusCode())));
+                .withValue(String.valueOf(context.getResponse().statusCode())))
+                .and(Outcome.forStatus(context.getResponse().statusCode()).asKeyValue());
         }
         return keyValues;
     }

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -51,7 +51,8 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
             keyValues = keyValues
                 .and(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
                     .withValue(String.valueOf(context.getResponse().statusCode())))
-                .and(Outcome.forStatus(context.getResponse().statusCode()).asKeyValue());
+                .and(HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME
+                    .withValue(Outcome.forStatus(context.getResponse().statusCode()).name()));
         }
         return keyValues;
     }

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -48,8 +48,9 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
                 HttpClientObservationDocumentation.LowCardinalityKeys.URI
                     .withValue(getUriTag(httpRequest, context.getResponse(), context.getUriMapper())));
         if (context.getResponse() != null) {
-            keyValues = keyValues.and(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
-                .withValue(String.valueOf(context.getResponse().statusCode())))
+            keyValues = keyValues
+                .and(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
+                    .withValue(String.valueOf(context.getResponse().statusCode())))
                 .and(Outcome.forStatus(context.getResponse().statusCode()).asKeyValue());
         }
         return keyValues;

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
@@ -68,13 +68,6 @@ enum HttpClientObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "uri";
             }
-        },
-
-        OUTCOME {
-            @Override
-            public String asString() {
-                return "outcome";
-            }
         }
 
     }

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
@@ -68,6 +68,13 @@ enum HttpClientObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "uri";
             }
+        },
+
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
         }
 
     }

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
@@ -60,6 +60,13 @@ enum HttpClientObservationDocumentation implements ObservationDocumentation {
             }
         },
 
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
+
         /**
          * HTTP URI.
          */

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
@@ -19,6 +19,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.observation.ObservationOrTimerCompatibleInstrumentation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -239,7 +240,8 @@ public class MicrometerHttpClient extends HttpClient {
                             DefaultHttpClientObservationConvention.INSTANCE.getUriTag(request, res, uriMapper));
                     if (res != null) {
                         tags = tags.and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
-                                String.valueOf(res.statusCode())));
+                                String.valueOf(res.statusCode())))
+                            .and(Outcome.forStatus(res.statusCode()).asTag());
                     }
                     return tags;
                 });

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
@@ -239,9 +239,11 @@ public class MicrometerHttpClient extends HttpClient {
                             request.method(), HttpClientObservationDocumentation.LowCardinalityKeys.URI.asString(),
                             DefaultHttpClientObservationConvention.INSTANCE.getUriTag(request, res, uriMapper));
                     if (res != null) {
-                        tags = tags.and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
-                                String.valueOf(res.statusCode())))
-                            .and(Outcome.forStatus(res.statusCode()).asTag());
+                        tags = tags
+                            .and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
+                                    String.valueOf(res.statusCode())))
+                            .and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME.asString(),
+                                    Outcome.forStatus(res.statusCode()).name()));
                     }
                     return tags;
                 });

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
@@ -96,12 +96,18 @@ class MicrometerHttpRequestExecutorTest {
         EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/ok")).getEntity());
         EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/notfound")).getEntity());
         EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/error")).getEntity());
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "200").timer().count())
-            .isEqualTo(2L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "404").timer().count())
-            .isEqualTo(1L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "500").timer().count())
-            .isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "200", "outcome", "SUCCESS")
+            .timer()
+            .count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "404", "outcome", "CLIENT_ERROR")
+            .timer()
+            .count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "500", "outcome", "SERVER_ERROR")
+            .timer()
+            .count()).isEqualTo(1L);
     }
 
     @ParameterizedTest
@@ -329,8 +335,10 @@ class MicrometerHttpRequestExecutorTest {
         assertThatThrownBy(
                 () -> EntityUtils.consume(client.execute(new HttpGet(server.baseUrl() + "/error")).getEntity()))
             .isInstanceOf(ClientProtocolException.class);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "IO_ERROR").timer().count())
-            .isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "IO_ERROR", "outcome", "UNKNOWN")
+            .timer()
+            .count()).isEqualTo(1L);
     }
 
     static class CustomGlobalApacheHttpConvention extends DefaultApacheHttpClientObservationConvention

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -107,12 +107,18 @@ class MicrometerHttpRequestExecutorTest {
         execute(client, new HttpGet(server.baseUrl() + "/ok"));
         execute(client, new HttpGet(server.baseUrl() + "/notfound"));
         execute(client, new HttpGet(server.baseUrl() + "/error"));
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "200", "outcome", "SUCCESS").timer().count())
-            .isEqualTo(2L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "404", "outcome", "CLIENT_ERROR").timer().count())
-            .isEqualTo(1L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "500", "outcome", "SERVER_ERROR").timer().count())
-            .isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "200", "outcome", "SUCCESS")
+            .timer()
+            .count()).isEqualTo(2L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "404", "outcome", "CLIENT_ERROR")
+            .timer()
+            .count()).isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "500", "outcome", "SERVER_ERROR")
+            .timer()
+            .count()).isEqualTo(1L);
     }
 
     @ParameterizedTest
@@ -323,8 +329,10 @@ class MicrometerHttpRequestExecutorTest {
         CloseableHttpClient client = client(executor(false, configureObservationRegistry));
         assertThatThrownBy(() -> execute(client, new HttpGet(server.baseUrl() + "/error")))
             .isInstanceOf(ClientProtocolException.class);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "IO_ERROR", "outcome", "UNKNOWN").timer().count())
-            .isEqualTo(1L);
+        assertThat(registry.get(EXPECTED_METER_NAME)
+            .tags("method", "GET", "status", "IO_ERROR", "outcome", "UNKNOWN")
+            .timer()
+            .count()).isEqualTo(1L);
     }
 
     static class CustomGlobalApacheHttpConvention extends DefaultApacheHttpClientObservationConvention

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -107,11 +107,11 @@ class MicrometerHttpRequestExecutorTest {
         execute(client, new HttpGet(server.baseUrl() + "/ok"));
         execute(client, new HttpGet(server.baseUrl() + "/notfound"));
         execute(client, new HttpGet(server.baseUrl() + "/error"));
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "200").timer().count())
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "200", "outcome", "SUCCESS").timer().count())
             .isEqualTo(2L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "404").timer().count())
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "404", "outcome", "CLIENT_ERROR").timer().count())
             .isEqualTo(1L);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "500").timer().count())
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "500", "outcome", "SERVER_ERROR").timer().count())
             .isEqualTo(1L);
     }
 
@@ -323,7 +323,7 @@ class MicrometerHttpRequestExecutorTest {
         CloseableHttpClient client = client(executor(false, configureObservationRegistry));
         assertThatThrownBy(() -> execute(client, new HttpGet(server.baseUrl() + "/error")))
             .isInstanceOf(ClientProtocolException.class);
-        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "IO_ERROR").timer().count())
+        assertThat(registry.get(EXPECTED_METER_NAME).tags("method", "GET", "status", "IO_ERROR", "outcome", "UNKNOWN").timer().count())
             .isEqualTo(1L);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
@@ -72,8 +72,8 @@ class OkHttpMetricsEventListenerTest {
         client.newCall(request).execute().close();
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "status", "200", "outcome", "SUCCESS", "uri", URI_EXAMPLE_VALUE, "target.host", "localhost", "target.port",
-                    String.valueOf(server.port()), "target.scheme", "http")
+            .tags("foo", "bar", "status", "200", "outcome", "SUCCESS", "uri", URI_EXAMPLE_VALUE, "target.host",
+                    "localhost", "target.port", String.valueOf(server.port()), "target.scheme", "http")
             .timer()
             .count()).isEqualTo(1L);
     }
@@ -86,8 +86,8 @@ class OkHttpMetricsEventListenerTest {
         client.newCall(request).execute().close();
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "status", "404", "outcome", "CLIENT_ERROR", "uri", "NOT_FOUND", "target.host", "localhost", "target.port",
-                    String.valueOf(server.port()), "target.scheme", "http")
+            .tags("foo", "bar", "status", "404", "outcome", "CLIENT_ERROR", "uri", "NOT_FOUND", "target.host",
+                    "localhost", "target.port", String.valueOf(server.port()), "target.scheme", "http")
             .timer()
             .count()).isEqualTo(1L);
     }
@@ -114,7 +114,8 @@ class OkHttpMetricsEventListenerTest {
         }
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "uri", URI_EXAMPLE_VALUE, "status", "IO_ERROR", "outcome", "UNKNOWN", "target.host", "localhost")
+            .tags("foo", "bar", "uri", URI_EXAMPLE_VALUE, "status", "IO_ERROR", "outcome", "UNKNOWN", "target.host",
+                    "localhost")
             .timer()
             .count()).isEqualTo(1L);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListenerTest.java
@@ -72,7 +72,7 @@ class OkHttpMetricsEventListenerTest {
         client.newCall(request).execute().close();
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "status", "200", "uri", URI_EXAMPLE_VALUE, "target.host", "localhost", "target.port",
+            .tags("foo", "bar", "status", "200", "outcome", "SUCCESS", "uri", URI_EXAMPLE_VALUE, "target.host", "localhost", "target.port",
                     String.valueOf(server.port()), "target.scheme", "http")
             .timer()
             .count()).isEqualTo(1L);
@@ -86,7 +86,7 @@ class OkHttpMetricsEventListenerTest {
         client.newCall(request).execute().close();
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "status", "404", "uri", "NOT_FOUND", "target.host", "localhost", "target.port",
+            .tags("foo", "bar", "status", "404", "outcome", "CLIENT_ERROR", "uri", "NOT_FOUND", "target.host", "localhost", "target.port",
                     String.valueOf(server.port()), "target.scheme", "http")
             .timer()
             .count()).isEqualTo(1L);
@@ -114,7 +114,7 @@ class OkHttpMetricsEventListenerTest {
         }
 
         assertThat(registry.get("okhttp.requests")
-            .tags("foo", "bar", "uri", URI_EXAMPLE_VALUE, "status", "IO_ERROR", "target.host", "localhost")
+            .tags("foo", "bar", "uri", URI_EXAMPLE_VALUE, "status", "IO_ERROR", "outcome", "UNKNOWN", "target.host", "localhost")
             .timer()
             .count()).isEqualTo(1L);
     }

--- a/micrometer-core/src/test/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClientTests.java
+++ b/micrometer-core/src/test/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClientTests.java
@@ -88,6 +88,7 @@ class MicrometerHttpClientTests {
         then(meterRegistry.find("http.client.requests")
             .tag("method", "GET")
             .tag("status", "200")
+            .tag("outcome", "SUCCESS")
             .tag("uri", "UNKNOWN")
             .timer()).isNotNull();
     }

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
@@ -155,7 +155,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
                 templatedPath, "112", "5");
 
         Timer timer = getRegistry().get(timerName())
-            .tags("method", "GET", "status", "200", "uri", templatedPath)
+            .tags("method", "GET", "status", "200", "outcome", "SUCCESS", "uri", templatedPath)
             .timer();
         assertThat(timer.count()).isEqualTo(1);
         assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
@@ -195,7 +195,9 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
         sendHttpRequest(instrumentedClient(testType), HttpMethod.GET, null, URI.create(wmRuntimeInfo.getHttpBaseUrl()),
                 "/socks");
 
-        Timer timer = getRegistry().get(timerName()).tags("method", "GET", "status", "500").timer();
+        Timer timer = getRegistry().get(timerName())
+            .tags("method", "GET", "status", "500", "outcome", "SERVER_ERROR")
+            .timer();
         assertThat(timer.count()).isEqualTo(1);
         assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
     }
@@ -211,7 +213,9 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
         sendHttpRequest(instrumentedClient(testType), HttpMethod.POST, new byte[0],
                 URI.create(wmRuntimeInfo.getHttpBaseUrl()), "/socks");
 
-        Timer timer = getRegistry().get(timerName()).tags("method", "POST", "status", "400").timer();
+        Timer timer = getRegistry().get(timerName())
+            .tags("method", "POST", "status", "400", "outcome", "CLIENT_ERROR")
+            .timer();
         assertThat(timer.count()).isEqualTo(1);
         assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isPositive();
     }


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/micrometer/issues/3729

Aligning tags between `http_client_requests` metrics. A grouping outcome tag was added to all http client binders - similar to the outcome tag in `JettyClient` and the `http_server_requests`.