### PR TITLE
[Dynatrace v2] Only serialize metadata when set on the meter

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -457,7 +457,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
         if (!config.exportMeterMetadata()) {
             return false;
         }
-        // if at least one of unit or description are set, add metadata.
+        // if at least one of unit or description are set, export metadata.
         if (id.getBaseUnit() != null && !id.getBaseUnit().isEmpty()) {
             return true;
         }


### PR DESCRIPTION
(Bugfix)

In #4006, we added support for metrics metadata (unit/description). While working on something unrelated, we realized that the exporter will try to serialize metadata to the Dynatrace transport format. When no metadata is set on the meter (e.g. custom metrics introduced by users) the serialization library will log a warning stating that metadata serialization had been called without setting data. This can lead to many log lines.

Since it is perfectly fine to create meters without metadata, the exporter should not attempt to create metadata lines if no metadata was set on the metric. 