### PR TITLE
Do not ignore composite meter filters child meter filters

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -849,6 +849,24 @@ public abstract class MeterRegistry {
             return this;
         }
 
+        MeterFilter[] getFilters() {
+            return filters;
+        }
+
+        /**
+         * Merges the provided configuration with this one.
+         * @param config configuration to merge
+         * @return this configuration with merged elements from the provided configuration
+         * @since 1.9.18
+         */
+        public Config merge(Config config) {
+            for (MeterFilter filter : config.getFilters()) {
+                meterFilter(filter);
+            }
+            // TODO: What else should we merge?
+            return this;
+        }
+
         /**
          * @return The pause detector that is currently in effect.
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -227,6 +227,13 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
         nonCompositeDescendants = descendants;
 
+        for (MeterRegistry nonCompositeDescendant : nonCompositeDescendants) {
+            Config config = nonCompositeDescendant.config();
+            if (config != null) { // for tests
+                config.merge(config());
+            }
+        }
+
         lock(parentLock, () -> parents.forEach(CompositeMeterRegistry::updateDescendants));
     }
 


### PR DESCRIPTION
without this change non composite descendant do not know about the configuration of their parents 
with this change we're merging that configuration

fixes gh-3020