### PR TITLE
Added check on rotate frequency

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowMax.java
@@ -54,7 +54,7 @@ public class TimeWindowMax {
 
     public TimeWindowMax(Clock clock, long rotateFrequencyMillis, int bufferLength) {
         this.clock = clock;
-        this.durationBetweenRotatesMillis = rotateFrequencyMillis;
+        this.durationBetweenRotatesMillis = checkPositive(rotateFrequencyMillis);
         this.lastRotateTimestampMillis = clock.wallTime();
         this.currentBucket = 0;
 
@@ -62,6 +62,13 @@ public class TimeWindowMax {
         for (int i = 0; i < bufferLength; i++) {
             this.ringBuffer[i] = new AtomicLong();
         }
+    }
+
+    private static long checkPositive(long rotateFrequencyMillis) {
+        if (rotateFrequencyMillis <= 0) {
+            throw new IllegalArgumentException("Rotate frequency must be a positive number");
+        }
+        return rotateFrequencyMillis;
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowMaxTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowMaxTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.MockClock;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -66,6 +67,13 @@ class TimeWindowMaxTest {
         clock.add(Duration.ofSeconds(62));
         timeWindowMax.record(100500);
         assertThat(timeWindowMax.poll()).isEqualTo(100500); // 666 | 500 | 100500
+    }
+
+    @Test
+    void throwsExceptionWhenRotateFrequency0() {
+        Assertions.assertThatThrownBy(() -> new TimeWindowMax(clock, 0, 3))
+            .isInstanceOf(IllegalArgumentException.class)
+            .withFailMessage("Rotate frequency must be a positive number");
     }
 
 }


### PR DESCRIPTION
without this change you can get an arithmetic exception if you pass a 0. Negative numbers don't make sense

fixes gh-3068