### PR TITLE
Add exemplar support to _count

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusTimer.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.prometheus;
 
+import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
@@ -22,10 +23,12 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
+import io.prometheus.client.exemplars.CounterExemplarSampler;
 import io.prometheus.client.exemplars.Exemplar;
-import io.prometheus.client.exemplars.HistogramExemplarSampler;
+import io.prometheus.client.exemplars.ExemplarSampler;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -49,11 +52,16 @@ public class PrometheusTimer extends AbstractTimer {
     @Nullable
     private final Histogram histogram;
 
-    private boolean exemplarsEnabled = false;
+    @Nullable
+    private final ExemplarSampler exemplarSampler;
+
+    @Nullable
+    private final AtomicReference<Exemplar> lastExemplar;
+
+    private boolean histogramExemplarsEnabled = false;
 
     PrometheusTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            PauseDetector pauseDetector, HistogramFlavor histogramFlavor,
-            @Nullable HistogramExemplarSampler exemplarSampler) {
+            PauseDetector pauseDetector, HistogramFlavor histogramFlavor, @Nullable ExemplarSampler exemplarSampler) {
         super(id, clock,
                 DistributionStatisticConfig.builder()
                     .percentilesHistogram(false)
@@ -71,7 +79,7 @@ public class PrometheusTimer extends AbstractTimer {
                     PrometheusHistogram prometheusHistogram = new PrometheusHistogram(clock,
                             distributionStatisticConfig, exemplarSampler);
                     this.histogram = prometheusHistogram;
-                    this.exemplarsEnabled = prometheusHistogram.isExemplarsEnabled();
+                    this.histogramExemplarsEnabled = prometheusHistogram.isExemplarsEnabled();
                     break;
                 case VictoriaMetrics:
                     this.histogram = new FixedBoundaryVictoriaMetricsHistogram();
@@ -83,6 +91,15 @@ public class PrometheusTimer extends AbstractTimer {
         }
         else {
             this.histogram = null;
+        }
+
+        if (!this.histogramExemplarsEnabled && exemplarSampler != null) {
+            this.exemplarSampler = exemplarSampler;
+            this.lastExemplar = new AtomicReference<>();
+        }
+        else {
+            this.exemplarSampler = null;
+            this.lastExemplar = null;
         }
     }
 
@@ -96,15 +113,40 @@ public class PrometheusTimer extends AbstractTimer {
         if (histogram != null) {
             histogram.recordLong(TimeUnit.NANOSECONDS.convert(amount, unit));
         }
+
+        if (!histogramExemplarsEnabled && exemplarSampler != null) {
+            updateLastExemplar(TimeUtils.nanosToUnit(amount, this.baseTimeUnit()), exemplarSampler);
+        }
+    }
+
+    // Similar to exemplar.updateAndGet(...) but it does nothing if the next value is null
+    private void updateLastExemplar(double amount, @NonNull CounterExemplarSampler exemplarSampler) {
+        Exemplar prev;
+        Exemplar next;
+        do {
+            prev = lastExemplar.get();
+            next = exemplarSampler.sample(amount, prev);
+        }
+        while (next != null && next != prev && !lastExemplar.compareAndSet(prev, next));
     }
 
     @Nullable
-    Exemplar[] exemplars() {
-        if (exemplarsEnabled) {
+    Exemplar[] histogramExemplars() {
+        if (histogramExemplarsEnabled) {
             return ((PrometheusHistogram) histogram).exemplars();
         }
         else {
             return null;
+        }
+    }
+
+    @Nullable
+    Exemplar lastExemplar() {
+        if (histogramExemplarsEnabled) {
+            return ((PrometheusHistogram) histogram).lastExemplar();
+        }
+        else {
+            return lastExemplar != null ? lastExemplar.get() : null;
         }
     }
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -611,40 +611,64 @@ class PrometheusMeterRegistryTest {
         Counter counter = Counter.builder("my.counter").register(registry);
         counter.increment();
 
-        Timer timer = Timer.builder("test.timer")
+        Timer timer = Timer.builder("timer.noHistogram").register(registry);
+        timer.record(Duration.ofMillis(100));
+        timer.record(Duration.ofMillis(200));
+        timer.record(Duration.ofMillis(150));
+
+        Timer timerWithHistogram = Timer.builder("timer.withHistogram")
             .serviceLevelObjectives(Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(300))
             .register(registry);
-        timer.record(Duration.ofMillis(15));
-        timer.record(Duration.ofMillis(150));
-        timer.record(Duration.ofMillis(1_500));
+        timerWithHistogram.record(Duration.ofMillis(15));
+        timerWithHistogram.record(Duration.ofMillis(1_500));
+        timerWithHistogram.record(Duration.ofMillis(150));
 
-        DistributionSummary histogram = DistributionSummary.builder("test.histogram")
+        DistributionSummary summary = DistributionSummary.builder("summary.noHistogram").register(registry);
+        summary.record(0.10);
+        summary.record(1E18);
+        summary.record(20);
+
+        DistributionSummary summaryWithHistogram = DistributionSummary.builder("summary.withHistogram")
             .publishPercentileHistogram()
             .register(registry);
-        histogram.record(0.15);
-        histogram.record(15);
-        histogram.record(5E18);
+        summaryWithHistogram.record(0.15);
+        summaryWithHistogram.record(5E18);
+        summaryWithHistogram.record(15);
 
-        DistributionSummary slos = DistributionSummary.builder("test.slos")
+        DistributionSummary slos = DistributionSummary.builder("summary.withSlos")
             .serviceLevelObjectives(100, 200, 300)
             .register(registry);
         slos.record(10);
-        slos.record(250);
         slos.record(1_000);
+        slos.record(250);
 
         String scraped = registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
-        assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"} 1.0");
-        assertThat(scraped).contains("test_timer_seconds_bucket{le=\"0.1\"} 1.0 # {span_id=\"3\",trace_id=\"4\"} 0.015")
-            .contains("test_timer_seconds_bucket{le=\"0.2\"} 2.0 # {span_id=\"5\",trace_id=\"6\"} 0.15")
-            .contains("test_timer_seconds_bucket{le=\"0.3\"} 2.0\n")
-            .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3.0 # {span_id=\"7\",trace_id=\"8\"} 1.5");
-        assertThat(scraped).contains("test_histogram_bucket{le=\"1.0\"} 1.0 # {span_id=\"9\",trace_id=\"10\"} 0.15")
-            .contains("test_histogram_bucket{le=\"16.0\"} 2.0 # {span_id=\"11\",trace_id=\"12\"} 15.0")
-            .contains("test_histogram_bucket{le=\"+Inf\"} 3.0 # {span_id=\"13\",trace_id=\"14\"} 5.0E18");
-        assertThat(scraped).contains("test_slos_bucket{le=\"100.0\"} 1.0 # {span_id=\"15\",trace_id=\"16\"} 10.0")
-            .contains("test_slos_bucket{le=\"200.0\"} 1.0\n")
-            .contains("test_slos_bucket{le=\"300.0\"} 2.0 # {span_id=\"17\",trace_id=\"18\"} 250.0")
-            .contains("test_slos_bucket{le=\"+Inf\"} 3.0 # {span_id=\"19\",trace_id=\"20\"} 1000.0");
+        assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"} 1.0 ");
+
+        assertThat(scraped).contains("timer_noHistogram_seconds_count 3.0 # {span_id=\"3\",trace_id=\"4\"} 1.0 ");
+
+        assertThat(scraped)
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.1\"} 1.0 # {span_id=\"5\",trace_id=\"6\"} 0.015 ")
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.2\"} 2.0 # {span_id=\"9\",trace_id=\"10\"} 0.15 ")
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.3\"} 2.0\n")
+            .contains("timer_withHistogram_seconds_bucket{le=\"+Inf\"} 3.0 # {span_id=\"7\",trace_id=\"8\"} 1.5 ");
+        assertThat(scraped).contains("timer_withHistogram_seconds_count 3.0 # {span_id=\"9\",trace_id=\"10\"} 1.0 ");
+
+        assertThat(scraped).contains("summary_noHistogram_count 3.0 # {span_id=\"11\",trace_id=\"12\"} 1.0 ");
+
+        assertThat(scraped)
+            .contains("summary_withHistogram_bucket{le=\"1.0\"} 1.0 # {span_id=\"13\",trace_id=\"14\"} 0.15 ")
+            .contains("summary_withHistogram_bucket{le=\"16.0\"} 2.0 # {span_id=\"17\",trace_id=\"18\"} 15.0 ")
+            .contains("summary_withHistogram_bucket{le=\"+Inf\"} 3.0 # {span_id=\"15\",trace_id=\"16\"} 5.0E18 ");
+        assertThat(scraped).contains("summary_withHistogram_count 3.0 # {span_id=\"17\",trace_id=\"18\"} 1.0 ");
+
+        assertThat(scraped)
+            .contains("summary_withSlos_bucket{le=\"100.0\"} 1.0 # {span_id=\"19\",trace_id=\"20\"} 10.0 ")
+            .contains("summary_withSlos_bucket{le=\"200.0\"} 1.0\n")
+            .contains("summary_withSlos_bucket{le=\"300.0\"} 2.0 # {span_id=\"23\",trace_id=\"24\"} 250.0 ")
+            .contains("summary_withSlos_bucket{le=\"+Inf\"} 3.0 # {span_id=\"21\",trace_id=\"22\"} 1000.0 ");
+        assertThat(scraped).contains("summary_withSlos_count 3.0 # {span_id=\"23\",trace_id=\"24\"} 1.0 ");
+
         assertThat(scraped).endsWith("# EOF\n");
     }
 


### PR DESCRIPTION
Prometheus did not support exemplars for Summaries and it did not support exemplars for anything else than buckets on Histograms. Since Prometheus now supports exemplars on every time series, we can add exemplars to Summary/Histogram _count, see: https://github.com/prometheus/prometheus/issues/11982

Also related: https://github.com/micrometer-metrics/micrometer/pull/3460

Since the support for this [was added](https://github.com/prometheus/prometheus/pull/11984) in Prometheus sever in [`2.43.0`](https://github.com/prometheus/prometheus/releases/tag/v2.43.0) and the previous behavior was dropping the whole scrape response, this change (as-is in this draft) will break users who are using older Prometheus servers ([`2.43.0` was released on 2023-03-21](https://github.com/prometheus/prometheus/releases/tag/v2.43.0)).
We should figure out how to handle this based on the [Prometheus support terms](https://prometheus.io/docs/introduction/release-cycle/): it seems the oldest version that is still supported by Prometheus maintainers but does not have this functionality will reach EOL by 2023-07-31 (in a ~week).