### PR TITLE
Ensure OTLP histograms always contain bucket counts

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpCumulativeMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpCumulativeMeterRegistryTest.java
@@ -91,11 +91,11 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
         timer.record(111, TimeUnit.MILLISECONDS);
         clock.add(otlpConfig().step());
         timer.record(4, TimeUnit.MILLISECONDS);
-        assertThat(writeToMetric(timer).toString()).isEqualTo(
-                "name: \"web.requests\"\n" + "description: \"timing web requests\"\n" + "unit: \"milliseconds\"\n"
-                        + "histogram {\n" + "  data_points {\n" + "    start_time_unix_nano: 1000000\n"
-                        + "    time_unix_nano: 60001000000\n" + "    count: 4\n" + "    sum: 202.0\n" + "  }\n"
-                        + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
+        assertThat(writeToMetric(timer).toString()).isEqualTo("name: \"web.requests\"\n"
+                + "description: \"timing web requests\"\n" + "unit: \"milliseconds\"\n" + "histogram {\n"
+                + "  data_points {\n" + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 60001000000\n"
+                + "    count: 4\n" + "    sum: 202.0\n" + "    bucket_counts: 4\n" + "  }\n"
+                + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
     }
 
     @Test
@@ -195,8 +195,8 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
         assertThat(writeToMetric(functionTimer).toString())
             .isEqualTo("name: \"function.timer\"\n" + "unit: \"milliseconds\"\n" + "histogram {\n" + "  data_points {\n"
                     + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 1000000\n" + "    count: 5\n"
-                    + "    sum: 127.0\n" + "  }\n" + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n"
-                    + "}\n");
+                    + "    sum: 127.0\n" + "    bucket_counts: 5\n" + "  }\n"
+                    + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
     }
 
     @Test
@@ -210,10 +210,11 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
         clock.add(otlpConfig().step());
         size.record(204);
 
-        assertThat(writeToMetric(size).toString()).isEqualTo("name: \"http.response.size\"\n" + "unit: \"bytes\"\n"
-                + "histogram {\n" + "  data_points {\n" + "    start_time_unix_nano: 1000000\n"
-                + "    time_unix_nano: 60001000000\n" + "    count: 4\n" + "    sum: 2552.0\n" + "  }\n"
-                + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
+        assertThat(writeToMetric(size).toString())
+            .isEqualTo("name: \"http.response.size\"\n" + "unit: \"bytes\"\n" + "histogram {\n" + "  data_points {\n"
+                    + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 60001000000\n" + "    count: 4\n"
+                    + "    sum: 2552.0\n" + "    bucket_counts: 4\n" + "  }\n"
+                    + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
     }
 
     @Test
@@ -487,7 +488,7 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
         assertThat(writeToMetric(taskTimer).toString())
             .isEqualTo("name: \"checkout.batch\"\n" + "unit: \"milliseconds\"\n" + "histogram {\n" + "  data_points {\n"
                     + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 180001000000\n" + "    count: 2\n"
-                    + "    sum: 360000.0\n" + "  }\n"
+                    + "    sum: 360000.0\n" + "    bucket_counts: 2\n" + "  }\n"
                     + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
 
         task1.stop();
@@ -499,7 +500,8 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
         assertThat(writeToMetric(taskTimer).toString())
             .isEqualTo("name: \"checkout.batch\"\n" + "unit: \"milliseconds\"\n" + "histogram {\n" + "  data_points {\n"
                     + "    start_time_unix_nano: 1000000\n" + "    time_unix_nano: 240001000000\n" + "    sum: 0.0\n"
-                    + "  }\n" + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
+                    + "    bucket_counts: 0\n" + "  }\n"
+                    + "  aggregation_temporality: AGGREGATION_TEMPORALITY_CUMULATIVE\n" + "}\n");
     }
 
     @Override


### PR DESCRIPTION
The `micrometer-registry-otlp` artifact emits histograms without the [bucket_counts](https://github.com/open-telemetry/opentelemetry-proto/blob/c4dfbc51f3cd4089778555a2ac5d9bc093ed2956/opentelemetry/proto/metrics/v1/metrics.proto#L428) field.

Although this field is optional and the value is redundant in cases where `explicit_bounds` are not set (if `explicit_bounds` are unset its a single bucket histogram with range [-infinity, infinity] and therefore the single entry in `bucket_counts` is redundant with the total `count` field). 

Its in these types of cases that `micrometer-registry-otlp` omits `bucket_counts`. This PR adjusts the behavior to _always_ include `bucket_counts`, which makes the messages easier to consume.