### PR TITLE
Use exponential backoff when retrying connecting to statsd via UDP

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -247,7 +247,9 @@ public class StatsdMeterRegistry extends MeterRegistry {
             .remoteAddress(remoteAddress)
             .handle((in, out) -> out.sendString(publisher)
                 .neverComplete()
-                .retryWhen(Retry.indefinitely().filter(throwable -> throwable instanceof PortUnreachableException)))
+                .retryWhen(Retry.backoff(Long.MAX_VALUE, Duration.ofSeconds(1))
+                    .maxBackoff(Duration.ofSeconds(10))
+                    .filter(throwable -> throwable instanceof PortUnreachableException)))
             .doOnDisconnected(connection -> {
                 Boolean connectionDisposed = connection.channel().attr(CONNECTION_DISPOSED).getAndSet(Boolean.TRUE);
                 if (connectionDisposed == null || !connectionDisposed) {


### PR DESCRIPTION
When connecting to a statsd server via UDP, `StatsdMeterRegistry` will retry the connection attempt indefinitely and without delay if the connection cannot be established immediately. In a scenario where an application container is launching alongside a statsd sidecar container, it may be the case that the statsd container will not be ready immediately when the application container starts. This can lead to excessive CPU consumption and the logging of thousands or even millions of spurious warnings.

This change moves from an indefinite/immediate retry strategy to an indefinite/exponential backoff strategy. This should _dramatically_ reduce resource consumption and log production in cases where statsd isn't immediately available, and it fixes #2624.