### PR TITLE
Allow waiting instead of dropping data in `duplicate call to publish()`.

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceConfig.java
@@ -21,6 +21,7 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.step.StepRegistryConfig;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -163,6 +164,11 @@ public interface DynatraceConfig extends StepRegistryConfig {
             return false;
         }
         return getBoolean(this, "exportMeterMetadata").orElse(true);
+    }
+
+    @Override
+    default Duration overlappingShutdownWaitTimeout() {
+        return getDuration(this, "overlappingShutdownWaitTimeout").orElse(Duration.ofSeconds(5));
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -141,7 +141,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
                         config.overlappingShutdownWaitTimeout().toMillis());
 
                 ExecutorService executor = Executors.newSingleThreadExecutor();
-                FutureTask futureTask = new FutureTask(() -> {
+                FutureTask<Void> futureTask = new FutureTask<>(() -> {
                     while (isPublishing()) {
                         // check if the export is already finished every 50ms.
                         Thread.sleep(50);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushRegistryConfig.java
@@ -82,6 +82,10 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
         return getDuration(this, "readTimeout").orElse(Duration.ofSeconds(10));
     }
 
+    default Duration overlappingShutdownWaitTimeout() {
+        return getDuration(this, "overlappingShutdownWaitTimeout").orElse(Duration.ZERO);
+    }
+
     /**
      * @return The number of measurements per request to use for the backend. If more
      * measurements are found, then multiple requests will be made. The default is 10,000.
@@ -105,6 +109,7 @@ public interface PushRegistryConfig extends MeterRegistryConfig {
         return checkAll(config, check("step", PushRegistryConfig::step),
                 check("connectTimeout", PushRegistryConfig::connectTimeout),
                 check("readTimeout", PushRegistryConfig::readTimeout),
+                check("overlappingShutdownWaitTimeout", PushRegistryConfig::overlappingShutdownWaitTimeout),
                 check("batchSize", PushRegistryConfig::batchSize), check("numThreads", PushRegistryConfig::numThreads));
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -39,7 +39,6 @@ import java.util.stream.LongStream;
 
 import static java.util.concurrent.TimeUnit.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 
 /**
  * Tests for {@link PushMeterRegistry}.

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -158,6 +158,7 @@ class PushMeterRegistryTest {
     }
 
     @Test
+    @Issue("#3872")
     void scheduledPublishInterruptedByCloseWillDropData_whenShutdownTimeoutIsZero()
             throws InterruptedException, BrokenBarrierException, TimeoutException {
 
@@ -200,7 +201,7 @@ class PushMeterRegistryTest {
                 publishWorkBarrier, publishFinishedBarrier);
         registry.start(threadFactory);
 
-        // first export cycle starts here
+        // data collection for the first export cycle starts here
 
         Counter counter = registry.counter("counter");
         counter.increment(3);
@@ -209,39 +210,45 @@ class PushMeterRegistryTest {
         assertThat(registry.getMeasurements()).isEmpty();
         assertThat(registry.getNumExports()).isZero();
 
-        // # first export
+        // first export: everything goes according to plan, no overlaps.
         clock.add(config.step());
         // wait until publish has started from the timed invocation.
         publishStartedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
         // artificial work finishes.
         publishWorkBarrier.await(barrierTimeoutMillis, MILLISECONDS);
-        // second export cycle starts here
-
         // wait for the publish to finish. Ensures values are processed when retrieving
         // them from the registry
         publishFinishedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
 
+        // data collection for the second export cycle starts here.
+        // before continuing to the second export, assert on data from the first cycle:
         assertThat(registry.getNumExports()).isOne();
         assertThat(registry.getMeasurements()).hasSize(1);
         assertThat(registry.getMeasurements().get(0)).isCloseTo(3, tolerance);
 
+        // record data in the second export interval
         clock.add(config.step().dividedBy(2));
         counter.increment(4);
         clock.add(config.step().dividedBy(2));
 
+        // second export: will be interrupted by a shutdown signal
         // wait until the second publish starts
         publishStartedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
 
-        // third export cycle starts here, since we waited for the publishStartedBarrier
-        // above we know that publishing is in progress
+        // data collection for the third export cycle starts here.
+        // Since we waited for the publishStartedBarrier above, we know that publishing is
+        // in progress
 
         // close registry while export is still running. When close returns, the
         // application exits.
+        // The overlapping duration timeout is zero in this case, so close will return
+        // immediately, since publishing is already in progress.
         registry.close();
 
-        // value has not yet rolled over, and we export the value from the previous export
-        // and only 1 export finished
-        // THIS IS A STALE STATE, the last export was not finished.
+        // value has not yet rolled over, and the last exported data is from the previous
+        // export.
+        // THIS IS A STALE STATE, the last export was not finished and the final exported
+        // state is "old" data.
         assertThat(registry.getNumExports()).isOne();
         assertThat(registry.getMeasurements()).hasSize(1);
         assertThat(registry.getMeasurements().get(0)).isCloseTo(3, tolerance);
@@ -250,7 +257,7 @@ class PushMeterRegistryTest {
         publishWorkBarrier.await(barrierTimeoutMillis, MILLISECONDS);
 
         // This would not happen when registry.close() is called, as the app will wait for
-        // waits for close() to finish, then shut down immediately.
+        // close() to finish, then shut down immediately.
         // In this test, we can see that it _would_ fix itself if we waited for the
         // already in-progress publish to finish.
         publishFinishedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
@@ -261,6 +268,7 @@ class PushMeterRegistryTest {
     }
 
     @Test
+    @Issue("#3872")
     void scheduledPublishInterruptedByCloseWillNotDropData_whenShutdownTimeoutIsBigEnough()
             throws InterruptedException, BrokenBarrierException, TimeoutException, ExecutionException {
 
@@ -304,7 +312,7 @@ class PushMeterRegistryTest {
                 publishWorkBarrier, publishFinishedBarrier);
         registry.start(threadFactory);
 
-        // first export cycle starts here
+        // data collection for first export cycle starts here.
 
         Counter counter = registry.counter("counter");
         counter.increment(3);
@@ -313,35 +321,42 @@ class PushMeterRegistryTest {
         assertThat(registry.getMeasurements()).isEmpty();
         assertThat(registry.getNumExports()).isZero();
 
-        // # first export
+        // first export: no overlap, everything works as expected.
         clock.add(config.step());
+
         // wait until publish has started from the timed invocation.
         publishStartedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
         // do not do any artificial work.
         publishWorkBarrier.await(barrierTimeoutMillis, MILLISECONDS);
 
-        // second export cycle starts here
-
-        // wait for the publish to finish. Ensures values are processed when retrieving
-        // them from the registry
+        // wait for the first publish to finish. Ensures values are processed when
+        // retrieving them from the registry
         publishFinishedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
+
+        // data collection for the second export cycle starts
+        // First assert on the data exported in the first cycle:
 
         assertThat(registry.getNumExports()).isOne();
         assertThat(registry.getMeasurements()).hasSize(1);
         assertThat(registry.getMeasurements().get(0)).isCloseTo(3, tolerance);
 
+        // add data for the second export
         clock.add(config.step().dividedBy(2));
         counter.increment(4);
         clock.add(config.step().dividedBy(2));
 
+        // second publish: will be interrupted by the shutdown signal, but will wait for
+        // the export to finish since the timeout is big enough.
         // wait until the second publish starts
         publishStartedBarrier.await(barrierTimeoutMillis, MILLISECONDS);
-        // third export cycle starts here, we're waiting for artificial work to be done
+        // data collection for the third export cycle starts here.
 
         // close registry while export is still running. When close returns, the
         // application exits. Since the overlappingShutdownWaitTimeout is large enough,
         // registry.close() will wait until the scheduled export is finished.
         assertThat(registry.isPublishing()).isTrue();
+        // Run close from a background thread, to ensure this is happening at the same
+        // time as the export already in progress:
         ExecutorService executor = Executors.newSingleThreadExecutor();
         executor.submit(registry::close);
         var assertionFuture = executor.submit(() -> {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -367,7 +367,6 @@ class PushMeterRegistryTest {
         CyclicBarrier barrier = new CyclicBarrier(2);
         OverlappingStepMeterRegistry overlappingStepMeterRegistry = new OverlappingStepMeterRegistry(config, clock,
                 barrier);
-
         Counter c1 = overlappingStepMeterRegistry.counter("c1");
         Counter c2 = overlappingStepMeterRegistry.counter("c2");
         c1.increment();
@@ -384,7 +383,6 @@ class PushMeterRegistryTest {
         onClosePublishThread.start();
         scheduledPublishingThread.join();
         onClosePublishThread.join();
-        // myThreadFactory.join();
 
         assertThat(overlappingStepMeterRegistry.publishes).as("only one publish happened").hasSize(1);
         Deque<Double> firstPublishValues = overlappingStepMeterRegistry.publishes.get(0);


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/micrometer/issues/3872

When the scheduled publish is already in progress when `close()` is called on the registry, the `duplicate call to publish()` error will show up and the data from the last export will be dropped. This is the intended behavior in Micrometer (influence the application lifecycle as little as possible). See #3872 and #3832 for more details. 

To honor the commitment to not influencing shutdown, I implemented this in a way where the current behavior does not change unless the user explicitly opts in. For the Dynatrace exporter, I added a higher timeout by default, as multiple of our customers asked us to ensure they can rely on the final export. It is still possible to opt-out for users of the dynatrace-registry by setting the timeout to zero.