### PR TITLE
Enable whenConnectionCheckedInAfterPoolClose_thenNoExceptionThrown()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/mongodb/MongoMetricsConnectionPoolListenerTest.java
@@ -114,6 +114,7 @@ class MongoMetricsConnectionPoolListenerTest extends AbstractMongoDbTest {
     }
 
     @Issue("#2384")
+    @Test
     void whenConnectionCheckedInAfterPoolClose_thenNoExceptionThrown() {
         ServerId serverId = new ServerId(new ClusterId(), new ServerAddress(host, port));
         ConnectionId connectionId = new ConnectionId(serverId);


### PR DESCRIPTION
This PR adds a missing `@Test` to `whenConnectionCheckedInAfterPoolClose_thenNoExceptionThrown()` in `MongoMetricsConnectionPoolListenerTest` as it seems to be missing accidentally.