### PR TITLE
Add Meter.Cache for dynamic meter registration

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument;
 import io.micrometer.common.lang.Nullable;
 
 import java.util.Collections;
+import java.util.function.Function;
 
 /**
  * Counters monitor monotonically increasing values. Counters may never be reset to a
@@ -128,6 +129,14 @@ public interface Counter extends Meter {
          * @return A new or existing counter.
          */
         public Counter register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        public <K> Meter.Provider<K, Counter> register(MeterRegistry registry, Function<K, Tags> provider) {
+            return new Meter.Cache<>(key -> register(registry, tags.and(provider.apply(key))));
+        }
+
+        private Counter register(MeterRegistry registry, Tags tags) {
             return registry.counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER));
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * Track the sample distribution of events. An example would be the response sizes for
@@ -395,6 +396,14 @@ public interface DistributionSummary extends Meter, HistogramSupport {
          * @return A new or existing distribution summary.
          */
         public DistributionSummary register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        public <K> Meter.Provider<K, DistributionSummary> register(MeterRegistry registry, Function<K, Tags> provider) {
+            return new Meter.Cache<>(key -> register(registry, tags.and(provider.apply(key))));
+        }
+
+        private DistributionSummary register(MeterRegistry registry, Tags tags) {
             return registry.summary(new Meter.Id(name, tags, baseUnit, description, Type.DISTRIBUTION_SUMMARY),
                     distributionConfigBuilder.build(), scale);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -23,7 +23,9 @@ import io.micrometer.core.instrument.distribution.HistogramGauges;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -481,6 +483,29 @@ public interface Meter {
     }
 
     default void close() {
+    }
+
+    interface Provider<K, V> {
+
+        V get(@Nullable K key);
+
+    }
+
+    class Cache<K, V> implements Provider<K, V> {
+
+        private final Map<K, V> cache = new ConcurrentHashMap<>();
+
+        private final Function<K, V> mappingFunction;
+
+        public Cache(Function<K, V> mappingFunction) {
+            this.mappingFunction = mappingFunction;
+        }
+
+        @Override
+        public V get(@Nullable K key) {
+            return cache.computeIfAbsent(key, mappingFunction);
+        }
+
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -439,6 +440,14 @@ public interface Timer extends Meter, HistogramSupport {
          * @return A new or existing timer.
          */
         public Timer register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        public <K> Meter.Provider<K, Timer> register(MeterRegistry registry, Function<K, Tags> provider) {
+            return new Meter.Cache<>(key -> register(registry, tags.and(provider.apply(key))));
+        }
+
+        private Timer register(MeterRegistry registry, Tags tags) {
             // the base unit for a timer will be determined by the monitoring system
             // implementation
             return registry.timer(new Meter.Id(name, tags, null, description, Type.TIMER),

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterCacheTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterCacheTest.java
@@ -1,0 +1,122 @@
+package io.micrometer.core.instrument;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Meter.Cache}.
+ *
+ * @author qweek
+ */
+public class MeterCacheTest {
+
+    private MeterRegistry registry = new SimpleMeterRegistry();
+
+    @Test
+    void provideCounter() {
+        Meter.Provider<String, Counter> counterProvider = Counter.builder("my.counter")
+            .register(registry, value -> value == null ? Tags.empty() : Tags.of("my.key", value));
+
+        assertThat(registry.getMeters()).hasSize(0);
+
+        Counter firstCounter = counterProvider.get("first.value");
+        firstCounter.increment();
+
+        assertThat(registry.find("my.counter").counter()).isEqualTo(firstCounter);
+        assertThat(firstCounter.count()).isEqualTo(1);
+
+        Counter sameCounter = counterProvider.get("first.value");
+        sameCounter.increment();
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(sameCounter.count()).isEqualTo(2);
+
+        Counter secondCounter = counterProvider.get("second.value");
+        secondCounter.increment();
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(secondCounter.count()).isEqualTo(1);
+    }
+
+    @Test
+    void provideTimer() {
+        Meter.Provider<String, Timer> timerProvider = Timer.builder("my.timer")
+            .register(registry, value -> value == null ? Tags.empty() : Tags.of("my.key", value));
+
+        assertThat(registry.getMeters()).hasSize(0);
+
+        Timer firstTimer = timerProvider.get("first.value");
+        firstTimer.record(1, TimeUnit.NANOSECONDS);
+
+        assertThat(registry.find("my.timer").timer()).isEqualTo(firstTimer);
+        assertThat(firstTimer.count()).isEqualTo(1);
+
+        Timer sameTimer = timerProvider.get("first.value");
+        sameTimer.record(2, TimeUnit.NANOSECONDS);
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(sameTimer.count()).isEqualTo(2);
+
+        Timer secondTimer = timerProvider.get("second.value");
+        secondTimer.record(4, TimeUnit.NANOSECONDS);
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(secondTimer.count()).isEqualTo(1);
+    }
+
+    @Test
+    void provideSummary() {
+        Meter.Provider<String, DistributionSummary> summaryProvider = DistributionSummary.builder("my.summary")
+            .register(registry, value -> value == null ? Tags.empty() : Tags.of("my.key", value));
+
+        assertThat(registry.getMeters()).hasSize(0);
+
+        DistributionSummary firstSummary = summaryProvider.get("first.value");
+        firstSummary.record(1);
+
+        assertThat(registry.find("my.summary").summary()).isEqualTo(firstSummary);
+        assertThat(firstSummary.count()).isEqualTo(1);
+
+        DistributionSummary sameSummary = summaryProvider.get("first.value");
+        sameSummary.record(2);
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(sameSummary.count()).isEqualTo(2);
+
+        DistributionSummary secondSummary = summaryProvider.get("second.value");
+        secondSummary.record(4);
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(secondSummary.count()).isEqualTo(1);
+    }
+
+    @Test
+    void provideGauge() {
+        Meter.Provider<String, AtomicInteger> gaugeProvider = Gauge
+            .builder("my.gauge", null, AtomicInteger::doubleValue)
+            .register(registry, AtomicInteger::new, value -> value == null ? Tags.empty() : Tags.of("my.key", value));
+
+        assertThat(registry.getMeters()).hasSize(0);
+
+        AtomicInteger firstGauge = gaugeProvider.get("first.value");
+        firstGauge.set(1);
+
+        assertThat(firstGauge.get()).isEqualTo(1);
+
+        AtomicInteger sameGauge = gaugeProvider.get("first.value");
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(sameGauge).isEqualTo(firstGauge);
+
+        AtomicInteger secondGauge = gaugeProvider.get("second.value");
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(secondGauge).isNotEqualTo(firstGauge);
+    }
+
+}


### PR DESCRIPTION
**Summary**
This PR aims to add Meter.Cache for dynamic meter registration. This allows to create meters with dynamic tags, making it more customizable and adaptable to systems with tags depending on external sources. This change is backward-compatible.

**Changes**
Introduce additional register() method in specific Meter to create Meter.Provider for ad-hoc Meter creation.


**Why is this important?**
Currently, Micrometer's Meter doesn't provide a straightforward way to customize tags without additional allocations in runtime. This PR eliminates the need to build, deduplicate and sort Tags on each call and allow to re-use metrics builder, thereby simplifying metric management.

**Backwards Compatibility**
This feature is backward-compatible because it doesn't affect existing register() method.

**Test Coverage**
MeterCacheTest class has been created to include tests that verify this new functionality, ensuring that all basic metrics supports dynamic registration.

**Usage Example**
After this change, you can use new register() method to create metric with dynamic tags.

```
Meter.Provider<String, Counter> provider = Counter.builder("counter")
            .register(registry, value -> Tags.of("source", value));

void request(String source) {
    provider.get(source).increment();
}
```