### PR TITLE
Add `database` tag to `DefaultMongoCommandTagsProvider`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoCommandTagsProvider.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoCommandTagsProvider.java
@@ -54,7 +54,7 @@ public class DefaultMongoCommandTagsProvider implements MongoCommandTagsProvider
 
     @Override
     public Iterable<Tag> commandTags(CommandEvent event) {
-        return Tags.of(Tag.of("command", event.getCommandName()),
+        return Tags.of(Tag.of("command", event.getCommandName()), Tag.of("database", event.getDatabaseName()),
                 Tag.of("collection", getAndRemoveCollectionNameForCommand(event)),
                 Tag.of("cluster.id",
                         event.getConnectionDescription().getConnectionId().getServerId().getClusterId().getValue()),

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoCommandTagsProviderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/DefaultMongoCommandTagsProviderTest.java
@@ -49,7 +49,8 @@ class DefaultMongoCommandTagsProviderTest {
     void defaultCommandTags() {
         CommandSucceededEvent event = commandSucceededEvent(5150);
         Iterable<Tag> tags = tagsProvider.commandTags(event);
-        assertThat(tags).containsExactlyInAnyOrder(Tag.of("command", "find"), Tag.of("collection", "unknown"),
+        assertThat(tags).containsExactlyInAnyOrder(Tag.of("command", "find"), Tag.of("database", "db1"),
+                Tag.of("collection", "unknown"),
                 Tag.of("cluster.id", connectionDesc.getConnectionId().getServerId().getClusterId().getValue()),
                 Tag.of("server.address", "localhost:5150"), Tag.of("status", "SUCCESS"));
     }
@@ -84,12 +85,12 @@ class DefaultMongoCommandTagsProviderTest {
     }
 
     private CommandStartedEvent commandStartedEvent(int requestId) {
-        return new CommandStartedEvent(requestId, connectionDesc, "db1", "find",
+        return new CommandStartedEvent(null, -1, requestId, connectionDesc, "db1", "find",
                 new BsonDocument("find", new BsonString("collection-" + requestId)));
     }
 
     private CommandSucceededEvent commandSucceededEvent(int requestId) {
-        return new CommandSucceededEvent(requestId, connectionDesc, "find", new BsonDocument(), 1200L);
+        return new CommandSucceededEvent(null, -1, requestId, connectionDesc, "db1", "find", new BsonDocument(), 1200L);
     }
 
     @Nested

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsCommandListenerTest.java
@@ -76,7 +76,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         mongo.getDatabase("test").getCollection("testCol").insertOne(new Document("testDoc", new Date()));
 
         Tags tags = Tags.of("cluster.id", clusterId.get(), "server.address", String.format("%s:%s", host, port),
-                "command", "insert", "collection", "testCol", "status", "SUCCESS");
+                "command", "insert", "database", "test", "collection", "testCol", "status", "SUCCESS");
         assertThat(registry.get("mongodb.driver.commands").tags(tags).timer().count()).isEqualTo(1);
     }
 
@@ -85,7 +85,7 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         mongo.getDatabase("test").getCollection("testCol").dropIndex("nonExistentIndex");
 
         Tags tags = Tags.of("cluster.id", clusterId.get(), "server.address", String.format("%s:%s", host, port),
-                "command", "dropIndexes", "collection", "testCol", "status", "FAILED");
+                "command", "dropIndexes", "database", "test", "collection", "testCol", "status", "FAILED");
         assertThat(registry.get("mongodb.driver.commands").tags(tags).timer().count()).isEqualTo(1);
     }
 
@@ -110,7 +110,8 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         try (MongoClient mongo = MongoClients.create(settings)) {
             mongo.getDatabase("test").getCollection("testCol").insertOne(new Document("testDoc", new Date()));
             Tags tags = Tags.of("cluster.id", clusterId.get(), "server.address", String.format("%s:%s", host, port),
-                    "command", "insert", "collection", "testCol", "status", "SUCCESS", "mongoz", "5150");
+                    "command", "insert", "database", "test", "collection", "testCol", "status", "SUCCESS", "mongoz",
+                    "5150");
             assertThat(registry.get("mongodb.driver.commands").tags(tags).timer().count()).isEqualTo(1);
         }
     }
@@ -136,7 +137,8 @@ class MongoMetricsCommandListenerTest extends AbstractMongoDbTest {
         try (MongoClient mongo = MongoClients.create(settings)) {
             mongo.getDatabase("test").getCollection("testCol").dropIndex("nonExistentIndex");
             Tags tags = Tags.of("cluster.id", clusterId.get(), "server.address", String.format("%s:%s", host, port),
-                    "command", "dropIndexes", "collection", "testCol", "status", "FAILED", "mongoz", "5150");
+                    "command", "dropIndexes", "database", "test", "collection", "testCol", "status", "FAILED", "mongoz",
+                    "5150");
             assertThat(registry.get("mongodb.driver.commands").tags(tags).timer().count()).isEqualTo(1);
         }
     }


### PR DESCRIPTION
The MongoDB Java driver [added](https://jira.mongodb.org/browse/JAVA-4875) the `databaseName` field to commands in 4.11. We can expose this via the `DefaultMongoCommandTagsProvider`. While there, I've also replaced usage of deprecated constructors.