### PR TITLE
Add debug logs for failed PutMetricDataRequests in CloudWatchMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -127,6 +127,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
                 else {
                     logger.error("error sending metric data.", t);
                 }
+                logger.debug("failed PutMetricDataRequest: {}", putMetricDataRequest);
             }
             else {
                 logger.debug("published {} metrics with namespace:{}", metricData.size(),


### PR DESCRIPTION
This PR adds debug logs for failed `PutMetricDataRequest`s in `CloudWatchMeterRegistry` to try to resolve https://github.com/micrometer-metrics/micrometer/issues/1396.