### PR TITLE
Update osgi import for okhttp after downgrade

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -39,7 +39,7 @@ jar {
             com.netflix.hystrix.*;resolution:=dynamic;version="${@}",\
             ch.qos.logback.*;resolution:=dynamic;version="${@}",\
             org.apache.logging.log4j.*;resolution:=dynamic;version="${@}",\
-            okhttp3.*;resolution:=dynamic;version="${@}",\
+            okhttp3.*;resolution:=dynamic,\
             com.mongodb.*;resolution:=dynamic;version="${@}",\
             org.jooq.*;resolution:=dynamic;version="${@}",\
             org.apache.kafka.*;resolution:=dynamic,\


### PR DESCRIPTION
I don't understand why this change is needed upon downgrading, but without it the `testOSGI` task prints an exception and runs indefinitely.

@driessamyn could you shed any light on this? We downgraded okhttp from a 5.0 alpha version to 4.11.0 and the osgi test started exhibiting the behavior above. This seems to fix it, but I don't understand why the change was needed. Separately, it would be good if the `testOSGI` task would fail instead of hang when this happens.