### PR TITLE
[Dynatrace v2] Switch to primitive types and ensure synchronization

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceDistributionSummary.java
@@ -64,21 +64,46 @@ public final class DynatraceDistributionSummary extends AbstractDistributionSumm
         summary.recordNonNegative(amount);
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public long count() {
         return summary.getCount();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double totalAmount() {
         return summary.getTotal();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot() take a snapshot} and use
+     * the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double max() {
         return summary.getMax();
     }
 
+    /**
+     * @deprecated since 1.9.10. Using this method is not synchronized and might give
+     * inconsistent results when multiple getters are called sequentially. It is
+     * recommended to {@link DynatraceDistributionSummary#takeSummarySnapshot() take a
+     * snapshot} and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
+    @Deprecated
     public double min() {
         return summary.getMin();
     }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceTimer.java
@@ -104,21 +104,47 @@ public final class DynatraceTimer extends AbstractTimer implements DynatraceSumm
         summary.recordNonNegative(inBaseUnit);
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public long count() {
         return summary.getCount();
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double totalTime(TimeUnit unit) {
         return unit.convert((long) summary.getTotal(), baseTimeUnit());
     }
 
+    /**
+     * Using this method is not synchronized and might give inconsistent results when
+     * multiple getters are called sequentially. It is recommended to
+     * {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit) take a snapshot}
+     * and use the getters on the {@link DynatraceSummarySnapshot} instead.
+     */
     @Override
     public double max(TimeUnit unit) {
         return unit.convert((long) summary.getMax(), baseTimeUnit());
     }
 
+    /**
+     * @deprecated since 1.9.10. Using this method is not synchronized and might give
+     * inconsistent results when multiple getters are called sequentially. It is
+     * recommended to {@link DynatraceDistributionSummary#takeSummarySnapshot(TimeUnit)
+     * take a snapshot} and use the getters on the {@link DynatraceSummarySnapshot}
+     * instead.
+     */
+    @Deprecated
     public double min(TimeUnit unit) {
         return unit.convert((long) summary.getMin(), baseTimeUnit());
     }


### PR DESCRIPTION
Presumably due to the numeric instability of the `DoubleAdder`, we have seen cases in which the Min and Max did not represent a consistent value when compared to the sum stored in the DoubleAdder. Given that the addition and snapshotting of values are already `synchronized`, this PR removes the used atomic tracking instruments and replaces them with primitive types. 

Do you think it is possible to get this bugfix into the upcoming ~minor~ patch releases?