### PR TITLE
:bug: Avoid potential race condition with Observation.NOOP

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -29,14 +29,9 @@ import io.micrometer.common.lang.Nullable;
  */
 final class NoopObservation implements Observation {
 
-    /**
-     * Instance of {@link NoopObservation}.
-     */
-    static final NoopObservation INSTANCE = new NoopObservation();
-
     private static final Context CONTEXT = new Context();
 
-    private NoopObservation() {
+    NoopObservation() {
     }
 
     @Override
@@ -119,7 +114,7 @@ final class NoopObservation implements Observation {
 
         @Override
         public Observation getCurrentObservation() {
-            return NoopObservation.INSTANCE;
+            return Observation.NOOP;
         }
 
         @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
@@ -38,7 +38,7 @@ final class NoopObservationRegistry implements ObservationRegistry {
 
     @Override
     public Observation getCurrentObservation() {
-        return NoopObservation.INSTANCE;
+        return Observation.NOOP;
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -51,7 +51,7 @@ public interface Observation extends ObservationView {
     /**
      * No-op observation.
      */
-    Observation NOOP = NoopObservation.INSTANCE;
+    Observation NOOP = new NoopObservation();
 
     /**
      * Create and start an {@link Observation} with the given name. All Observations of

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -387,7 +387,7 @@ class ObservationTests {
                 passedContextHolder.set(ctx);
                 return "World";
             });
-        assertThat(passedContextHolder).as("passed a noop context").hasValue(NoopObservation.INSTANCE.getContext());
+        assertThat(passedContextHolder).as("passed a noop context").hasValue(Observation.NOOP.getContext());
         assertThat(contextCreated).isFalse();
         assertThat(result).isEqualTo("World");
     }


### PR DESCRIPTION
It seems that in some situations `Observation.NOOP` can be null even if `NoopObservation.INSTANCE` is properly set (see [comment in issue](https://github.com/micrometer-metrics/micrometer/issues/3943#issuecomment-1612566866)).

This PR removes `NoopObservation.INSTANCE` so that there's no duplication and no risk of race condition on `Observation.NOOP`. This change resolves the NPE reported in the [comment](https://github.com/micrometer-metrics/micrometer/issues/3943#issuecomment-1612566866), but is not sufficient to resolve the problem reported by #3943 