### PR TITLE
Use 5.10.+ for junit-bom

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -95,7 +95,7 @@ def VERSIONS = [
 def PLATFORM_BOMS = [
         'io.projectreactor:reactor-bom:2020.0.+',
         'io.netty:netty-bom:4.1.+',
-        'org.junit:junit-bom:5.9.+', // Not using latest.release to avoid using a milestone version.
+        'org.junit:junit-bom:5.10.+', // Not using latest.release to avoid using a milestone version.
 ]
 
 subprojects {


### PR DESCRIPTION
This PR changes to use `5.10.+` for `org.junit:junit-bom`.