### PR TITLE
Don't add `PercentileHistogramBuckets` when `supportsAggregablePercentiles` is false

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -15,7 +15,10 @@
  */
 package io.micrometer.registry.otlp;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
@@ -28,6 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import static io.micrometer.core.instrument.MockClock.clock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables;
 
@@ -159,6 +163,46 @@ abstract class OtlpMeterRegistryTest {
 
         assertThat(writeToMetric(timer).getDataCase().getNumber()).isEqualTo(Metric.DataCase.HISTOGRAM.getNumber());
         assertThat(writeToMetric(ds).getDataCase().getNumber()).isEqualTo(Metric.DataCase.HISTOGRAM.getNumber());
+    }
+
+    @Issue("#3904")
+    @Test
+    void histogramCountsPublishPercentileHistogramAndSlos() {
+        DistributionSummary summary = DistributionSummary.builder("my.summmary")
+            .serviceLevelObjectives(5, 50, 95)
+            .publishPercentileHistogram()
+            .register(registry);
+
+        // ensure time-window based histograms are not fully rotated when we assert
+        Duration halfStep = otlpConfig().step().dividedBy(2);
+        clock(registry).add(halfStep);
+
+        for (int val : new int[] { 22, 55, 66, 98 }) {
+            summary.record(val);
+        }
+        // accommodate StepBucketHistogram
+        clock(registry).add(halfStep);
+
+        HistogramSnapshot snapshot = summary.takeSnapshot();
+        CountAtBucket[] countAtBuckets = snapshot.histogramCounts();
+
+        // May have more buckets, but must have at least the configured SLOs
+        assertThat(countAtBuckets).extracting(CountAtBucket::bucket).contains(5.0, 50.0, 95.0);
+        // Assert the count of the SLO buckets only
+        assertThat(nonCumulativeBucketCountForBucketRange(countAtBuckets, 0, 5)).isEqualTo(0);
+        assertThat(nonCumulativeBucketCountForBucketRange(countAtBuckets, 5, 50)).isEqualTo(1);
+        assertThat(nonCumulativeBucketCountForBucketRange(countAtBuckets, 50, 95)).isEqualTo(2);
+    }
+
+    private double nonCumulativeBucketCountForBucketRange(CountAtBucket[] countAtBuckets, double exclusiveMinBucket,
+            double inclusiveMaxBucket) {
+        double count = 0;
+        for (CountAtBucket countAtBucket : countAtBuckets) {
+            if (countAtBucket.bucket() > exclusiveMinBucket && countAtBucket.bucket() <= inclusiveMaxBucket) {
+                count += countAtBucket.count();
+            }
+        }
+        return count;
     }
 
     @Test

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
@@ -60,11 +60,6 @@ public class TimeWindowFixedBoundaryHistogram extends AbstractTimeWindowHistogra
         NavigableSet<Double> histogramBuckets = distributionStatisticConfig
             .getHistogramBuckets(supportsAggregablePercentiles);
 
-        Boolean percentileHistogram = distributionStatisticConfig.isPercentileHistogram();
-        if (percentileHistogram != null && percentileHistogram && supportsAggregablePercentiles) {
-            histogramBuckets.addAll(PercentileHistogramBuckets.buckets(distributionStatisticConfig));
-        }
-
         this.buckets = histogramBuckets.stream().filter(Objects::nonNull).mapToDouble(Double::doubleValue).toArray();
         initRingBuffer();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowFixedBoundaryHistogram.java
@@ -61,7 +61,7 @@ public class TimeWindowFixedBoundaryHistogram extends AbstractTimeWindowHistogra
             .getHistogramBuckets(supportsAggregablePercentiles);
 
         Boolean percentileHistogram = distributionStatisticConfig.isPercentileHistogram();
-        if (percentileHistogram != null && percentileHistogram) {
+        if (percentileHistogram != null && percentileHistogram && supportsAggregablePercentiles) {
             histogramBuckets.addAll(PercentileHistogramBuckets.buckets(distributionStatisticConfig));
         }
 
@@ -110,7 +110,7 @@ public class TimeWindowFixedBoundaryHistogram extends AbstractTimeWindowHistogra
 
     /**
      * For recording efficiency, we turn normal histogram into cumulative count histogram
-     * only on calls to {@link #countsAtValues(Iterator<Double>)}.
+     * only on calls to {@link FixedBoundaryHistogram#countsAtValues(Iterator)}.
      */
     @Override
     Iterator<CountAtBucket> countsAtValues(Iterator<Double> values) {

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -322,22 +322,13 @@ public abstract class MeterRegistryCompatibilityKit {
             HistogramSnapshot snapshot = summary.takeSnapshot();
             CountAtBucket[] countAtBuckets = snapshot.histogramCounts();
 
-            assertThat(countAtBuckets).satisfiesAnyOf(
-                    MeterRegistryCompatibilityKit.this::assertHistogramNotSupportingPercentileHistogramBuckets,
-                    MeterRegistryCompatibilityKit.this::assertHistogramSupportingPercentileHistogramBuckets);
+            assertHistogramBuckets(countAtBuckets);
         }
 
     }
 
-    private void assertHistogramNotSupportingPercentileHistogramBuckets(CountAtBucket[] countAtBuckets) {
-        // only SLO buckets added because percentile histogram buckets are not supported
-        assertThat(countAtBuckets).extracting(CountAtBucket::bucket).containsExactly(5.0, 50.0, 95.0);
-
-        assertThat(countAtBuckets).extracting(CountAtBucket::count).containsExactly(0.0, 1.0, 3.0);
-    }
-
-    private void assertHistogramSupportingPercentileHistogramBuckets(CountAtBucket[] countAtBuckets) {
-        // percentile histogram buckets will be there, but assert SLO buckets are present
+    private void assertHistogramBuckets(CountAtBucket[] countAtBuckets) {
+        // percentile histogram buckets may be there, assert SLO buckets are present
         assertThat(countAtBuckets).extracting(CountAtBucket::bucket).contains(5.0, 50.0, 95.0);
 
         assertThat(countAtBuckets).satisfiesAnyOf(
@@ -835,9 +826,7 @@ public abstract class MeterRegistryCompatibilityKit {
             HistogramSnapshot snapshot = timer.takeSnapshot();
             CountAtBucket[] countAtBuckets = snapshot.histogramCounts();
 
-            assertThat(countAtBuckets).satisfiesAnyOf(
-                    MeterRegistryCompatibilityKit.this::assertHistogramNotSupportingPercentileHistogramBuckets,
-                    MeterRegistryCompatibilityKit.this::assertHistogramSupportingPercentileHistogramBuckets);
+            assertHistogramBuckets(countAtBuckets);
         }
 
     }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -339,13 +339,13 @@ public abstract class MeterRegistryCompatibilityKit {
                     .containsExactly(0.0, 1.0, 3.0),
                 // if not cumulative buckets, we need to add up buckets in range.
                 bucketCounts -> {
-                    assertThat(nonCumulativeBucketCountForValueRange(bucketCounts, 0, 5)).isEqualTo(0);
-                    assertThat(nonCumulativeBucketCountForValueRange(bucketCounts, 5, 50)).isEqualTo(1);
-                    assertThat(nonCumulativeBucketCountForValueRange(bucketCounts, 50, 95)).isEqualTo(2);
+                    assertThat(nonCumulativeBucketCountForRange(bucketCounts, 0, 5)).isEqualTo(0);
+                    assertThat(nonCumulativeBucketCountForRange(bucketCounts, 5, 50)).isEqualTo(1);
+                    assertThat(nonCumulativeBucketCountForRange(bucketCounts, 50, 95)).isEqualTo(2);
                 });
     }
 
-    private double nonCumulativeBucketCountForValueRange(CountAtBucket[] countAtBuckets, double exclusiveMinBucket,
+    private double nonCumulativeBucketCountForRange(CountAtBucket[] countAtBuckets, double exclusiveMinBucket,
             double inclusiveMaxBucket) {
         double count = 0;
         for (CountAtBucket countAtBucket : countAtBuckets) {


### PR DESCRIPTION
There was a mismatch between the underlying buckets used in a histogram and the buckets that would be returned in a HistogramSnapshot. This resulted in the wrong counts due to a change in the way we calculate the bucket count (see gh-3581), which assumes underlying buckets = buckets to return. This change makes the underlying buckets used the same as the buckets that will be returned, since there is no benefit of using more buckets than we will return.

A test has been added to the TCK to cover this case. It needs to be overly flexible since we don't know at the TCK level whether a MeterRegistry uses cumulative bucket counts or whether it supports aggregable percentile histogram buckets.

Resolves #3904