### PR TITLE
Replace deprecated ContextSnapshot.captureAllUsing()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/kotlin/KotlinObservationContextElement.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/kotlin/KotlinObservationContextElement.java
@@ -19,6 +19,7 @@ package io.micrometer.core.instrument.kotlin;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
@@ -41,8 +42,11 @@ class KotlinObservationContextElement implements ThreadContextElement<ContextSna
 
     KotlinObservationContextElement(ObservationRegistry observationRegistry, ContextRegistry contextRegistry) {
         this.observationRegistry = observationRegistry;
-        this.contextSnapshot = ContextSnapshot.captureAllUsing(ObservationThreadLocalAccessor.KEY::equals,
-                contextRegistry);
+        this.contextSnapshot = ContextSnapshotFactory.builder()
+            .captureKeyPredicate(ObservationThreadLocalAccessor.KEY::equals)
+            .contextRegistry(contextRegistry)
+            .build()
+            .captureAll();
     }
 
     @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -20,6 +20,7 @@ import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.context.ContextRegistry;
 import io.micrometer.context.ContextSnapshot;
+import io.micrometer.context.ContextSnapshotFactory;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.ObservationTextPublisher;
@@ -351,7 +352,11 @@ class ObservedAspectTests {
         @Observed(name = "test.async")
         CompletableFuture<String> async(FakeAsyncTask fakeAsyncTask) {
             System.out.println("async");
-            ContextSnapshot contextSnapshot = ContextSnapshot.captureAllUsing(o -> true, ContextRegistry.getInstance());
+            ContextSnapshot contextSnapshot = ContextSnapshotFactory.builder()
+                .captureKeyPredicate(key -> true)
+                .contextRegistry(ContextRegistry.getInstance())
+                .build()
+                .captureAll();
             return CompletableFuture.supplyAsync(fakeAsyncTask,
                     contextSnapshot.wrapExecutor(Executors.newSingleThreadExecutor()));
         }
@@ -373,7 +378,11 @@ class ObservedAspectTests {
 
         CompletableFuture<String> async(FakeAsyncTask fakeAsyncTask) {
             System.out.println("async");
-            ContextSnapshot contextSnapshot = ContextSnapshot.captureAllUsing(o -> true, ContextRegistry.getInstance());
+            ContextSnapshot contextSnapshot = ContextSnapshotFactory.builder()
+                .captureKeyPredicate(key -> true)
+                .contextRegistry(ContextRegistry.getInstance())
+                .build()
+                .captureAll();
             return CompletableFuture.supplyAsync(fakeAsyncTask,
                     contextSnapshot.wrapExecutor(Executors.newSingleThreadExecutor()));
         }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -107,7 +107,11 @@ class ObservationThreadLocalAccessorTests {
             try (Observation.Scope scope2 = child.openScope()) {
                 thenCurrentObservationHasParent(parent, child);
                 then(child.getEnclosingScope()).isSameAs(scope2);
-                container = ContextSnapshot.captureAllUsing(key -> true, registry);
+                container = ContextSnapshotFactory.builder()
+                    .captureKeyPredicate(key -> true)
+                    .contextRegistry(registry)
+                    .build()
+                    .captureAll();
             }
         }
 


### PR DESCRIPTION
This PR replaces deprecated `ContextSnapshot.captureAllUsing()` usages.