### PR TITLE
Proper scope handling in gRPC client instrumentation

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -185,7 +185,6 @@ class GrpcObservationTest {
             SimpleRequest request2 = SimpleRequest.newBuilder().setRequestMessage("Hello-2").build();
             StreamObserver<SimpleRequest> requestObserver = asyncStub.clientStreamingRpc(responseObserver);
 
-            assertThat(serverHandler.getContext()).isNull();
             verifyClientContext("grpc.testing.SimpleService", "ClientStreamingRpc",
                     "grpc.testing.SimpleService/ClientStreamingRpc", MethodType.CLIENT_STREAMING);
 


### PR DESCRIPTION
Prior to this change, scope in gRPC client instrumentation was not properly handled when client methods are called on different threads.
This change properly populates scope on callback methods.