### PR TITLE
Add Javadoc since for WavefrontConfig.apiTokenType()

### DIFF
--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontConfig.java
@@ -113,6 +113,11 @@ public interface WavefrontConfig extends PushRegistryConfig {
         });
     }
 
+    /**
+     * API token type.
+     * @return API token type
+     * @since 1.12.0
+     */
     default TokenService.Type apiTokenType() {
         return getEnum(this, TokenService.Type.class, "apiTokenType")
             .invalidateWhen(tokenType -> tokenType == Type.NO_TOKEN && WavefrontMeterRegistry.isDirectToApi(this),


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `WavefrontConfig.apiTokenType()`.

See gh-4054