### PR TITLE
Enclosing scopes not being popped

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
@@ -32,7 +32,7 @@ public interface ObservationView {
     ContextView getContextView();
 
     /**
-     * Returns the last scope attached to this {@link ObservationView} in this thread.
+     * Pops the last scope attached to this {@link ObservationView} in this thread.
      * @return scope for this {@link ObservationView}, {@code null} if there was no scope
      * @since 1.10.6
      */


### PR DESCRIPTION
there are 2 issues we're trying to fix here

- when we're getting the enclosing scope we should pop it, since once we do we should make it current. However, we also must pop it for the current thread to make it current so we changed the behaviour of `getEnclosingScope` to also pop. We're not renaming the method because the probability that the users will use it is very small
- we're observing that certain frameworks (e.g. Reactor Netty) are taking into consideration what we're setting in ThreadLocals of Observation. What results in memory leaks like this one (https://github.com/spring-projects/spring-boot/issues/35102). After changing the ThreadLocal to a Map the problem seems to be gone

fixes gh-3787