### PR TITLE
fix(GRPC interceptor): customizable tag names

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingClientInterceptor.java
@@ -85,7 +85,30 @@ public class MetricCollectingClientInterceptor extends AbstractMetricCollectingI
     public MetricCollectingClientInterceptor(final MeterRegistry registry,
             final UnaryOperator<Counter.Builder> counterCustomizer, final UnaryOperator<Timer.Builder> timerCustomizer,
             final Code... eagerInitializedCodes) {
-        super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+        super(DEFAULT_TAG_SERVICE_NAME, DEFAULT_TAG_METHOD_NAME, DEFAULT_TAG_METHOD_TYPE, DEFAULT_TAG_STATUS_CODE,
+                registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    }
+
+    /**
+     * Creates a new gRPC client interceptor that will collect metrics into the given
+     * {@link MeterRegistry} and uses the given customizers to configure the
+     * {@link Counter}s and {@link Timer}s.
+     * @param tagServiceName Tag name to use for service name
+     * @param tagMethodName Tag name to use for method name
+     * @param tagMethodType Tag name to use for method type
+     * @param tagStatusCode Tag name to use for status code
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the
+     * created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created
+     * timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingClientInterceptor(String tagServiceName, String tagMethodName, String tagMethodType,
+            String tagStatusCode, final MeterRegistry registry, final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final Code... eagerInitializedCodes) {
+        super(tagServiceName, tagMethodName, tagMethodType, tagStatusCode, registry, counterCustomizer, timerCustomizer,
+                eagerInitializedCodes);
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/MetricCollectingServerInterceptor.java
@@ -85,7 +85,30 @@ public class MetricCollectingServerInterceptor extends AbstractMetricCollectingI
     public MetricCollectingServerInterceptor(final MeterRegistry registry,
             final UnaryOperator<Counter.Builder> counterCustomizer, final UnaryOperator<Timer.Builder> timerCustomizer,
             final Code... eagerInitializedCodes) {
-        super(registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+        this(DEFAULT_TAG_SERVICE_NAME, DEFAULT_TAG_METHOD_NAME, DEFAULT_TAG_METHOD_TYPE, DEFAULT_TAG_STATUS_CODE,
+                registry, counterCustomizer, timerCustomizer, eagerInitializedCodes);
+    }
+
+    /**
+     * Creates a new gRPC server interceptor that will collect metrics into the given
+     * {@link MeterRegistry} and uses the given customizers to configure the
+     * {@link Counter}s and {@link Timer}s.
+     * @param tagServiceName Tag name to use for service name
+     * @param tagMethodName Tag name to use for method name
+     * @param tagMethodType Tag name to use for method type
+     * @param tagStatusCode Tag name to use for status code
+     * @param registry The registry to use.
+     * @param counterCustomizer The unary function that can be used to customize the
+     * created counters.
+     * @param timerCustomizer The unary function that can be used to customize the created
+     * timers.
+     * @param eagerInitializedCodes The status codes that should be eager initialized.
+     */
+    public MetricCollectingServerInterceptor(String tagServiceName, String tagMethodName, String tagMethodType,
+            String tagStatusCode, final MeterRegistry registry, final UnaryOperator<Counter.Builder> counterCustomizer,
+            final UnaryOperator<Timer.Builder> timerCustomizer, final Code... eagerInitializedCodes) {
+        super(tagServiceName, tagMethodName, tagMethodType, tagStatusCode, registry, counterCustomizer, timerCustomizer,
+                eagerInitializedCodes);
     }
 
     /**


### PR DESCRIPTION
This PR changes GRPC's `MetricCollectingClientInterceptor` and `MetricCollectingServerInterceptor` to allow tag names customization.

### The problem:
Both interceptors use `service` tag name for **_GRPC_** service names (think endpoint names), while in most cases this tag name is used for the actual service name (e.g. deployment name in k8s). This causes inconsistency in metrics and there is no way to customize the tag name at the moment.

### The solution:
Technically, both interceptors allow providing `counterCustomizer` and `timerCustomizer`, but both are just functions on `Counter`/`Timer` Builder, and builders don't have any methods to **_remove_** the tags added before.

So I had two options here:

1. Add a `remove` method to the builder interface (which would be kinda weird I think).
2. Allow passing custom tag names via the constructor.

I went for the second option here. While technically it wasn't necessary to customize other tag names, I did that too, so that I can have consistent tag names for those metrics.

What I eventually went for in our app is: `grpc.service`, `grpc.method`, `grpc.methodType` and `grpc.statusCode`.

I guess, I could've as well just changed the tag names here to those values, but I imagine that could break dashboards/alerts for some folks :smile: 