### PR TITLE
[Dynatrace v2] Update to utils library v2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ def VERSIONS = [
         'ch.qos.logback:logback-classic:1.2.+',
         'colt:colt:1.2.0',
         'com.amazonaws:aws-java-sdk-cloudwatch:latest.release',
-        'com.dynatrace.metric.util:dynatrace-metric-utils-java:1.+',
+        'com.dynatrace.metric.util:dynatrace-metric-utils-java:latest.release',
         'com.fasterxml.jackson.core:jackson-databind:latest.release',
         'com.github.ben-manes.caffeine:caffeine:2.+',
         'com.github.charithe:kafka-junit:latest.release',

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -67,8 +67,6 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source",
             "micrometer");
 
-    private static final int MINIMUM_CAPACITY = 64;
-
     // This should be non-static for MockLoggerFactory.injectLogger() in tests.
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
 
@@ -127,9 +125,9 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     private Map<String, String> enrichWithMetricsSourceDimension(Map<String, String> defaultDimensions) {
-        LinkedHashMap<String, String> orderDimensions = new LinkedHashMap<>(defaultDimensions);
-        orderDimensions.putAll(staticDimensions);
-        return orderDimensions;
+        LinkedHashMap<String, String> orderedDimensions = new LinkedHashMap<>(defaultDimensions);
+        orderedDimensions.putAll(staticDimensions);
+        return orderedDimensions;
     }
 
     /**
@@ -531,7 +529,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return null;
         }
 
-        StringBuilder metricKey = new StringBuilder(MINIMUM_CAPACITY);
+        StringBuilder metricKey = new StringBuilder(32);
 
         for (int i = 1; i < metadataLine.length(); i++) {
             char c = metadataLine.charAt(i);

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -536,6 +536,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
         StringBuilder metricKey = new StringBuilder(32);
 
+        // Start at index 1 as index 0 will always be '#'
         for (int i = 1; i < metadataLine.length(); i++) {
             char c = metadataLine.charAt(i);
             if (c == ' ' || c == ',') {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -222,11 +222,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         meter.getId().getName()));
                 return null;
             }
-            MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
+            MetricLineBuilder.GaugeStep gaugeStep = createTypeStep(meter).gauge();
 
-            storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
+            storeMetadataLine(createMetadataStep(gaugeStep, meter), seenMetadata);
 
-            return metricBuilder.value(value).timestamp(Instant.ofEpochMilli(clock.wallTime())).build();
+            return gaugeStep.value(value).timestamp(Instant.ofEpochMilli(clock.wallTime())).build();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -242,11 +242,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private String createCounterLine(Meter meter, Map<String, String> seenMetadata, Measurement measurement) {
         try {
-            MetricLineBuilder.CounterStep metricBuilder = createMetricBuilder(meter).count();
+            MetricLineBuilder.CounterStep counterStep = createTypeStep(meter).count();
 
-            storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
+            storeMetadataLine(createMetadataStep(counterStep, meter), seenMetadata);
 
-            return metricBuilder.delta(measurement.getValue())
+            return counterStep.delta(measurement.getValue())
                 .timestamp(Instant.ofEpochMilli(clock.wallTime()))
                 .build();
         }
@@ -299,7 +299,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private Stream<String> createSummaryLine(Meter meter, Map<String, String> seenMetadata, double min, double max,
             double total, long count) {
         try {
-            MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
+            MetricLineBuilder.GaugeStep metricBuilder = createTypeStep(meter).gauge();
 
             storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
 
@@ -391,14 +391,14 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             .filter(Objects::nonNull);
     }
 
-    private MetricLineBuilder.TypeStep createMetricBuilder(Meter meter) throws MetricException {
-        MetricLineBuilder.TypeStep metricLineBuilder = MetricLineBuilder.create(preConfiguration)
+    private MetricLineBuilder.TypeStep createTypeStep(Meter meter) throws MetricException {
+        MetricLineBuilder.TypeStep typeStep = MetricLineBuilder.create(preConfiguration)
             .metricKey(meter.getId().getName());
         for (Tag tag : meter.getId().getTags()) {
-            metricLineBuilder.dimension(tag.getKey(), tag.getValue());
+            typeStep.dimension(tag.getKey(), tag.getValue());
         }
 
-        return metricLineBuilder;
+        return typeStep;
     }
 
     private <T> Stream<T> streamOf(Iterable<T> iterable) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -68,25 +67,38 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source",
             "micrometer");
 
+    private static final int MINIMUM_CAPACITY = 64;
+
     // This should be non-static for MockLoggerFactory.injectLogger() in tests.
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
 
-    private final MetricBuilderFactory metricBuilderFactory;
+    private MetricLinePreConfiguration preConfiguration;
+
+    private boolean skipExport = false;
 
     public DynatraceExporterV2(DynatraceConfig config, Clock clock, HttpSender httpClient) {
         super(config, clock, httpClient);
 
         logger.info("Exporting to endpoint {}", config.uri());
 
-        MetricBuilderFactory.MetricBuilderFactoryBuilder factoryBuilder = MetricBuilderFactory.builder()
-            .withPrefix(config.metricKeyPrefix())
-            .withDefaultDimensions(parseDefaultDimensions(config.defaultDimensions()));
+        try {
+            MetricLinePreConfiguration.Builder preConfigBuilder = MetricLinePreConfiguration.builder()
+                .prefix(config.metricKeyPrefix())
+                .defaultDimensions(enrichWithMetricsSourceDimension(config.defaultDimensions()));
 
-        if (config.enrichWithDynatraceMetadata()) {
-            factoryBuilder.withDynatraceMetadata();
+            if (config.enrichWithDynatraceMetadata()) {
+                preConfigBuilder.dynatraceMetadataDimensions();
+            }
+
+            preConfiguration = preConfigBuilder.build();
         }
-
-        metricBuilderFactory = factoryBuilder.build();
+        catch (MetricException e) {
+            // if the preconfiguration is invalid, all created metric lines would be
+            // invalid, and exporting any line becomes useless. Therefore, we log an
+            // error, and don't export at all.
+            logger.error(e.getMessage());
+            skipExport = true;
+        }
     }
 
     private boolean isValidEndpoint(String uri) {
@@ -114,12 +126,10 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return false;
     }
 
-    private DimensionList parseDefaultDimensions(Map<String, String> defaultDimensions) {
-        List<Dimension> dimensions = Stream
-            .concat(defaultDimensions.entrySet().stream(), staticDimensions.entrySet().stream())
-            .map(entry -> Dimension.create(entry.getKey(), entry.getValue()))
-            .collect(Collectors.toList());
-        return DimensionList.fromCollection(dimensions);
+    private Map<String, String> enrichWithMetricsSourceDimension(Map<String, String> defaultDimensions) {
+        LinkedHashMap<String, String> orderDimensions = new LinkedHashMap<>(defaultDimensions);
+        orderDimensions.putAll(staticDimensions);
+        return orderDimensions;
     }
 
     /**
@@ -133,6 +143,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
      */
     @Override
     public void export(List<Meter> meters) {
+        if (skipExport) {
+            logger.warn("Dynatrace configuration is invalid, skipping export.");
+            return;
+        }
+
         Map<String, String> seenMetadata = null;
         if (config.exportMeterMetadata()) {
             seenMetadata = new HashMap<>();
@@ -209,11 +224,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         meter.getId().getName()));
                 return null;
             }
-            Metric.Builder metricBuilder = createMetricBuilder(meter).setDoubleGaugeValue(value);
+            MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
 
-            storeMetadataLine(metricBuilder, seenMetadata);
+            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
 
-            return metricBuilder.serializeMetricLine();
+            return metricBuilder.value(value).timestamp(Instant.ofEpochMilli(clock.wallTime())).build();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -229,12 +244,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private String createCounterLine(Meter meter, Map<String, String> seenMetadata, Measurement measurement) {
         try {
-            Metric.Builder metricBuilder = createMetricBuilder(meter)
-                .setDoubleCounterValueDelta(measurement.getValue());
+            MetricLineBuilder.CounterStep metricBuilder = createMetricBuilder(meter).count();
 
-            storeMetadataLine(metricBuilder, seenMetadata);
+            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
 
-            return metricBuilder.serializeMetricLine();
+            return metricBuilder.delta(measurement.getValue())
+                .timestamp(Instant.ofEpochMilli(clock.wallTime()))
+                .build();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -285,11 +301,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private Stream<String> createSummaryLine(Meter meter, Map<String, String> seenMetadata, double min, double max,
             double total, long count) {
         try {
-            Metric.Builder builder = createMetricBuilder(meter).setDoubleSummaryValue(min, max, total, count);
+            MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
 
-            storeMetadataLine(builder, seenMetadata);
+            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
 
-            return Stream.of(builder.serializeMetricLine());
+            return Stream.of(metricBuilder.summary(min, max, total, count)
+                .timestamp(Instant.ofEpochMilli(clock.wallTime()))
+                .build());
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -375,17 +393,14 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             .filter(Objects::nonNull);
     }
 
-    private Metric.Builder createMetricBuilder(Meter meter) {
-        return metricBuilderFactory.newMetricBuilder(meter.getId().getName())
-            .setDimensions(fromTags(meter.getId().getTags()))
-            .setTimestamp(Instant.ofEpochMilli(clock.wallTime()))
-            .setUnit(meter.getId().getBaseUnit())
-            .setDescription(meter.getId().getDescription());
-    }
+    private MetricLineBuilder.TypeStep createMetricBuilder(Meter meter) throws MetricException {
+        MetricLineBuilder.TypeStep metricLineBuilder = MetricLineBuilder.create(preConfiguration)
+            .metricKey(meter.getId().getName());
+        for (Tag tag : meter.getId().getTags()) {
+            metricLineBuilder.dimension(tag.getKey(), tag.getValue());
+        }
 
-    private DimensionList fromTags(List<Tag> tags) {
-        return DimensionList.fromCollection(
-                tags.stream().map(tag -> Dimension.create(tag.getKey(), tag.getValue())).collect(Collectors.toList()));
+        return metricLineBuilder;
     }
 
     private <T> Stream<T> streamOf(Iterable<T> iterable) {
@@ -453,7 +468,22 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         }
     }
 
-    private void storeMetadataLine(Metric.Builder metricBuilder, Map<String, String> seenMetadata)
+    private MetricLineBuilder.MetadataStep createMetadataBuilder(MetricLineBuilder.GaugeStep metricBuilder,
+            Meter meter) {
+        return enrichMetadataBuilder(metricBuilder.metadata(), meter);
+    }
+
+    private MetricLineBuilder.MetadataStep createMetadataBuilder(MetricLineBuilder.CounterStep metricBuilder,
+            Meter meter) {
+        return enrichMetadataBuilder(metricBuilder.metadata(), meter);
+    }
+
+    private MetricLineBuilder.MetadataStep enrichMetadataBuilder(MetricLineBuilder.MetadataStep metadataBuilder,
+            Meter meter) {
+        return metadataBuilder.description(meter.getId().getDescription()).unit(meter.getId().getBaseUnit());
+    }
+
+    private void storeMetadataLine(MetricLineBuilder.MetadataStep metadataBuilder, Map<String, String> seenMetadata)
             throws MetricException {
         // if the config to export metadata is turned off, the seenMetadata map will be
         // null.
@@ -461,11 +491,15 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return;
         }
 
-        String key = metricBuilder.getNormalizedMetricKey();
+        String metadataLine = metadataBuilder.build();
+        if (metadataBuilder == null) {
+            return;
+        }
 
+        String key = extractMetricKey(metadataLine);
         if (!seenMetadata.containsKey(key)) {
             // if there is no metadata associated with the key, add it.
-            seenMetadata.put(key, metricBuilder.serializeMetadataLine());
+            seenMetadata.put(key, metadataLine);
         }
         else {
             // get the previously stored metadata line
@@ -473,17 +507,16 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             // if the previous line is not null, a metadata object had already been set in
             // the past and no conflicting metadata lines had been added thereafter.
             if (previousMetadataLine != null) {
-                String newMetadataLine = metricBuilder.serializeMetadataLine();
                 // if the new metadata line conflicts with the old one, we don't know
                 // which one is the correct metadata and will not export any.
                 // the map entry is set to null to ensure other metadata lines cannot be
                 // set for this metric key.
-                if (!previousMetadataLine.equals(newMetadataLine)) {
+                if (!previousMetadataLine.equals(metadataLine)) {
                     seenMetadata.put(key, null);
                     logger.warn(
                             "Metadata discrepancy detected:\n" + "original metadata:\t{}\n" + "tried to set new:\t{}\n"
                                     + "Metadata for metric key {} will not be sent.",
-                            previousMetadataLine, newMetadataLine, key);
+                            previousMetadataLine, metadataLine, key);
                 }
             }
             // else:
@@ -491,6 +524,25 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             // identified before. we will ignore any other metadata for this key, so there
             // is nothing to do here.
         }
+    }
+
+    private String extractMetricKey(String metadataLine) {
+        if (metadataLine == null) {
+            return null;
+        }
+
+        StringBuilder metricKey = new StringBuilder(MINIMUM_CAPACITY);
+
+        for (int i = 1; i < metadataLine.length(); i++) {
+            char c = metadataLine.charAt(i);
+            if (c == ' ' || c == ',') {
+                break;
+            }
+
+            metricKey.append(c);
+        }
+
+        return metricKey.toString();
     }
 
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -466,19 +466,19 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         }
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.GaugeStep metricBuilder,
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.GaugeStep gaugeStep,
                                                               Meter meter) {
-        return enrichMetadataBuilder(metricBuilder.metadata(), meter);
+        return enrichMetadataStep(gaugeStep.metadata(), meter);
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.CounterStep metricBuilder,
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.CounterStep counterStep,
                                                               Meter meter) {
-        return enrichMetadataBuilder(metricBuilder.metadata(), meter);
+        return enrichMetadataStep(counterStep.metadata(), meter);
     }
 
-    private MetricLineBuilder.MetadataStep enrichMetadataBuilder(MetricLineBuilder.MetadataStep metadataBuilder,
-            Meter meter) {
-        return metadataBuilder.description(meter.getId().getDescription()).unit(meter.getId().getBaseUnit());
+    private MetricLineBuilder.MetadataStep enrichMetadataStep(MetricLineBuilder.MetadataStep metadataStep,
+                                                              Meter meter) {
+        return metadataStep.description(meter.getId().getDescription()).unit(meter.getId().getBaseUnit());
     }
 
     private void storeMetadataLine(MetricLineBuilder.MetadataStep metadataStep, Map<String, String> seenMetadata)

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -246,9 +246,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
             storeMetadataLine(createMetadataStep(counterStep, meter), seenMetadata);
 
-            return counterStep.delta(measurement.getValue())
-                .timestamp(Instant.ofEpochMilli(clock.wallTime()))
-                .build();
+            return counterStep.delta(measurement.getValue()).timestamp(Instant.ofEpochMilli(clock.wallTime())).build();
         }
         catch (MetricException e) {
             logger.warn(METER_EXCEPTION_LOG_FORMAT, meter.getId(), e.getMessage());
@@ -466,18 +464,16 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         }
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.GaugeStep gaugeStep,
-                                                              Meter meter) {
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.GaugeStep gaugeStep, Meter meter) {
         return enrichMetadataStep(gaugeStep.metadata(), meter);
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.CounterStep counterStep,
-                                                              Meter meter) {
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.CounterStep counterStep, Meter meter) {
         return enrichMetadataStep(counterStep.metadata(), meter);
     }
 
     private MetricLineBuilder.MetadataStep enrichMetadataStep(MetricLineBuilder.MetadataStep metadataStep,
-                                                              Meter meter) {
+            Meter meter) {
         return metadataStep.description(meter.getId().getDescription()).unit(meter.getId().getBaseUnit());
     }
 
@@ -495,7 +491,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
         String metadataLine = metadataStep.build();
 
-        if (metadataLine == null){
+        if (metadataLine == null) {
             return;
         }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -224,7 +224,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             }
             MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
 
-            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
+            storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
 
             return metricBuilder.value(value).timestamp(Instant.ofEpochMilli(clock.wallTime())).build();
         }
@@ -244,7 +244,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         try {
             MetricLineBuilder.CounterStep metricBuilder = createMetricBuilder(meter).count();
 
-            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
+            storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
 
             return metricBuilder.delta(measurement.getValue())
                 .timestamp(Instant.ofEpochMilli(clock.wallTime()))
@@ -301,7 +301,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         try {
             MetricLineBuilder.GaugeStep metricBuilder = createMetricBuilder(meter).gauge();
 
-            storeMetadataLine(createMetadataBuilder(metricBuilder, meter), seenMetadata);
+            storeMetadataLine(createMetadataStep(metricBuilder, meter), seenMetadata);
 
             return Stream.of(metricBuilder.summary(min, max, total, count)
                 .timestamp(Instant.ofEpochMilli(clock.wallTime()))
@@ -466,13 +466,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         }
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataBuilder(MetricLineBuilder.GaugeStep metricBuilder,
-            Meter meter) {
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.GaugeStep metricBuilder,
+                                                              Meter meter) {
         return enrichMetadataBuilder(metricBuilder.metadata(), meter);
     }
 
-    private MetricLineBuilder.MetadataStep createMetadataBuilder(MetricLineBuilder.CounterStep metricBuilder,
-            Meter meter) {
+    private MetricLineBuilder.MetadataStep createMetadataStep(MetricLineBuilder.CounterStep metricBuilder,
+                                                              Meter meter) {
         return enrichMetadataBuilder(metricBuilder.metadata(), meter);
     }
 
@@ -481,7 +481,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         return metadataBuilder.description(meter.getId().getDescription()).unit(meter.getId().getBaseUnit());
     }
 
-    private void storeMetadataLine(MetricLineBuilder.MetadataStep metadataBuilder, Map<String, String> seenMetadata)
+    private void storeMetadataLine(MetricLineBuilder.MetadataStep metadataStep, Map<String, String> seenMetadata)
             throws MetricException {
         // if the config to export metadata is turned off, the seenMetadata map will be
         // null.
@@ -489,11 +489,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return;
         }
 
-        if (metadataBuilder == null) {
+        if (metadataStep == null) {
             return;
         }
 
-        String metadataLine = metadataBuilder.build();
+        String metadataLine = metadataStep.build();
 
         if (metadataLine == null){
             return;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -489,8 +489,13 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return;
         }
 
-        String metadataLine = metadataBuilder.build();
         if (metadataBuilder == null) {
+            return;
+        }
+
+        String metadataLine = metadataBuilder.build();
+
+        if (metadataLine == null){
             return;
         }
 

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
@@ -85,10 +85,9 @@ class DynatraceMeterRegistryTest {
 
             String[] lines = new String(request.getEntity(), StandardCharsets.UTF_8).trim().split("\n");
             assertThat(lines).hasSize(4)
-                .containsExactly("my.counter,dt.metrics.source=micrometer count,delta=12.0 " + clock.wallTime(),
-                        "my.timer,dt.metrics.source=micrometer gauge,min=12.0,max=42.0,sum=108.0,count=4 "
-                                + clock.wallTime(),
-                        "my.gauge,dt.metrics.source=micrometer gauge," + gauge + " " + clock.wallTime(),
+                .containsExactly("my.counter,dt.metrics.source=micrometer count,delta=12 " + clock.wallTime(),
+                        "my.timer,dt.metrics.source=micrometer gauge,min=12,max=42,sum=108,count=4 " + clock.wallTime(),
+                        "my.gauge,dt.metrics.source=micrometer gauge," + formatDouble(gauge) + " " + clock.wallTime(),
                         "#my.timer gauge dt.meta.unit=milliseconds");
         })));
     }
@@ -113,8 +112,8 @@ class DynatraceMeterRegistryTest {
 
         assertThat(request.getEntity()).asString()
             .hasLineCount(2)
-            .contains("my.timer,dt.metrics.source=micrometer gauge,min=22.0,max=50.0,sum=72.0,count=2 "
-                    + clock.wallTime(), "#my.timer gauge dt.meta.unit=milliseconds");
+            .contains("my.timer,dt.metrics.source=micrometer gauge,min=22,max=50,sum=72,count=2 " + clock.wallTime(),
+                    "#my.timer gauge dt.meta.unit=milliseconds");
 
         // both are bigger than the previous min and smaller than the previous max. They
         // will only show up if the
@@ -131,8 +130,9 @@ class DynatraceMeterRegistryTest {
 
         assertThat(request2.getEntity()).asString()
             .hasLineCount(2)
-            .containsIgnoringNewLines("my.timer,dt.metrics.source=micrometer gauge,min=33.0,max=44.0,sum=77.0,count=2 "
-                    + clock.wallTime(), "#my.timer gauge dt.meta.unit=milliseconds");
+            .containsIgnoringNewLines(
+                    "my.timer,dt.metrics.source=micrometer gauge,min=33,max=44,sum=77,count=2 " + clock.wallTime(),
+                    "#my.timer gauge dt.meta.unit=milliseconds");
     }
 
     @Test
@@ -148,8 +148,9 @@ class DynatraceMeterRegistryTest {
 
         verify(httpClient).send(assertArg((request -> assertThat(request.getEntity()).asString()
             .hasLineCount(2)
-            .containsIgnoringNewLines("my.timer,dt.metrics.source=micrometer gauge,min=22.0,max=55.0,sum=77.0,count=2 "
-                    + clock.wallTime(), "#my.timer gauge dt.meta.unit=milliseconds"))));
+            .containsIgnoringNewLines(
+                    "my.timer,dt.metrics.source=micrometer gauge,min=22,max=55,sum=77,count=2 " + clock.wallTime(),
+                    "#my.timer gauge dt.meta.unit=milliseconds"))));
     }
 
     @Test
@@ -165,8 +166,9 @@ class DynatraceMeterRegistryTest {
 
         verify(httpClient).send(assertArg(request -> assertThat(request.getEntity()).asString()
             .hasLineCount(2)
-            .containsIgnoringNewLines("my.timer,dt.metrics.source=micrometer gauge,min=44.0,max=44.0,sum=44.0,count=1 "
-                    + clock.wallTime(), "#my.timer gauge dt.meta.unit=milliseconds")));
+            .containsIgnoringNewLines(
+                    "my.timer,dt.metrics.source=micrometer gauge,min=44,max=44,sum=44,count=1 " + clock.wallTime(),
+                    "#my.timer gauge dt.meta.unit=milliseconds")));
 
         // reset for next export interval
         reset(httpClient);
@@ -190,8 +192,9 @@ class DynatraceMeterRegistryTest {
 
         verify(httpClient).send(assertArg(request -> assertThat(request.getEntity()).asString()
             .hasLineCount(2)
-            .containsIgnoringNewLines("my.timer,dt.metrics.source=micrometer gauge,min=33.0,max=33.0,sum=33.0,count=1 "
-                    + clock.wallTime(), "#my.timer gauge dt.meta.unit=milliseconds")));
+            .containsIgnoringNewLines(
+                    "my.timer,dt.metrics.source=micrometer gauge,min=33,max=33,sum=33,count=1 " + clock.wallTime(),
+                    "#my.timer gauge dt.meta.unit=milliseconds")));
     }
 
     private DynatraceConfig createDefaultDynatraceConfig() {
@@ -216,6 +219,14 @@ class DynatraceMeterRegistryTest {
                 return DynatraceApiVersion.V2;
             }
         };
+    }
+
+    private String formatDouble(double value) {
+        if (value == (long) value) {
+            return Long.toString((long) value);
+        }
+
+        return Double.toString(value);
     }
 
 }


### PR DESCRIPTION
This PR updates the Dynatrace exporter v2 to use the new dynatrace-metric-utils library v2.0.0 which provides a big boost in performance while also reducing the memory overhead. v2 has been [released on Maven central](https://central.sonatype.com/artifact/com.dynatrace.metric.util/dynatrace-metric-utils-java/2.0.0). 