### PR TITLE
fix support for "seconds" base time unit

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -233,7 +233,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         return DistributionStatisticConfig.builder()
             .expiry(this.config.step())
             .build()
-            .merge(DistributionStatisticConfig.DEFAULT);
+            .merge(DistributionStatisticConfig.DEFAULT.toBuilder().baseTimeUnit(baseTimeUnit).build());
     }
 
     @Override


### PR DESCRIPTION
histograms have a lower bound of 1s if you use seconds as the base time unit