### PR TITLE
Downgrade okhttp to 4.11.0 upgrade Kotlin to 1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,8 @@ subprojects {
 
             toolchain {
                 languageVersion = javaLanguageVersion
+                sourceCompatibility = javaTargetVersion
+                targetCompatibility = javaTargetVersion
             }
         }
 
@@ -117,6 +119,9 @@ subprojects {
             compileTestJava {
                 options.encoding = 'UTF-8'
                 options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
+
+                sourceCompatibility = JavaVersion.VERSION_11
+                targetCompatibility = JavaVersion.VERSION_11
             }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,7 +61,8 @@ mockito = "5.8.0"
 mongo = "4.11.1"
 netty = "4.1.104.Final"
 newrelic-api = "5.14.0"
-okhttp = "5.0.0-alpha.11" # TODO is compiling against an alpha version intentional?
+# Kotlin 1.7 sample will fail from OkHttp 4.12.0 due to okio dependency being a Kotlin 1.9 module
+okhttp = "4.11.0"
 postgre = "42.7.1"
 prometheus = "0.16.0"
 reactor = "2022.0.13"

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.kotlin17)
+    alias(libs.plugins.kotlin19)
     id 'me.champeau.mrjar' version "0.1.1"
 }
 
@@ -12,12 +12,14 @@ multiRelease {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = javaTargetVersion
+        apiVersion = "1.7"
+        languageVersion = "1.7"
     }
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinTest).all {
+compileTestKotlin {
     kotlinOptions {
-        jvmTarget = JavaVersion.toVersion(javaLanguageVersion)
+        jvmTarget = JavaVersion.VERSION_11
     }
 }
 
@@ -272,4 +274,9 @@ java11Test {
         maxFailures = 5
         maxRetries = 3
     }
+}
+
+compileJava11TestJava {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }

--- a/micrometer-jetty11/build.gradle
+++ b/micrometer-jetty11/build.gradle
@@ -8,6 +8,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core'
 }
 
+java {
+    targetCompatibility = 11
+}
+
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -80,3 +80,8 @@ java11Test {
         maxRetries = 3
     }
 }
+
+compileJava11TestJava {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}

--- a/samples/micrometer-samples-javalin/build.gradle
+++ b/samples/micrometer-samples-javalin/build.gradle
@@ -11,6 +11,10 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic'
 }
 
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/samples/micrometer-samples-kotlin/build.gradle
+++ b/samples/micrometer-samples-kotlin/build.gradle
@@ -1,6 +1,14 @@
 plugins {
-    // test with the highest version of Kotlin supported because we compile with oldest version supported
-    alias(libs.plugins.kotlin19)
+    // test with the lowest version of Kotlin supported because we compile with highest version supported
+    alias(libs.plugins.kotlin17)
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = javaTargetVersion
+        apiVersion = "1.7"
+        languageVersion = "1.7"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
OkHttp 4.12.0 depends on a version of okio that ends up requiring Kotlin 1.9. We only have an optional dependency on OkHttp so we could upgrade to 4.12.0, but I would rather not compile against a newer version of OkHttp than our users can use if they are on our minimum supported version of Kotlin (1.7). For that reason, compiles against the latest version of OkHttp that is compatible with Kotlin 1.7 - OkHttp 4.11.0.
Uses Kotlin 1.9 to compile but remains compatible with Kotlin 1.7.