### PR TITLE
Polish UnusedImports Checkstyle configuration

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -25,9 +25,7 @@
             <property name="illegalPkgs" value="org.slf4j.*"/>
             <property name="regexp" value="true"/>
         </module>
-        <module name="UnusedImports">
-            <property name="processJavadoc" value="true" />
-        </module>
+        <module name="UnusedImports" />
 
         <!-- Regexp -->
         <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">


### PR DESCRIPTION
This PR polishes `UnusedImports` Checkstyle configuration by removing redundant configuration as it's the default value.

See https://checkstyle.sourceforge.io/checks/imports/unusedimports.html