### PR TITLE
[Dynatrace] Logging verbosity: Move metadata discrepancy logging to WarnThenDebug

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -60,17 +60,17 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
 
     private static final Pattern IS_NULL_ERROR_RESPONSE = Pattern.compile("\"error\":\\s?null");
 
-    private static final WarnThenDebugLogger stackTraceWarnThenDebugLogger = new WarnThenDebugLogger(
-            DynatraceExporterV2.class);
-
-    private static final WarnThenDebugLogger nanGaugeWarnThenDebugLogger = new WarnThenDebugLogger(
-            DynatraceExporterV2.class);
-
     private static final Map<String, String> staticDimensions = Collections.singletonMap("dt.metrics.source",
             "micrometer");
 
-    // This should be non-static for MockLoggerFactory.injectLogger() in tests.
+    // Loggers must be non-static for MockLoggerFactory.injectLogger() in tests.
     private final InternalLogger logger = InternalLoggerFactory.getInstance(DynatraceExporterV2.class);
+
+    private final WarnThenDebugLogger stackTraceLogger = new WarnThenDebugLoggers.StackTraceLogger();
+
+    private final WarnThenDebugLogger nanGaugeLogger = new WarnThenDebugLoggers.NanGaugeLogger();
+
+    private final WarnThenDebugLogger metadataDiscrepancyLogger = new WarnThenDebugLoggers.MetadataDiscrepancyLogger();
 
     private MetricLinePreConfiguration preConfiguration;
 
@@ -219,7 +219,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 // NaN's are currently dropped on the Dynatrace side, so dropping them
                 // on the client side here will not change the metrics in Dynatrace.
 
-                nanGaugeWarnThenDebugLogger.log(() -> String.format(
+                nanGaugeLogger.log(() -> String.format(
                         "Meter '%s' returned a value of NaN, which will not be exported. This can be a deliberate value or because the weak reference to the backing object expired.",
                         meter.getId().getName()));
                 return null;
@@ -418,9 +418,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                         response.code(), getTruncatedBody(response)));
         }
         catch (Throwable throwable) {
-            logger.warn("Failed metric ingestion: " + throwable);
-            stackTraceWarnThenDebugLogger.log("Stack trace for previous 'Failed metric ingestion' warning log: ",
-                    throwable);
+            // the "general" logger logs the message, the WarnThenDebugLogger logs the
+            // stack trace.
+            logger.warn("Failed metric ingestion: {}", throwable.toString());
+            stackTraceLogger.log(String.format("Stack trace for previous 'Failed metric ingestion' warning log: %s",
+                    throwable.getMessage()), throwable);
         }
     }
 
@@ -501,10 +503,10 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 // set for this metric key.
                 if (!previousMetadataLine.equals(metadataLine)) {
                     seenMetadata.put(key, null);
-                    logger.warn(
-                            "Metadata discrepancy detected:\n" + "original metadata:\t{}\n" + "tried to set new:\t{}\n"
-                                    + "Metadata for metric key {} will not be sent.",
-                            previousMetadataLine, metadataLine, key);
+                    metadataDiscrepancyLogger.log(() -> String.format(
+                            "Metadata discrepancy detected:\n" + "original metadata:\t%s\n" + "tried to set new:\t%s\n"
+                                    + "Metadata for metric key %s will not be sent.",
+                            previousMetadataLine, metadataLine, key));
                 }
             }
             // else:

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/WarnThenDebugLoggers.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/WarnThenDebugLoggers.java
@@ -21,10 +21,9 @@ import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
  * This internal class holds loggers that are used in {@link DynatraceExporterV2}. They
  * are all just extending the default {@link WarnThenDebugLogger}. It is necessary to
  * extend them, because the {@link WarnThenDebugLogger} does not allow creating a new
- * logger with just a name (a class object has to be passed). If the WarnThenDebugLogger
- * is created with the same class type multiple times, the same instance will be returned.
- * This would mean that in a scenario with multiple loggers, only the first call would log
- * the warning, and all subsequent calls will log at debug.
+ * logger with just a name (a class object has to be passed). Creating the
+ * WarnThenDebugLogger with the same class multiple times makes it impossible to test, as
+ * the MockLoggerFactory will ignore multiple loggers with the same name.
  */
 class WarnThenDebugLoggers {
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/WarnThenDebugLoggers.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/WarnThenDebugLoggers.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.v2;
+
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
+
+/**
+ * This internal class holds loggers that are used in {@link DynatraceExporterV2}. They
+ * are all just extending the default {@link WarnThenDebugLogger}. It is necessary to
+ * extend them, because the {@link WarnThenDebugLogger} does not allow creating a new
+ * logger with just a name (a class object has to be passed). If the WarnThenDebugLogger
+ * is created with the same class type multiple times, the same instance will be returned.
+ * This would mean that in a scenario with multiple loggers, only the first call would log
+ * the warning, and all subsequent calls will log at debug.
+ */
+class WarnThenDebugLoggers {
+
+    static class StackTraceLogger extends WarnThenDebugLogger {
+
+        public StackTraceLogger() {
+            super(StackTraceLogger.class);
+        }
+
+    }
+
+    static class NanGaugeLogger extends WarnThenDebugLogger {
+
+        public NanGaugeLogger() {
+            super(NanGaugeLogger.class);
+        }
+
+    }
+
+    static class MetadataDiscrepancyLogger extends WarnThenDebugLogger {
+
+        public MetadataDiscrepancyLogger() {
+            super(MetadataDiscrepancyLogger.class);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Many metrics have different descriptions based on their attributes (e.g., `log4j2.events` with tag `loglevel=info` has description `Number of info level log events`, while the same metric key with tag `loglevel=trace` has the description `Number of trace level log events`). Every time a discrepancy like that is detected, the Dynatrace exporter will log a warning. Consequently, many warnings will be logged, and continue to be logged during the runtime of the process. In order to reduce the number of warning logs produced, this PR introduces a WarnThenDebugLogger for this particular log. 

While working on this, I realized that the other WarnThenDebugLoggers in the Dynatrace exporter are actually using the same instance (since they are initialized with the same class type). I fixed that by introducing thin wrappers for different WarnThenDebugLoggers. There is no change in application behaviour, just in the logging output. 