### PR TITLE
Update gRPC trailers metadata consumption by observation context

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
@@ -61,9 +61,12 @@ class ObservationGrpcServerCall<ReqT, RespT> extends SimpleForwardingServerCall<
         if (status.getCause() != null) {
             this.observation.error(status.getCause());
         }
+        // Per javadoc, trailers are not thread-safe. Make a copy.
+        Metadata trailersToKeep = new Metadata();
+        trailersToKeep.merge(trailers);
         GrpcServerObservationContext context = (GrpcServerObservationContext) this.observation.getContext();
         context.setStatusCode(status.getCode());
-        context.setTrailers(trailers);
+        context.setTrailers(trailersToKeep);
         super.close(status, trailers);
     }
 


### PR DESCRIPTION
According to gRPC Javadoc, the passed metadata variable is not thread-safe.  
Similar to the approach taken for handling headers metadata, this commit ensures that the trailers metadata is also copied for later consumption by `GrpcServerObservationContext`.