### PR TITLE
Make Context.getParentObservation() available for ObservationPredicate

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
+ * @author Yanming Zhou
  * @since 1.10.0
  */
 public interface Observation extends ObservationView {
@@ -125,10 +126,11 @@ public interface Observation extends ObservationView {
             return NOOP;
         }
         Context context = contextSupplier.get();
+        context.setParentFromCurrentObservation(registry);
         if (!registry.observationConfig().isObservationEnabled(name, context)) {
             return NOOP;
         }
-        return new SimpleObservation(name, registry, context == null ? new Context() : context);
+        return new SimpleObservation(name, registry, context);
     }
 
     // @formatter:off
@@ -168,6 +170,7 @@ public interface Observation extends ObservationView {
         }
         ObservationConvention<T> convention;
         T context = contextSupplier.get();
+        context.setParentFromCurrentObservation(registry);
         if (customConvention != null) {
             convention = customConvention;
         }
@@ -177,7 +180,7 @@ public interface Observation extends ObservationView {
         if (!registry.observationConfig().isObservationEnabled(convention.getName(), context)) {
             return NOOP;
         }
-        return new SimpleObservation(convention, registry, context == null ? new Context() : context);
+        return new SimpleObservation(convention, registry, context);
     }
 
     /**
@@ -311,10 +314,11 @@ public interface Observation extends ObservationView {
             return NOOP;
         }
         T context = contextSupplier.get();
+        context.setParentFromCurrentObservation(registry);
         if (!registry.observationConfig().isObservationEnabled(observationConvention.getName(), context)) {
             return NOOP;
         }
-        return new SimpleObservation(observationConvention, registry, context == null ? new Context() : context);
+        return new SimpleObservation(observationConvention, registry, context);
     }
 
     /**
@@ -975,6 +979,20 @@ public interface Observation extends ObservationView {
          */
         public void setParentObservation(@Nullable ObservationView parentObservation) {
             this.parentObservation = parentObservation;
+        }
+
+        /**
+         * Sets the parent {@link ObservationView} to current one if parent is null and
+         * current one exists.
+         * @param registry the {@link ObservationRegistry} in using
+         */
+        void setParentFromCurrentObservation(ObservationRegistry registry) {
+            if (this.parentObservation == null) {
+                Observation currentObservation = registry.getCurrentObservation();
+                if (currentObservation != null) {
+                    setParentObservation(currentObservation);
+                }
+            }
         }
 
         /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
+ * @author Yanming Zhou
  * @since 1.10.0
  */
 class SimpleObservation implements Observation {
@@ -61,7 +62,6 @@ class SimpleObservation implements Observation {
         this.convention = getConventionFromConfig(registry, context);
         this.handlers = getHandlersFromConfig(registry, context);
         this.filters = registry.observationConfig().getObservationFilters();
-        setParentFromCurrentObservation();
     }
 
     SimpleObservation(ObservationConvention<? extends Context> convention, ObservationRegistry registry,
@@ -77,14 +77,6 @@ class SimpleObservation implements Observation {
         else {
             throw new IllegalStateException(
                     "Convention [" + convention + "] doesn't support context [" + context + "]");
-        }
-        setParentFromCurrentObservation();
-    }
-
-    private void setParentFromCurrentObservation() {
-        Observation currentObservation = this.registry.getCurrentObservation();
-        if (currentObservation != null) {
-            this.context.setParentObservation(currentObservation);
         }
     }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Jonatan Ivanov
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
+ * @author Yanming Zhou
  */
 class ObservationTests {
 
@@ -78,6 +79,20 @@ class ObservationTests {
         Observation observation = Observation.createNotStarted("foo", registry);
 
         assertThat(observation).isNotSameAs(Observation.NOOP);
+    }
+
+    @Test
+    void usingParentObservationToMatchPredicate() {
+        registry.observationConfig().observationHandler(context -> true);
+        registry.observationConfig()
+            .observationPredicate((s, context) -> !s.equals("child") || context.getParentObservation() != null);
+
+        Observation childWithoutParent = Observation.createNotStarted("child", registry);
+        assertThat(childWithoutParent).isSameAs(Observation.NOOP);
+
+        Observation childWithParent = Observation.createNotStarted("parent", registry)
+            .observe(() -> Observation.createNotStarted("child", registry));
+        assertThat(childWithParent).isNotSameAs(Observation.NOOP);
     }
 
     @Test


### PR DESCRIPTION
After this commit, Context.setParentObservation() is called before matching predicate.
now we can filter out parentless observations like this:
```java
	@Bean
	ObservationPredicate noParentlessDatabaseObservations() {
		return (name, context) -> {
			if (context instanceof LettuceObservationContext || context instanceof DataSourceBaseContext) {
				return context.getParentObservation() != null;
			}
			return true;
		};
	}
```

Resolves  #3678