### PR TITLE
Use Dynatrace snapshot for LongTaskTimer (1.12.x)

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -17,10 +17,7 @@ package io.micrometer.dynatrace;
 
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -30,6 +27,7 @@ import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import io.micrometer.dynatrace.types.DynatraceDistributionSummary;
+import io.micrometer.dynatrace.types.DynatraceLongTaskTimer;
 import io.micrometer.dynatrace.types.DynatraceTimer;
 import io.micrometer.dynatrace.v1.DynatraceExporterV1;
 import io.micrometer.dynatrace.v2.DynatraceExporterV2;
@@ -122,6 +120,15 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                     exporter.getBaseTimeUnit());
         }
         return super.newTimer(id, distributionStatisticConfig, pauseDetector);
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
+        if (useDynatraceSummaryInstruments) {
+            return new DynatraceLongTaskTimer(id, clock, exporter.getBaseTimeUnit(), distributionStatisticConfig,
+                    false);
+        }
+        return super.newLongTaskTimer(id, distributionStatisticConfig);
     }
 
     /**

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -195,6 +195,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
         switch (id.getType()) {
             case DISTRIBUTION_SUMMARY:
             case TIMER:
+            case LONG_TASK_TIMER:
                 return true;
             default:
                 return false;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of the LongTaskTimer that ensures produced data is consistent for
+ * exporting to Dynatrace.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.12.3
+ */
+public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements DynatraceSummarySnapshotSupport {
+
+    public DynatraceLongTaskTimer(Id id, Clock clock, TimeUnit baseTimeUnit,
+            DistributionStatisticConfig distributionStatisticConfig, boolean supportsAggregablePercentiles) {
+        super(id, clock, baseTimeUnit, distributionStatisticConfig, supportsAggregablePercentiles);
+    }
+
+    /**
+     * @deprecated see {@link DynatraceSummarySnapshotSupport#hasValues()}.
+     */
+    @Override
+    @Deprecated
+    public boolean hasValues() {
+        return activeTasks() > 0;
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot() {
+        return takeSummarySnapshot(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
+        if (activeTasks() < 1) {
+            return DynatraceSummarySnapshot.NO_RECORDED_VALUES;
+        }
+
+        DynatraceSummary summary = new DynatraceSummary();
+
+        // iterate active samples and create a Dynatrace summary.
+        super.forEachActive(sample -> {
+            // sample.duration will return -1 if the task is already finished (only
+            // currently active tasks are measured).
+            // -1 will be ignored in recordNonNegative.
+            summary.recordNonNegative(sample.duration(unit));
+        });
+
+        return summary.takeSummarySnapshot();
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
+        return takeSummarySnapshotAndReset(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
+        // LongTaskTimers record a snapshot of in-flight operations, e.g., the number of
+        // active requests.
+        // Therefore, the Snapshot needs to be created from scratch during the export.
+        // In takeSummarySnapshot() above, the Summary object is deleted at the end of the
+        // method, therefore effectively resetting the snapshot.
+        return takeSummarySnapshot(unit);
+    }
+
+}

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -71,7 +71,7 @@ public final class DynatraceLongTaskTimer extends DefaultLongTaskTimer implement
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
-        // LongTaskTimer record a snapshot of in-flight operations, e.g.: the number of
+        // LongTaskTimer records a snapshot of in-flight operations, e.g.: the number of
         // active requests.
         // Therefore, the Snapshot needs to be created from scratch during the export.
         // In takeSummarySnapshot(TimeUnit) above, the Summary object is deleted at the

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -22,13 +22,13 @@ import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Implementation of the LongTaskTimer that ensures produced data is consistent for
+ * {@code LongTaskTimer} implementation that ensures produced data is consistent for
  * exporting to Dynatrace.
  *
  * @author Georg Pirklbauer
  * @since 1.12.4
  */
-public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements DynatraceSummarySnapshotSupport {
+public final class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements DynatraceSummarySnapshotSupport {
 
     public DynatraceLongTaskTimer(Id id, Clock clock, TimeUnit baseTimeUnit,
             DistributionStatisticConfig distributionStatisticConfig, boolean supportsAggregablePercentiles) {
@@ -52,18 +52,14 @@ public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements Dyna
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
         if (activeTasks() < 1) {
-            return DynatraceSummarySnapshot.NO_RECORDED_VALUES;
+            return DynatraceSummarySnapshot.EMPTY;
         }
 
         DynatraceSummary summary = new DynatraceSummary();
-
-        // iterate active samples and create a Dynatrace summary.
-        super.forEachActive(sample -> {
-            // sample.duration will return -1 if the task is already finished (only
-            // currently active tasks are measured).
-            // -1 will be ignored in recordNonNegative.
-            summary.recordNonNegative(sample.duration(unit));
-        });
+        // sample.duration(...) will return -1 if the task is already finished
+        // (only currently active tasks are measured).
+        // -1 will be ignored in recordNonNegative.
+        super.forEachActive(sample -> summary.recordNonNegative(sample.duration(unit)));
 
         return summary.takeSummarySnapshot();
     }
@@ -75,11 +71,11 @@ public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements Dyna
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
-        // LongTaskTimers record a snapshot of in-flight operations, e.g., the number of
+        // LongTaskTimer record a snapshot of in-flight operations, e.g.: the number of
         // active requests.
         // Therefore, the Snapshot needs to be created from scratch during the export.
-        // In takeSummarySnapshot() above, the Summary object is deleted at the end of the
-        // method, therefore effectively resetting the snapshot.
+        // In takeSummarySnapshot(TimeUnit) above, the Summary object is deleted at the
+        // end of the method, therefore effectively resetting the snapshot.
         return takeSummarySnapshot(unit);
     }
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * exporting to Dynatrace.
  *
  * @author Georg Pirklbauer
- * @since 1.12.3
+ * @since 1.12.4
  */
 public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements DynatraceSummarySnapshotSupport {
 

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
@@ -26,6 +26,8 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DynatraceSummarySnapshot {
 
+    public static final DynatraceSummarySnapshot NO_RECORDED_VALUES = new DynatraceSummarySnapshot(0, 0, 0, 0);
+
     private final double min;
 
     private final double max;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
@@ -26,7 +26,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DynatraceSummarySnapshot {
 
-    public static final DynatraceSummarySnapshot NO_RECORDED_VALUES = new DynatraceSummarySnapshot(0, 0, 0, 0);
+    public static final DynatraceSummarySnapshot EMPTY = new DynatraceSummarySnapshot(0, 0, 0, 0);
 
     private final double min;
 
@@ -57,6 +57,12 @@ public final class DynatraceSummarySnapshot {
 
     public long getCount() {
         return count;
+    }
+
+    @Override
+    public String toString() {
+        return "DynatraceSummarySnapshot{" + "min=" + min + ", max=" + max + ", total=" + total + ", count=" + count
+                + '}';
     }
 
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -329,7 +329,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toLongTaskTimerLine(LongTaskTimer meter, Map<String, String> seenMetadata) {
-        // use Dynatrace Snapshotting to ensure consistent data.
+        // use Dynatrace Snapshotting to ensure consistent data
         if (meter instanceof DynatraceSummarySnapshotSupport) {
             DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
                 .takeSummarySnapshot(getBaseTimeUnit());
@@ -341,8 +341,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                     snapshot.getCount());
         }
 
-        // fall back to default implementation if the meter is not a
-        // DynatraceLongTaskTimer.
+        // fall back to default implementation if the meter is not DynatraceLongTaskTimer
         HistogramSnapshot snapshot = meter.takeSnapshot();
 
         long count = snapshot.count();

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -329,6 +329,20 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toLongTaskTimerLine(LongTaskTimer meter, Map<String, String> seenMetadata) {
+        // use Dynatrace Snapshotting to ensure consistent data.
+        if (meter instanceof DynatraceSummarySnapshotSupport) {
+            DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
+                .takeSummarySnapshot(getBaseTimeUnit());
+            if (snapshot.getCount() == 0) {
+                return Stream.empty();
+            }
+
+            return createSummaryLine(meter, seenMetadata, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(),
+                    snapshot.getCount());
+        }
+
+        // fall back to default implementation if the meter is not a
+        // DynatraceLongTaskTimer.
         HistogramSnapshot snapshot = meter.takeSnapshot();
 
         long count = snapshot.count();

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DynatraceLongTaskTimer}.
+ */
+class DynatraceLongTaskTimerTest {
+
+    private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc",
+            Meter.Type.DISTRIBUTION_SUMMARY);
+
+    private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
+
+    private static final MockClock CLOCK = new MockClock();
+
+    private static final Offset<Double> TOLERANCE = Offset.offset(0.000001);
+
+    @Test
+    void testValuesAreRecorded() throws InterruptedException {
+        DynatraceLongTaskTimer ltt = new DynatraceLongTaskTimer(ID, CLOCK, TimeUnit.MILLISECONDS,
+                DISTRIBUTION_STATISTIC_CONFIG, false);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        CountDownLatch taskHasBeenRunningLatch = new CountDownLatch(1);
+        CountDownLatch stopLatch = new CountDownLatch(1);
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                CLOCK.add(Duration.ofMillis(100));
+                taskHasBeenRunningLatch.countDown();
+
+                try {
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        taskHasBeenRunningLatch.await(300, TimeUnit.MILLISECONDS);
+
+        DynatraceSummarySnapshot snapshot = ltt.takeSummarySnapshot();
+        // can release the background task
+        stopLatch.countDown();
+
+        assertThat(snapshot.getMin()).isCloseTo(100, TOLERANCE);
+        assertThat(snapshot.getMax()).isCloseTo(100, TOLERANCE);
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        // in the case of count == 1, the total has to be equal to min and max
+        assertThat(snapshot.getTotal()).isGreaterThan(0)
+            .isCloseTo(snapshot.getMin(), TOLERANCE)
+            .isCloseTo(snapshot.getMax(), TOLERANCE);
+    }
+
+    /**
+     * This test *could* be done with the MockClock, but it gets pretty unintuitive. That
+     * is because when adding to the MockClock in one Thread, it automatically adds to the
+     * other thread as well and time is basically "double-counted".
+     */
+    @Test
+    void testTwoValuesAreRecorded() throws InterruptedException {
+        // use the system clock, as it is much easier to understand than when using the
+        // MockClock (When using MockClock, adding to the clock in two separate threads
+        // basically means that two things happen at the same time).
+        DynatraceLongTaskTimer ltt = new DynatraceLongTaskTimer(ID, Clock.SYSTEM, TimeUnit.MILLISECONDS,
+                DISTRIBUTION_STATISTIC_CONFIG, false);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        // both tasks need to be running for a while before we take the snapshot
+        CountDownLatch taskHasBeenRunningLatch = new CountDownLatch(2);
+        CountDownLatch stopLatch = new CountDownLatch(1);
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                try {
+                    Thread.sleep(70);
+                    taskHasBeenRunningLatch.countDown();
+
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                try {
+                    Thread.sleep(30);
+                    taskHasBeenRunningLatch.countDown();
+
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        taskHasBeenRunningLatch.await(300, TimeUnit.MILLISECONDS);
+
+        DynatraceSummarySnapshot snapshot = ltt.takeSummarySnapshot();
+        // can release the background tasks
+        stopLatch.countDown();
+
+        // the first Thread has been "running" for ~30ms at the time of recording and will
+        // supply the min
+        assertThat(snapshot.getMin()).isGreaterThanOrEqualTo(30);
+        // the second Thread has been "running" for ~70ms at the time of recording and
+        // will supply the max
+        assertThat(snapshot.getMax()).isGreaterThanOrEqualTo(70).isLessThan(100);
+        // the min is greater than 30, and the max is greater than 70, so together they
+        // have to be greater than 100.
+        assertThat(snapshot.getTotal()).isGreaterThan(100);
+        assertThat(snapshot.getCount()).isEqualTo(2);
+    }
+
+}


### PR DESCRIPTION
Similar to https://github.com/micrometer-metrics/micrometer/pull/3093, this PR introduces a Dynatrace-specific instrument for the LongTaskTimer. This is necessary because we still see instances of LongTaskTimer data rejected by the Dynatrace API. We tried to fix this in https://github.com/micrometer-metrics/micrometer/pull/3985, which reduced the number of errors, but did not completely solve the problem.

--- 
**The long version (an example):**

I have (albeit unsuccessfully) tried to reproduce this issue, and am now pretty sure that it has to do with a race condition. For example, this is one of the inconsistent datapoints we saw: 
```
min <= avg <= max doesn't hold: min: 44.809818, max: 44.812933, sum: 89.628272, count: 3, avg: 29.876091
```
These values are calculated in the `DefaultLongTaskTimer.takeSnapshot` method: https://github.com/micrometer-metrics/micrometer/blob/9a19c9c1dd345cdd97bc67089c6a1c367762d61c/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java#L130-L216 We are estimating the min as the 0% quantile of the data, since the min is not tracked by the LongTaskTimer instrument. The 0% quantile is calculated in the first section of the `takeSnapshot` method ([L131-L201](https://github.com/micrometer-metrics/micrometer/blob/9a19c9c1dd345cdd97bc67089c6a1c367762d61c/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java#L131-L201)). Duration and max are calculated down below: 
https://github.com/micrometer-metrics/micrometer/blob/9a19c9c1dd345cdd97bc67089c6a1c367762d61c/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java#L203-L204 Finally, in line 214, the count is retrieved (by calling `activeTasks.size()`): 
https://github.com/micrometer-metrics/micrometer/blob/9a19c9c1dd345cdd97bc67089c6a1c367762d61c/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java#L214 

These numbers are calculated in consecutive steps, which are _not synchronized_. If we look at the numbers for the error data again, this seems to be reflected:
1. The min is calculated as the 0% quantile, thus it is the smallest number: `44.809818`. 
2. Just after that, the duration (total) is calculated and it turns out to be `89.628272`. Note that this is _very close_ to min+max (which comes out to `89.622751`), so there must be two active tasks that have been running for approximately the same time at this point. 
3. The max is calculated: `44.812933`. It is very close to the min, so there were either two tasks running for almost the exact same length of time, or there was only one task, and the calculation of the total is off (which seems unlikely).
Note that we know that there must have been at most one or two tasks running at this point in time.
4. The count is retrieved by getting  `activeTasks.size()`. It is `3`, so there must be three items in the collection. Note however the notice on the [`ConcurrentLinkedDeque#size()`](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/util/concurrent/ConcurrentLinkedDeque.html#size()) method: 

>Beware that, unlike in most collections, this method is NOT a constant-time operation. Because of the asynchronous nature of these deques, determining the current number of elements requires traversing them all to count them. **Additionally, it is possible for the size to change during execution of this method, in which case the returned result will be inaccurate. Thus, this method is typically not very useful in concurrent applications.**

(emphasis mine)

The only way I can see this happening, is if a new task was added to be recorded between the time the min/max/sum values were calculated, and the point in time where the count is retrieved. In a case like `http.server.requests.active`, it is actually quite likely that a request starts/finishes _while_ the export is still running.

We have also seen other examples that point to the size of the collection changing while the snapshot is being prepared. One example I saw had failed to create a 0% quantile because there were no activeTasks to estimate the quantile from, but had a `count > 0`. This means, that when the method started there were 0 activeTasks, but when it reached the point where the count was retrieved, suddenly there was at least one activeTask. 

**TL;DR:** min, max, sum, and count retrieval are not synchronized and are therefore potentially inconsistent if tasks finish/start during the calculation of the values.

--- 
**Proposed fix:** As we did for multiple instruments in https://github.com/micrometer-metrics/micrometer/pull/3093, we suggest to replace the LongTaskTimer with the DynatraceLongTaskTimer for the DynatraceMeterRegistry, which records data in a synchronized way and ensures that the data is consistent (as per the Dynatrace definition) at the time of export. As an added benefit, the min is automatically tracked in the DynatraceSnapshot, so it does not have to be estimated at export time.