### PR TITLE
For long task timers fixes the percentiles above interpolatable line

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -116,7 +116,7 @@ public class HistogramGauges {
             ToDoubleFunction<HistogramSupport> percentileValueFunction = m -> {
                 snapshotIfNecessary();
                 polledGaugesLatch.countDown();
-                return percentileValue.apply(snapshot.percentileValues()[index]);
+                return percentileValue.apply(valueAtPercentiles[index]);
             };
 
             Gauge.builder(percentileName.apply(valueAtPercentiles[i]), meter, percentileValueFunction)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -141,7 +141,7 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
         CountAtBucket[] countAtBucketsArr = new CountAtBucket[0];
 
         List<Double> percentilesAboveInterpolatableLine = percentilesRequested.stream()
-            .filter(p -> p * (activeTasks.size() + 1) > activeTasks.size())
+            .filter(p -> p * (activeTasks.size() + 1) >= activeTasks.size())
             .collect(Collectors.toList());
 
         percentilesRequested.removeAll(percentilesAboveInterpolatableLine);


### PR DESCRIPTION
without this change for the provided test one of the histogram buckets gets removed and an ArrayIndexOutOfBoundsException is thrown with this change the exception is not thrown anymore

fixes gh-3877