### PR TITLE
Improve StepBucketHistogram

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -413,7 +413,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                     .merge(distributionStatisticConfig), true, false);
             }
             else if (AggregationTemporality.isDelta(aggregationTemporality) && stepMillis > 0) {
-                return new StepBucketHistogram(clock, stepMillis, distributionStatisticConfig, true);
+                return new StepBucketHistogram(clock, stepMillis, distributionStatisticConfig, true, false);
             }
         }
 

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -151,7 +151,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         timer.record(111, TimeUnit.MILLISECONDS);
 
         HistogramDataPoint histogramDataPoint = writeToMetric(timer).getHistogram().getDataPoints(0);
-        assertThat(histogramDataPoint.getExplicitBoundsCount()).isZero();
+        assertThat(histogramDataPoint.getExplicitBoundsCount()).isEqualTo(4);
         this.stepOverNStep(1);
         assertHistogram(writeToMetric(timer), TimeUnit.MINUTES.toNanos(1), TimeUnit.MINUTES.toNanos(2), "milliseconds",
                 3, 198, 111);
@@ -243,7 +243,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         assertHistogram(writeToMetric(ds), 0, TimeUnit.MINUTES.toNanos(1), "bytes", 0, 0, 0);
 
         HistogramDataPoint histogramDataPoint = writeToMetric(ds).getHistogram().getDataPoints(0);
-        assertThat(histogramDataPoint.getExplicitBoundsCount()).isZero();
+        assertThat(histogramDataPoint.getExplicitBoundsCount()).isEqualTo(4);
         this.stepOverNStep(1);
         assertHistogram(writeToMetric(ds), TimeUnit.MINUTES.toNanos(1), TimeUnit.MINUTES.toNanos(2), "bytes", 3, 198,
                 111);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepValue.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.step;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.Clock;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,13 +35,18 @@ public abstract class StepValue<V> {
 
     private final long stepMillis;
 
-    private AtomicLong lastInitPos;
+    private final AtomicLong lastInitPos;
 
-    private volatile V previous = noValue();
+    private volatile V previous;
 
     public StepValue(final Clock clock, final long stepMillis) {
+        this(clock, stepMillis, null);
+    }
+
+    protected StepValue(final Clock clock, final long stepMillis, @Nullable final V initValue) {
         this.clock = clock;
         this.stepMillis = stepMillis;
+        this.previous = initValue == null ? noValue() : initValue;
         lastInitPos = new AtomicLong(clock.wallTime() / stepMillis);
     }
 


### PR DESCRIPTION
This polishes/fixes [gh-3749](https://github.com/micrometer-metrics/micrometer/pull/3749)
* eliminate null check on noValue
* to support exporting cumulative buckets, more so in a view that this can be leveraged in other libraries as well. (see - https://github.com/micrometer-metrics/micrometer/issues/3774)
* fix explicit histogram buckets (SLO), was zero previously
