### PR TITLE
Set current scope on ObservationRegistry when Scope#makeCurrent is called

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -365,6 +365,7 @@ class SimpleObservation implements Observation {
             for (SimpleScope simpleScope : scopes) {
                 simpleScope.currentObservation.notifyOnScopeMakeCurrent();
             }
+            this.registry.setCurrentObservationScope(this);
         }
 
     }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
@@ -113,4 +113,21 @@ class CurrentObservationTest {
         assertThat(registry.getCurrentObservation()).isNull();
     }
 
+    @Test
+    void nestedScopes_makeCurrent() {
+        Observation observation = Observation.createNotStarted("test.observation", registry);
+        assertThat(registry.getCurrentObservationScope()).isNull();
+        try (Observation.Scope scopeA = observation.openScope()) {
+            assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
+            try (Observation.Scope scopeB = observation.openScope()) {
+                assertThat(registry.getCurrentObservationScope()).isSameAs(scopeB);
+
+                scopeA.makeCurrent();
+                assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
+            }
+            assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
+        }
+        assertThat(registry.getCurrentObservationScope()).isNull();
+    }
+
 }


### PR DESCRIPTION
Currently, `scope#makeCurrent()` does not update the current observation scope on `ObservationRegistry`.

This commit changes the `makeCurrent()` method to also update the scope on the registry.