### PR TITLE
Move Jakarta JMS instrumentation to micrometer-jakarta10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-osgi-test'])) {
+            if (!(project.name in ['micrometer-jakarta10'])) {
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/micrometer-jakarta10/build.gradle
+++ b/micrometer-jakarta10/build.gradle
@@ -1,0 +1,26 @@
+description 'Module for Jakarta 10+ based instrumentations'
+
+jar {
+    bundle {
+
+        bnd '''\
+        Import-Package: \
+            jakarta.jms.*;resolution:=dynamic;version="${@}",\
+            io.micrometer.observation.*;resolution:=dynamic;version="${@}",\
+            *
+        '''.stripIndent()
+    }
+}
+
+dependencies {
+    api project(":micrometer-core")
+    api project(":micrometer-commons")
+    api project(":micrometer-observation")
+
+    optionalApi 'jakarta.jms:jakarta.jms-api'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'com.tngtech.archunit:archunit-junit5'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.assertj:assertj-core'
+}

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsInstrumentation.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsInstrumentation.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.Session;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsObservationDocumentation.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsObservationDocumentation.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.docs.KeyName;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsProcessObservationContext.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsProcessObservationContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.transport.ReceiverContext;
 import jakarta.jms.JMSException;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsProcessObservationConvention.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsProcessObservationConvention.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsPublishObservationContext.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsPublishObservationContext.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.transport.SenderContext;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsPublishObservationConvention.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/JmsPublishObservationConvention.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationConvention;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/MessageConsumerInvocationHandler.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/MessageConsumerInvocationHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/MessageProducerInvocationHandler.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/MessageProducerInvocationHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/SessionInvocationHandler.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/SessionInvocationHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.MessageConsumer;

--- a/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/package-info.java
+++ b/micrometer-jakarta10/src/main/java/io/micrometer/jakarta10/instrument/jms/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Observation instrumentation for Jakarta JMS.
+ */
+@NonNullFields
+@NonNullApi
+package io.micrometer.jakarta10.instrument.jms;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;

--- a/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/NoJavaxArchitectureTests.java
+++ b/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/NoJavaxArchitectureTests.java
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.micrometer.jakarta10;
 
-/**
- * Observation instrumentation for Jakarta JMS.
- */
-@NonNullFields
-@NonNullApi
-package io.micrometer.core.instrument.binder.jms;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+@AnalyzeClasses(packages = "io.micrometer.jakarta10")
+class NoJavaxArchitectureTests {
+
+    @ArchTest
+    static final ArchRule noJavaxDependencies = noClasses().that()
+        .resideInAPackage("io.micrometer.jakarta10..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("javax..");
+
+}

--- a/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/instrument/jms/DefaultJmsProcessObservationConventionTests.java
+++ b/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/instrument/jms/DefaultJmsProcessObservationConventionTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.common.KeyValue;
 import jakarta.jms.*;
@@ -24,42 +24,42 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link DefaultJmsPublishObservationConvention}.
+ * Tests for {@link DefaultJmsProcessObservationConvention}.
  *
  * @author Brian Clozel
  */
-class DefaultJmsPublishObservationConventionTests {
+class DefaultJmsProcessObservationConventionTests {
 
-    private final DefaultJmsPublishObservationConvention convention = new DefaultJmsPublishObservationConvention();
+    private final DefaultJmsProcessObservationConvention convention = new DefaultJmsProcessObservationConvention();
 
     @Test
     void shouldHaveObservationName() {
-        assertThat(convention.getName()).isEqualTo("jms.message.publish");
+        assertThat(convention.getName()).isEqualTo("jms.message.process");
     }
 
     @Test
     void shouldHaveQueueContextualName() throws Exception {
-        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
-        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.queue publish");
+        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
+        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.queue process");
     }
 
     @Test
     void shouldHaveTopicContextualName() throws Exception {
-        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithTopic());
-        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.topic publish");
+        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithTopic());
+        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.topic process");
     }
 
     @Test
     void shouldHaveOperationName() throws Exception {
-        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
+        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
         assertThat(convention.getLowCardinalityKeyValues(context))
-            .contains(KeyValue.of("messaging.operation", "publish"));
+            .contains(KeyValue.of("messaging.operation", "process"));
     }
 
     @Test
     void shouldHaveCorrelationIdWhenAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         when(message.getJMSCorrelationID()).thenReturn("test-correlation");
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "test-correlation"));
@@ -68,7 +68,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveUnknownCorrelationIdWhenNotAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "unknown"));
     }
@@ -76,7 +76,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveUnknownCorrelationIdWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         when(message.getJMSCorrelationID()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "unknown"));
@@ -84,14 +84,14 @@ class DefaultJmsPublishObservationConventionTests {
 
     @Test
     void shouldHaveQueueDestinationName() throws Exception {
-        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
+        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "micrometer.test.queue"));
     }
 
     @Test
     void shouldHaveTopicDestinationName() throws Exception {
-        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithTopic());
+        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithTopic());
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "micrometer.test.topic"));
     }
@@ -99,7 +99,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveUnknownDestinationNameWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         when(((Queue) message.getJMSDestination()).getQueueName()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "unknown"));
@@ -108,7 +108,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveMessageIdWhenAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         when(message.getJMSMessageID()).thenReturn("test-id");
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "test-id"));
@@ -117,7 +117,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveUnknownMessageIdWhenNotAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "unknown"));
     }
@@ -125,7 +125,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveUnknownMessageIdWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         when(message.getJMSMessageID()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "unknown"));
@@ -134,7 +134,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveDurableDestinationForQueue() throws Exception {
         Message message = createMessageWithQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "false"));
     }
@@ -142,7 +142,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveTempDestinationForTemporaryQueue() throws Exception {
         Message message = createMessageWithTempQueue();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "true"));
     }
@@ -150,7 +150,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveDurableDestinationForTopic() throws Exception {
         Message message = createMessageWithTopic();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "false"));
     }
@@ -158,7 +158,7 @@ class DefaultJmsPublishObservationConventionTests {
     @Test
     void shouldHaveTempDestinationForTemporaryTopic() throws Exception {
         Message message = createMessageWithTempTopic();
-        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "true"));
     }

--- a/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/instrument/jms/DefaultJmsPublishObservationConventionTests.java
+++ b/micrometer-jakarta10/src/test/java/io/micrometer/jakarta10/instrument/jms/DefaultJmsPublishObservationConventionTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jms;
+package io.micrometer.jakarta10.instrument.jms;
 
 import io.micrometer.common.KeyValue;
 import jakarta.jms.*;
@@ -24,42 +24,42 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link DefaultJmsProcessObservationConvention}.
+ * Tests for {@link DefaultJmsPublishObservationConvention}.
  *
  * @author Brian Clozel
  */
-class DefaultJmsProcessObservationConventionTests {
+class DefaultJmsPublishObservationConventionTests {
 
-    private final DefaultJmsProcessObservationConvention convention = new DefaultJmsProcessObservationConvention();
+    private final DefaultJmsPublishObservationConvention convention = new DefaultJmsPublishObservationConvention();
 
     @Test
     void shouldHaveObservationName() {
-        assertThat(convention.getName()).isEqualTo("jms.message.process");
+        assertThat(convention.getName()).isEqualTo("jms.message.publish");
     }
 
     @Test
     void shouldHaveQueueContextualName() throws Exception {
-        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
-        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.queue process");
+        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
+        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.queue publish");
     }
 
     @Test
     void shouldHaveTopicContextualName() throws Exception {
-        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithTopic());
-        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.topic process");
+        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithTopic());
+        assertThat(convention.getContextualName(context)).isEqualTo("micrometer.test.topic publish");
     }
 
     @Test
     void shouldHaveOperationName() throws Exception {
-        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
+        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
         assertThat(convention.getLowCardinalityKeyValues(context))
-            .contains(KeyValue.of("messaging.operation", "process"));
+            .contains(KeyValue.of("messaging.operation", "publish"));
     }
 
     @Test
     void shouldHaveCorrelationIdWhenAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         when(message.getJMSCorrelationID()).thenReturn("test-correlation");
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "test-correlation"));
@@ -68,7 +68,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveUnknownCorrelationIdWhenNotAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "unknown"));
     }
@@ -76,7 +76,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveUnknownCorrelationIdWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         when(message.getJMSCorrelationID()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.conversation_id", "unknown"));
@@ -84,14 +84,14 @@ class DefaultJmsProcessObservationConventionTests {
 
     @Test
     void shouldHaveQueueDestinationName() throws Exception {
-        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithQueue());
+        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithQueue());
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "micrometer.test.queue"));
     }
 
     @Test
     void shouldHaveTopicDestinationName() throws Exception {
-        JmsProcessObservationContext context = new JmsProcessObservationContext(createMessageWithTopic());
+        JmsPublishObservationContext context = new JmsPublishObservationContext(createMessageWithTopic());
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "micrometer.test.topic"));
     }
@@ -99,7 +99,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveUnknownDestinationNameWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         when(((Queue) message.getJMSDestination()).getQueueName()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.name", "unknown"));
@@ -108,7 +108,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveMessageIdWhenAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         when(message.getJMSMessageID()).thenReturn("test-id");
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "test-id"));
@@ -117,7 +117,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveUnknownMessageIdWhenNotAvailable() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "unknown"));
     }
@@ -125,7 +125,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveUnknownMessageIdWhenException() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         when(message.getJMSMessageID()).thenThrow(new JMSException("test exception"));
         assertThat(convention.getHighCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.message.id", "unknown"));
@@ -134,7 +134,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveDurableDestinationForQueue() throws Exception {
         Message message = createMessageWithQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "false"));
     }
@@ -142,7 +142,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveTempDestinationForTemporaryQueue() throws Exception {
         Message message = createMessageWithTempQueue();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "true"));
     }
@@ -150,7 +150,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveDurableDestinationForTopic() throws Exception {
         Message message = createMessageWithTopic();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "false"));
     }
@@ -158,7 +158,7 @@ class DefaultJmsProcessObservationConventionTests {
     @Test
     void shouldHaveTempDestinationForTemporaryTopic() throws Exception {
         Message message = createMessageWithTempTopic();
-        JmsProcessObservationContext context = new JmsProcessObservationContext(message);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(message);
         assertThat(convention.getLowCardinalityKeyValues(context))
             .contains(KeyValue.of("messaging.destination.temporary", "true"));
     }

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'org.awaitility:awaitility'
 
     testImplementation project(':micrometer-observation-test')
+    testImplementation project(':micrometer-jakarta10')
 
     testImplementation 'org.jsr107.ri:cache-ri-impl'
 

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -19,6 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import io.micrometer.jakarta10.instrument.jms.JmsInstrumentation;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import jakarta.jms.*;

--- a/settings.gradle
+++ b/settings.gradle
@@ -43,6 +43,7 @@ include 'micrometer-test', 'micrometer-observation-test'
 }
 
 include 'micrometer-bom'
+include 'micrometer-jakarta10'
 include 'micrometer-jetty11'
 include 'micrometer-osgi-test'
 include 'docs'


### PR DESCRIPTION
Introduces a new module micrometer-jakarta10 and moves the previously merged JMS instrumentation there. The reason for this is that we tend to try to support a range of versions when possible for our users, and if Jakarta makes breaking changes in the future, we would not be able to support that in a single module (such as micrometer-core, or micrometer-jakarta) unless the new Jakarta artifacts used different coordinates.

The Jakarta JMS instrumentation was introduced in #4007. This moves it, unchanged, to the new module for the above mentioned reason.
This is a portion of the changes that were proposed in #3989.