### PR TITLE
Compile sources with '-parameters' to retain method parameter names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ subprojects {
         tasks {
             compileJava {
                 options.encoding = 'UTF-8'
-                options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
+                options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation' << '-parameters'
 
                 sourceCompatibility = javaTargetVersion
                 targetCompatibility = javaTargetVersion


### PR DESCRIPTION
Fix warning raised by spring
```
o.s.c.LocalVariableTableParameterNameDiscoverer WARN Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: io.micrometer.core.aop.CountedAspect
```