### PR TITLE
Add DeferredScope

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -103,6 +103,11 @@ final class NoopObservation implements Observation {
         return NoopScope.INSTANCE;
     }
 
+    @Override
+    public DeferredScope deferredScope() {
+        return NoopDeferredScope.INSTANCE;
+    }
+
     /**
      * Scope that does nothing.
      */
@@ -132,6 +137,37 @@ final class NoopObservation implements Observation {
 
         @Override
         public void makeCurrent() {
+
+        }
+
+    }
+
+    static final class NoopDeferredScope implements DeferredScope {
+
+        static final DeferredScope INSTANCE = new NoopDeferredScope();
+
+        @Override
+        public Observation getCurrentObservation() {
+            return NoopObservation.INSTANCE;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public void reset() {
+
+        }
+
+        @Override
+        public void makeCurrent() {
+
+        }
+
+        @Override
+        public void open() {
 
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -475,6 +475,8 @@ public interface Observation extends ObservationView {
      */
     Scope openScope();
 
+    DeferredScope deferredScope();
+
     /**
      * Observes the passed {@link Runnable}, this means the followings:
      *
@@ -840,6 +842,12 @@ public interface Observation extends ObservationView {
         default boolean isNoop() {
             return this == NOOP;
         }
+
+    }
+
+    interface DeferredScope extends Scope {
+
+        void open();
 
     }
 


### PR DESCRIPTION
`DeferredScope` allows creating a scope instance without opening it.

For example, when creating, opening, and closing a scope need to happen independently, this `DeferredScope` can be used as:

```java
// create a scope object without starting it
DeferredScope scope = observation.deferredScope();

// two different callbacks for start and stop
StartCallback startCallback = new StartCallback(scope);
StopCallback stopCallback = new StopCallback(scope);

// callback will be invoked later by underlying framework
return new Listener(startCallback, stopCallback);
```
