### PR TITLE
Wait for in-progress publish before closing step rollover

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -243,8 +243,8 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
     @Override
     public void close() {
         stop();
-        if (!isPublishing() && isDelta()) {
-            if (!isDataPublishedForCurrentStep()) {
+        if (config.enabled() && isDelta() && !isClosed()) {
+            if (!isDataPublishedForCurrentStep() && !isPublishing()) {
                 // Data was not published for the current step. So, we should flush that
                 // first.
                 try {
@@ -255,6 +255,9 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                             "Unexpected exception thrown while publishing metrics for " + getClass().getSimpleName(),
                             e);
                 }
+            }
+            else if (isPublishing()) {
+                waitForInProgressScheduledPublish();
             }
             getMeters().forEach(this::closingRollover);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -136,7 +136,12 @@ public abstract class PushMeterRegistry extends MeterRegistry {
         super.close();
     }
 
-    private void waitForInProgressScheduledPublish() {
+    /**
+     * Wait until scheduled publishing by {@link PushMeterRegistry} completes, if in
+     * progress.
+     * @since 1.11.6
+     */
+    protected void waitForInProgressScheduledPublish() {
         try {
             // block until in progress publish finishes
             publishingSemaphore.acquire();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -138,8 +138,8 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     public void close() {
         stop();
 
-        if (!isPublishing() && config.enabled() && !isClosed()) {
-            if (!isDataPublishedForCurrentStep()) {
+        if (config.enabled() && !isClosed()) {
+            if (!isDataPublishedForCurrentStep() && !isPublishing()) {
                 // Data was not published for the current step. So, we should flush that
                 // first.
                 try {
@@ -150,6 +150,9 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
                             "Unexpected exception thrown while publishing metrics for " + getClass().getSimpleName(),
                             e);
                 }
+            }
+            else if (isPublishing()) {
+                waitForInProgressScheduledPublish();
             }
             closingRolloverStepMeters();
         }


### PR DESCRIPTION
If a scheduled publish is in progress when `close` is called, `StepMeterRegistry` was not performing the closing rollover and was not doing a subsequent publish of the final partial step.

Wait for the in-progress publish to finish before the closing rollover is called, which is followed by a final publish of the partial step (in `PushMeterRegistry#close`).

Fixes gh-3846