### PR TITLE
"Failed to publish metrics to OTLP receiver" error message contains no actionable context

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -174,14 +174,25 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                 this.config.headers().forEach(httpRequest::withHeader);
                 HttpSender.Response response = httpRequest.send();
                 if (!response.isSuccessful()) {
-                    logger.warn("Failed to publish metrics. Server responded with HTTP status code {} and body {}",
-                            response.code(), response.body());
+                    logger.warn(
+                            "Failed to publish metrics (context: {}). Server responded with HTTP status code {} and body {}",
+                            getConfigurationContext(), response.code(), response.body());
                 }
             }
             catch (Throwable e) {
-                logger.warn("Failed to publish metrics to OTLP receiver", e);
+                logger.warn("Failed to publish metrics to OTLP receiver (context: {})", getConfigurationContext(), e);
             }
         }
+    }
+
+    /**
+     * Get the configuration context.
+     * @return A message containing enough information for the log reader to figure out
+     * what configuration details may have contributed to the failure.
+     */
+    private String getConfigurationContext() {
+        // While other values may contribute to failures, these two are most common
+        return "url=" + config.url() + ", resource-attributes=" + config.resourceAttributes();
     }
 
     @Override


### PR DESCRIPTION
**Existing Behavior**
`Failed to publish metrics to OTLP receiver` is the only information users see in the log (other than the exception trace which often doesn't contain actionable information).

**Updated Behavior**
`Failed to publish metrics to OTLP receiver (context: ...) ` is the message they will now see, where context contains the config URL and resource attributes. This will make troubleshooting easier.

**Additional Context**
#4828 

@pivotal-cla This is an Obvious Fix
