### PR TITLE
Constant version of otel collector for integration test

### DIFF
--- a/implementations/micrometer-registry-otlp/build.gradle
+++ b/implementations/micrometer-registry-otlp/build.gradle
@@ -13,6 +13,10 @@ dependencies {
     testImplementation 'org.awaitility:awaitility'
 }
 
+dockerTest {
+    systemProperty 'otel-collector-image.version', '0.79.0'
+}
+
 // new module in 1.9. This should be removed in later branches.
 japicmp.enabled = false
 downloadBaseline.enabled = false


### PR DESCRIPTION
We should have reproducible builds and maintenance branches frequently breaking on new versions of the otel collector blocks other work like unrelated bug fixes. This change fixes the version and manages it in the build file. It's not the same as how other dependencies are managed (no version range, no lock file), but it's maybe an improvement and keeps versions in build files rather than in a Java test class. Once merged to `main` it can be set to `latest` until that branches off as a maintenance branch.

This does add a little work to run the integration test from an IDE because the system property configuration needs to be added to your IDE run config.

I'm open to feedback on taking a different approach. This is just what I thought of on first try.

Closes #3925