### PR TITLE
Polish "Avoid concurrent publish calls from publishSafely"

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -67,12 +67,14 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             }
         }
         else {
-            logger.warn("Publishing is already in progress. Skipping duplicate call to publishSafely().");
+            logger.warn("Publishing is already in progress. Skipping duplicate call to publish().");
         }
     }
 
     /**
-     * Returns - true if scheduled publishing of metrics is in progress.
+     * Returns if scheduled publishing of metrics is in progress.
+     * @return if scheduled publishing of metrics is in progress
+     * @since 1.11.0
      */
     protected boolean isPublishing() {
         return publishing.get();


### PR DESCRIPTION
This PR polishes the "Avoid concurrent publish calls from publishSafely" changes a bit.

See gh-3714