### PR TITLE
Ignore class level AOP annotation if method level present

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -69,6 +69,7 @@ import java.util.function.Predicate;
  * @author Ali Dehghani
  * @author Jonatan Ivanov
  * @author Johnny Lim
+ * @author Yanming Zhou
  * @since 1.2.0
  * @see Counted
  */
@@ -166,7 +167,7 @@ public class CountedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Counted)")
+    @Around("@within(io.micrometer.core.annotation.Counted) and not @annotation(io.micrometer.core.annotation.Counted)")
     @Nullable
     public Object countedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -76,6 +76,7 @@ import java.util.function.Predicate;
  * @author Johnny Lim
  * @author Nejc Korasa
  * @author Jonatan Ivanov
+ * @author Yanming Zhou
  * @since 1.0.0
  */
 @Aspect
@@ -160,7 +161,7 @@ public class TimedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Timed)")
+    @Around("@within(io.micrometer.core.annotation.Timed) and not @annotation(io.micrometer.core.annotation.Timed)")
     @Nullable
     public Object timedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -68,6 +68,7 @@ import java.util.function.Predicate;
  * </pre>
  *
  * @author Jonatan Ivanov
+ * @author Yanming Zhou
  * @since 1.10.0
  */
 @Aspect
@@ -104,7 +105,7 @@ public class ObservedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.observation.annotation.Observed)")
+    @Around("@within(io.micrometer.observation.annotation.Observed) and not @annotation(io.micrometer.observation.annotation.Observed)")
     @Nullable
     public Object observeClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -335,6 +335,23 @@ class ObservedAspectTests {
         TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation();
     }
 
+    @Test
+    void ignoreClassLevelAnnotationIfMethodLevelPresent() {
+        registry.observationConfig().observationHandler(new ObservationTextPublisher());
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedClassLevelAnnotatedService());
+        pf.addAspect(new ObservedAspect(registry));
+
+        ObservedClassLevelAnnotatedService service = pf.getProxy();
+        service.annotatedOnMethod();
+        TestObservationRegistryAssert.assertThat(registry)
+            .doesNotHaveAnyRemainingCurrentObservation()
+            .hasSingleObservationThat()
+            .hasBeenStopped()
+            .hasNameEqualTo("test.class")
+            .hasContextualNameEqualTo("test.class#annotatedOnMethod");
+    }
+
     static class ObservedService {
 
         @Observed(name = "test.call", contextualName = "test#call",
@@ -385,6 +402,10 @@ class ObservedAspectTests {
                 .captureAll();
             return CompletableFuture.supplyAsync(fakeAsyncTask,
                     contextSnapshot.wrapExecutor(Executors.newSingleThreadExecutor()));
+        }
+
+        @Observed(name = "test.class", contextualName = "test.class#annotatedOnMethod")
+        void annotatedOnMethod() {
         }
 
     }


### PR DESCRIPTION
Do not advise twice