### PR TITLE
Make lastMeterRolloverStartTime volatile

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -89,7 +89,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
 
     // Time when the last scheduled rollOver has started. Applicable only for delta
     // flavour.
-    private long lastMeterRolloverStartTime = -1;
+    private volatile long lastMeterRolloverStartTime = -1;
 
     @Nullable
     private ScheduledExecutorService meterPollingService;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -51,7 +51,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     private ScheduledExecutorService meterPollingService;
 
     // Time when the last scheduled rollOver has started.
-    private long lastMeterRolloverStartTime = -1;
+    private volatile long lastMeterRolloverStartTime = -1;
 
     public StepMeterRegistry(StepRegistryConfig config, Clock clock) {
         super(config, clock);


### PR DESCRIPTION
This PR changes to make `lastMeterRolloverStartTime` fields from `OtlpMeterRegistry` and `StepMeterRegistry` `volatile` to guarantee their visibility.

See gh-4357