### PR TITLE
Upgrade to com.github.johnrengelman.shadow 8.1.1

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 dependencies {


### PR DESCRIPTION
This PR upgrades `com.github.johnrengelman.shadow` Gradle plugin to 8.1.1.