### PR TITLE
NoOpRegistry and NoOpObservation respect scopes

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -31,9 +31,6 @@ final class NoopObservation implements Observation {
 
     private static final Context CONTEXT = new Context();
 
-    NoopObservation() {
-    }
-
     @Override
     public Observation contextualName(@Nullable String contextualName) {
         return this;
@@ -95,7 +92,7 @@ final class NoopObservation implements Observation {
 
     @Override
     public Scope openScope() {
-        return NoopScope.INSTANCE;
+        return new SimpleObservation.SimpleScope(NoopObservationRegistry.FOR_SCOPES, this);
     }
 
     /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
@@ -31,6 +31,8 @@ final class NoopObservationRegistry implements ObservationRegistry {
      */
     static final NoopObservationRegistry INSTANCE = new NoopObservationRegistry();
 
+    static final ObservationRegistry FOR_SCOPES = ObservationRegistry.create();
+
     private final ObservationConfig observationConfig = NoopObservationConfig.INSTANCE;
 
     private NoopObservationRegistry() {
@@ -38,17 +40,17 @@ final class NoopObservationRegistry implements ObservationRegistry {
 
     @Override
     public Observation getCurrentObservation() {
-        return Observation.NOOP;
+        return FOR_SCOPES.getCurrentObservation();
     }
 
     @Override
     public Observation.Scope getCurrentObservationScope() {
-        return NoopObservation.NoopScope.INSTANCE;
+        return FOR_SCOPES.getCurrentObservationScope();
     }
 
     @Override
     public void setCurrentObservationScope(Observation.Scope current) {
-
+        FOR_SCOPES.setCurrentObservationScope(current);
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -312,7 +312,7 @@ class SimpleObservation implements Observation {
                 }
                 observation.notifyOnScopeClosed();
             }
-            else if (!currentObservation.isNoop()) {
+            else if (currentObservation != null && !currentObservation.isNoop()) {
                 log.debug("Custom observation type was used in combination with SimpleScope - that's unexpected");
             }
             else {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -312,8 +312,11 @@ class SimpleObservation implements Observation {
                 }
                 observation.notifyOnScopeClosed();
             }
-            else {
+            else if (!currentObservation.isNoop()) {
                 log.debug("Custom observation type was used in combination with SimpleScope - that's unexpected");
+            }
+            else {
+                log.trace("NoOp observation used with SimpleScope");
             }
             this.registry.setCurrentObservationScope(previousObservationScope);
         }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/NoopObservationRegistryTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/NoopObservationRegistryTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+class NoopObservationRegistryTests {
+
+    @Test
+    void should_respect_scopes() {
+        ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+        then(observationRegistry.getCurrentObservation()).isNull();
+
+        Observation observation = Observation.start("foo", observationRegistry);
+        then(observation.isNoop()).isTrue();
+        then(observationRegistry.getCurrentObservation()).isNull();
+
+        try (Observation.Scope scope = observation.openScope()) {
+            then(observationRegistry.getCurrentObservationScope()).isSameAs(scope);
+            then(observationRegistry.getCurrentObservation()).isSameAs(observation);
+            try (Observation.Scope scope2 = observation.openScope()) {
+                then(observationRegistry.getCurrentObservationScope()).isSameAs(scope2);
+                then(observationRegistry.getCurrentObservationScope().getPreviousObservationScope()).isSameAs(scope);
+                then(observationRegistry.getCurrentObservation()).isSameAs(observation);
+            }
+            then(observationRegistry.getCurrentObservation()).isSameAs(observation);
+        }
+
+        then(observationRegistry.getCurrentObservation()).isNull();
+    }
+
+}


### PR DESCRIPTION
without this change there was a problem with OTLA, default ObservationRegistry and NoOpRegistry interop. They didn't see each other scopes

with this change we're allowing scopes for NoOpRegistry and NoOpObservations

fixes gh-3943