### PR TITLE
Remove JDK 19-specific tests in TagsTest

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/TagsTest.java
@@ -329,26 +329,7 @@ class TagsTest {
     @Issue("#3313")
     @DisabledIfSystemProperty(named = "java.vm.name", matches = JAVA_VM_NAME_J9_REGEX,
             disabledReason = "Sun ThreadMXBean with allocation counter not available")
-    @EnabledForJreRange(max = JRE.JAVA_18)
     void andEmptyDoesNotAllocate() {
-        andEmptyDoesNotAllocate(0);
-    }
-
-    // See https://github.com/micrometer-metrics/micrometer/issues/3436
-    @Test
-    @Issue("#3313")
-    @DisabledIfSystemProperty(named = "java.vm.name", matches = JAVA_VM_NAME_J9_REGEX,
-            disabledReason = "Sun ThreadMXBean with allocation counter not available")
-    @EnabledIf("java19")
-    void andEmptyDoesNotAllocateOnJava19() {
-        andEmptyDoesNotAllocate(16);
-    }
-
-    static boolean java19() {
-        return "19".equals(System.getProperty("java.version"));
-    }
-
-    private void andEmptyDoesNotAllocate(int expectedAllocatedBytes) {
         ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
         long currentThreadId = Thread.currentThread().getId();
         Tags tags = Tags.of("a", "b");
@@ -359,29 +340,14 @@ class TagsTest {
         long allocatedBytes = threadMXBean.getThreadAllocatedBytes(currentThreadId) - allocatedBytesBefore;
 
         assertThat(combined).isEqualTo(tags);
-        assertThat(allocatedBytes).isEqualTo(expectedAllocatedBytes);
+        assertThat(allocatedBytes).isEqualTo(0);
     }
 
     @Test
     @Issue("#3313")
     @DisabledIfSystemProperty(named = "java.vm.name", matches = JAVA_VM_NAME_J9_REGEX,
             disabledReason = "Sun ThreadMXBean with allocation counter not available")
-    @EnabledForJreRange(max = JRE.JAVA_18)
     void ofEmptyDoesNotAllocate() {
-        ofEmptyDoesNotAllocate(0);
-    }
-
-    // See https://github.com/micrometer-metrics/micrometer/issues/3436
-    @Test
-    @Issue("#3313")
-    @DisabledIfSystemProperty(named = "java.vm.name", matches = JAVA_VM_NAME_J9_REGEX,
-            disabledReason = "Sun ThreadMXBean with allocation counter not available")
-    @EnabledIf("java19")
-    void ofEmptyDoesNotAllocateOnJava19() {
-        ofEmptyDoesNotAllocate(16);
-    }
-
-    private void ofEmptyDoesNotAllocate(int expectedAllocatedBytes) {
         ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
         long currentThreadId = Thread.currentThread().getId();
         Tags extraTags = Tags.empty();
@@ -391,7 +357,7 @@ class TagsTest {
         long allocatedBytes = threadMXBean.getThreadAllocatedBytes(currentThreadId) - allocatedBytesBefore;
 
         assertThat(of).isEqualTo(Tags.empty());
-        assertThat(allocatedBytes).isEqualTo(expectedAllocatedBytes);
+        assertThat(allocatedBytes).isEqualTo(0);
     }
 
     private void assertTags(Tags tags, String... keyValues) {


### PR DESCRIPTION
This PR polishes `TagsTest` by using `JRE.JAVA_19`.

See gh-3436
See gh-3437