### PR TITLE
Add shortcuts to assign dynamic tags to Meters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.common.lang.Nullable;
 
 import java.util.Collections;
-import java.util.function.Function;
 
 /**
  * Counters monitor monotonically increasing values. Counters may never be reset to a
@@ -122,14 +121,16 @@ public interface Counter extends Meter {
         }
 
         /**
-         * Convenience method to create new meters from the builder that only differ in
-         * tags. This method can be used for dynamic tagging by creating the builder once
-         * and applying the dynamically changing tags using the returned {@link Function}.
+         * Convenience method to create meters from the builder that only differ in tags.
+         * This method can be used for dynamic tagging by creating the builder once and
+         * applying the dynamically changing tags using the returned
+         * {@link MeterProvider}.
          * @param registry A registry to add the meter to, if it doesn't already exist.
-         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @return A {@link MeterProvider} that returns a meter based on the provided
+         * tags.
          * @since 1.12.0
          */
-        public Function<Tags, Counter> with(MeterRegistry registry) {
+        public MeterProvider<Counter> withRegistry(MeterRegistry registry) {
             return extraTags -> register(registry, tags.and(extraTags));
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Counter.java
@@ -18,12 +18,14 @@ package io.micrometer.core.instrument;
 import io.micrometer.common.lang.Nullable;
 
 import java.util.Collections;
+import java.util.function.Function;
 
 /**
  * Counters monitor monotonically increasing values. Counters may never be reset to a
  * lesser value. If you need to track a value that goes up and down, use a {@link Gauge}.
  *
  * @author Jon Schneider
+ * @author Jonatan Ivanov
  */
 public interface Counter extends Meter {
 
@@ -120,6 +122,18 @@ public interface Counter extends Meter {
         }
 
         /**
+         * Convenience method to create new meters from the builder that only differ in
+         * tags. This method can be used for dynamic tagging by creating the builder once
+         * and applying the dynamically changing tags using the returned {@link Function}.
+         * @param registry A registry to add the meter to, if it doesn't already exist.
+         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @since 1.12.0
+         */
+        public Function<Tags, Counter> with(MeterRegistry registry) {
+            return extraTags -> register(registry, tags.and(extraTags));
+        }
+
+        /**
          * Add the counter to a single registry, or return an existing counter in that
          * registry. The returned counter will be unique for each registry, but each
          * registry is guaranteed to only create one counter for the same combination of
@@ -128,6 +142,10 @@ public interface Counter extends Meter {
          * @return A new or existing counter.
          */
         public Counter register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        private Counter register(MeterRegistry registry, Tags tags) {
             return registry.counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER));
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/DistributionSummary.java
@@ -24,7 +24,6 @@ import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * Track the sample distribution of events. An example would be the response sizes for
@@ -388,14 +387,16 @@ public interface DistributionSummary extends Meter, HistogramSupport {
         }
 
         /**
-         * Convenience method to create new meters from the builder that only differ in
-         * tags. This method can be used for dynamic tagging by creating the builder once
-         * and applying the dynamically changing tags using the returned {@link Function}.
+         * Convenience method to create meters from the builder that only differ in tags.
+         * This method can be used for dynamic tagging by creating the builder once and
+         * applying the dynamically changing tags using the returned
+         * {@link MeterProvider}.
          * @param registry A registry to add the meter to, if it doesn't already exist.
-         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @return A {@link MeterProvider} that returns a meter based on the provided
+         * tags.
          * @since 1.12.0
          */
-        public Function<Tags, DistributionSummary> with(MeterRegistry registry) {
+        public MeterProvider<DistributionSummary> withRegistry(MeterRegistry registry) {
             return extraTags -> register(registry, tags.and(extraTags));
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -474,14 +474,16 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
         }
 
         /**
-         * Convenience method to create new meters from the builder that only differ in
-         * tags. This method can be used for dynamic tagging by creating the builder once
-         * and applying the dynamically changing tags using the returned {@link Function}.
+         * Convenience method to create meters from the builder that only differ in tags.
+         * This method can be used for dynamic tagging by creating the builder once and
+         * applying the dynamically changing tags using the returned
+         * {@link MeterProvider}.
          * @param registry A registry to add the meter to, if it doesn't already exist.
-         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @return A {@link MeterProvider} that returns a meter based on the provided
+         * tags.
          * @since 1.12.0
          */
-        public Function<Tags, LongTaskTimer> with(MeterRegistry registry) {
+        public MeterProvider<LongTaskTimer> withRegistry(MeterRegistry registry) {
             return extraTags -> register(registry, tags.and(extraTags));
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -24,18 +24,14 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
-import java.util.function.DoubleSupplier;
-import java.util.function.IntSupplier;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 /**
  * A long task timer is used to track the total duration of all in-flight long-running
  * tasks and the number of such tasks.
  *
  * @author Jon Schneider
+ * @author Jonatan Ivanov
  */
 public interface LongTaskTimer extends Meter, HistogramSupport {
 
@@ -478,6 +474,18 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
         }
 
         /**
+         * Convenience method to create new meters from the builder that only differ in
+         * tags. This method can be used for dynamic tagging by creating the builder once
+         * and applying the dynamically changing tags using the returned {@link Function}.
+         * @param registry A registry to add the meter to, if it doesn't already exist.
+         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @since 1.12.0
+         */
+        public Function<Tags, LongTaskTimer> with(MeterRegistry registry) {
+            return extraTags -> register(registry, tags.and(extraTags));
+        }
+
+        /**
          * Add the long task timer to a single registry, or return an existing long task
          * timer in that registry. The returned long task timer will be unique for each
          * registry, but each registry is guaranteed to only create one long task timer
@@ -487,6 +495,10 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
          * @return A new or existing long task timer.
          */
         public LongTaskTimer register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        private LongTaskTimer register(MeterRegistry registry, Tags tags) {
             return registry.more()
                 .longTaskTimer(new Meter.Id(name, tags, null, description, Type.LONG_TASK_TIMER),
                         distributionConfigBuilder.build());

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -35,6 +35,7 @@ import static java.util.Collections.singletonList;
  * A named and dimensioned producer of one or more measurements.
  *
  * @author Jon Schneider
+ * @author Jonatan Ivanov
  */
 public interface Meter {
 
@@ -477,6 +478,26 @@ public interface Meter {
         public Meter register(MeterRegistry registry) {
             return registry.register(new Meter.Id(name, tags, baseUnit, description, type), type, measurements);
         }
+
+    }
+
+    /**
+     * Convenience interface to create new meters from tags based on a common
+     * "template"/builder. See usage in Meter implementations, e.g.: {@code Timer},
+     * {@code Counter}
+     *
+     * @param <T> Meter type
+     * @since 1.12.0
+     */
+    interface MeterProvider<T extends Meter> {
+
+        /**
+         * Registers (creates a new or gets an existing one if already exists) Meters
+         * using the provided tags.
+         * @param tags Tags to attach to the Meter about to be registered
+         * @return A new or existing Meter
+         */
+        T withTags(Iterable<? extends Tag> tags);
 
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -499,6 +499,27 @@ public interface Meter {
          */
         T withTags(Iterable<? extends Tag> tags);
 
+        /**
+         * Registers (creates a new or gets an existing one if already exists) Meters
+         * using the provided tags.
+         * @param tags Tags to attach to the Meter about to be registered
+         * @return A new or existing Meter
+         */
+        default T withTags(String... tags) {
+            return withTags(Tags.of(tags));
+        }
+
+        /**
+         * Registers (creates a new or gets an existing one if already exists) Meters
+         * using the provided tags.
+         * @param key the tag key to add
+         * @param value the tag value to add
+         * @return A new or existing Meter
+         */
+        default T withTag(String key, String value) {
+            return withTags(Tags.of(key, value));
+        }
+
     }
 
     default void close() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -27,11 +27,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BooleanSupplier;
-import java.util.function.DoubleSupplier;
-import java.util.function.IntSupplier;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
+import java.util.function.*;
 
 /**
  * Timer intended to track of a large number of short running events. Example would be
@@ -40,6 +36,7 @@ import java.util.function.Supplier;
  *
  * @author Jon Schneider
  * @author Oleksii Bondar
+ * @author Jonatan Ivanov
  */
 public interface Timer extends Meter, HistogramSupport {
 
@@ -431,6 +428,18 @@ public interface Timer extends Meter, HistogramSupport {
         }
 
         /**
+         * Convenience method to create new meters from the builder that only differ in
+         * tags. This method can be used for dynamic tagging by creating the builder once
+         * and applying the dynamically changing tags using the returned {@link Function}.
+         * @param registry A registry to add the meter to, if it doesn't already exist.
+         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @since 1.12.0
+         */
+        public Function<Tags, Timer> with(MeterRegistry registry) {
+            return extraTags -> register(registry, tags.and(extraTags));
+        }
+
+        /**
          * Add the timer to a single registry, or return an existing timer in that
          * registry. The returned timer will be unique for each registry, but each
          * registry is guaranteed to only create one timer for the same combination of
@@ -439,6 +448,10 @@ public interface Timer extends Meter, HistogramSupport {
          * @return A new or existing timer.
          */
         public Timer register(MeterRegistry registry) {
+            return register(registry, tags);
+        }
+
+        private Timer register(MeterRegistry registry, Tags tags) {
             // the base unit for a timer will be determined by the monitoring system
             // implementation
             return registry.timer(new Meter.Id(name, tags, null, description, Type.TIMER),

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -428,14 +428,16 @@ public interface Timer extends Meter, HistogramSupport {
         }
 
         /**
-         * Convenience method to create new meters from the builder that only differ in
-         * tags. This method can be used for dynamic tagging by creating the builder once
-         * and applying the dynamically changing tags using the returned {@link Function}.
+         * Convenience method to create meters from the builder that only differ in tags.
+         * This method can be used for dynamic tagging by creating the builder once and
+         * applying the dynamically changing tags using the returned
+         * {@link MeterProvider}.
          * @param registry A registry to add the meter to, if it doesn't already exist.
-         * @return A {@link Function} that returns a meter based on the provided tags.
+         * @return A {@link MeterProvider} that returns a meter based on the provided
+         * tags.
          * @since 1.12.0
          */
-        public Function<Tags, Timer> with(MeterRegistry registry) {
+        public MeterProvider<Timer> withRegistry(MeterRegistry registry) {
             return extraTags -> register(registry, tags.and(extraTags));
         }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
@@ -15,12 +15,12 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,11 +40,13 @@ class DynamicTagsTests {
 
     @Test
     void shouldCreateCountersDynamically() {
-        Function<Tags, Counter> counterFactory = Counter.builder("test.counter").tag("static", "abc").with(registry);
+        MeterProvider<Counter> counterProvider = Counter.builder("test.counter")
+            .tag("static", "abc")
+            .withRegistry(registry);
 
-        counterFactory.apply(Tags.of("dynamic", "1")).increment();
-        counterFactory.apply(Tags.of("dynamic", "2")).increment();
-        counterFactory.apply(Tags.of("dynamic", "1")).increment();
+        counterProvider.withTags(Tags.of("dynamic", "1")).increment();
+        counterProvider.withTags(Tags.of("dynamic", "2")).increment();
+        counterProvider.withTags(Tags.of("dynamic", "1")).increment();
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.counter").tags("static", "abc", "dynamic", "1").counters()).hasSize(1);
@@ -53,9 +55,11 @@ class DynamicTagsTests {
 
     @Test
     void shouldOverrideStaticTagsWhenCreatesCountersDynamically() {
-        Function<Tags, Counter> counterFactory = Counter.builder("test.counter").tag("static", "abc").with(registry);
+        MeterProvider<Counter> counterProvider = Counter.builder("test.counter")
+            .tag("static", "abc")
+            .withRegistry(registry);
 
-        counterFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).increment();
+        counterProvider.withTags(Tags.of("static", "xyz", "dynamic", "1")).increment();
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.find("test.counter").tags("static", "xyz", "dynamic", "1").counters()).hasSize(1);
@@ -63,11 +67,11 @@ class DynamicTagsTests {
 
     @Test
     void shouldCreateTimersDynamically() {
-        Function<Tags, Timer> timerFactory = Timer.builder("test.timer").tag("static", "abc").with(registry);
+        MeterProvider<Timer> timerProvider = Timer.builder("test.timer").tag("static", "abc").withRegistry(registry);
 
-        timerFactory.apply(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
-        timerFactory.apply(Tags.of("dynamic", "2")).record(Duration.ofMillis(200));
-        timerFactory.apply(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
+        timerProvider.withTags(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
+        timerProvider.withTags(Tags.of("dynamic", "2")).record(Duration.ofMillis(200));
+        timerProvider.withTags(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.timer").tags("static", "abc", "dynamic", "1").timers()).hasSize(1);
@@ -76,9 +80,9 @@ class DynamicTagsTests {
 
     @Test
     void shouldOverrideStaticTagsWhenCreatesTimersDynamically() {
-        Function<Tags, Timer> timerFactory = Timer.builder("test.timer").tag("static", "abc").with(registry);
+        MeterProvider<Timer> timerProvider = Timer.builder("test.timer").tag("static", "abc").withRegistry(registry);
 
-        timerFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).record(Duration.ofMillis(100));
+        timerProvider.withTags(Tags.of("static", "xyz", "dynamic", "1")).record(Duration.ofMillis(100));
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.find("test.timer").tags("static", "xyz", "dynamic", "1").timers()).hasSize(1);
@@ -86,13 +90,13 @@ class DynamicTagsTests {
 
     @Test
     void shouldCreateLongTaskTimersDynamically() {
-        Function<Tags, LongTaskTimer> timerFactory = LongTaskTimer.builder("test.active.timer")
+        MeterProvider<LongTaskTimer> timeProvider = LongTaskTimer.builder("test.active.timer")
             .tag("static", "abc")
-            .with(registry);
+            .withRegistry(registry);
 
-        timerFactory.apply(Tags.of("dynamic", "1")).start().stop();
-        timerFactory.apply(Tags.of("dynamic", "2")).start().stop();
-        timerFactory.apply(Tags.of("dynamic", "1")).start().stop();
+        timeProvider.withTags(Tags.of("dynamic", "1")).start().stop();
+        timeProvider.withTags(Tags.of("dynamic", "2")).start().stop();
+        timeProvider.withTags(Tags.of("dynamic", "1")).start().stop();
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.active.timer").tags("static", "abc", "dynamic", "1").longTaskTimers())
@@ -103,11 +107,11 @@ class DynamicTagsTests {
 
     @Test
     void shouldOverrideStaticTagsWhenCreatesLongTaskTimersDynamically() {
-        Function<Tags, LongTaskTimer> timerFactory = LongTaskTimer.builder("test.active.timer")
+        MeterProvider<LongTaskTimer> timeProvider = LongTaskTimer.builder("test.active.timer")
             .tag("static", "abc")
-            .with(registry);
+            .withRegistry(registry);
 
-        timerFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).start().stop();
+        timeProvider.withTags(Tags.of("static", "xyz", "dynamic", "1")).start().stop();
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.find("test.active.timer").tags("static", "xyz", "dynamic", "1").longTaskTimers())
@@ -116,13 +120,13 @@ class DynamicTagsTests {
 
     @Test
     void shouldCreateDistributionSummariesDynamically() {
-        Function<Tags, DistributionSummary> distributionFactory = DistributionSummary.builder("test.distribution")
+        MeterProvider<DistributionSummary> distributionProvider = DistributionSummary.builder("test.distribution")
             .tag("static", "abc")
-            .with(registry);
+            .withRegistry(registry);
 
-        distributionFactory.apply(Tags.of("dynamic", "1")).record(1);
-        distributionFactory.apply(Tags.of("dynamic", "2")).record(2);
-        distributionFactory.apply(Tags.of("dynamic", "1")).record(1);
+        distributionProvider.withTags(Tags.of("dynamic", "1")).record(1);
+        distributionProvider.withTags(Tags.of("dynamic", "2")).record(2);
+        distributionProvider.withTags(Tags.of("dynamic", "1")).record(1);
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.distribution").tags("static", "abc", "dynamic", "1").summaries()).hasSize(1);
@@ -131,11 +135,11 @@ class DynamicTagsTests {
 
     @Test
     void shouldOverrideStaticTagsWhenCreatesDistributionSummariesDynamically() {
-        Function<Tags, DistributionSummary> distributionFactory = DistributionSummary.builder("test.distribution")
+        MeterProvider<DistributionSummary> distributionProvider = DistributionSummary.builder("test.distribution")
             .tag("static", "abc")
-            .with(registry);
+            .withRegistry(registry);
 
-        distributionFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).record(1);
+        distributionProvider.withTags(Tags.of("static", "xyz", "dynamic", "1")).record(1);
 
         assertThat(registry.getMeters()).hasSize(1);
         assertThat(registry.find("test.distribution").tags("static", "xyz", "dynamic", "1").summaries()).hasSize(1);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
@@ -45,8 +45,8 @@ class DynamicTagsTests {
             .withRegistry(registry);
 
         counterProvider.withTags(Tags.of("dynamic", "1")).increment();
-        counterProvider.withTags(Tags.of("dynamic", "2")).increment();
-        counterProvider.withTags(Tags.of("dynamic", "1")).increment();
+        counterProvider.withTags("dynamic", "2").increment();
+        counterProvider.withTag("dynamic", "1").increment();
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.counter").tags("static", "abc", "dynamic", "1").counters()).hasSize(1);
@@ -70,8 +70,8 @@ class DynamicTagsTests {
         MeterProvider<Timer> timerProvider = Timer.builder("test.timer").tag("static", "abc").withRegistry(registry);
 
         timerProvider.withTags(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
-        timerProvider.withTags(Tags.of("dynamic", "2")).record(Duration.ofMillis(200));
-        timerProvider.withTags(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
+        timerProvider.withTags("dynamic", "2").record(Duration.ofMillis(200));
+        timerProvider.withTag("dynamic", "1").record(Duration.ofMillis(100));
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.timer").tags("static", "abc", "dynamic", "1").timers()).hasSize(1);
@@ -95,8 +95,8 @@ class DynamicTagsTests {
             .withRegistry(registry);
 
         timeProvider.withTags(Tags.of("dynamic", "1")).start().stop();
-        timeProvider.withTags(Tags.of("dynamic", "2")).start().stop();
-        timeProvider.withTags(Tags.of("dynamic", "1")).start().stop();
+        timeProvider.withTags("dynamic", "2").start().stop();
+        timeProvider.withTag("dynamic", "1").start().stop();
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.active.timer").tags("static", "abc", "dynamic", "1").longTaskTimers())
@@ -125,8 +125,8 @@ class DynamicTagsTests {
             .withRegistry(registry);
 
         distributionProvider.withTags(Tags.of("dynamic", "1")).record(1);
-        distributionProvider.withTags(Tags.of("dynamic", "2")).record(2);
-        distributionProvider.withTags(Tags.of("dynamic", "1")).record(1);
+        distributionProvider.withTags("dynamic", "2").record(2);
+        distributionProvider.withTag("dynamic", "1").record(1);
 
         assertThat(registry.getMeters()).hasSize(2);
         assertThat(registry.find("test.distribution").tags("static", "abc", "dynamic", "1").summaries()).hasSize(1);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/DynamicTagsTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for convenience methods for dynamic tagging.
+ *
+ * @author Jonatan Ivanov
+ */
+class DynamicTagsTests {
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+    }
+
+    @Test
+    void shouldCreateCountersDynamically() {
+        Function<Tags, Counter> counterFactory = Counter.builder("test.counter").tag("static", "abc").with(registry);
+
+        counterFactory.apply(Tags.of("dynamic", "1")).increment();
+        counterFactory.apply(Tags.of("dynamic", "2")).increment();
+        counterFactory.apply(Tags.of("dynamic", "1")).increment();
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(registry.find("test.counter").tags("static", "abc", "dynamic", "1").counters()).hasSize(1);
+        assertThat(registry.find("test.counter").tags("static", "abc", "dynamic", "2").counters()).hasSize(1);
+    }
+
+    @Test
+    void shouldOverrideStaticTagsWhenCreatesCountersDynamically() {
+        Function<Tags, Counter> counterFactory = Counter.builder("test.counter").tag("static", "abc").with(registry);
+
+        counterFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).increment();
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.find("test.counter").tags("static", "xyz", "dynamic", "1").counters()).hasSize(1);
+    }
+
+    @Test
+    void shouldCreateTimersDynamically() {
+        Function<Tags, Timer> timerFactory = Timer.builder("test.timer").tag("static", "abc").with(registry);
+
+        timerFactory.apply(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
+        timerFactory.apply(Tags.of("dynamic", "2")).record(Duration.ofMillis(200));
+        timerFactory.apply(Tags.of("dynamic", "1")).record(Duration.ofMillis(100));
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(registry.find("test.timer").tags("static", "abc", "dynamic", "1").timers()).hasSize(1);
+        assertThat(registry.find("test.timer").tags("static", "abc", "dynamic", "2").timers()).hasSize(1);
+    }
+
+    @Test
+    void shouldOverrideStaticTagsWhenCreatesTimersDynamically() {
+        Function<Tags, Timer> timerFactory = Timer.builder("test.timer").tag("static", "abc").with(registry);
+
+        timerFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).record(Duration.ofMillis(100));
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.find("test.timer").tags("static", "xyz", "dynamic", "1").timers()).hasSize(1);
+    }
+
+    @Test
+    void shouldCreateLongTaskTimersDynamically() {
+        Function<Tags, LongTaskTimer> timerFactory = LongTaskTimer.builder("test.active.timer")
+            .tag("static", "abc")
+            .with(registry);
+
+        timerFactory.apply(Tags.of("dynamic", "1")).start().stop();
+        timerFactory.apply(Tags.of("dynamic", "2")).start().stop();
+        timerFactory.apply(Tags.of("dynamic", "1")).start().stop();
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(registry.find("test.active.timer").tags("static", "abc", "dynamic", "1").longTaskTimers())
+            .hasSize(1);
+        assertThat(registry.find("test.active.timer").tags("static", "abc", "dynamic", "2").longTaskTimers())
+            .hasSize(1);
+    }
+
+    @Test
+    void shouldOverrideStaticTagsWhenCreatesLongTaskTimersDynamically() {
+        Function<Tags, LongTaskTimer> timerFactory = LongTaskTimer.builder("test.active.timer")
+            .tag("static", "abc")
+            .with(registry);
+
+        timerFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).start().stop();
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.find("test.active.timer").tags("static", "xyz", "dynamic", "1").longTaskTimers())
+            .hasSize(1);
+    }
+
+    @Test
+    void shouldCreateDistributionSummariesDynamically() {
+        Function<Tags, DistributionSummary> distributionFactory = DistributionSummary.builder("test.distribution")
+            .tag("static", "abc")
+            .with(registry);
+
+        distributionFactory.apply(Tags.of("dynamic", "1")).record(1);
+        distributionFactory.apply(Tags.of("dynamic", "2")).record(2);
+        distributionFactory.apply(Tags.of("dynamic", "1")).record(1);
+
+        assertThat(registry.getMeters()).hasSize(2);
+        assertThat(registry.find("test.distribution").tags("static", "abc", "dynamic", "1").summaries()).hasSize(1);
+        assertThat(registry.find("test.distribution").tags("static", "abc", "dynamic", "2").summaries()).hasSize(1);
+    }
+
+    @Test
+    void shouldOverrideStaticTagsWhenCreatesDistributionSummariesDynamically() {
+        Function<Tags, DistributionSummary> distributionFactory = DistributionSummary.builder("test.distribution")
+            .tag("static", "abc")
+            .with(registry);
+
+        distributionFactory.apply(Tags.of("static", "xyz", "dynamic", "1")).record(1);
+
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.find("test.distribution").tags("static", "xyz", "dynamic", "1").summaries()).hasSize(1);
+    }
+
+}


### PR DESCRIPTION
This feature is a shortcut to create/get certain meters in a simpler way using the builder of that meter but without the need of recreating the builder every time.

This is what dynamic tagging looks like before this change (a bit longer and multiple builder instances will be created):
```java
private final MeterRegistry registry = ...;

void favoriteColor(Color color) {
    Counter.builder("colors")
        .tags(Tags.of("color", color.name()))
        .register(registry)
        .increment();
}

```
And this is what you can do after (a bit shorter and one builder instance will be created):
```java
private final MeterRegistry registry = ...;
private final MeterProvider<Counter> meterProvider = Counter.builder("colors").withRegistry(registry);

void favoriteColor(Color color) {
    meterProvider.withTags(Tags.of("color", color.name())).increment();
}
```

Closes gh-535
See gh-4092