### PR TITLE
Record Jetty bytes in/out metrics through network listeners

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
@@ -19,7 +19,12 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.TimeWindowMax;
+
+import java.net.Socket;
+import java.nio.ByteBuffer;
+
 import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.NetworkTrafficListener;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.HttpConnection;
 import org.eclipse.jetty.server.Server;
@@ -48,7 +53,7 @@ import java.util.Map;
  * @author Jon Schneider
  * @since 1.4.0
  */
-public class JettyConnectionMetrics extends AbstractLifeCycle implements Connection.Listener {
+public class JettyConnectionMetrics extends AbstractLifeCycle implements Connection.Listener, NetworkTrafficListener {
 
     private final MeterRegistry registry;
 
@@ -169,12 +174,18 @@ public class JettyConnectionMetrics extends AbstractLifeCycle implements Connect
                 .tags(tags)
                 .register(registry));
         }
-
         messagesIn.increment(connection.getMessagesIn());
         messagesOut.increment(connection.getMessagesOut());
+    }
 
-        bytesIn.record(connection.getBytesIn());
-        bytesOut.record(connection.getBytesOut());
+    @Override
+    public void incoming(Socket socket, ByteBuffer bytes) {
+        bytesIn.record(bytes.limit());
+    }
+
+    @Override
+    public void outgoing(Socket socket, ByteBuffer bytes) {
+        bytesOut.record(bytes.limit());
     }
 
     public static void addToAllConnectors(Server server, MeterRegistry registry, Iterable<Tag> tags) {


### PR DESCRIPTION
before this change we were dumping in / out bytes from the connection upon the connection close which could result in big traffic whenever the connection got closed after this change we're measuring the bytes through `NetworkTrafficListener` that hooks in whenever actual in / out bytes are being processed

fixes gh-3873