### PR TITLE
Add WARN message when OtlpMeterRegistry fails to publish metrics

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -107,9 +107,13 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                             .build())
                         .build())
                     .build();
-                this.httpSender.post(this.config.url())
+                HttpSender.Response response = this.httpSender.post(this.config.url())
                     .withContent("application/x-protobuf", request.toByteArray())
                     .send();
+                if (!response.isSuccessful()) {
+                    logger.warn("Failed to publish metrics. Server responded with HTTP status code {} and body {}",
+                            response.code(), response.body());
+                }
             }
             catch (Throwable e) {
                 logger.warn("Failed to publish metrics to OTLP receiver", e);


### PR DESCRIPTION
Experienced this bad behaviour while plugging my application to an APM; as I configured the bad endpoint, it answered me with `403` http status, yet nothing appeared in logs, as if everything was normal. I had to use debugger to see the status.