### PR TITLE
Add xxxKeyValue() variants with KeyValue to ObservationContextAssert

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -253,6 +253,16 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Return whether it has the given low cardinality key value.
+     * @param keyValue key value
+     * @return whether it has the given low cardinality key value
+     * @since 1.12.0
+     */
+    public SELF hasLowCardinalityKeyValue(KeyValue keyValue) {
+        return hasLowCardinalityKeyValue(keyValue.getKey(), keyValue.getValue());
+    }
+
     public SELF doesNotHaveLowCardinalityKeyValueWithKey(String key) {
         isNotNull();
         if (this.actual.getLowCardinalityKeyValues().stream().anyMatch(tag -> tag.getKey().equals(key))) {
@@ -276,6 +286,16 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
                     value);
         }
         return (SELF) this;
+    }
+
+    /**
+     * Return whether it does not have the given low cardinality key value.
+     * @param keyValue key value
+     * @return whether it does not have the given low cardinality key value
+     * @since 1.12.0
+     */
+    public SELF doesNotHaveLowCardinalityKeyValue(KeyValue keyValue) {
+        return doesNotHaveLowCardinalityKeyValue(keyValue.getKey(), keyValue.getValue());
     }
 
     public SELF hasHighCardinalityKeyValueWithKey(String key) {
@@ -305,6 +325,16 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         return (SELF) this;
     }
 
+    /**
+     * Return whether it has the given high cardinality key value.
+     * @param keyValue key value
+     * @return whether it has the given high cardinality key value
+     * @since 1.12.0
+     */
+    public SELF hasHighCardinalityKeyValue(KeyValue keyValue) {
+        return hasHighCardinalityKeyValue(keyValue.getKey(), keyValue.getValue());
+    }
+
     public SELF doesNotHaveHighCardinalityKeyValueWithKey(String key) {
         isNotNull();
         if (this.actual.getHighCardinalityKeyValues().stream().anyMatch(tag -> tag.getKey().equals(key))) {
@@ -328,6 +358,16 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
                     value);
         }
         return (SELF) this;
+    }
+
+    /**
+     * Return whether it does not have the given high cardinality key value.
+     * @param keyValue key value
+     * @return whether it does not have the given high cardinality key value
+     * @since 1.12.0
+     */
+    public SELF doesNotHaveHighCardinalityKeyValue(KeyValue keyValue) {
+        return doesNotHaveHighCardinalityKeyValue(keyValue.getKey(), keyValue.getValue());
     }
 
     public SELF hasMapEntry(Object key, Object value) {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.observation.tck;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -237,7 +238,8 @@ class ObservationContextAssertTests {
         Observation observation = Observation.start("foo", context, registry);
         observation.lowCardinalityKeyValue("foo", "bar");
 
-        thenNoException().isThrownBy(() -> assertThat(context).hasLowCardinalityKeyValue("foo", "bar"));
+        thenNoException().isThrownBy(() -> assertThat(context).hasLowCardinalityKeyValue("foo", "bar")
+            .hasLowCardinalityKeyValue(KeyValue.of("foo", "bar")));
     }
 
     @Test
@@ -256,7 +258,8 @@ class ObservationContextAssertTests {
         Observation observation = Observation.start("foo", context, registry);
         observation.highCardinalityKeyValue("foo", "bar");
 
-        thenNoException().isThrownBy(() -> assertThat(context).hasHighCardinalityKeyValue("foo", "bar"));
+        thenNoException().isThrownBy(() -> assertThat(context).hasHighCardinalityKeyValue("foo", "bar")
+            .hasHighCardinalityKeyValue(KeyValue.of("foo", "bar")));
     }
 
     @Test
@@ -272,7 +275,8 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_high_cardinality_key_value_present() {
-        thenNoException().isThrownBy(() -> assertThat(context).doesNotHaveHighCardinalityKeyValue("foo", "bar"));
+        thenNoException().isThrownBy(() -> assertThat(context).doesNotHaveHighCardinalityKeyValue("foo", "bar")
+            .doesNotHaveHighCardinalityKeyValue(KeyValue.of("foo", "bar")));
     }
 
     @Test
@@ -299,7 +303,8 @@ class ObservationContextAssertTests {
 
     @Test
     void should_not_throw_exception_when_low_cardinality_key_value_missing() {
-        thenNoException().isThrownBy(() -> assertThat(context).doesNotHaveLowCardinalityKeyValue("foo", "bar"));
+        thenNoException().isThrownBy(() -> assertThat(context).doesNotHaveLowCardinalityKeyValue("foo", "bar")
+            .doesNotHaveLowCardinalityKeyValue(KeyValue.of("foo", "bar")));
     }
 
     @Test


### PR DESCRIPTION
While working on #4037, `xxxKeyValue()` variants with `KeyValue` in `ObservationContextAssert` seem to be useful, so this PR adds them.