### PR TITLE
Reduce Regex object creation in SignalFx Naming Convention

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -75,7 +75,7 @@ public class SignalFxNamingConvention implements NamingConvention {
 
         if (conventionKey.startsWith("sf_") || !isAlphabet(conventionKey.charAt(0))) {
             logger.log(conventionKey
-                    + " doesn't adhere to SignalFx naming standards. Appending 'a' to the tag/dimension key.");
+                    + " doesn't adhere to SignalFx naming standards. Prefixing the tag/dimension key with 'a'.");
             conventionKey = "a" + conventionKey;
         }
 

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -106,7 +106,8 @@ public class SignalFxNamingConvention implements NamingConvention {
 
         if (conventionKey.startsWith("aws_") || conventionKey.startsWith("gcp_")
                 || conventionKey.startsWith("azure_")) {
-            logger.log("'" + conventionKey + "' (original name: '" + key + "') is not a valid tag key. "
+            String finalConventionKey = conventionKey;
+            logger.log(() -> "'" + finalConventionKey + "' (original name: '" + key + "') is not a valid tag key. "
                     + "Must not start with any of these prefixes: aws_, gcp_, or azure_. "
                     + "Please rename it to conform to the constraints. "
                     + "If it comes from a third party, please use MeterFilter to rename it.");

--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxNamingConvention.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 /**
  * {@link NamingConvention} for SignalFx.
  *
- * See
- * https://developers.signalfx.com/metrics/data_ingest_overview.html#_criteria_for_metric_and_dimension_names_and_values
+ * @see <a href="https://docs.splunk.com/Observability/metrics-and-metadata/metric-names.html">
+ *     Naming conventions for metrics and dimensions</a>
  *
  * @author Jon Schneider
  * @author Johnny Lim
@@ -72,14 +72,14 @@ public class SignalFxNamingConvention implements NamingConvention {
     @Override
     public String tagKey(String key) {
         String conventionKey = delegate.tagKey(key);
+        conventionKey = PATTERN_TAG_KEY_DENYLISTED_CHARS.matcher(conventionKey).replaceAll("_");
 
-        if (conventionKey.startsWith("sf_") || !isAlphabet(conventionKey.charAt(0))) {
+        if (conventionKey.startsWith("sf_") || !Character.isLetter(conventionKey.charAt(0))) {
             logger.log(conventionKey
                     + " doesn't adhere to SignalFx naming standards. Prefixing the tag/dimension key with 'a'.");
             conventionKey = "a" + conventionKey;
         }
 
-        conventionKey = PATTERN_TAG_KEY_DENYLISTED_CHARS.matcher(conventionKey).replaceAll("_");
         return StringUtils.truncate(conventionKey, KEY_MAX_LENGTH);
     }
 
@@ -89,10 +89,6 @@ public class SignalFxNamingConvention implements NamingConvention {
     public String tagValue(String value) {
         String formattedValue = StringEscapeUtils.escapeJson(delegate.tagValue(value));
         return StringUtils.truncate(formattedValue, TAG_VALUE_MAX_LENGTH);
-    }
-
-    private static boolean isAlphabet(char c) {
-        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
     }
 
 }

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
@@ -31,8 +31,11 @@ class SignalFxNamingConventionTest {
 
     @Test
     void tagKey() {
-        assertThat(convention.tagKey("_boo")).isEqualTo("boo");
-        assertThat(convention.tagKey("sf_boo")).isEqualTo("boo");
+        assertThat(convention.tagKey("_boo")).isEqualTo("a_boo");
+        assertThat(convention.tagKey("__boo")).isEqualTo("a__boo");
+        assertThat(convention.tagKey("sf_boo")).isEqualTo("asf_boo");
+        assertThat(convention.tagKey("sf__boo")).isEqualTo("asf__boo");
+        assertThat(convention.tagKey("sf_sf_boo")).isEqualTo("asf_sf_boo");
 
         assertThat(convention.tagKey("123")).isEqualTo("a123");
     }

--- a/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
+++ b/implementations/micrometer-registry-signalfx/src/test/java/io/micrometer/signalfx/SignalFxNamingConventionTest.java
@@ -43,6 +43,9 @@ class SignalFxNamingConventionTest {
     @Test
     void tagKeyWhenKeyHasDenylistedCharShouldSanitize() {
         assertThat(convention.tagKey("a.b")).isEqualTo("a_b");
+        assertThat(convention.tagKey("sf.boo")).isEqualTo("asf_boo");
+        assertThat(convention.tagKey("àboo")).isEqualTo("a_boo");
+        assertThat(convention.tagKey("sf_àboo")).isEqualTo("asf__boo");
     }
 
 }


### PR DESCRIPTION
This reduces the allocation of regex objects while publishing to SignalFx. This to an extent alters the existing behavior in the below cases,

Cases with the previous implementation:

- If a tag starts with "sf_", it strips it off. But it doesn't guard against something like "sf_sf_"
- If a tag starts with "\_" , it strips it off. If it starts with "__" it strips first "_" and adds an "a" to the beginning
- If a tag starts does not start with an (a-z) or (A-Z), it adds an "a" at the beginning.

This PR makes the behavior consistent to prefix with "a" for all the above cases, thus making the tags stick to naming standards.

- If a tag starts with "aws_|gcp_|azure_", earlier implementation, logged a message but this PR ignores it.

Reference Issue: https://github.com/micrometer-metrics/micrometer/issues/3745