### PR TITLE
Start publish at randomized time in next step

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -132,7 +132,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
         Random random = new Random();
         long randomOffsetWithinStep = (long) (stepMillis * random.nextDouble()
                 * PERCENT_RANGE_OF_RANDOM_PUBLISHING_OFFSET);
-        long offsetToStartOfNextStep = stepMillis - clock.wallTime() % stepMillis;
+        long offsetToStartOfNextStep = stepMillis - (clock.wallTime() % stepMillis);
         return offsetToStartOfNextStep + 2 + randomOffsetWithinStep;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -35,7 +35,6 @@ public abstract class PushMeterRegistry extends MeterRegistry {
 
     // Schedule publishing in the beginning X percent of the step to avoid spill-over into
     // the next step.
-    // VisibleForTesting
     private static final double PERCENT_RANGE_OF_RANDOM_PUBLISHING_OFFSET = 0.8;
 
     private final PushRegistryConfig config;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -157,7 +157,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     private long getInitialDelay() {
         long stepMillis = config.step().toMillis();
         // schedule one millisecond into the next step
-        return stepMillis - clock.wallTime() % stepMillis + 1;
+        return stepMillis - (clock.wallTime() % stepMillis) + 1;
     }
 
 }


### PR DESCRIPTION
This avoids different instances calling publish at the same time by scheduling them at a time randomly chosen within the next step upon start being called. It will avoid scheduling publishing at the last 20% of a step interval to avoid the issue described in gh-1218 where publishing could take long enough to finish in a subsequent step after it started. An additional background thread is added for StepMeterRegistry that will poll all meters at the start of the step, separate from when publishing happens. This is so the values published are the ones recorded in the previous step. We need rollCount to be called for step meters as early as possible in the step to minimize the number of recordings reported for the wrong step. This is not perfect, but it is no worse than the status quo.

Resolves gh-2818