### PR TITLE
Remove shaded netty dependency from POM

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -58,7 +58,7 @@ publishing {
                 asNode()
                     .dependencies
                     .dependency
-                    .findAll { ['reactor-core', 'reactor-netty-core'].contains(it.artifactId.text()) }
+                    .findAll { ['reactor-core', 'reactor-netty-core', 'netty-transport-native-epoll'].contains(it.artifactId.text()) }
                     .each { it.parent().remove(it) }
             }
         }


### PR DESCRIPTION
The dependency is shaded and so it should not be in the POM. We missed excluding this one when it was added in gh-3605.

Fixes gh-4492

Before:
```xml
  <dependencies>
    <dependency>
      <groupId>io.micrometer</groupId>
      <artifactId>micrometer-core</artifactId>
      <version>1.9.18-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>io.netty</groupId>
      <artifactId>netty-transport-native-epoll</artifactId>
      <classifier>linux-aarch_64</classifier>
      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <classifier>linux-x86_64</classifier>
       <scope>runtime</scope>
     </dependency>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
  </dependencies>
```

After:
```xml
  <dependencies>
    <dependency>
      <groupId>io.micrometer</groupId>
      <artifactId>micrometer-core</artifactId>
      <version>1.9.18-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
      <scope>compile</scope>
      <optional>true</optional>
    </dependency>
  </dependencies>
```