### PR TITLE
feat: Unify micrometer collector name

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/MicrometerCollector.java
@@ -51,6 +51,13 @@ class MicrometerCollector extends Collector implements Collector.Describable {
         this.help = config.descriptions() ? Optional.ofNullable(id.getDescription()).orElse(" ") : " ";
     }
 
+    public MicrometerCollector(String name, Meter.Id id, NamingConvention convention, PrometheusConfig config) {
+        this.id = id;
+        this.conventionName = name;
+        this.tagKeys = id.getConventionTags(convention).stream().map(Tag::getKey).collect(toList());
+        this.help = config.descriptions() ? Optional.ofNullable(id.getDescription()).orElse(" ") : " ";
+    }
+
     public void add(List<String> tagValues, Child child) {
         children.put(tagValues, child);
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -575,7 +575,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {
         collectorMap.compute(getConventionName(id), (name, existingCollector) -> {
             if (existingCollector == null) {
-                MicrometerCollector micrometerCollector = new MicrometerCollector(id, config().namingConvention(),
+                MicrometerCollector micrometerCollector = new MicrometerCollector(name, id, config().namingConvention(),
                         prometheusConfig);
                 consumer.accept(micrometerCollector);
                 return micrometerCollector.register(registry);

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 VMware, Inc.
+ * Copyright 2024 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
@@ -1,0 +1,34 @@
+package io.micrometer.prometheus;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.prometheus.client.CollectorRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PrometheusMeterRegistryCustomizeTest {
+
+    private final CollectorRegistry prometheusRegistry = new CollectorRegistry(true);
+
+    private final MockClock clock = new MockClock();
+    
+    private final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry,
+        clock) {
+        
+        @Override
+        protected String getConventionName(Meter.Id id) {
+            return "custom_prefix_" + super.getConventionName(id);
+        }
+    };
+
+    @DisplayName("registered counter collector name is the same that calculated by PrometheusMeterRegistry")
+    @Test
+    void customNamedCollectorName() {
+        Counter.builder("counter").description("my counter").register(registry);
+        assertThat(this.registry.getPrometheusRegistry().metricFamilySamples().nextElement().name).isEqualTo("custom_prefix_counter");
+    }
+        
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.prometheus;
 
 import io.micrometer.core.instrument.Counter;

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryCustomizeTest.java
@@ -14,10 +14,10 @@ class PrometheusMeterRegistryCustomizeTest {
     private final CollectorRegistry prometheusRegistry = new CollectorRegistry(true);
 
     private final MockClock clock = new MockClock();
-    
-    private final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry,
-        clock) {
-        
+
+    private final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT,
+            prometheusRegistry, clock) {
+
         @Override
         protected String getConventionName(Meter.Id id) {
             return "custom_prefix_" + super.getConventionName(id);
@@ -28,7 +28,8 @@ class PrometheusMeterRegistryCustomizeTest {
     @Test
     void customNamedCollectorName() {
         Counter.builder("counter").description("my counter").register(registry);
-        assertThat(this.registry.getPrometheusRegistry().metricFamilySamples().nextElement().name).isEqualTo("custom_prefix_counter");
+        assertThat(this.registry.getPrometheusRegistry().metricFamilySamples().nextElement().name)
+            .isEqualTo("custom_prefix_counter");
     }
-        
+
 }


### PR DESCRIPTION
We propose to unify the collector name passing the first calculated name (in `PrometheusMeterRegistry.getConventionName(id)`) to `MicrometerCollector` constructor.

With this easy change, it is posible to uncouple the metric name to the collector name, and resolve some existent issues related to some Prometheus metric name restrictions that doesn't exist in Micrometer. 