### PR TITLE
Support API Token Type from the Wavefront SDK

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.wavefront;
 
+import com.wavefront.sdk.common.clients.service.token.TokenService;
+import com.wavefront.sdk.common.clients.service.token.TokenService.Type;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.config.validate.InvalidReason;
 import io.micrometer.core.instrument.config.validate.Validated;
@@ -109,6 +111,14 @@ public interface WavefrontConfig extends PushRegistryConfig {
                 return "unknown";
             }
         });
+    }
+
+    default TokenService.Type apiTokenType() {
+        return getEnum(this, TokenService.Type.class, "apiTokenType")
+            .invalidateWhen(tokenType -> tokenType == Type.NO_TOKEN && WavefrontMeterRegistry.isDirectToApi(this),
+                    "must be set to something else whenever publishing directly to the Wavefront API",
+                    InvalidReason.MISSING)
+            .orElse(WavefrontMeterRegistry.isDirectToApi(this) ? Type.WAVEFRONT_API_TOKEN : Type.NO_TOKEN);
     }
 
     /**

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -353,7 +353,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
      * @since 1.5.0
      */
     public static WavefrontClient.Builder getDefaultSenderBuilder(WavefrontConfig config) {
-        return new WavefrontClient.Builder(getWavefrontReportingUri(config), config.apiToken())
+        return new WavefrontClient.Builder(getWavefrontReportingUri(config), config.apiTokenType(), config.apiToken())
             .batchSize(config.batchSize())
             .flushInterval((int) config.step().toMillis(), TimeUnit.MILLISECONDS);
     }

--- a/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontConfigTest.java
+++ b/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontConfigTest.java
@@ -15,13 +15,16 @@
  */
 package io.micrometer.wavefront;
 
+import com.wavefront.sdk.common.clients.service.token.TokenService.Type;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.config.validate.ValidationException;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 class WavefrontConfigTest {
@@ -42,6 +45,52 @@ class WavefrontConfigTest {
         WavefrontConfig config = wavefrontProps::getProperty;
         assertThatCode(config::uri).isExactlyInstanceOf(ValidationException.class)
             .hasMessageContaining("it must be a valid URI");
+    }
+
+    @Test
+    void noExceptionAndNoTokenTypeIfTokenMissingButProxyUsed() {
+        Map<String, String> wavefrontProps = Map.of("wavefront.uri", "proxy://example.org:2878");
+        WavefrontConfig config = wavefrontProps::get;
+        assertThatCode(config::apiToken).doesNotThrowAnyException();
+        assertThat(config.apiTokenType()).isSameAs(Type.NO_TOKEN);
+    }
+
+    @Test
+    void noExceptionAndWavefrontTokenTypeIfTokenPresentAndDirectAccessUsed() {
+        Map<String, String> wavefrontProps = Map.of("wavefront.uri", "https://example.org:2878", "wavefront.apiToken",
+                "s3cr3t");
+        WavefrontConfig config = wavefrontProps::get;
+        assertThatCode(config::apiToken).doesNotThrowAnyException();
+        assertThat(config.apiTokenType()).isSameAs(Type.WAVEFRONT_API_TOKEN);
+    }
+
+    @Test
+    void apiTokenFailsIfNoTokenPresentAndDirectAccessUsed() {
+        Map<String, String> wavefrontProps = Map.of("wavefront.uri", "https://example.org:2878");
+        WavefrontConfig config = wavefrontProps::get;
+        assertThatCode(config::apiToken).isExactlyInstanceOf(ValidationException.class)
+            .hasNoCause()
+            .hasMessage(
+                    "wavefront.apiToken was 'null' but it must be set whenever publishing directly to the Wavefront API");
+    }
+
+    @Test
+    void apiTokenTypeFailsIfNoTokenTypeAndDirectAccessUsed() {
+        Map<String, String> wavefrontProps = Map.of("wavefront.uri", "https://example.org:2878",
+                "wavefront.apiTokenType", Type.NO_TOKEN.name());
+        WavefrontConfig config = wavefrontProps::get;
+        assertThatCode(config::apiTokenType).isExactlyInstanceOf(ValidationException.class)
+            .hasNoCause()
+            .hasMessage(
+                    "wavefront.apiTokenType was 'No-Op/Proxy' but it must be set to something else whenever publishing directly to the Wavefront API");
+    }
+
+    @Test
+    void apiTokenTypeShouldBeUsedIfDirectAccessUsed() {
+        Map<String, String> wavefrontProps = Map.of("wavefront.uri", "https://example.org:2878",
+                "wavefront.apiTokenType", Type.CSP_API_TOKEN.name());
+        WavefrontConfig config = wavefrontProps::get;
+        assertThat(config.apiTokenType()).isSameAs(Type.CSP_API_TOKEN);
     }
 
 }


### PR DESCRIPTION
API Token type was added to the Wavefront SDK so that Wavefront can support multiple types of tokens/auth mechanisms: https://github.com/wavefrontHQ/wavefront-sdk-java/releases/tag/v3.4.1