### PR TITLE
Removes the need to set OR on OTLA

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
@@ -26,6 +26,15 @@ import io.micrometer.observation.Observation.ContextView;
 public interface ObservationView {
 
     /**
+     * Returns the {@link ObservationRegistry} attached to this observation.
+     * @return corresponding observation registry
+     * @since 1.10.10
+     */
+    default ObservationRegistry getObservationRegistry() {
+        return ObservationRegistry.NOOP;
+    }
+
+    /**
      * Returns the {@link ContextView} attached to this observation.
      * @return corresponding context
      */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -276,6 +276,11 @@ class SimpleObservation implements Observation {
         this.handlers.descendingIterator().forEachRemaining(handler -> handler.onStop(context));
     }
 
+    @Override
+    public ObservationRegistry getObservationRegistry() {
+        return this.registry;
+    }
+
     static class SimpleScope implements Scope {
 
         private static final InternalLogger log = InternalLoggerFactory.getInstance(SimpleScope.class);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
@@ -49,7 +49,6 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
      */
     public ObservationThreadLocalAccessor() {
         instance = this;
-        log.debug("Remember to set the ObservationRegistry on this accessor!");
     }
 
     /**
@@ -111,11 +110,16 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
 
     @Override
     public void setValue() {
+        Observation currentObservation = observationRegistry.getCurrentObservation();
+        if (currentObservation == null) {
+            return;
+        }
+        ObservationRegistry registry = currentObservation.getObservationRegistry();
         // Not closing a scope (we're not resetting)
         // Creating a new one with empty context and opens a new scope
         // This scope will remember the previously created one to
         // which we will revert once "null scope" is closed
-        new NullObservation(observationRegistry).start().openScope();
+        new NullObservation(registry).start().openScope();
     }
 
     private void closeCurrentScope() {


### PR DESCRIPTION
without this change we are required to set OR on OTLA so that when NullObservation gets created we will call the proper handlers to e.g. clear tracing values.

with this change we no longer require to set OR on OTLA because we will reuse the OR that was set on the Observation before clearing happens in OTLA via `setValue()`. When there was no Observation before calling `setValue()` we just skip creating any scopes. That way we are always reusing the ObservationRegistry that is used between Observations.