### PR TITLE
Avoid IllegalArgumentException on DefaultLongTaskTimer when percentiles is empty

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -128,10 +128,10 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
 
     @Override
     public HistogramSnapshot takeSnapshot() {
-        Queue<Double> percentilesRequested = new ArrayBlockingQueue<>(
-                distributionStatisticConfig.getPercentiles() == null ? 1
-                        : distributionStatisticConfig.getPercentiles().length);
         double[] percentilesRequestedArr = distributionStatisticConfig.getPercentiles();
+        Queue<Double> percentilesRequested = new ArrayBlockingQueue<>(
+                percentilesRequestedArr == null || percentilesRequestedArr.length == 0 ? 1
+                        : distributionStatisticConfig.getPercentiles().length);
         if (percentilesRequestedArr != null && percentilesRequestedArr.length > 0) {
             Arrays.stream(percentilesRequestedArr).sorted().boxed().forEach(percentilesRequested::add);
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -214,4 +214,11 @@ class MeterRegistryTest {
         assertThat(timer1.getId().getBaseUnit()).isSameAs(timer2.getId().getBaseUnit());
     }
 
+    @Test
+    @Issue("#4482")
+    void acceptPercentilesNullOrEmpty() {
+        LongTaskTimer.builder("timer.percentiles.null").publishPercentiles(null).register(registry);
+        LongTaskTimer.builder("timer.percentiles.empty").publishPercentiles(new double[] {}).register(registry);
+    }
+
 }


### PR DESCRIPTION
closes #4482