### PR TITLE
Add ObservationApplier abstraction

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -135,6 +135,9 @@ dependencies {
     optionalApi 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     optionalApi 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
 
+    // reactor
+    optionalApi 'io.projectreactor:reactor-core'
+
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation project(":micrometer-observation-test")
     java11TestImplementation project(":micrometer-observation-test")

--- a/micrometer-core/src/main/kotlin/io/micrometer/core/aop/kotlin/ObservationToSuspendingMethodApplier.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/aop/kotlin/ObservationToSuspendingMethodApplier.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.core.aop.kotlin
 
 import io.micrometer.core.instrument.kotlin.asContextElement

--- a/micrometer-core/src/main/kotlin/io/micrometer/core/aop/kotlin/ObservationToSuspendingMethodApplier.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/aop/kotlin/ObservationToSuspendingMethodApplier.kt
@@ -1,0 +1,60 @@
+package io.micrometer.core.aop.kotlin
+
+import io.micrometer.core.instrument.kotlin.asContextElement
+import io.micrometer.observation.Observation
+import io.micrometer.observation.aop.applier.ObservationApplier
+import org.aspectj.lang.ProceedingJoinPoint
+import reactor.core.publisher.Mono
+import java.lang.reflect.Method
+import java.util.Arrays
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+
+object ObservationToSuspendingMethodApplier : ObservationApplier {
+    /**
+     * Using such a simplistic implementation of [kotlin.coroutines.Continuation] interface is only enough,
+     * because of how AopUtils#invokeJoinpointUsingReflection() in Spring Framework is implemented.
+     * This means that this whole implementation is only usable in conjunction with Spring Framework.
+     * @see <a href="https://github.com/spring-projects/spring-framework/blob/main/spring-aop/src/main/java/org/springframework/aop/support/AopUtils.java">AopUtils.java</a>
+     * @see <a href="https://github.com/spring-projects/spring-framework/blob/main/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java">CoroutinesUtils.java</a>
+     */
+    private class DelegatingContinuation<T>(
+        override val context: CoroutineContext,
+        private val underlying: Continuation<T>
+    ) : Continuation<T> {
+        override fun resumeWith(result: Result<T>) {
+            underlying.resumeWith(result)
+        }
+    }
+
+    override fun isApplicable(pjp: ProceedingJoinPoint, method: Method): Boolean {
+        return method.parameterTypes.isNotEmpty()
+            && Continuation::class.java.isAssignableFrom(method.parameterTypes.last())
+    }
+
+    override fun applyAndProceed(pjp: ProceedingJoinPoint, method: Method, observation: Observation): Any {
+        observation.start()
+        return try {
+            val continuation = pjp.args.last() as Continuation<*>
+            val coroutineContext = continuation.context
+
+            val newCoroutineContext = coroutineContext + observation.openScope().use {
+                observation.observationRegistry.asContextElement()
+            }
+
+            val newArgs = Arrays.copyOf(pjp.args, pjp.args.size)
+            newArgs[newArgs.size - 1] = DelegatingContinuation(newCoroutineContext, continuation)
+
+            @Suppress("ReactiveStreamsUnusedPublisher")
+            (pjp.proceed(newArgs) as Mono<*>).doOnError { error ->
+                observation.error(error)
+            }.doOnTerminate {
+                observation.stop()
+            }
+        } catch (error: Throwable) {
+            observation.error(error)
+            observation.stop()
+            throw error
+        }
+    }
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplier.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplier.java
@@ -1,0 +1,18 @@
+package io.micrometer.observation.aop.applier;
+
+import io.micrometer.common.lang.NonNull;
+import io.micrometer.observation.Observation;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+import java.lang.reflect.Method;
+
+public interface ObservationApplier {
+
+    boolean isApplicable(@NonNull ProceedingJoinPoint pjp, @NonNull Method method);
+
+    Object applyAndProceed(
+        @NonNull ProceedingJoinPoint pjp,
+        @NonNull Method method,
+        @NonNull Observation observation
+    ) throws Throwable;
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplier.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.observation.aop.applier;
 
 import io.micrometer.common.lang.NonNull;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplierRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplierRegistry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.observation.aop.applier;
 
 import org.aspectj.lang.ProceedingJoinPoint;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplierRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationApplierRegistry.java
@@ -1,0 +1,42 @@
+package io.micrometer.observation.aop.applier;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class ObservationApplierRegistry {
+
+    private static ObservationApplierRegistry instance;
+
+    private final List<ObservationApplier> observationAppliers;
+
+    public ObservationApplierRegistry(List<ObservationApplier> observationAppliers) {
+        this.observationAppliers = new CopyOnWriteArrayList<>(observationAppliers);
+    }
+
+    public Optional<ObservationApplier> findApplicable(ProceedingJoinPoint pjp, Method method) {
+        for (ObservationApplier observationApplier : observationAppliers) {
+            if (observationApplier.isApplicable(pjp, method)) {
+                return Optional.of(observationApplier);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public void register(ObservationApplier observationApplier) {
+        this.observationAppliers.add(observationApplier);
+    }
+
+    public static ObservationApplierRegistry getInstance() {
+        if (instance == null) {
+            instance = new ObservationApplierRegistry(
+                Collections.singletonList(new ObservationToCompletionStageApplier())
+            );
+        }
+        return instance;
+    }
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationToCompletionStageApplier.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationToCompletionStageApplier.java
@@ -1,0 +1,43 @@
+package io.micrometer.observation.aop.applier;
+
+import io.micrometer.common.lang.NonNull;
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.observation.Observation;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.CompletionStage;
+
+public class ObservationToCompletionStageApplier implements ObservationApplier {
+    @Override
+    public boolean isApplicable(@NonNull ProceedingJoinPoint pjp, @NonNull Method method) {
+        return CompletionStage.class.isAssignableFrom(method.getReturnType());
+    }
+
+    @Override
+    public Object applyAndProceed(
+        @NonNull ProceedingJoinPoint pjp,
+        @NonNull Method method,
+        @NonNull Observation observation
+    ) throws Throwable {
+        observation.start();
+        Observation.Scope scope = observation.openScope();
+        try {
+            return ((CompletionStage<?>) pjp.proceed())
+                .whenComplete((result, error) -> stopObservation(observation, scope, error));
+        } catch (Throwable error) {
+            stopObservation(observation, scope, error);
+            throw error;
+        } finally {
+            scope.close();
+        }
+    }
+
+    private void stopObservation(Observation observation, Observation.Scope scope, @Nullable Throwable error) {
+        if (error != null) {
+            observation.error(error);
+        }
+        scope.close();
+        observation.stop();
+    }
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationToCompletionStageApplier.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/applier/ObservationToCompletionStageApplier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micrometer.observation.aop.applier;
 
 import io.micrometer.common.lang.NonNull;


### PR DESCRIPTION
This PR is trying to address the problem described in gh-4827.

* Introduce `ObservationApplier` and `ObservationApplierRegistry` abstractions
* Create an implementation of `ObservationApplier` for `CompletionStage`
* Create an implementation of `ObservationApplier` that can be used on suspending methods

Cons:
* `ObservationToSuspendingMethodApplier` will only work correctly when Spring Framework is in use (due the implementation taking advantage of how Spring AOP is handling calls to suspending functions)
  *  Due to this, I'm not quite sure how to write tests for this class at the moment
* `ObservationToSuspendingMethodApplier` needs to refer to `Mono`, and so `io.projectreactor:reactor-core` is needed on the classpath
* `ObservationToSuspendingMethodApplier` is not registered automatically (could be done at the service startup by Spring Boot etc.)

Not done yet:
* Javadocs
* Tests

Open Questions:
*  Given the Cons mentioned above, should `ObservationToSuspendingMethodApplier` potentially be moved to Spring Framework or Spring Boot instead?