### PR TITLE
Minor change: Align the types of elements on which @Timed and @Counted can be applied

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Counted.java
@@ -35,7 +35,7 @@ import java.lang.annotation.*;
  * @see io.micrometer.core.aop.CountedAspect
  */
 @Inherited
-@Target(ElementType.METHOD)
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Counted {
 


### PR DESCRIPTION
Add `ElementType.ANNOTATION_TYPE`, `ElementType.TYPE` as targetTypes to `@Counted`

`@Timed` and `@Counted` are used in very similar ways. 
However the type of elements where the annotation is allowed is not aligned.

This pr proposes to fix the inconsistency.