### PR TITLE
Ignore noop children when polling composite meters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -18,11 +18,11 @@ package io.micrometer.core.instrument.composite;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.noop.NoopMeter;
 import io.micrometer.core.lang.Nullable;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -49,9 +49,11 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
     }
 
     T firstChild() {
-        final Iterator<T> i = children.values().iterator();
-        if (i.hasNext())
-            return i.next();
+        for (T next : children.values()) {
+            if (!(next instanceof NoopMeter)) {
+                return next;
+            }
+        }
 
         // There are no child meters. Return a lazily instantiated no-op meter.
         final T noopMeter = this.noopMeter;


### PR DESCRIPTION
When a CompositeMeterRegistry is used and one of its CompositeMeters is polled (its value is fetched), the returned value can depend on the order of the registries inside of the composite if the composite contains a registry that has any NoopMeters.

Example: a CompositeMeterRegistry contains two registries, A and B. We create a counter in the composite and increment it once. After this both A and B contain one counter but lets say that in A the counter is ignored so it will be noop.
When the count called on CompositeCounter, it can return either 0 (if NoopCounter was used)
or 1 (if the non-noop counter was used).

In order to fix this, we can ignore the NoopMeters when Meters are polled in a composite registry.

Closes gh-1441