### PR TITLE
Allow customizing start log message in PushMeterRegistry implementations

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -107,8 +107,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             stop();
 
         if (config.enabled()) {
-            logger.info("publishing metrics for " + getClass().getSimpleName() + " every "
-                    + TimeUtils.format(config.step()));
+            logger.info(startMessage());
 
             scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(threadFactory);
             long stepMillis = config.step().toMillis();
@@ -116,6 +115,17 @@ public abstract class PushMeterRegistry extends MeterRegistry {
             scheduledExecutorService.scheduleAtFixedRate(this::publishSafelyOrSkipIfInProgress, initialDelayMillis,
                     stepMillis, TimeUnit.MILLISECONDS);
         }
+    }
+
+    /**
+     * Message that will be logged when the registry is {@link #start(ThreadFactory)
+     * started}. This can be overridden to customize the message with info specific to the
+     * registry implementation that may be helpful in troubleshooting. By default, the
+     * registry class name and step interval are included.
+     * @return message to log on registry start
+     */
+    protected String startMessage() {
+        return "publishing metrics for " + getClass().getSimpleName() + " every " + TimeUtils.format(config.step());
     }
 
     public void stop() {


### PR DESCRIPTION
It will be helpful in troubleshooting to be able to log more specific information to the implementation than is available at the level of PushMeterRegistry. Allowing this to be overridden also avoids registry implementations from logging similar messages resulting in multiple logs on start for essentially the same thing.

See https://github.com/micrometer-metrics/micrometer/pull/4830#discussion_r1519789028