### PR TITLE
Move WavefrontConfig.getUriString() to PropertyValidator

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -15,14 +15,12 @@
  */
 package io.micrometer.wavefront;
 
-import io.micrometer.core.instrument.config.MeterRegistryConfig;
 import io.micrometer.core.instrument.config.validate.InvalidReason;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.push.PushRegistryConfig;
 import io.micrometer.core.lang.Nullable;
 
 import java.net.InetAddress;
-import java.net.URI;
 import java.net.UnknownHostException;
 
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;
@@ -174,19 +172,6 @@ public interface WavefrontConfig extends PushRegistryConfig {
                 check("apiToken", WavefrontConfig::apiToken)
                     .andThen(v -> v.invalidateWhen(token -> token == null && WavefrontMeterRegistry.isDirectToApi(this),
                             "must be set whenever publishing directly to the Wavefront API", InvalidReason.MISSING)));
-    }
-
-    // different from getUrlString for gh-3903
-    static Validated<String> getUriString(MeterRegistryConfig config, String property) {
-        String prefixedProperty = config.prefix() + '.' + property;
-        String value = config.get(prefixedProperty);
-
-        try {
-            return Validated.valid(prefixedProperty, value == null ? null : URI.create(value)).map(url -> value);
-        }
-        catch (IllegalArgumentException ex) {
-            return Validated.invalid(prefixedProperty, value, "must be a valid URI", InvalidReason.MALFORMED, ex);
-        }
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/PropertyValidator.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/PropertyValidator.java
@@ -119,6 +119,28 @@ public class PropertyValidator {
         }
     }
 
+    /**
+     * Get a validated URI string.
+     * @param config config
+     * @param property property
+     * @return a validated URI string
+     * @see #getUrlString(MeterRegistryConfig, String)
+     * @see <a href=
+     * "https://github.com/micrometer-metrics/micrometer/issues/3903">gh-3903</a>
+     * @since 1.9.14
+     */
+    public static Validated<String> getUriString(MeterRegistryConfig config, String property) {
+        String prefixedProperty = prefixedProperty(config, property);
+        String value = config.get(prefixedProperty);
+
+        try {
+            return Validated.valid(prefixedProperty, value == null ? null : URI.create(value)).map(uri -> value);
+        }
+        catch (IllegalArgumentException ex) {
+            return Validated.invalid(prefixedProperty, value, "must be a valid URI", InvalidReason.MALFORMED, ex);
+        }
+    }
+
     private static String prefixedProperty(MeterRegistryConfig config, String property) {
         return config.prefix() + '.' + property;
     }


### PR DESCRIPTION
This PR moves `WavefrontConfig.getUriString()` to `PropertyValidator` as it seems to have been exposed accidentally.

It's implementation details but technically breaking changes, so I'm not sure if it's okay.

See gh-3903