### PR TITLE
Avoid needing compiler parameter metadata in CountedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -182,7 +182,7 @@ public class CountedAspect {
      * @return Whatever the intercepted method returns.
      * @throws Throwable When the intercepted method throws one.
      */
-    @Around("@annotation(counted)")
+    @Around(value = "@annotation(counted)", argNames = "pjp,counted")
     public Object interceptAndRecord(ProceedingJoinPoint pjp, Counted counted) throws Throwable {
         if (shouldSkip.test(pjp)) {
             return pjp.proceed();


### PR DESCRIPTION
Info about the parameter name is not necessarily available unless we compile with `-parameters`. Explicitly give `argNames` to avoid needing to compile with `-parameters`.

~This is technically breaking public API, but an Aspect class should generally only have its constructor(s) called by users, so I felt this shouldn't be a problem even in a patch release. Let me know if anyone disagrees.~
Thanks to @sbrannen's suggestion, we can make an alternate change that maintains the API signature.

See #3776