### PR TITLE
Clarify complete expiry of distribution statistics in Javadoc

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
@@ -199,7 +199,8 @@ public abstract class AbstractTimerBuilder<B extends AbstractTimerBuilder<B>> {
      * over time to give greater weight to recent samples (exception: histogram counts are
      * cumulative for those systems that expect cumulative histogram buckets). Samples are
      * accumulated to such statistics in ring buffers which rotate after this expiry, with
-     * a buffer length of {@link #distributionStatisticBufferLength(Integer)}.
+     * a buffer length of {@link #distributionStatisticBufferLength(Integer)}, hence
+     * complete expiry happens after this expiry * buffer length.
      * @param expiry The amount of time samples are accumulated to a histogram before it
      * is reset and rotated.
      * @return This builder.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -214,7 +214,8 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
      * greater weight to recent samples (exception: histogram counts are cumulative for
      * those systems that expect cumulative histogram buckets). Samples are accumulated to
      * such statistics in ring buffers which rotate after this expiry, with a buffer
-     * length of {@link #bufferLength}.
+     * length of {@link #bufferLength}, hence complete expiry happens after this expiry *
+     * buffer length.
      * @return The amount of time samples are accumulated to a histogram before it is
      * reset and rotated.
      */
@@ -426,7 +427,8 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
          * greater weight to recent samples (exception: histogram counts are cumulative
          * for those systems that expect cumulative histogram buckets). Samples are
          * accumulated to such statistics in ring buffers which rotate after this expiry,
-         * with a buffer length of {@link #bufferLength}.
+         * with a buffer length of {@link #bufferLength}, hence complete expiry happens
+         * after this expiry * buffer length.
          * @param expiry The amount of time samples are accumulated to decaying
          * distribution statistics before they are reset and rotated.
          * @return This builder.


### PR DESCRIPTION
This PR tries to clarify complete expiry of distribution statistics in Javadoc.

See gh-2751