### PR TITLE
Group OTLP data points under same metric

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -20,6 +20,7 @@ import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.Histogram;
@@ -34,7 +35,6 @@ import io.micrometer.core.instrument.step.StepFunctionTimer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
-import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
@@ -52,13 +52,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.function.DoubleSupplier;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
-import java.util.stream.Collectors;
-
-import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_CUMULATIVE;
-import static io.opentelemetry.proto.metrics.v1.AggregationTemporality.AGGREGATION_TEMPORALITY_DELTA;
 
 /**
  * Publishes meters in OTLP (OpenTelemetry Protocol) format. HTTP with Protobuf encoding
@@ -83,11 +78,9 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
 
     private final Resource resource;
 
-    private final io.opentelemetry.proto.metrics.v1.AggregationTemporality otlpAggregationTemporality;
+    private final AggregationTemporality aggregationTemporality;
 
     private final TimeUnit baseTimeUnit;
-
-    private long deltaAggregationTimeUnixNano = 0L;
 
     // Time when the last scheduled rollOver has started. Applicable only for delta
     // flavour.
@@ -112,9 +105,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         this.baseTimeUnit = config.baseTimeUnit();
         this.httpSender = httpSender;
         this.resource = Resource.newBuilder().addAllAttributes(getResourceAttributes()).build();
-        this.otlpAggregationTemporality = AggregationTemporality
-            .toOtlpAggregationTemporality(config.aggregationTemporality());
-        setDeltaAggregationTimeUnixNano();
+        this.aggregationTemporality = config.aggregationTemporality();
         config().namingConvention(NamingConvention.dot);
         start(DEFAULT_THREAD_FACTORY);
     }
@@ -140,15 +131,10 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
 
     @Override
     protected void publish() {
-        if (isDelta()) {
-            setDeltaAggregationTimeUnixNano();
-        }
         for (List<Meter> batch : MeterPartition.partition(this, config.batchSize())) {
-            List<Metric> metrics = batch.stream()
-                .map(meter -> meter.match(this::writeGauge, this::writeCounter, this::writeHistogramSupport,
-                        this::writeHistogramSupport, this::writeHistogramSupport, this::writeGauge,
-                        this::writeFunctionCounter, this::writeFunctionTimer, this::writeMeter))
-                .collect(Collectors.toList());
+            OtlpMetricConverter otlpMetricConverter = new OtlpMetricConverter(clock, config.step(), getBaseTimeUnit(),
+                    config.aggregationTemporality(), config().namingConvention());
+            otlpMetricConverter.addMeters(batch);
 
             try {
                 ExportMetricsServiceRequest request = ExportMetricsServiceRequest.newBuilder()
@@ -158,7 +144,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                             // we don't have instrumentation library/version
                             // attached to meters; leave unknown for now
                             // .setScope(InstrumentationScope.newBuilder().setName("").setVersion("").build())
-                            .addAllMetrics(metrics)
+                            .addAllMetrics(otlpMetricConverter.getAllMetrics())
                             .build())
                         .build())
                     .build();
@@ -300,50 +286,6 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         }
     }
 
-    // VisibleForTesting
-    Metric writeMeter(Meter meter) {
-        // TODO support writing custom meters
-        // one gauge per measurement
-        return getMetricBuilder(meter.getId()).build();
-    }
-
-    // VisibleForTesting
-    Metric writeGauge(Gauge gauge) {
-        return getMetricBuilder(gauge.getId())
-            .setGauge(io.opentelemetry.proto.metrics.v1.Gauge.newBuilder()
-                .addDataPoints(NumberDataPoint.newBuilder()
-                    .setTimeUnixNano(getTimeUnixNano())
-                    .setAsDouble(gauge.value())
-                    .addAllAttributes(getTagsForId(gauge.getId()))
-                    .build()))
-            .build();
-    }
-
-    // VisibleForTesting
-    Metric writeCounter(Counter counter) {
-        return writeSum(counter, counter::count);
-    }
-
-    // VisibleForTesting
-    Metric writeFunctionCounter(FunctionCounter functionCounter) {
-        return writeSum(functionCounter, functionCounter::count);
-    }
-
-    private Metric writeSum(Meter meter, DoubleSupplier count) {
-        return getMetricBuilder(meter.getId())
-            .setSum(Sum.newBuilder()
-                .addDataPoints(NumberDataPoint.newBuilder()
-                    .setStartTimeUnixNano(getStartTimeNanos(meter))
-                    .setTimeUnixNano(getTimeUnixNano())
-                    .setAsDouble(count.getAsDouble())
-                    .addAllAttributes(getTagsForId(meter.getId()))
-                    .build())
-                .setIsMonotonic(true)
-                .setAggregationTemporality(otlpAggregationTemporality)
-                .build())
-            .build();
-    }
-
     /**
      * This will poll the values from meters, which will cause a roll over for Step-meters
      * if past the step boundary. This gives some control over when roll over happens
@@ -366,122 +308,12 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         return stepMillis - (clock.wallTime() % stepMillis) + 1;
     }
 
-    // VisibleForTesting
-    Metric writeHistogramSupport(HistogramSupport histogramSupport) {
-        Metric.Builder metricBuilder = getMetricBuilder(histogramSupport.getId());
-        boolean isTimeBased = histogramSupport instanceof Timer || histogramSupport instanceof LongTaskTimer;
-        HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
-
-        Iterable<? extends KeyValue> tags = getTagsForId(histogramSupport.getId());
-        long startTimeNanos = getStartTimeNanos(histogramSupport);
-        double total = isTimeBased ? histogramSnapshot.total(getBaseTimeUnit()) : histogramSnapshot.total();
-        long count = histogramSnapshot.count();
-
-        // if percentiles configured, use summary
-        if (histogramSnapshot.percentileValues().length != 0) {
-            SummaryDataPoint.Builder summaryData = SummaryDataPoint.newBuilder()
-                .addAllAttributes(tags)
-                .setStartTimeUnixNano(startTimeNanos)
-                .setTimeUnixNano(getTimeUnixNano())
-                .setSum(total)
-                .setCount(count);
-            for (ValueAtPercentile percentile : histogramSnapshot.percentileValues()) {
-                summaryData.addQuantileValues(SummaryDataPoint.ValueAtQuantile.newBuilder()
-                    .setQuantile(percentile.percentile())
-                    .setValue(TimeUtils.convert(percentile.value(), TimeUnit.NANOSECONDS, getBaseTimeUnit())));
-            }
-            metricBuilder.setSummary(Summary.newBuilder().addDataPoints(summaryData));
-            return metricBuilder.build();
-        }
-
-        HistogramDataPoint.Builder histogramDataPoint = HistogramDataPoint.newBuilder()
-            .addAllAttributes(tags)
-            .setStartTimeUnixNano(startTimeNanos)
-            .setTimeUnixNano(getTimeUnixNano())
-            .setSum(total)
-            .setCount(count);
-
-        if (isDelta()) {
-            histogramDataPoint.setMax(isTimeBased ? histogramSnapshot.max(getBaseTimeUnit()) : histogramSnapshot.max());
-        }
-        // if histogram enabled, add histogram buckets
-        if (histogramSnapshot.histogramCounts().length != 0) {
-            for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
-                if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
-                    // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
-                    // there should be a
-                    // bucket count representing values between last bucket and
-                    // POSITIVE_INFINITY.
-                    histogramDataPoint.addExplicitBounds(
-                            isTimeBased ? countAtBucket.bucket(getBaseTimeUnit()) : countAtBucket.bucket());
-                }
-                histogramDataPoint.addBucketCounts((long) countAtBucket.count());
-            }
-            metricBuilder.setHistogram(io.opentelemetry.proto.metrics.v1.Histogram.newBuilder()
-                .setAggregationTemporality(otlpAggregationTemporality)
-                .addDataPoints(histogramDataPoint));
-            return metricBuilder.build();
-        }
-
-        return metricBuilder
-            .setHistogram(io.opentelemetry.proto.metrics.v1.Histogram.newBuilder()
-                .setAggregationTemporality(otlpAggregationTemporality)
-                .addDataPoints(histogramDataPoint))
-            .build();
-    }
-
-    // VisibleForTesting
-    Metric writeFunctionTimer(FunctionTimer functionTimer) {
-        return getMetricBuilder(functionTimer.getId())
-            .setHistogram(io.opentelemetry.proto.metrics.v1.Histogram.newBuilder()
-                .addDataPoints(HistogramDataPoint.newBuilder()
-                    .addAllAttributes(getTagsForId(functionTimer.getId()))
-                    .setStartTimeUnixNano(getStartTimeNanos((functionTimer)))
-                    .setTimeUnixNano(getTimeUnixNano())
-                    .setSum(functionTimer.totalTime(getBaseTimeUnit()))
-                    .setCount((long) functionTimer.count()))
-                .setAggregationTemporality(otlpAggregationTemporality))
-            .build();
-    }
-
     private boolean isCumulative() {
-        return this.otlpAggregationTemporality == AGGREGATION_TEMPORALITY_CUMULATIVE;
+        return this.aggregationTemporality == AggregationTemporality.CUMULATIVE;
     }
 
     private boolean isDelta() {
-        return this.otlpAggregationTemporality == AGGREGATION_TEMPORALITY_DELTA;
-    }
-
-    // VisibleForTesting
-    void setDeltaAggregationTimeUnixNano() {
-        this.deltaAggregationTimeUnixNano = (clock.wallTime() / config.step().toMillis()) * config.step().toNanos();
-    }
-
-    private long getTimeUnixNano() {
-        return isCumulative() ? TimeUnit.MILLISECONDS.toNanos(this.clock.wallTime()) : deltaAggregationTimeUnixNano;
-    }
-
-    private long getStartTimeNanos(Meter meter) {
-        return isCumulative() ? ((StartTimeAwareMeter) meter).getStartTimeNanos()
-                : deltaAggregationTimeUnixNano - config.step().toNanos();
-    }
-
-    private Metric.Builder getMetricBuilder(Meter.Id id) {
-        Metric.Builder builder = Metric.newBuilder().setName(getConventionName(id));
-        if (id.getBaseUnit() != null) {
-            builder.setUnit(id.getBaseUnit());
-        }
-        if (id.getDescription() != null) {
-            builder.setDescription(id.getDescription());
-        }
-        return builder;
-    }
-
-    private Iterable<? extends KeyValue> getTagsForId(Meter.Id id) {
-        return id.getTags()
-            .stream()
-            .map(tag -> createKeyValue(tag.getKey(), tag.getValue()))
-            .collect(Collectors.toList());
+        return this.aggregationTemporality == AggregationTemporality.DELTA;
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.registry.otlp;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.HistogramSupport;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.util.TimeUtils;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.metrics.v1.*;
+import io.opentelemetry.proto.metrics.v1.Metric.DataCase;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleSupplier;
+import java.util.stream.Collectors;
+
+/**
+ * A bridge for converting Micrometer meters to OTLP metrics.
+ */
+class OtlpMetricConverter {
+
+    private final Clock clock;
+
+    private final Duration step;
+
+    private final AggregationTemporality aggregationTemporality;
+
+    private final io.opentelemetry.proto.metrics.v1.AggregationTemporality otlpAggregationTemporality;
+
+    private final TimeUnit baseTimeUnit;
+
+    private final NamingConvention namingConvention;
+
+    private final Map<MetricMetaData, Metric.Builder> metricTypeBuilderMap = new HashMap<>();
+
+    private final long deltaTimeUnixNano;
+
+    OtlpMetricConverter(Clock clock, Duration step, TimeUnit baseTimeUnit,
+            AggregationTemporality aggregationTemporality, NamingConvention namingConvention) {
+        this.clock = clock;
+        this.step = step;
+        this.aggregationTemporality = aggregationTemporality;
+        this.otlpAggregationTemporality = AggregationTemporality.toOtlpAggregationTemporality(aggregationTemporality);
+        this.baseTimeUnit = baseTimeUnit;
+        this.namingConvention = namingConvention;
+        this.deltaTimeUnixNano = (clock.wallTime() / step.toMillis()) * step.toNanos();
+    }
+
+    void addMeters(List<Meter> meters) {
+        meters.forEach(this::addMeter);
+    }
+
+    void addMeter(Meter meter) {
+        meter.use(this::writeGauge, this::writeCounter, this::writeHistogramSupport, this::writeHistogramSupport,
+                this::writeHistogramSupport, this::writeGauge, this::writeFunctionCounter, this::writeFunctionTimer,
+                this::writeMeter);
+    }
+
+    List<Metric> getAllMetrics() {
+        List<Metric> metrics = new ArrayList<>();
+        for (Metric.Builder metricSet : metricTypeBuilderMap.values()) {
+            metrics.add(metricSet.build());
+        }
+        return metrics;
+    }
+
+    private void writeMeter(Meter meter) {
+        // TODO support writing custom meters
+        // one gauge per measurement
+        getOrCreateMetricBuilder(meter.getId(), DataCase.GAUGE);
+    }
+
+    private void writeGauge(Gauge gauge) {
+        Metric.Builder metricBuilder = getOrCreateMetricBuilder(gauge.getId(), DataCase.GAUGE);
+        if (metricBuilder != null) {
+            if (!metricBuilder.hasGauge()) {
+                metricBuilder.setGauge(io.opentelemetry.proto.metrics.v1.Gauge.newBuilder());
+            }
+            metricBuilder.getGaugeBuilder()
+                .addDataPoints(NumberDataPoint.newBuilder()
+                    .setTimeUnixNano(getTimeUnixNano())
+                    .setAsDouble(gauge.value())
+                    .addAllAttributes(getKeyValuesForId(gauge.getId()))
+                    .build());
+        }
+    }
+
+    private void writeCounter(Counter counter) {
+        Metric.Builder metricBuilder = getOrCreateMetricBuilder(counter.getId(), DataCase.SUM);
+        if (metricBuilder != null) {
+            setSumDataPoint(metricBuilder, counter, counter::count);
+        }
+    }
+
+    private void writeFunctionCounter(FunctionCounter functionCounter) {
+        Metric.Builder metricBuilder = getOrCreateMetricBuilder(functionCounter.getId(), DataCase.SUM);
+        if (metricBuilder != null) {
+            setSumDataPoint(metricBuilder, functionCounter, functionCounter::count);
+        }
+    }
+
+    private void writeHistogramSupport(HistogramSupport histogramSupport) {
+        final Meter.Id id = histogramSupport.getId();
+        boolean isTimeBased = isTimeBasedMeter(id);
+        HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
+
+        Iterable<KeyValue> tags = getKeyValuesForId(id);
+        long startTimeNanos = getStartTimeNanos(histogramSupport);
+        double total = isTimeBased ? histogramSnapshot.total(baseTimeUnit) : histogramSnapshot.total();
+        long count = histogramSnapshot.count();
+
+        // if percentiles configured, use summary
+        if (histogramSnapshot.percentileValues().length != 0) {
+            buildSummaryDataPoint(histogramSupport, tags, startTimeNanos, total, count, histogramSnapshot);
+        }
+        else {
+            buildHistogramDataPoint(histogramSupport, tags, startTimeNanos, total, count, isTimeBased,
+                    histogramSnapshot);
+        }
+    }
+
+    private void writeFunctionTimer(FunctionTimer functionTimer) {
+        Metric.Builder builder = getOrCreateMetricBuilder(functionTimer.getId(), DataCase.HISTOGRAM);
+        if (builder != null) {
+            HistogramDataPoint.Builder histogramDataPoint = HistogramDataPoint.newBuilder()
+                .addAllAttributes(getKeyValuesForId(functionTimer.getId()))
+                .setStartTimeUnixNano(getStartTimeNanos((functionTimer)))
+                .setTimeUnixNano(getTimeUnixNano())
+                .setSum(functionTimer.totalTime(baseTimeUnit))
+                .setCount((long) functionTimer.count());
+
+            setHistogramDataPoint(builder, histogramDataPoint.build());
+        }
+    }
+
+    private boolean isTimeBasedMeter(final Meter.Id id) {
+        return id.getType() == Meter.Type.TIMER || id.getType() == Meter.Type.LONG_TASK_TIMER;
+    }
+
+    private void buildHistogramDataPoint(final HistogramSupport histogramSupport, final Iterable<KeyValue> tags,
+            final long startTimeNanos, final double total, final long count, final boolean isTimeBased,
+            final HistogramSnapshot histogramSnapshot) {
+        Metric.Builder metricBuilder = getOrCreateMetricBuilder(histogramSupport.getId(), DataCase.HISTOGRAM);
+        if (metricBuilder != null) {
+            HistogramDataPoint.Builder histogramDataPoint = HistogramDataPoint.newBuilder()
+                .addAllAttributes(tags)
+                .setStartTimeUnixNano(startTimeNanos)
+                .setTimeUnixNano(getTimeUnixNano())
+                .setSum(total)
+                .setCount(count);
+
+            if (isDelta()) {
+                histogramDataPoint.setMax(isTimeBased ? histogramSnapshot.max(baseTimeUnit) : histogramSnapshot.max());
+            }
+
+            // if histogram enabled, add histogram buckets
+            for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
+                if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
+                    // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
+                    // there should be a
+                    // bucket count representing values between last bucket and
+                    // POSITIVE_INFINITY.
+                    histogramDataPoint
+                        .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
+                }
+                histogramDataPoint.addBucketCounts((long) countAtBucket.count());
+            }
+
+            setHistogramDataPoint(metricBuilder, histogramDataPoint.build());
+        }
+    }
+
+    private void buildSummaryDataPoint(final HistogramSupport histogramSupport, final Iterable<KeyValue> tags,
+            final long startTimeNanos, final double total, final long count,
+            final HistogramSnapshot histogramSnapshot) {
+        Metric.Builder metricBuilder = getOrCreateMetricBuilder(histogramSupport.getId(), DataCase.SUMMARY);
+        if (metricBuilder != null) {
+            SummaryDataPoint.Builder summaryDataPoint = SummaryDataPoint.newBuilder()
+                .addAllAttributes(tags)
+                .setStartTimeUnixNano(startTimeNanos)
+                .setTimeUnixNano(getTimeUnixNano())
+                .setSum(total)
+                .setCount(count);
+            for (ValueAtPercentile percentile : histogramSnapshot.percentileValues()) {
+                summaryDataPoint.addQuantileValues(SummaryDataPoint.ValueAtQuantile.newBuilder()
+                    .setQuantile(percentile.percentile())
+                    .setValue(TimeUtils.convert(percentile.value(), TimeUnit.NANOSECONDS, baseTimeUnit)));
+            }
+
+            setSummaryDataPoint(metricBuilder, summaryDataPoint);
+        }
+    }
+
+    private void setSumDataPoint(final Metric.Builder builder, Meter meter, DoubleSupplier count) {
+        if (!builder.hasSum()) {
+            builder
+                .setSum(Sum.newBuilder().setIsMonotonic(true).setAggregationTemporality(otlpAggregationTemporality()));
+        }
+
+        builder.getSumBuilder()
+            .addDataPoints(NumberDataPoint.newBuilder()
+                .setStartTimeUnixNano(getStartTimeNanos(meter))
+                .setTimeUnixNano(getTimeUnixNano())
+                .setAsDouble(count.getAsDouble())
+                .addAllAttributes(getKeyValuesForId(meter.getId()))
+                .build());
+    }
+
+    private void setHistogramDataPoint(final Metric.Builder builder, HistogramDataPoint histogramDataPoint) {
+        if (!builder.hasHistogram()) {
+            builder.setHistogram(Histogram.newBuilder().setAggregationTemporality(otlpAggregationTemporality()));
+        }
+        builder.getHistogramBuilder().addDataPoints(histogramDataPoint);
+    }
+
+    private static void setSummaryDataPoint(final Metric.Builder metricBuilder,
+            final SummaryDataPoint.Builder summaryDataPoint) {
+        if (!metricBuilder.hasSummary()) {
+            metricBuilder.setSummary(Summary.newBuilder());
+        }
+        metricBuilder.getSummaryBuilder().addDataPoints(summaryDataPoint);
+    }
+
+    private long getStartTimeNanos(Meter meter) {
+        return isDelta() ? deltaTimeUnixNano - step.toNanos() : ((StartTimeAwareMeter) meter).getStartTimeNanos();
+    }
+
+    private long getTimeUnixNano() {
+        return isDelta() ? deltaTimeUnixNano : TimeUnit.MILLISECONDS.toNanos(clock.wallTime());
+    }
+
+    private boolean isDelta() {
+        return this.aggregationTemporality == AggregationTemporality.DELTA;
+    }
+
+    private io.opentelemetry.proto.metrics.v1.AggregationTemporality otlpAggregationTemporality() {
+        return otlpAggregationTemporality;
+    }
+
+    // VisibleForTesting
+    @Nullable
+    Metric.Builder getOrCreateMetricBuilder(Meter.Id id, final DataCase dataCase) {
+        final String conventionName = id.getConventionName(namingConvention);
+
+        MetricMetaData metricMetaData = new MetricMetaData(dataCase, conventionName, id.getBaseUnit(),
+                id.getDescription());
+        final Metric.Builder builder = metricTypeBuilderMap.get(metricMetaData);
+        return builder != null ? builder : createMetricBuilder(metricMetaData);
+    }
+
+    private Metric.Builder createMetricBuilder(final MetricMetaData metricMetaData) {
+        Metric.Builder builder = Metric.newBuilder().setName(metricMetaData.getName());
+        if (metricMetaData.getBaseUnit() != null) {
+            builder.setUnit(metricMetaData.getBaseUnit());
+        }
+        if (metricMetaData.getDescription() != null) {
+            builder.setDescription(metricMetaData.getDescription());
+        }
+        metricTypeBuilderMap.put(metricMetaData, builder);
+        return builder;
+    }
+
+    private Iterable<KeyValue> getKeyValuesForId(Meter.Id id) {
+        return id.getTags()
+            .stream()
+            .map(tag -> createKeyValue(tag.getKey(), tag.getValue()))
+            .collect(Collectors.toList());
+    }
+
+    private static KeyValue createKeyValue(String key, String value) {
+        return KeyValue.newBuilder().setKey(key).setValue(AnyValue.newBuilder().setStringValue(value)).build();
+    }
+
+    private static class MetricMetaData {
+
+        final DataCase dataCase;
+
+        final String name;
+
+        @Nullable
+        final String baseUnit;
+
+        @Nullable
+        final String description;
+
+        MetricMetaData(DataCase dataCase, String name, @Nullable String baseUnit, @Nullable String description) {
+            this.dataCase = dataCase;
+            this.name = name;
+            this.baseUnit = baseUnit;
+            this.description = description;
+        }
+
+        private String getName() {
+            return name;
+        }
+
+        @Nullable
+        private String getBaseUnit() {
+            return baseUnit;
+        }
+
+        @Nullable
+        private String getDescription() {
+            return description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            MetricMetaData that = (MetricMetaData) o;
+            return Objects.equals(name, that.name) && Objects.equals(baseUnit, that.baseUnit)
+                    && Objects.equals(description, that.description) && Objects.equals(dataCase, that.dataCase);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, baseUnit, description, dataCase);
+        }
+
+    }
+
+}

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -21,7 +21,6 @@ import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -51,11 +50,6 @@ abstract class OtlpMeterRegistryTest {
     protected OtlpMeterRegistry registry = new OtlpMeterRegistry(otlpConfig(), clock);
 
     abstract OtlpConfig otlpConfig();
-
-    @AfterEach
-    void clearRegistry() {
-        registry.clear();
-    }
 
     // If the service.name was not specified, SDKs MUST fallback to 'unknown_service'
     @Test

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -16,17 +16,17 @@
 package io.micrometer.registry.otlp;
 
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
 import io.opentelemetry.proto.metrics.v1.NumberDataPoint;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +51,11 @@ abstract class OtlpMeterRegistryTest {
     protected OtlpMeterRegistry registry = new OtlpMeterRegistry(otlpConfig(), clock);
 
     abstract OtlpConfig otlpConfig();
+
+    @AfterEach
+    void clearRegistry() {
+        registry.clear();
+    }
 
     // If the service.name was not specified, SDKs MUST fallback to 'unknown_service'
     @Test
@@ -124,6 +129,80 @@ abstract class OtlpMeterRegistryTest {
     }
 
     @Test
+    void multipleMetricsWithSameMetaDataShouldBeSingleMetric() {
+        Tags firstTag = Tags.of("key", "first");
+        Tags secondTag = Tags.of("key", "second");
+
+        Gauge.builder("test.gauge", () -> 1).description("description").tags(firstTag).register(registry);
+        Gauge.builder("test.gauge", () -> 1).description("description").tags(secondTag).register(registry);
+
+        Counter.builder("test.counter").description("description").tags(firstTag).register(registry);
+        Counter.builder("test.counter").description("description").tags(secondTag).register(registry);
+
+        Timer.builder("test.timer").description("description").tags(firstTag).register(registry);
+        Timer.builder("test.timer").description("description").tags(secondTag).register(registry);
+
+        List<Metric> metrics = writeAllMeters();
+        assertThat(metrics).hasSize(3);
+
+        assertThat(metrics).filteredOn(Metric::hasGauge).hasSize(1).first().satisfies(metric -> {
+            assertThat(metric.getDescription()).isEqualTo("description");
+            assertThat(metric.getGauge().getDataPointsCount()).isEqualTo(2);
+        });
+
+        assertThat(metrics).filteredOn(Metric::hasSum).hasSize(1).first().satisfies(metric -> {
+            assertThat(metric.getDescription()).isEqualTo("description");
+            assertThat(metric.getSum().getDataPointsCount()).isEqualTo(2);
+            assertThat(metric.getSum().getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.toOtlpAggregationTemporality(otlpConfig().aggregationTemporality()));
+        });
+
+        assertThat(metrics).filteredOn(Metric::hasHistogram).hasSize(1).first().satisfies(metric -> {
+            assertThat(metric.getDescription()).isEqualTo("description");
+            assertThat(metric.getHistogram().getDataPointsCount()).isEqualTo(2);
+            assertThat(metric.getHistogram().getAggregationTemporality())
+                .isEqualTo(AggregationTemporality.toOtlpAggregationTemporality(otlpConfig().aggregationTemporality()));
+        });
+    }
+
+    @Test
+    void metricsWithDifferentMetadataShouldBeMultipleMetrics() {
+        Tags firstTag = Tags.of("key", "first");
+        Tags secondTag = Tags.of("key", "second");
+
+        final String description1 = "description1";
+        final String description2 = "description2";
+        Gauge.builder("test.gauge", () -> 1).description(description1).tags(firstTag).register(registry);
+        Gauge.builder("test.gauge", () -> 1).description(description2).tags(secondTag).register(registry);
+
+        Counter.builder("test.counter").description(description1).tags(firstTag).register(registry);
+        Counter.builder("test.counter").baseUnit("xyz").description(description1).tags(secondTag).register(registry);
+
+        Timer.builder("test.timer").description(description1).tags(firstTag).register(registry);
+        Timer.builder("test.timer").description(description2).tags(secondTag).register(registry);
+
+        List<Metric> metrics = writeAllMeters();
+        assertThat(metrics).hasSize(6);
+        assertThat(metrics).filteredOn(Metric::hasGauge).hasSize(2).satisfiesExactlyInAnyOrder(metric -> {
+            assertThat(metric.getDescription()).isEqualTo(description1);
+        }, metric -> {
+            assertThat(metric.getDescription()).isEqualTo(description2);
+        });
+
+        assertThat(metrics).filteredOn(Metric::hasSum).hasSize(2).satisfiesExactlyInAnyOrder(metric -> {
+            assertThat(metric.getUnit()).isEmpty();
+        }, metric -> {
+            assertThat(metric.getUnit()).isEqualTo("xyz");
+        });
+
+        assertThat(metrics).filteredOn(Metric::hasHistogram).hasSize(2).satisfiesExactlyInAnyOrder(metric -> {
+            assertThat(metric.getDescription()).isEqualTo(description1);
+        }, metric -> {
+            assertThat(metric.getDescription()).isEqualTo(description2);
+        });
+    }
+
+    @Test
     void distributionWithPercentileAndHistogramShouldWriteHistogramDataPoint() {
         Timer timer = Timer.builder("timer")
             .description(METER_DESCRIPTION)
@@ -190,10 +269,20 @@ abstract class OtlpMeterRegistryTest {
     abstract void testMetricsStartAndEndTime();
 
     protected Metric writeToMetric(Meter meter) {
-        registry.setDeltaAggregationTimeUnixNano();
-        return meter.match(registry::writeGauge, registry::writeCounter, registry::writeHistogramSupport,
-                registry::writeHistogramSupport, registry::writeHistogramSupport, registry::writeGauge,
-                registry::writeFunctionCounter, registry::writeFunctionTimer, registry::writeMeter);
+        OtlpMetricConverter otlpMetricConverter = new OtlpMetricConverter(clock, otlpConfig().step(),
+                registry.getBaseTimeUnit(), otlpConfig().aggregationTemporality(),
+                registry.config().namingConvention());
+        otlpMetricConverter.addMeter(meter);
+        final List<Metric> metrics = otlpMetricConverter.getAllMetrics();
+        return metrics.isEmpty() ? Metric.getDefaultInstance() : metrics.get(0);
+    }
+
+    protected List<Metric> writeAllMeters() {
+        OtlpMetricConverter otlpMetricConverter = new OtlpMetricConverter(clock, otlpConfig().step(),
+                registry.getBaseTimeUnit(), otlpConfig().aggregationTemporality(),
+                registry.config().namingConvention());
+        otlpMetricConverter.addMeters(registry.getMeters());
+        return otlpMetricConverter.getAllMetrics();
     }
 
     protected void stepOverNStep(int numStepsToSkip) {


### PR DESCRIPTION
This PR improves the OTLP export by effectively leveraging OpenTelemetry Line Protocol to encode metrics. This will both reduce the network bytes as well as the memory allocation we do in the JVM. I have attached a sample of what is changing. This will provide huge gains since in a real-world environment where there will only be a limited set of metrics that differ only in the tags/attributes (usually 100's - 1000s of time series for the same metric name and we will avoid duplicate publishing of the metadata). This will partially resolve https://github.com/micrometer-metrics/micrometer/issues/4053 by optimizing the publishing and eliminating most of the semantic errors.

### What is not addressed?
1. When a metric name has multiple descriptions (this shouldn't be an ideal usage but the micrometer allows this), we consider this a separate metric and add it to a new metric. (OTLP suggestion is to prefer the longest string but with micrometer design, this will need a lot of changes at the core and how a metric is treated in micrometer).
2. When a metric name has multiple base units, we will consider that a separate metric. (OTLP suggestion is to convert the data if possible.)

However, the above 2 will be extreme cases where the same metric name will have these properties with differing descriptions or baseUnit. Addressing this will need to have a different approach to how we identify metrics in micrometers and this corner case can be continued to be resolved as part of the mentioned issue.

### Comparison before and after:
Let's assume 2 counters - counter{tag=key1}, counter{tag=key2}. The description of the counters is "Test counter" and the base unit is "byte".

<details>
<summary>DataExported before this change </summary>

```
Metric #0
Descriptor:
     -> Name: counter
     -> Description: Test counter
     -> Unit: bytes
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Delta
NumberDataPoints #0
Data point attributes:
     -> key: Str(value2)
StartTimestamp: 2024-01-12 08:50:25 +0000 UTC
Timestamp: 2024-01-12 08:50:30 +0000 UTC
Value: 1.000000
Metric #1
Descriptor:
     -> Name: counter
     -> Description: Test counter
     -> Unit: bytes
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Delta
NumberDataPoints #0
Data point attributes:
     -> key: Str(value1)
StartTimestamp: 2024-01-12 08:50:25 +0000 UTC
Timestamp: 2024-01-12 08:50:30 +0000 UTC
Value: 1.000000
```
</details>


<details>
<summary>DataExported after this change </summary>

```
Metric #0
Descriptor:
     -> Name: counter
     -> Description: Test counter
     -> Unit: bytes
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Delta
NumberDataPoints #0
Data point attributes:
     -> key: Str(value2)
StartTimestamp: 2024-01-12 08:50:25 +0000 UTC
Timestamp: 2024-01-12 08:50:30 +0000 UTC
Value: 1.000000
NumberDataPoints #1
Data point attributes:
     -> key: Str(value1)
StartTimestamp: 2024-01-12 08:50:25 +0000 UTC
Timestamp: 2024-01-12 08:50:30 +0000 UTC
Value: 1.000000
```
</details>
