### PR TITLE
Add Javadoc since for outcome key name enum values

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/ApacheHttpClientObservationDocumentation.java
@@ -52,6 +52,11 @@ public enum ApacheHttpClientObservationDocumentation implements ObservationDocum
                 return "status";
             }
         },
+
+        /**
+         * Key name for outcome.
+         * @since 1.11.0
+         */
         OUTCOME {
             @Override
             public String asString() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ApacheHttpClientObservationDocumentation.java
@@ -48,6 +48,11 @@ public enum ApacheHttpClientObservationDocumentation implements ObservationDocum
                 return "status";
             }
         },
+
+        /**
+         * Key name for outcome.
+         * @since 1.11.0
+         */
         OUTCOME {
             @Override
             public String asString() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationDocumentation.java
@@ -97,6 +97,10 @@ public enum OkHttpObservationDocumentation implements ObservationDocumentation {
             }
         },
 
+        /**
+         * Key name for outcome.
+         * @since 1.11.0
+         */
         OUTCOME {
             @Override
             public String asString() {

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/HttpClientObservationDocumentation.java
@@ -60,6 +60,10 @@ enum HttpClientObservationDocumentation implements ObservationDocumentation {
             }
         },
 
+        /**
+         * Key name for outcome.
+         * @since 1.11.0
+         */
         OUTCOME {
             @Override
             public String asString() {


### PR DESCRIPTION
This PR adds Javadoc `@since` tags for `outcome` key name `enum` values.

See gh-3729