### PR TITLE
Improve aggregationTemporalityUseEnvVarWhenConfigNotSet()

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
@@ -193,8 +193,8 @@ class OtlpConfigTest {
     @Test
     void aggregationTemporalityUseEnvVarWhenConfigNotSet() throws Exception {
         OtlpConfig config = k -> null;
-        withEnvironmentVariable("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "CUMULATIVE")
-            .execute(() -> assertThat(config.aggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE));
+        withEnvironmentVariable("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "DELTA")
+            .execute(() -> assertThat(config.aggregationTemporality()).isEqualTo(AggregationTemporality.DELTA));
     }
 
     @Test


### PR DESCRIPTION
This PR improves `aggregationTemporalityUseEnvVarWhenConfigNotSet()` by using a non-default value as it passes without the environment variable now.

See gh-4500