### PR TITLE
Use Dynatrace snapshot for LongTaskTimer

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -15,10 +15,7 @@
  */
 package io.micrometer.dynatrace;
 
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -30,6 +27,7 @@ import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import io.micrometer.core.util.internal.logging.InternalLogger;
 import io.micrometer.core.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.dynatrace.types.DynatraceDistributionSummary;
+import io.micrometer.dynatrace.types.DynatraceLongTaskTimer;
 import io.micrometer.dynatrace.types.DynatraceTimer;
 import io.micrometer.dynatrace.v1.DynatraceExporterV1;
 import io.micrometer.dynatrace.v2.DynatraceExporterV2;
@@ -122,6 +120,15 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
                     exporter.getBaseTimeUnit());
         }
         return super.newTimer(id, distributionStatisticConfig, pauseDetector);
+    }
+
+    @Override
+    protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
+        if (useDynatraceSummaryInstruments) {
+            return new DynatraceLongTaskTimer(id, clock, exporter.getBaseTimeUnit(), distributionStatisticConfig,
+                    false);
+        }
+        return super.newLongTaskTimer(id, distributionStatisticConfig);
     }
 
     /**

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/DynatraceMeterRegistry.java
@@ -195,6 +195,7 @@ public class DynatraceMeterRegistry extends StepMeterRegistry {
         switch (id.getType()) {
             case DISTRIBUTION_SUMMARY:
             case TIMER:
+            case LONG_TASK_TIMER:
                 return true;
             default:
                 return false;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -71,7 +71,7 @@ public final class DynatraceLongTaskTimer extends DefaultLongTaskTimer implement
 
     @Override
     public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
-        // LongTaskTimer record a snapshot of in-flight operations, e.g.: the number of
+        // LongTaskTimer records a snapshot of in-flight operations, e.g.: the number of
         // active requests.
         // Therefore, the Snapshot needs to be created from scratch during the export.
         // In takeSummarySnapshot(TimeUnit) above, the Summary object is deleted at the

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of the LongTaskTimer that ensures produced data is consistent for
+ * exporting to Dynatrace.
+ *
+ * @author Georg Pirklbauer
+ * @since 1.9.18
+ */
+public class DynatraceLongTaskTimer extends DefaultLongTaskTimer implements DynatraceSummarySnapshotSupport {
+
+    public DynatraceLongTaskTimer(Id id, Clock clock, TimeUnit baseTimeUnit,
+            DistributionStatisticConfig distributionStatisticConfig, boolean supportsAggregablePercentiles) {
+        super(id, clock, baseTimeUnit, distributionStatisticConfig, supportsAggregablePercentiles);
+    }
+
+    /**
+     * @deprecated see {@link DynatraceSummarySnapshotSupport#hasValues()}.
+     */
+    @Override
+    @Deprecated
+    public boolean hasValues() {
+        return activeTasks() > 0;
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot() {
+        return takeSummarySnapshot(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshot(TimeUnit unit) {
+        if (activeTasks() < 1) {
+            return DynatraceSummarySnapshot.NO_RECORDED_VALUES;
+        }
+
+        DynatraceSummary summary = new DynatraceSummary();
+
+        // iterate active samples and create a Dynatrace summary.
+        super.forEachActive(sample -> {
+            // sample.duration will return -1 if the task is already finished (only
+            // currently active tasks are measured).
+            // -1 will be ignored in recordNonNegative.
+            summary.recordNonNegative(sample.duration(unit));
+        });
+
+        return summary.takeSummarySnapshot();
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset() {
+        return takeSummarySnapshotAndReset(baseTimeUnit());
+    }
+
+    @Override
+    public DynatraceSummarySnapshot takeSummarySnapshotAndReset(TimeUnit unit) {
+        // LongTaskTimers record a snapshot of in-flight operations, e.g., the number of
+        // active requests.
+        // Therefore, the Snapshot needs to be created from scratch during the export.
+        // In takeSummarySnapshot() above, the Summary object is deleted at the end of the
+        // method, therefore effectively resetting the snapshot.
+        return takeSummarySnapshot(unit);
+    }
+
+}

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
@@ -26,6 +26,8 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DynatraceSummarySnapshot {
 
+    public static final DynatraceSummarySnapshot NO_RECORDED_VALUES = new DynatraceSummarySnapshot(0, 0, 0, 0);
+
     private final double min;
 
     private final double max;

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/types/DynatraceSummarySnapshot.java
@@ -26,7 +26,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class DynatraceSummarySnapshot {
 
-    public static final DynatraceSummarySnapshot NO_RECORDED_VALUES = new DynatraceSummarySnapshot(0, 0, 0, 0);
+    public static final DynatraceSummarySnapshot EMPTY = new DynatraceSummarySnapshot(0, 0, 0, 0);
 
     private final double min;
 
@@ -57,6 +57,12 @@ public final class DynatraceSummarySnapshot {
 
     public long getCount() {
         return count;
+    }
+
+    @Override
+    public String toString() {
+        return "DynatraceSummarySnapshot{" + "min=" + min + ", max=" + max + ", total=" + total + ", count=" + count
+                + '}';
     }
 
 }

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -274,7 +274,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toLongTaskTimerLine(LongTaskTimer meter) {
-        // use Dynatrace Snapshotting to ensure consistent data.
+        // use Dynatrace Snapshotting to ensure consistent data
         if (meter instanceof DynatraceSummarySnapshotSupport) {
             DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
                 .takeSummarySnapshot(getBaseTimeUnit());
@@ -285,8 +285,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 snapshot.getCount());
         }
 
-        // fall back to default implementation if the meter is not a
-        // DynatraceLongTaskTimer.
+        // fall back to default implementation if the meter is not DynatraceLongTaskTimer
         HistogramSnapshot snapshot = meter.takeSnapshot();
 
         long count = snapshot.count();

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -282,7 +282,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 return Stream.empty();
             }
             return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(),
-                snapshot.getCount());
+                    snapshot.getCount());
         }
 
         // fall back to default implementation if the meter is not DynatraceLongTaskTimer

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -274,6 +274,19 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     }
 
     Stream<String> toLongTaskTimerLine(LongTaskTimer meter) {
+        // use Dynatrace Snapshotting to ensure consistent data.
+        if (meter instanceof DynatraceSummarySnapshotSupport) {
+            DynatraceSummarySnapshot snapshot = ((DynatraceSummarySnapshotSupport) meter)
+                .takeSummarySnapshot(getBaseTimeUnit());
+            if (snapshot.getCount() == 0) {
+                return Stream.empty();
+            }
+            return createSummaryLine(meter, snapshot.getMin(), snapshot.getMax(), snapshot.getTotal(),
+                snapshot.getCount());
+        }
+
+        // fall back to default implementation if the meter is not a
+        // DynatraceLongTaskTimer.
         HistogramSnapshot snapshot = meter.takeSnapshot();
 
         long count = snapshot.count();

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceLongTaskTimerTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.dynatrace.types;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link DynatraceLongTaskTimer}.
+ */
+class DynatraceLongTaskTimerTest {
+
+    private static final Meter.Id ID = new Meter.Id("test.id", Tags.empty(), "1", "desc",
+            Meter.Type.DISTRIBUTION_SUMMARY);
+
+    private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
+
+    private static final MockClock CLOCK = new MockClock();
+
+    private static final Offset<Double> TOLERANCE = Offset.offset(0.000001);
+
+    @Test
+    void testValuesAreRecorded() throws InterruptedException {
+        DynatraceLongTaskTimer ltt = new DynatraceLongTaskTimer(ID, CLOCK, TimeUnit.MILLISECONDS,
+                DISTRIBUTION_STATISTIC_CONFIG, false);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        CountDownLatch taskHasBeenRunningLatch = new CountDownLatch(1);
+        CountDownLatch stopLatch = new CountDownLatch(1);
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                CLOCK.add(Duration.ofMillis(100));
+                taskHasBeenRunningLatch.countDown();
+
+                try {
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        taskHasBeenRunningLatch.await(300, TimeUnit.MILLISECONDS);
+
+        DynatraceSummarySnapshot snapshot = ltt.takeSummarySnapshot();
+        // can release the background task
+        stopLatch.countDown();
+
+        assertThat(snapshot.getMin()).isCloseTo(100, TOLERANCE);
+        assertThat(snapshot.getMax()).isCloseTo(100, TOLERANCE);
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        // in the case of count == 1, the total has to be equal to min and max
+        assertThat(snapshot.getTotal()).isGreaterThan(0)
+            .isCloseTo(snapshot.getMin(), TOLERANCE)
+            .isCloseTo(snapshot.getMax(), TOLERANCE);
+    }
+
+    /**
+     * This test *could* be done with the MockClock, but it gets pretty unintuitive. That
+     * is because when adding to the MockClock in one Thread, it automatically adds to the
+     * other thread as well and time is basically "double-counted".
+     */
+    @Test
+    void testTwoValuesAreRecorded() throws InterruptedException {
+        // use the system clock, as it is much easier to understand than when using the
+        // MockClock (When using MockClock, adding to the clock in two separate threads
+        // basically means that two things happen at the same time).
+        DynatraceLongTaskTimer ltt = new DynatraceLongTaskTimer(ID, Clock.SYSTEM, TimeUnit.MILLISECONDS,
+                DISTRIBUTION_STATISTIC_CONFIG, false);
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        // both tasks need to be running for a while before we take the snapshot
+        CountDownLatch taskHasBeenRunningLatch = new CountDownLatch(2);
+        CountDownLatch stopLatch = new CountDownLatch(1);
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                try {
+                    Thread.sleep(70);
+                    taskHasBeenRunningLatch.countDown();
+
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        executorService.submit(() -> {
+            ltt.record(() -> {
+                try {
+                    Thread.sleep(30);
+                    taskHasBeenRunningLatch.countDown();
+
+                    // wait until the snapshot has been taken.
+                    stopLatch.await(300, TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        });
+
+        taskHasBeenRunningLatch.await(300, TimeUnit.MILLISECONDS);
+
+        DynatraceSummarySnapshot snapshot = ltt.takeSummarySnapshot();
+        // can release the background tasks
+        stopLatch.countDown();
+
+        // the first Thread has been "running" for ~30ms at the time of recording and will
+        // supply the min
+        assertThat(snapshot.getMin()).isGreaterThanOrEqualTo(30);
+        // the second Thread has been "running" for ~70ms at the time of recording and
+        // will supply the max
+        assertThat(snapshot.getMax()).isGreaterThanOrEqualTo(70).isLessThan(100);
+        // the min is greater than 30, and the max is greater than 70, so together they
+        // have to be greater than 100.
+        assertThat(snapshot.getTotal()).isGreaterThan(100);
+        assertThat(snapshot.getCount()).isEqualTo(2);
+    }
+
+}


### PR DESCRIPTION
This is the same PR as https://github.com/micrometer-metrics/micrometer/pull/4724, but targeted at 1.9.x. When one of them merges, feel free to close the other one. 