### PR TITLE
Suppress unchecked warning in StepFunctionCounterTest.closingRolloverPartialStep()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -67,6 +67,7 @@ class StepFunctionCounterTest {
     @Test
     void closingRolloverPartialStep() {
         AtomicInteger n = new AtomicInteger(3);
+        @SuppressWarnings("unchecked")
         StepFunctionCounter<AtomicInteger> counter = (StepFunctionCounter) registry.more()
             .counter("my.counter", Tags.empty(), n);
 


### PR DESCRIPTION
This PR suppresses an unchecked warning in the `StepFunctionCounterTest.closingRolloverPartialStep()`.