### PR TITLE
Add missing metrics for Jersey in cases of client errors

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListener.java
@@ -73,7 +73,7 @@ public class MetricsRequestEventListener implements RequestEventListener {
 
         switch (event.getType()) {
             case ON_EXCEPTION:
-                if (!isNotFoundException(event)) {
+                if (!isClientError(event)) {
                     break;
                 }
             case REQUEST_MATCHED:
@@ -109,13 +109,14 @@ public class MetricsRequestEventListener implements RequestEventListener {
         }
     }
 
-    private boolean isNotFoundException(RequestEvent event) {
+    private boolean isClientError(RequestEvent event) {
         Throwable t = event.getException();
         if (t == null) {
             return false;
         }
-        String className = t.getClass().getCanonicalName();
-        return className.equals("jakarta.ws.rs.NotFoundException") || className.equals("javax.ws.rs.NotFoundException");
+        String className = t.getClass().getSuperclass().getCanonicalName();
+        return className.equals("jakarta.ws.rs.ClientErrorException")
+                || className.equals("javax.ws.rs.ClientErrorException");
     }
 
     private Set<Timer> shortTimers(Set<Timed> timed, RequestEvent event) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jersey/server/ObservationRequestEventListener.java
@@ -65,7 +65,7 @@ public class ObservationRequestEventListener implements RequestEventListener {
 
         switch (event.getType()) {
             case ON_EXCEPTION:
-                if (!isNotFoundException(event)) {
+                if (!isClientError(event)) {
                     break;
                 }
             case REQUEST_MATCHED:
@@ -96,13 +96,14 @@ public class ObservationRequestEventListener implements RequestEventListener {
         }
     }
 
-    private boolean isNotFoundException(RequestEvent event) {
+    private boolean isClientError(RequestEvent event) {
         Throwable t = event.getException();
         if (t == null) {
             return false;
         }
-        String className = t.getClass().getCanonicalName();
-        return className.equals("jakarta.ws.rs.NotFoundException") || className.equals("javax.ws.rs.NotFoundException");
+        String className = t.getClass().getSuperclass().getCanonicalName();
+        return className.equals("jakarta.ws.rs.ClientErrorException")
+                || className.equals("javax.ws.rs.ClientErrorException");
     }
 
     private static class ObservationScopeAndContext {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/MetricsRequestEventListenerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -148,6 +149,11 @@ class MetricsRequestEventListenerTest extends JerseyTest {
         }
         catch (Exception ignored) {
         }
+        try {
+            target("produces-text-plain").request(MediaType.APPLICATION_JSON).get();
+        }
+        catch (Exception ignored) {
+        }
 
         assertThat(registry.get(METRIC_NAME)
             .tags(tagsFrom("/throws-exception", "500", "SERVER_ERROR", "IllegalArgumentException"))
@@ -161,6 +167,11 @@ class MetricsRequestEventListenerTest extends JerseyTest {
 
         assertThat(registry.get(METRIC_NAME)
             .tags(tagsFrom("/throws-mappable-exception", "410", "CLIENT_ERROR", "ResourceGoneException"))
+            .timer()
+            .count()).isEqualTo(1);
+
+        assertThat(registry.get(METRIC_NAME)
+            .tags(tagsFrom("root", "406", "CLIENT_ERROR", "NotAcceptableException"))
             .timer()
             .count()).isEqualTo(1);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/resources/TestResource.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/resources/TestResource.java
@@ -83,6 +83,13 @@ public class TestResource {
     }
 
     @GET
+    @Path("produces-text-plain")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String producesTextPlain() {
+        return "hello";
+    }
+
+    @GET
     @Path("redirect/{status}")
     public Response redirect(@PathParam("status") int status) {
         if (status == 307) {


### PR DESCRIPTION
We are using Jersey integration and we have noticed that some 40x errors (such as `406 Not Acceptable` or `415 Unsupported Media Type`) are not reported in the metrics.

After some debugging, we found out that the root cause of this issue is that only one kind of client exception (`NotFoundException`) is taken into account during metric collection.

This pull request should fix the problem, by taking into account all types of `ClientErrorExceptions`.

