### PR TITLE
Fix Javadoc for ObservationThreadLocalAccessor(ObservationRegistry)

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
@@ -55,7 +55,7 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
     }
 
     /**
-     * Creates a new instance of this class and stores a static handle to it.
+     * Creates a new instance of this class.
      * @param observationRegistry observation registry
      * @since 1.10.8
      */


### PR DESCRIPTION
This PR sets the `instance` static field in the `ObservationThreadLocalAccessor(ObservationRegistry)` constructor as it seems to have been missed based on its Javadoc.