### PR TITLE
Add support for `AutoShutdownDelegatedExecutorService`

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -296,7 +296,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
             if (className.equals("java.util.concurrent.Executors$DelegatedScheduledExecutorService")) {
                 monitor(registry, unwrapThreadPoolExecutor(executorService, executorService.getClass()));
             }
-            else if (className.equals("java.util.concurrent.Executors$FinalizableDelegatedExecutorService")) {
+            else if (className.equals("java.util.concurrent.Executors$FinalizableDelegatedExecutorService")
+                    || className.equals("java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService")) {
                 monitor(registry,
                         unwrapThreadPoolExecutor(executorService, executorService.getClass().getSuperclass()));
             }


### PR DESCRIPTION
This executor is returned by `Executors#newSingleThreadExecutor` under Java 21.