### PR TITLE
Announce OtlpMeterRegistry configuration found at startup

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -125,6 +125,15 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
             this.meterPollingService.scheduleAtFixedRate(this::pollMetersToRollover, getInitialDelay(),
                     config.step().toMillis(), TimeUnit.MILLISECONDS);
         }
+
+        if (config.enabled()) {
+            sayHello();
+        }
+    }
+
+    private void sayHello() {
+        logger.info("Publishing metrics for {} to {} with resource attributes {}", getClass().getSimpleName(),
+                config.url(), config.resourceAttributes());
     }
 
     @Override

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -35,6 +35,7 @@ import io.micrometer.core.instrument.step.StepFunctionTimer;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
 import io.micrometer.core.instrument.util.NamedThreadFactory;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
 import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest;
@@ -125,15 +126,12 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
             this.meterPollingService.scheduleAtFixedRate(this::pollMetersToRollover, getInitialDelay(),
                     config.step().toMillis(), TimeUnit.MILLISECONDS);
         }
-
-        if (config.enabled()) {
-            sayHello();
-        }
     }
 
-    private void sayHello() {
-        logger.info("Publishing metrics for {} to {} with resource attributes {}", getClass().getSimpleName(),
-                config.url(), config.resourceAttributes());
+    @Override
+    protected String startMessage() {
+        return String.format("Publishing metrics for %s every %s to %s with resource attributes %s",
+                getClass().getSimpleName(), TimeUtils.format(config.step()), config.url(), config.resourceAttributes());
     }
 
     @Override


### PR DESCRIPTION
**Existing Behavior**
`OtlpMeterRegistry` says nothing at startup.

**Updated Behavior**
`OtlpMeterRegistry` emits a startup message allowing to identify and troubleshoot the OTLP receiver endpoint.

**Additional Context**
#4693 

@pivotal-cla This is an Obvious Fix