### PR TITLE
Polish "Fix observation scope handlings in grpc server instrumentation"

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -16,7 +16,7 @@
         <!-- Imports -->
         <module name="IllegalImportCheck" >
             <property name="id" value="GeneralIllegalImportCheck"/>
-            <property name="illegalPkgs" value="com.google.common.(?![cache|concurrent]).*,org.apache.commons.text.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*,javax.ws.*"/>
+            <property name="illegalPkgs" value="com.google.common.(?!cache|util.concurrent).*,org.apache.commons.text.*,org.jetbrains.*,jdk.internal.jline.internal.*,reactor.util.annotation.*,org.checkerframework.checker.*,javax.ws.*"/>
             <property name="illegalClasses" value="org\.assertj\.core\.api\.Java6Assertions\..*,javax.annotation.Nullable"/>
             <property name="regexp" value="true"/>
         </module>

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcAsyncTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcAsyncTest.java
@@ -37,10 +37,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -96,12 +93,11 @@ class GrpcAsyncTest {
 
         // Send requests asynchronously with request-id in metadata.
         // The request-id is stored in threadlocal in server when scope is opened.
-        // The main logic retrieves the request-id from threadlocal and include it as
+        // The main logic retrieves the request-id from threadlocal and includes it as
         // part of the response message.
         // This simulates a tracer with span.
         SimpleServiceFutureStub stub = SimpleServiceGrpc.newFutureStub(this.channel);
         Map<ListenableFuture<SimpleResponse>, String> requestIds = new HashMap<>();
-        List<ListenableFuture<SimpleResponse>> futures = new ArrayList<>();
         int max = 40;
         for (int i = 0; i < max; i++) {
             String message = "Hello-" + i;
@@ -115,8 +111,8 @@ class GrpcAsyncTest {
                 .unaryRpc(request);
 
             requestIds.put(future, requestId);
-            futures.add(future);
         }
+        Set<ListenableFuture<SimpleResponse>> futures = requestIds.keySet();
         await().until(() -> futures.stream().allMatch(Future::isDone));
         assertThat(futures).allSatisfy((future) -> {
             // Make sure the request-id in the response message matches with the one sent

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -166,7 +166,7 @@ class GrpcObservationTest {
 
                     }
                 }, Executors.newCachedThreadPool());
-                futures.add(stub.unaryRpc(request));
+                futures.add(future);
             }
 
             await().until(() -> futures.stream().allMatch(Future::isDone));


### PR DESCRIPTION
This PR polishes the "Fix observation scope handlings in grpc server instrumentation" changes a bit.

See gh-3836