### PR TITLE
Use cache for base time unit strings

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -60,6 +60,18 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class MeterRegistry {
 
+    // @formatter:off
+    private static final EnumMap<TimeUnit, String> BASE_TIME_UNIT_STRING_CACHE = Arrays.stream(TimeUnit.values())
+        .collect(
+            Collectors.toMap(
+                Function.identity(),
+                (timeUnit) -> timeUnit.toString().toLowerCase(),
+                (k, v) -> { throw new IllegalStateException("Duplicate keys should not exist."); },
+                () -> new EnumMap<>(TimeUnit.class)
+            )
+        );
+    // @formatter:on
+
     protected final Clock clock;
 
     private final Object meterMapLock = new Object();
@@ -279,11 +291,6 @@ public abstract class MeterRegistry {
      * @return The default distribution statistics config.
      */
     protected abstract DistributionStatisticConfig defaultHistogramConfig();
-
-    private static final EnumMap<TimeUnit, String> BASE_TIME_UNIT_STRING_CACHE = Arrays.stream(TimeUnit.values())
-        .collect(Collectors.toMap(Function.identity(), (timeUnit) -> timeUnit.toString().toLowerCase(), (l, r) -> {
-            throw new IllegalStateException("Duplicate keys should not exist.");
-        }, () -> new EnumMap<>(TimeUnit.class)));
 
     private String getBaseTimeUnitStr() {
         return BASE_TIME_UNIT_STRING_CACHE.get(getBaseTimeUnit());

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.*;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
@@ -279,8 +280,13 @@ public abstract class MeterRegistry {
      */
     protected abstract DistributionStatisticConfig defaultHistogramConfig();
 
+    private static final EnumMap<TimeUnit, String> BASE_TIME_UNIT_STRING_CACHE = Arrays.stream(TimeUnit.values())
+        .collect(Collectors.toMap(Function.identity(), (timeUnit) -> timeUnit.toString().toLowerCase(), (l, r) -> {
+            throw new IllegalStateException("Duplicate keys should not exist.");
+        }, () -> new EnumMap<>(TimeUnit.class)));
+
     private String getBaseTimeUnitStr() {
-        return getBaseTimeUnit().toString().toLowerCase();
+        return BASE_TIME_UNIT_STRING_CACHE.get(getBaseTimeUnit());
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -203,6 +204,14 @@ class MeterRegistryTest {
             .hasMessage(
                     "There is already a registered meter of a different type (CumulativeCounter vs. Timer) with the same name: my.dupe.meter")
             .hasNoCause();
+    }
+
+    @Test
+    @Issue("#4352")
+    void baseUnitStringShouldBeCachedAndReturnTheSameInstance() {
+        Timer timer1 = registry.timer("test.timer1");
+        Timer timer2 = registry.timer("test.timer2");
+        assertThat(timer1.getId().getBaseUnit()).isSameAs(timer2.getId().getBaseUnit());
     }
 
 }


### PR DESCRIPTION
This PR changes to use a cache for base time unit strings.

Closes gh-4352