### PR TITLE
Use LongAdder in CumulativeTimer and CumulativeDistributionSummary

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeDistributionSummary.java
@@ -23,8 +23,8 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.TimeWindowMax;
 
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Cumulative distribution summary.
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.DoubleAdder;
  */
 public class CumulativeDistributionSummary extends AbstractDistributionSummary {
 
-    private final AtomicLong count;
+    private final LongAdder count;
 
     private final DoubleAdder total;
 
@@ -50,21 +50,21 @@ public class CumulativeDistributionSummary extends AbstractDistributionSummary {
     public CumulativeDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
             double scale, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, scale, supportsAggregablePercentiles);
-        this.count = new AtomicLong();
+        this.count = new LongAdder();
         this.total = new DoubleAdder();
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
     }
 
     @Override
     protected void recordNonNegative(double amount) {
-        count.incrementAndGet();
+        count.increment();
         total.add(amount);
         max.record(amount);
     }
 
     @Override
     public long count() {
-        return count.get();
+        return count.longValue();
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/cumulative/CumulativeTimer.java
@@ -23,16 +23,16 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * @author Jon Schneider
  */
 public class CumulativeTimer extends AbstractTimer {
 
-    private final AtomicLong count;
+    private final LongAdder count;
 
-    private final AtomicLong total;
+    private final LongAdder total;
 
     private final TimeWindowMax max;
 
@@ -44,27 +44,27 @@ public class CumulativeTimer extends AbstractTimer {
     public CumulativeTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
             PauseDetector pauseDetector, TimeUnit baseTimeUnit, boolean supportsAggregablePercentiles) {
         super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, supportsAggregablePercentiles);
-        this.count = new AtomicLong();
-        this.total = new AtomicLong();
+        this.count = new LongAdder();
+        this.total = new LongAdder();
         this.max = new TimeWindowMax(clock, distributionStatisticConfig);
     }
 
     @Override
     protected void recordNonNegative(long amount, TimeUnit unit) {
         long nanoAmount = (long) TimeUtils.convert(amount, unit, TimeUnit.NANOSECONDS);
-        count.getAndAdd(1);
-        total.getAndAdd(nanoAmount);
+        count.increment();
+        total.add(nanoAmount);
         max.record(nanoAmount, TimeUnit.NANOSECONDS);
     }
 
     @Override
     public long count() {
-        return count.get();
+        return count.longValue();
     }
 
     @Override
     public double totalTime(TimeUnit unit) {
-        return TimeUtils.nanosToUnit(total.get(), unit);
+        return TimeUtils.nanosToUnit(total.doubleValue(), unit);
     }
 
     @Override


### PR DESCRIPTION
This PR changes to use `LongAdder` in `CumulativeTimer` and `CumulativeDistributionSummary` like other implementations (ex. `PrometheusTimer`).