### PR TITLE
Make DefaultHttpClientObservationConvention#INSTANCE final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -365,6 +365,8 @@ subprojects {
 
                     packageExcludes = ['io.micrometer.shaded.*', 'io.micrometer.statsd.internal']
 
+                    fieldExcludes = ['io.micrometer.core.instrument.binder.jdk.DefaultHttpClientObservationConvention#INSTANCE']
+
                     onlyIf { compatibleVersion != 'SKIP' }
                 }
 

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -35,7 +35,7 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
     /**
      * Instance of this {@link DefaultHttpClientObservationConvention}.
      */
-    public static DefaultHttpClientObservationConvention INSTANCE = new DefaultHttpClientObservationConvention();
+    public static final DefaultHttpClientObservationConvention INSTANCE = new DefaultHttpClientObservationConvention();
 
     @Override
     public KeyValues getLowCardinalityKeyValues(HttpClientContext context) {


### PR DESCRIPTION
This PR makes `DefaultHttpClientObservationConvention#INSTANCE` `final` as being non-final seems to be accidental.