### PR TITLE
Use different name for StepMeterRegistry thread that polls to roll over

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.internal.DefaultGauge;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.push.PushMeterRegistry;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -119,8 +120,8 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
         super.start(threadFactory);
 
         if (config.enabled()) {
-            this.meterPollingService = Executors.newSingleThreadScheduledExecutor(threadFactory);
-
+            this.meterPollingService = Executors.newSingleThreadScheduledExecutor(
+                    new NamedThreadFactory("step-meter-registry-poller-for-" + getClass().getSimpleName()));
             this.meterPollingService.scheduleAtFixedRate(this::pollMetersToRollover, getInitialDelay(),
                     config.step().toMillis(), TimeUnit.MILLISECONDS);
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.step;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.util.concurrent.AtomicDouble;
 
@@ -448,6 +449,48 @@ class StepMeterRegistryTest {
         clock.add(config.step());
         disabledStepMeterRegistry.close();
         assertThat(publishes.get()).isEqualTo(publishCountBeforeClose);
+    }
+
+    @Test
+    void startWithNamedThreadFactoryShouldUseNamedThreadFactoryForPoller() {
+        StepMeterRegistry registry = new CustomStepMeterRegistry();
+        String publisherThreadName = "custom-metrics-publisher";
+        registry.start(new NamedThreadFactory(publisherThreadName));
+        List<String> threadNames = Thread.getAllStackTraces()
+            .keySet()
+            .stream()
+            .map((thread) -> thread.getName())
+            .collect(Collectors.toList());
+        assertThat(threadNames).contains(publisherThreadName)
+            .doesNotContain(publisherThreadName + "-2")
+            .contains("step-meter-registry-poller-for-CustomStepMeterRegistry");
+    }
+
+    static class CustomStepMeterRegistry extends StepMeterRegistry {
+
+        CustomStepMeterRegistry() {
+            super(new StepRegistryConfig() {
+                @Override
+                public String prefix() {
+                    return null;
+                }
+
+                @Override
+                public String get(String key) {
+                    return null;
+                }
+            }, new MockClock());
+        }
+
+        @Override
+        protected void publish() {
+        }
+
+        @Override
+        protected TimeUnit getBaseTimeUnit() {
+            return TimeUnit.SECONDS;
+        }
+
     }
 
     private class MyStepMeterRegistry extends StepMeterRegistry {


### PR DESCRIPTION
This is an attempt to resolve #3837.

Closes gh-3837