### PR TITLE
Use spin-wait hints

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -82,6 +82,7 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
                     childrenGuard.set(false);
                 }
             }
+            SpinLockSupport.onSpinWait();
         }
     }
 
@@ -104,6 +105,7 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
                     childrenGuard.set(false);
                 }
             }
+            SpinLockSupport.onSpinWait();
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -193,6 +193,7 @@ public class CompositeMeterRegistry extends MeterRegistry {
                     lock.set(false);
                 }
             }
+            SpinLockSupport.onSpinWait();
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/SpinLockSupport.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/SpinLockSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.composite;
+
+/**
+ * Utility functions for implementing spin locks.
+ * <p>
+ * This is a multi-release class with improved versions for later Java versions.
+ *
+ * @author Philippe Marschall
+ */
+final class SpinLockSupport {
+
+    /**
+     * Calls {@link java.lang.Thread#onSpinWait()} if available.
+     *
+     * @see java.lang.Thread#onSpinWait()
+     */
+    static void onSpinWait() {
+        // default implementation is empty
+    }
+
+}

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/composite/SpinLockSupport.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/composite/SpinLockSupport.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.composite;
+
+/**
+ * Utility functions for implementing spin locks.
+ * <p>
+ * This is a multi-release class with improved versions for later Java versions.
+ *
+ * @author Philippe Marschall
+ */
+final class SpinLockSupport {
+
+    /**
+     * Calls {@link java.lang.Thread#onSpinWait()} if available.
+     *
+     * @see java.lang.Thread#onSpinWait()
+     */
+    static void onSpinWait() {
+        Thread.onSpinWait();
+    }
+
+}

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/composite/package-info.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/composite/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.micrometer.core.instrument.composite;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;


### PR DESCRIPTION
Use spin-wait hints in the spin locks on Java 11 and later.

See: [JEP 285 Spin-Wait Hints](https://openjdk.org/jeps/285)

A couple of notes:
- I had to copy and paste the `package-info.java` otherwise the `JavadocPackage` rule would fail.
- Since I only found spin locks in the `io.micrometer.core.instrument.composite` I created a package private class there. An other option would be a public class in `io.micrometer.core.instrument.internal`.
- I used a multi-release class with version Java 11 since that is already in place.
- We could reduce memory consumption further by replacing the `AtomicBoolean childrenGuard` with a `volatile int childrenGuard` and a `static final AtomicIntegerFieldUpdater`. As long as we need to be backwards compatible we can unfortunately not use a `VarHandle`.