### PR TITLE
Escape/Unescape JMS String properties in contexts

### DIFF
--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContext.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContext.java
@@ -26,7 +26,10 @@ import jakarta.jms.Message;
  * {@link JmsObservationDocumentation#JMS_MESSAGE_PUBLISH publication of JMS messages}.
  * <p>
  * This propagates the tracing information with the message sent by
- * {@link Message#setStringProperty(String, String) setting a message header}.
+ * {@link Message#setStringProperty(String, String) setting a message header}. As the JMS
+ * spec only allows valid Java identifiers as String properties, we must escape "-" and
+ * "." characters as {@code "_HYPHEN_"} and {@code "_DOT_"}, assuming that they are
+ * escaped on the receiving side.
  *
  * @author Brian Clozel
  * @since 1.12.0
@@ -37,7 +40,7 @@ public class JmsPublishObservationContext extends SenderContext<Message> {
         super((message, key, value) -> {
             try {
                 if (message != null) {
-                    message.setStringProperty(key, value);
+                    message.setStringProperty(escapeKey(key), value);
                 }
             }
             catch (JMSException exc) {
@@ -45,6 +48,10 @@ public class JmsPublishObservationContext extends SenderContext<Message> {
             }
         });
         setCarrier(sendMessage);
+    }
+
+    private static String escapeKey(String key) {
+        return key.replace("-", "_HYPHEN_").replace(".", "_DOT_");
     }
 
 }

--- a/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/JmsProcessObservationContextTests.java
+++ b/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/JmsProcessObservationContextTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jakarta9.instrument.jms;
+
+import jakarta.jms.Message;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link JmsProcessObservationContext}.
+ *
+ * @author Brian Clozel
+ */
+class JmsProcessObservationContextTests {
+
+    @ParameterizedTest
+    @MethodSource("headerValues")
+    void propagatorShouldEscapeHeader(String value, String escaped) throws Exception {
+
+        Message sendMessage = mock(Message.class);
+        JmsProcessObservationContext context = new JmsProcessObservationContext(sendMessage);
+        context.getGetter().get(sendMessage, value);
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sendMessage).getStringProperty(argumentCaptor.capture());
+
+        assertThat(argumentCaptor.getValue()).isEqualTo(escaped);
+    }
+
+    static Stream<Arguments> headerValues() {
+        return Stream.of(Arguments.of("valid", "valid"), Arguments.of("with-hyphen", "with_HYPHEN_hyphen"),
+                Arguments.of("with.dot", "with_DOT_dot"));
+    }
+
+}

--- a/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContextTests.java
+++ b/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContextTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2002-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jakarta9.instrument.jms;
+
+import jakarta.jms.Message;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link JmsPublishObservationContext}.
+ *
+ * @author Brian Clozel
+ */
+class JmsPublishObservationContextTests {
+
+    @ParameterizedTest
+    @MethodSource("headerValues")
+    void propagatorShouldEscapeHeader(String value, String escaped) throws Exception {
+
+        Message sendMessage = mock(Message.class);
+        JmsPublishObservationContext context = new JmsPublishObservationContext(sendMessage);
+        context.getSetter().set(sendMessage, value, "testValue");
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sendMessage).setStringProperty(argumentCaptor.capture(), anyString());
+
+        assertThat(argumentCaptor.getValue()).isEqualTo(escaped);
+    }
+
+    static Stream<Arguments> headerValues() {
+        return Stream.of(Arguments.of("valid", "valid"), Arguments.of("with-hyphen", "with_HYPHEN_hyphen"),
+                Arguments.of("with.dot", "with_DOT_dot"));
+    }
+
+}


### PR DESCRIPTION
Prior to this commit, both `JmsPublishObservationContext` and `JmsProcessObservationContext` would set propagation headers as String properties on the JMS `Message`.
This would cause issues with JMS implementations, as the JMS specification only allows valid Java identifiers as keys. Typically, a `X-B3-TraceId` header fails this requirement as it contains "-" characters.

This commit ensures that the following characters are escaped when publishing messages, and unescaped when receiving messages:

* "-" becomes "_HYPHEN_"
* "." becomes "_DOT_"

See gh-4202