### PR TITLE
[Dynatrace v2] Export unit/description to Dynatrace

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -158,7 +158,7 @@ public interface DynatraceConfig extends StepRegistryConfig {
         if (apiVersion() == V1) {
             return false;
         }
-        return getBoolean(this, "exportDynatraceMetadata").orElse(true);
+        return getBoolean(this, "exportMeterMetadata").orElse(true);
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -125,6 +125,9 @@ public interface DynatraceConfig extends StepRegistryConfig {
      * @since 1.8.0
      */
     default boolean enrichWithDynatraceMetadata() {
+        if (apiVersion() == V1) {
+            return false;
+        }
         return getBoolean(this, "enrichWithDynatraceMetadata").orElse(true);
     }
 
@@ -141,6 +144,21 @@ public interface DynatraceConfig extends StepRegistryConfig {
             return false;
         }
         return getBoolean(this, "useDynatraceSummaryInstruments").orElse(true);
+    }
+
+    /**
+     * Toggle whether to export metadata (unit and description) to the Dynatrace backend
+     * for the V2 version of this exporter. Metadata will be exported by default from
+     * Micrometer version 1.12.0. This setting has no effect for the (legacy) Dynatrace
+     * Exporter v1
+     * @return true if metadata should be exported, false otherwise.
+     * @since 1.12.0
+     */
+    default boolean exportMeterMetadata() {
+        if (apiVersion() == V1) {
+            return false;
+        }
+        return getBoolean(this, "exportDynatraceMetadata").orElse(true);
     }
 
     @Override

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -120,7 +120,9 @@ public interface DynatraceConfig extends StepRegistryConfig {
     }
 
     /**
-     * Return whether to enrich with Dynatrace metadata.
+     * Return whether to enrich with Dynatrace metadata. Dynatrace metadata is provided by
+     * the Dynatrace OneAgent or Dynatrace Kubernetes Operator and helps put metrics
+     * emitted via the Micrometer exporter in context more easily.
      * @return whether to enrich with Dynatrace metadata
      * @since 1.8.0
      */
@@ -147,10 +149,12 @@ public interface DynatraceConfig extends StepRegistryConfig {
     }
 
     /**
-     * Toggle whether to export metadata (unit and description) to the Dynatrace backend
-     * for the V2 version of this exporter. Metadata will be exported by default from
-     * Micrometer version 1.12.0. This setting has no effect for the (legacy) Dynatrace
-     * Exporter v1
+     * Toggle whether to export meter metadata (unit and description) to the Dynatrace
+     * backend for the V2 version of this exporter. Metadata will be exported by default
+     * from Micrometer version 1.12.0. This setting has no effect for the (legacy)
+     * Dynatrace Exporter v1. Setting this toggle to {@code false} has a similar effect to
+     * registering a MeterFilter that removes unit and description from all registered
+     * meters.
      * @return true if metadata should be exported, false otherwise.
      * @since 1.12.0
      */

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -133,6 +133,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
      */
     @Override
     public void export(List<Meter> meters) {
+        Map<String, String> seenMetadata = null;
+        if (config.exportMeterMetadata()) {
+            seenMetadata = new HashMap<>();
+        }
+
         int partitionSize = Math.min(config.batchSize(), DynatraceMetricApiConstants.getPayloadLinesLimit());
         List<String> batch = new ArrayList<>(partitionSize);
 
@@ -140,33 +145,51 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             // Lines that are too long to be ingested into Dynatrace, as well as lines
             // that contain NaN or Inf values are not returned from "toMetricLines",
             // and are therefore dropped.
-            Stream<String> metricLines = toMetricLines(meter);
+            Stream<String> metricLines = toMetricLines(meter, seenMetadata);
 
             metricLines.forEach(line -> {
                 batch.add(line);
-                if (batch.size() == partitionSize) {
-                    send(batch);
-                    batch.clear();
+                trySendBatch(batch, partitionSize);
+            });
+        }
+
+        // if the config to export metadata is turned off, the seenMetadata map will be
+        // null.
+        if (seenMetadata != null) {
+            seenMetadata.values().forEach(line -> {
+                if (line != null) {
+                    batch.add(line);
+                    trySendBatch(batch, partitionSize);
                 }
             });
         }
 
+        // push remaining lines if any.
         if (!batch.isEmpty()) {
             send(batch);
         }
     }
 
-    private Stream<String> toMetricLines(Meter meter) {
-        return meter.match(this::toGaugeLine, this::toCounterLine, this::toTimerLine, this::toDistributionSummaryLine,
-                this::toLongTaskTimerLine, this::toTimeGaugeLine, this::toFunctionCounterLine,
-                this::toFunctionTimerLine, this::toMeterLine);
+    private void trySendBatch(List<String> batch, int partitionSize) {
+        if (batch.size() == partitionSize) {
+            send(batch);
+            batch.clear();
+        }
     }
 
-    Stream<String> toGaugeLine(Gauge meter) {
-        return toMeterLine(meter, this::createGaugeLine);
+    private Stream<String> toMetricLines(Meter meter, Map<String, String> seenMetadata) {
+        return meter.match(m -> toGaugeLine(m, seenMetadata), m -> toCounterLine(m, seenMetadata),
+                m -> toTimerLine(m, seenMetadata), m -> toDistributionSummaryLine(m, seenMetadata),
+                m -> toLongTaskTimerLine(m, seenMetadata), m -> toTimeGaugeLine(m, seenMetadata),
+                m -> toFunctionCounterLine(m, seenMetadata), m -> toFunctionTimerLine(m, seenMetadata),
+                m -> toGaugeLine(m, seenMetadata));
     }
 
-    private String createGaugeLine(Meter meter, Measurement measurement) {
+    Stream<String> toGaugeLine(Meter meter, Map<String, String> seenMetadata) {
+        return toMeterLine(meter, (theMeter, measurement) -> createGaugeLine(theMeter, seenMetadata, measurement));
+    }
+
+    private String createGaugeLine(Meter meter, Map<String, String> seenMetadata, Measurement measurement) {
         try {
             double value = measurement.getValue();
             if (Double.isNaN(value)) {
@@ -186,7 +209,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         meter.getId().getName()));
                 return null;
             }
-            return createMetricBuilder(meter).setDoubleGaugeValue(value).serialize();
+            Metric.Builder metricBuilder = createMetricBuilder(meter).setDoubleGaugeValue(value);
+
+            storeMetadataLine(metricBuilder, seenMetadata);
+
+            return metricBuilder.serializeMetricLine();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -195,13 +222,59 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return null;
     }
 
-    Stream<String> toCounterLine(Counter meter) {
-        return toMeterLine(meter, this::createCounterLine);
+    private void storeMetadataLine(Metric.Builder metricBuilder, Map<String, String> seenMetadata)
+            throws MetricException {
+        // if the config to export metadata is turned off, the seenMetadata map will be
+        // null.
+        if (seenMetadata == null) {
+            return;
+        }
+
+        String key = metricBuilder.getNormalizedMetricKey();
+
+        if (!seenMetadata.containsKey(key)) {
+            // if there is no metadata associated with the key, add it.
+            seenMetadata.put(key, metricBuilder.serializeMetadataLine());
+        }
+        else {
+            // get the previously stored metadata line
+            String previousMetadataLine = seenMetadata.get(key);
+            // if the previous line is not null, a metadata object had already been set in
+            // the past and no conflicting metadata lines had been added thereafter.
+            if (previousMetadataLine != null) {
+                String newMetadataLine = metricBuilder.serializeMetadataLine();
+                // if the new metadata line conflicts with the old one, we don't know
+                // which one is the correct metadata and will not export any.
+                // the map entry is set to null to ensure other metadata lines cannot be
+                // set for this metric key.
+                if (!previousMetadataLine.equals(newMetadataLine)) {
+                    seenMetadata.put(key, null);
+                    logger.warn(
+                            "Metadata discrepancy detected:\n" + "original metadata:\t{}\n" + "tried to set new:\t{}\n"
+                                    + "Metadata for metric key {} will not be sent.",
+                            previousMetadataLine, newMetadataLine, key);
+                }
+            }
+            // else:
+            // the key exists, but the value is null, so a conflicting state has been
+            // identified before. we will ignore any other metadata for this key, so there
+            // is nothing to do here.
+        }
     }
 
-    private String createCounterLine(Meter meter, Measurement measurement) {
+    Stream<String> toCounterLine(Counter counter, Map<String, String> seenMetadata) {
+        return toMeterLine(counter,
+                (Meter meter, Measurement measurement) -> this.createCounterLine(meter, seenMetadata, measurement));
+    }
+
+    private String createCounterLine(Meter meter, Map<String, String> seenMetadata, Measurement measurement) {
         try {
-            return createMetricBuilder(meter).setDoubleCounterValueDelta(measurement.getValue()).serialize();
+            Metric.Builder metricBuilder = createMetricBuilder(meter)
+                .setDoubleCounterValueDelta(measurement.getValue());
+
+            storeMetadataLine(metricBuilder, seenMetadata);
+
+            return metricBuilder.serializeMetricLine();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -210,9 +283,9 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return null;
     }
 
-    Stream<String> toTimerLine(Timer meter) {
+    Stream<String> toTimerLine(Timer meter, Map<String, String> seenMetadata) {
         if (!(meter instanceof DynatraceSummarySnapshotSupport)) {
-            return toSummaryLine(meter, meter.takeSnapshot(), getBaseTimeUnit());
+            return toSummaryLine(meter, seenMetadata, meter.takeSnapshot(), getBaseTimeUnit());
         }
 
         DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
@@ -222,10 +295,12 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return Stream.empty();
         }
 
-        return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(), snapshot.getCount());
+        return createSummaryLine(meter, seenMetadata, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(),
+                snapshot.getCount());
     }
 
-    private Stream<String> toSummaryLine(Meter meter, HistogramSnapshot histogramSnapshot, TimeUnit timeUnit) {
+    private Stream<String> toSummaryLine(Meter meter, Map<String, String> seenMetadata,
+            HistogramSnapshot histogramSnapshot, TimeUnit timeUnit) {
         long count = histogramSnapshot.count();
         if (count < 1) {
             logger.debug("Summary with 0 count dropped: {}", meter.getId().getName());
@@ -234,7 +309,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         double total = (timeUnit != null) ? histogramSnapshot.total(timeUnit) : histogramSnapshot.total();
         double max = (timeUnit != null) ? histogramSnapshot.max(timeUnit) : histogramSnapshot.max();
         double min = (count == 1) ? max : minFromHistogramSnapshot(histogramSnapshot, timeUnit);
-        return createSummaryLine(meter, min, max, total, count);
+        return createSummaryLine(meter, seenMetadata, min, max, total, count);
     }
 
     private double minFromHistogramSnapshot(HistogramSnapshot histogramSnapshot, TimeUnit timeUnit) {
@@ -247,10 +322,14 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return Double.NaN;
     }
 
-    private Stream<String> createSummaryLine(Meter meter, double min, double max, double total, long count) {
+    private Stream<String> createSummaryLine(Meter meter, Map<String, String> seenMetadata, double min, double max,
+            double total, long count) {
         try {
-            String line = createMetricBuilder(meter).setDoubleSummaryValue(min, max, total, count).serialize();
-            return Stream.of(line);
+            Metric.Builder builder = createMetricBuilder(meter).setDoubleSummaryValue(min, max, total, count);
+
+            storeMetadataLine(builder, seenMetadata);
+
+            return Stream.of(builder.serializeMetricLine());
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -259,9 +338,9 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return Stream.empty();
     }
 
-    Stream<String> toDistributionSummaryLine(DistributionSummary meter) {
+    Stream<String> toDistributionSummaryLine(DistributionSummary meter, Map<String, String> seenMetadata) {
         if (!(meter instanceof DynatraceSummarySnapshotSupport)) {
-            return toSummaryLine(meter, meter.takeSnapshot(), null);
+            return toSummaryLine(meter, seenMetadata, meter.takeSnapshot(), null);
         }
 
         DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter).takeSummarySnapshotAndReset();
@@ -270,22 +349,23 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return Stream.empty();
         }
 
-        return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(), snapshot.getCount());
+        return createSummaryLine(meter, seenMetadata, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(),
+                snapshot.getCount());
     }
 
-    Stream<String> toLongTaskTimerLine(LongTaskTimer meter) {
-        return toSummaryLine(meter, meter.takeSnapshot(), getBaseTimeUnit());
+    Stream<String> toLongTaskTimerLine(LongTaskTimer meter, Map<String, String> seenMetadata) {
+        return toSummaryLine(meter, seenMetadata, meter.takeSnapshot(), getBaseTimeUnit());
     }
 
-    Stream<String> toTimeGaugeLine(TimeGauge meter) {
-        return toMeterLine(meter, this::createGaugeLine);
+    Stream<String> toTimeGaugeLine(TimeGauge meter, Map<String, String> seenMetadata) {
+        return toMeterLine(meter, (theMeter, measurement) -> createGaugeLine(theMeter, seenMetadata, measurement));
     }
 
-    Stream<String> toFunctionCounterLine(FunctionCounter meter) {
-        return toMeterLine(meter, this::createCounterLine);
+    Stream<String> toFunctionCounterLine(FunctionCounter meter, Map<String, String> seenMetadata) {
+        return toMeterLine(meter, (theMeter, measurement) -> createCounterLine(theMeter, seenMetadata, measurement));
     }
 
-    Stream<String> toFunctionTimerLine(FunctionTimer meter) {
+    Stream<String> toFunctionTimerLine(FunctionTimer meter, Map<String, String> seenMetadata) {
         long count = (long) meter.count();
         if (count < 1) {
             logger.debug("Timer with 0 count dropped: {}", meter.getId().getName());
@@ -294,11 +374,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         double total = meter.totalTime(getBaseTimeUnit());
         double average = meter.mean(getBaseTimeUnit());
 
-        return createSummaryLine(meter, average, average, total, count);
+        return createSummaryLine(meter, seenMetadata, average, average, total, count);
     }
 
-    Stream<String> toMeterLine(Meter meter) {
-        return toMeterLine(meter, this::createGaugeLine);
+    Stream<String> toMeterLine(Meter meter, Map<String, String> seenMetadata) {
+        return toMeterLine(meter, (theMeter, measurement) -> createGaugeLine(theMeter, seenMetadata, measurement));
     }
 
     private Stream<String> toMeterLine(Meter meter, BiFunction<Meter, Measurement, String> measurementConverter) {
@@ -309,7 +389,9 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private Metric.Builder createMetricBuilder(Meter meter) {
         return metricBuilderFactory.newMetricBuilder(meter.getId().getName())
             .setDimensions(fromTags(meter.getId().getTags()))
-            .setTimestamp(Instant.ofEpochMilli(clock.wallTime()));
+            .setTimestamp(Instant.ofEpochMilli(clock.wallTime()))
+            .setUnit(meter.getId().getBaseUnit())
+            .setDescription(meter.getId().getDescription());
     }
 
     private DimensionList fromTags(List<Tag> tags) {

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
@@ -171,9 +171,33 @@ class DynatraceConfigTest {
         assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V2);
         assertThat(config.apiToken()).isEmpty();
         assertThat(config.uri()).isSameAs(DynatraceMetricApiConstants.getDefaultOneAgentEndpoint());
+        assertThat(config.deviceId()).isEmpty();
         assertThat(config.metricKeyPrefix()).isEmpty();
         assertThat(config.defaultDimensions()).isEmpty();
         assertThat(config.enrichWithDynatraceMetadata()).isTrue();
+        assertThat(config.exportMeterMetadata()).isTrue();
+
+        Validated<?> validated = config.validate();
+        assertThat(validated.isValid()).isTrue();
+    }
+
+    @Test
+    void testV1Defaults() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("dynatrace.apiVersion", "v1");
+        properties.put("dynatrace.apiToken", "my.token");
+        properties.put("dynatrace.uri", "https://my.uri.com");
+        properties.put("dynatrace.deviceId", "my.device.id");
+        DynatraceConfig config = properties::get;
+
+        assertThat(config.apiVersion()).isEqualTo(DynatraceApiVersion.V1);
+        assertThat(config.apiToken()).isEqualTo("my.token");
+        assertThat(config.uri()).isEqualTo("https://my.uri.com");
+        assertThat(config.deviceId()).isEqualTo("my.device.id");
+        assertThat(config.metricKeyPrefix()).isEmpty();
+        assertThat(config.defaultDimensions()).isEmpty();
+        assertThat(config.enrichWithDynatraceMetadata()).isFalse();
+        assertThat(config.exportMeterMetadata()).isFalse();
 
         Validated<?> validated = config.validate();
         assertThat(validated.isValid()).isTrue();


### PR DESCRIPTION
resolves #3979

Metadata (unit and description) can be sent to the Dynatrace metrics API in a special format. This addition will automatically create these lines if unit and/or description are set on the respective Micrometer meter. The feature is turned on by default and can be turned off by toggling the `exportMeterMetadata` switch.