### PR TITLE
@MeterTag does not work on package private method

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
@@ -89,7 +89,7 @@ public class AnnotationHandler<T> {
     public void addAnnotatedParameters(T objectToModify, ProceedingJoinPoint pjp) {
         try {
             Method method = ((MethodSignature) pjp.getSignature()).getMethod();
-            method = pjp.getTarget().getClass().getMethod(method.getName(), method.getParameterTypes());
+            method = pjp.getTarget().getClass().getDeclaredMethod(method.getName(), method.getParameterTypes());
             List<AnnotatedParameter> annotatedParameters = AnnotationUtils.findAnnotatedParameters(annotationClass,
                     method, pjp.getArgs());
             getAnnotationsFromInterfaces(pjp, method, annotatedParameters);

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -437,6 +437,23 @@ class TimedAspectTest {
             assertThat(registry.get("method.timed").tag("test", "hello characters").timer().count()).isEqualTo(1);
         }
 
+        @Test
+        void meterTagOnPackagePrivateMethod() {
+            MeterRegistry registry = new SimpleMeterRegistry();
+            TimedAspect timedAspect = new TimedAspect(registry);
+            timedAspect.setMeterTagAnnotationHandler(meterTagAnnotationHandler);
+
+            AspectJProxyFactory pf = new AspectJProxyFactory(new MeterTagClass());
+            pf.setProxyTargetClass(true);
+            pf.addAspect(timedAspect);
+
+            MeterTagClass service = pf.getProxy();
+
+            service.getAnnotationForPackagePrivateMethod("bar");
+
+            assertThat(registry.get("method.timed").tag("foo", "bar").timer().count()).isEqualTo(1);
+        }
+
         enum AnnotatedTestClass {
 
             CLASS_WITHOUT_INTERFACE(MeterTagClass.class), CLASS_WITH_INTERFACE(MeterTagClassChild.class);
@@ -490,6 +507,10 @@ class TimedAspectTest {
             @Timed
             @Override
             public void getAnnotationForArgumentToString(@MeterTag("test") Long param) {
+            }
+
+            @Timed
+            void getAnnotationForPackagePrivateMethod(@MeterTag("foo") String foo) {
             }
 
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -449,9 +449,9 @@ class TimedAspectTest {
 
             MeterTagClass service = pf.getProxy();
 
-            service.getAnnotationForPackagePrivateMethod("bar");
+            service.getAnnotationForPackagePrivateMethod("baz");
 
-            assertThat(registry.get("method.timed").tag("foo", "bar").timer().count()).isEqualTo(1);
+            assertThat(registry.get("method.timed").tag("foo", "baz").timer().count()).isEqualTo(1);
         }
 
         enum AnnotatedTestClass {

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -449,9 +449,9 @@ class TimedAspectTest {
 
             MeterTagClass service = pf.getProxy();
 
-            service.getAnnotationForPackagePrivateMethod("baz");
+            service.getAnnotationForPackagePrivateMethod("bar");
 
-            assertThat(registry.get("method.timed").tag("foo", "baz").timer().count()).isEqualTo(1);
+            assertThat(registry.get("method.timed").tag("foo", "bar").timer().count()).isEqualTo(1);
         }
 
         enum AnnotatedTestClass {


### PR DESCRIPTION
Fixes `NoSuchMethodException` being thrown when using `@MeterTag` on package private method.