### PR TITLE
Kotlin-specific ObservationRegistry API

### DIFF
--- a/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndAwait.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndAwait.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationRegistry
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Observes the provided **suspending** block of code, which means the following:
+ * - Creates and starts an [Observation]
+ * - Puts the [Observation] into [CoroutineContext]
+ * - Calls the provided [block] withing the augmented [CoroutineContext]
+ * - Signals the error to the [Observation] if any
+ * - Stops the [Observation]
+ *
+ * @param name name for the observation
+ * @param contextSupplier supplier of the context for the observation
+ * @param block the block of code to be observed
+ * @return the result of executing the provided block of code
+ */
+suspend fun <T> ObservationRegistry.observeAndAwait(
+    name: String,
+    contextSupplier: () -> Observation.Context = { Observation.Context() },
+    block: suspend () -> T,
+): T = Observation.start(name, contextSupplier, this).run {
+    try {
+        return withContext(
+            openScope().use { observationRegistry.asContextElement() },
+        ) {
+            block()
+        }
+    } catch (error: Throwable) {
+        error(error)
+        throw error
+    } finally {
+        stop()
+    }
+}

--- a/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndGet.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndGet.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.observation.Observation
+import io.micrometer.observation.Observation.Context
+import io.micrometer.observation.ObservationRegistry
+
+/**
+ * Observes the provided block of code, which means the following:
+ * - Creates and starts an [Observation]
+ * - Opens a scope
+ * - Calls the provided [block]
+ * - Closes the scope
+ * - Signals the error to the [Observation] if any
+ * - Stops the [Observation]
+ *
+ * For a suspending version, see [ObservationRegistry.observeAndAwait]
+ *
+ * @param name name for the observation
+ * @param contextSupplier supplier of the context for the observation
+ * @param block the block of code to be observed
+ * @return the result of executing the provided block of code
+ */
+fun <T> ObservationRegistry.observeAndGet(
+    name: String,
+    contextSupplier: () -> Context = { Context() },
+    block: () -> T,
+): T = Observation.start(name, contextSupplier, this).run {
+    try {
+        return openScope().use { block() }
+    } catch (error: Throwable) {
+        error(error)
+        throw error
+    } finally {
+        stop()
+    }
+}

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndAwaitKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndAwaitKtTests.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.BDDAssertions.assertThat
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.isA
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class ObserveAndAwaitKtTests {
+
+    private val observationHandler = mock(ObservationHandler::class.java).also { handler ->
+        `when`(handler.supportsContext(isA(Observation.Context::class.java)))
+            .thenReturn(true)
+    }
+
+    private val observationRegistry = ObservationRegistry.create().apply {
+        observationConfig().observationHandler(observationHandler)
+    }
+
+    @Test
+    fun `should start and stop the observation when block is executed successfully`(): Unit = runBlocking {
+        val nonNullValue = "computed value"
+
+        val result = observationRegistry.observeAndAwait(name = "observeNotNull") {
+            repeat(3) { delay(5) }
+            nonNullValue
+        }
+
+        then(result).isSameAs(nonNullValue)
+        verify(observationHandler, times(1)).onStart(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStop(ArgumentMatchers.any())
+        // 1 scope for call to openScope() + 1 scope for withContext + 3 scopes for 3 suspensions via delay
+        verify(observationHandler, times(1 + 1 + 3)).onScopeOpened(ArgumentMatchers.any())
+        verify(observationHandler, times(1 + 1 + 3)).onScopeClosed(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `should start and stop both observation and scope when block throws an exception`(): Unit = runBlocking {
+        val errorMessage = "Something went wrong"
+
+        val exception = kotlin.runCatching {
+            observationRegistry.observeAndAwait(name = "observeNotNull") {
+                throw RuntimeException(errorMessage)
+            }
+        }.exceptionOrNull()
+
+        assertThat(exception).hasMessage(errorMessage)
+        verify(observationHandler, times(1)).onError(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStart(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStop(ArgumentMatchers.any())
+        // 1 scope for call to openScope() + 1 scope for withContext
+        verify(observationHandler, times(1 + 1)).onScopeOpened(ArgumentMatchers.any())
+        verify(observationHandler, times(1 + 1)).onScopeClosed(ArgumentMatchers.any())
+    }
+}

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndGetKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/ObserveAndGetKtTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import org.assertj.core.api.BDDAssertions.assertThat
+import org.assertj.core.api.BDDAssertions.catchException
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.isA
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+class ObserveAndGetKtTests {
+
+    private val observationHandler = mock(ObservationHandler::class.java).also { handler ->
+        `when`(handler.supportsContext(isA(Observation.Context::class.java)))
+            .thenReturn(true)
+    }
+
+    private val observationRegistry = ObservationRegistry.create().apply {
+        observationConfig().observationHandler(observationHandler)
+    }
+
+    @Test
+    fun `should start and stop both observation and scope when block is executed successfully`() {
+        val nonNullValue = "computed value"
+
+        val result = observationRegistry.observeAndGet(name = "observeNotNull") {
+            nonNullValue
+        }
+
+        then(result).isSameAs(nonNullValue)
+        verify(observationHandler, times(1)).onStart(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStop(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onScopeOpened(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onScopeClosed(ArgumentMatchers.any())
+    }
+
+    @Test
+    fun `should start and stop both observation and scope when block throws an exception`() {
+        val errorMessage = "Something went wrong"
+
+        val exception = catchException {
+            observationRegistry.observeAndGet(name = "observeNotNull") {
+                throw RuntimeException(errorMessage)
+            }
+        }
+
+        assertThat(exception).hasMessage(errorMessage)
+        verify(observationHandler, times(1)).onError(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStart(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onStop(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onScopeOpened(ArgumentMatchers.any())
+        verify(observationHandler, times(1)).onScopeClosed(ArgumentMatchers.any())
+    }
+}


### PR DESCRIPTION
This PR introduces a couple of extension functions on `ObservationRegistry` to help using `Observation` API from Kotlin code.

- `ObservationRegistry.observeAndGet` allows to observe a non-suspending block of code:
  - this method is analogous to `Observation.observe`, but accepts a block of code instead of expecting a Java Supplier
  - this method will work with both nullable and non-nullable generic type (while usage of Supplier makes Kotlin compiler think the result of the nested block is always nullable)
- `ObservationRegistry.observeAndAwait` allows to observe a suspending block of code:
  - this method is again similar to `Observation.observe`, but will accept a suspending block of code
  - by using `openScope().use { observationRegistry.asContextElement() }` it manages to create an instance of `KotlinObservationContextElement` with the new observation captured as "current"

Initial idea: Why add those to `ObservationRegistry` and not to `Observation`? Mostly for consistency. I.e. `observeAndAwait` needs  access to `ObservationRegistry` anyway, so it's easy to add it to the registry as an extension. While `observeAndGet` could indeed be made into an extension function on `Observation`, however it still needs to be called something other than `observe`, as otherwise Intellij can't resolve which `observe` version the code is referring to.

**Update:** I realized that Observation also contains registry it was created for, so I created an alternative PR which adds both of the extension functions to `Observation` class: https://github.com/micrometer-metrics/micrometer/pull/4823 

gh-4754