### PR TITLE
Improve performance of meter interaction

### DIFF
--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -2,19 +2,29 @@ plugins {
     id "me.champeau.jmh" version "0.7.2"
 }
 
+// Uncomment as needed for benchmarking against released versions of Micrometer
+//repositories {
+//    mavenCentral()
+//    maven {
+//        url "https://repo.spring.io/milestone"
+//    }
+//}
+
 dependencies {
     jmh project(':micrometer-core')
+//    jmh 'io.micrometer:micrometer-core:1.13.0-M2'
     jmh project(':micrometer-registry-prometheus')
+//    jmh 'io.micrometer:micrometer-registry-prometheus:1.13.0-M2'
 
     jmh libs.dropwizardMetricsCore5
     jmh libs.prometheusMetrics
 
-    jmh 'io.dropwizard.metrics:metrics-core'
-    jmh 'com.google.guava:guava'
+    jmh libs.dropwizardMetricsCore
+    jmh libs.guava
 
     jmh libs.jmhCore
 
-    jmh 'ch.qos.logback:logback-classic'
+    jmh libs.logback12
 
     // Nebula doesn't like having jmhAnnotationProcessor without jmh so we just add it twice.
     jmh libs.jmhAnnotationProcessor

--- a/build.gradle
+++ b/build.gradle
@@ -289,7 +289,7 @@ subprojects {
     }
 
     // Do not publish some modules
-    if (!['samples', 'benchmarks', 'micrometer-osgi-test'].find { project.name.contains(it) }) {
+    if (!['samples', 'benchmarks', 'micrometer-osgi-test', 'concurrency-tests'].find { project.name.contains(it) }) {
         apply plugin: 'com.netflix.nebula.maven-publish'
         apply plugin: 'com.netflix.nebula.maven-manifest'
         apply plugin: 'com.netflix.nebula.maven-developer'

--- a/concurrency-tests/build.gradle
+++ b/concurrency-tests/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+    alias(libs.plugins.jcstress)
+}
+
+dependencies {
+    implementation project(":micrometer-core")
+//    implementation("io.micrometer:micrometer-core:1.12.4")
+    runtimeOnly(libs.logbackLatest)
+}
+
+jcstress {
+    jcstressDependency 'org.openjdk.jcstress:jcstress-core:0.16'
+
+    verbose = true
+}

--- a/concurrency-tests/src/jcstress/java/io/micrometer/concurrencytests/MeterRegistryConcurrencyTest.java
+++ b/concurrency-tests/src/jcstress/java/io/micrometer/concurrencytests/MeterRegistryConcurrencyTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.concurrencytests;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.openjdk.jcstress.annotations.*;
+import org.openjdk.jcstress.infra.results.LL_Result;
+import org.openjdk.jcstress.infra.results.Z_Result;
+
+public class MeterRegistryConcurrencyTest {
+
+    /*
+     * Registering the same new Meter from multiple threads should be safe and consistent.
+     */
+    @JCStressTest
+    @Outcome(id = { "true" }, expect = Expect.ACCEPTABLE, desc = "same meter returned for concurrent registers")
+    @Outcome(expect = Expect.FORBIDDEN)
+    @State
+    public static class ConcurrentRegisterNew {
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        Counter c1;
+
+        Counter c2;
+
+        @Actor
+        public void actor1() {
+            c1 = registry.counter("counter");
+        }
+
+        @Actor
+        public void actor2() {
+            c2 = registry.counter("counter");
+        }
+
+        @Arbiter
+        public void arbiter(Z_Result r) {
+            r.r1 = c1 == c2;
+        }
+
+    }
+
+    /*
+     * Likewise, registering an existing Meter from multiple threads is safe.
+     */
+    @JCStressTest
+    @Outcome(id = { "true" }, expect = Expect.ACCEPTABLE, desc = "same meter returned for concurrent registers")
+    @Outcome(expect = Expect.FORBIDDEN)
+    @State
+    public static class ConcurrentRegisterExisting {
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        Counter c1;
+
+        Counter c2;
+
+        public ConcurrentRegisterExisting() {
+            registry.counter("counter");
+        }
+
+        @Actor
+        public void actor1() {
+            c1 = registry.counter("counter");
+        }
+
+        @Actor
+        public void actor2() {
+            c2 = registry.counter("counter");
+        }
+
+        @Arbiter
+        public void arbiter(Z_Result r) {
+            r.r1 = c1 == c2;
+        }
+
+    }
+
+    // @formatter:off
+    /*
+      When configuring a MeterFilter after a Meter has already been registered, existing meters will be marked stale.
+      Subsequent calls to {@code getOrCreateMeter} for those Meters create a new Meter with all MeterFilters applied.
+      If multiple concurrent calls to {@code getOrCreateMeter} interleave, it's possible not all see the new Meter.
+      We ideally want both to get the new meter, but we don't want to pay the cost associated with that level of safety
+      given the expected rarity of this situation happening, so we aim to get as close as possible for cheap.
+
+            RESULT     SAMPLES     FREQ       EXPECT  DESCRIPTION
+        null, null           0    0.00%    Forbidden  both get stale meter
+         null, tag      39,491    0.13%  Interesting  one stale meter returned
+         tag, null      40,389    0.13%  Interesting  one stale meter returned
+          tag, tag  30,941,328   99.74%   Acceptable  both get new meter
+     */
+    // @formatter:on
+    @JCStressTest
+    @Outcome(id = { "tag, tag" }, expect = Expect.ACCEPTABLE, desc = "both get new meter")
+    @Outcome(id = { "null, tag", "tag, null" }, expect = Expect.ACCEPTABLE_INTERESTING,
+            desc = "one stale meter returned")
+    @Outcome(id = { "null, null" }, expect = Expect.FORBIDDEN, desc = "both get stale meter")
+    @State
+    public static class ConcurrentRegisterWithStaleId {
+
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        Counter c1;
+
+        Counter c2;
+
+        public ConcurrentRegisterWithStaleId() {
+            registry.counter("counter");
+            registry.counter("another");
+            registry.config().commonTags("common", "tag");
+        }
+
+        @Actor
+        public void actor1() {
+            c1 = registry.counter("counter");
+        }
+
+        @Actor
+        public void actor2() {
+            c2 = registry.counter("counter");
+        }
+
+        @Arbiter
+        public void arbiter(LL_Result r) {
+            r.r1 = c1.getId().getTag("common");
+            r.r2 = c2.getId().getTag("common");
+        }
+
+    }
+
+}

--- a/concurrency-tests/src/jcstress/resources/logback.xml
+++ b/concurrency-tests/src/jcstress/resources/logback.xml
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright 2024 VMware, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are  by default assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <!-- Late MeterFilter config logs are verbose in ConcurrentRegisterWithStaleId -->
+    <logger name="io.micrometer.core.instrument.simple.SimpleMeterRegistry" level="error"/>
+
+</configuration>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -13,6 +13,7 @@
 	<suppress checks="IllegalImport" files="docs[\\/].+" />
 
 	<suppress checks="JavadocPackageCheck" files="benchmarks[\\/].+" />
+	<suppress checks="JavadocPackageCheck" files="concurrency-tests[\\/].+" />
 	<suppress checks="JavadocPackageCheck" files="samples[\\/].+" />
 	<suppress checks="JavadocPackageCheck" files="[\\/]src[\\/]test[\\/].*" />
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -142,6 +142,7 @@ javax-cacheApi = { module = "javax.cache:cache-api", version.ref = "javax-cache"
 javax-inject = { module = "javax.inject:javax.inject", version.ref = "javax-inject" }
 javax-servletApi = { module = "javax.servlet:javax.servlet-api", version = "4.0.1" }
 jaxbApi = { module = "javax.xml.bind:jaxb-api", version.ref = "jaxb" }
+jcstressCore = { module = "org.openjdk.jcstress:jcstress-core", version = "0.16" }
 jetty9Client = { module = "org.eclipse.jetty:jetty-client", version.ref = "jetty9" }
 jetty9Server = { module = "org.eclipse.jetty:jetty-server", version.ref = "jetty9" }
 jetty9Servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "jetty9" }
@@ -231,3 +232,4 @@ plugin-bnd = "biz.aQute.bnd:biz.aQute.bnd.gradle:6.4.0"
 [plugins]
 kotlin19 = { id = "org.jetbrains.kotlin.jvm", version = "1.9.23" }
 kotlin17 = { id = "org.jetbrains.kotlin.jvm", version = "1.7.22" }
+jcstress = { id = "io.github.reyerizo.gradle.jcstress", version = "0.8.15" }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -94,11 +94,14 @@ public abstract class MeterRegistry {
 
     private final More more = new More();
 
-    // Even though writes are guarded by meterMapLock, iterators across value space are
-    // supported
-    // Hence, we use CHM to support that iteration without ConcurrentModificationException
-    // risk
+    /**
+     * Even though writes are guarded by meterMapLock, iterators across value space are
+     * supported. Hence, we use CHM to support that iteration without
+     * ConcurrentModificationException risk.
+     */
     private final Map<Id, Meter> meterMap = new ConcurrentHashMap<>();
+
+    private final Map<Id, Meter> preFilterIdToMeterMap = new HashMap<>();
 
     /**
      * Map of meter id whose associated meter contains synthetic counterparts to those
@@ -588,8 +591,7 @@ public abstract class MeterRegistry {
     private <M extends Meter> M registerMeterIfNecessary(Class<M> meterClass, Meter.Id id,
             @Nullable DistributionStatisticConfig config, BiFunction<Meter.Id, DistributionStatisticConfig, M> builder,
             Function<Meter.Id, M> noopBuilder) {
-        Id mappedId = getMappedId(id);
-        Meter m = getOrCreateMeter(config, builder, id, mappedId, noopBuilder);
+        Meter m = getOrCreateMeter(config, builder, id, noopBuilder);
 
         if (!meterClass.isInstance(m)) {
             throw new IllegalArgumentException(
@@ -612,8 +614,15 @@ public abstract class MeterRegistry {
 
     private Meter getOrCreateMeter(@Nullable DistributionStatisticConfig config,
             BiFunction<Id, /* Nullable Generic */ DistributionStatisticConfig, ? extends Meter> builder, Id originalId,
-            Id mappedId, Function<Meter.Id, ? extends Meter> noopBuilder) {
-        Meter m = meterMap.get(mappedId);
+            Function<Meter.Id, ? extends Meter> noopBuilder) {
+
+        Meter m = preFilterIdToMeterMap.get(originalId);
+        if (m != null) {
+            return m;
+        }
+
+        Id mappedId = getMappedId(originalId);
+        m = meterMap.get(mappedId);
 
         if (m == null) {
             if (isClosed()) {
@@ -649,6 +658,7 @@ public abstract class MeterRegistry {
                         onAdd.accept(m);
                     }
                     meterMap.put(mappedId, m);
+                    preFilterIdToMeterMap.put(originalId, m);
                 }
             }
         }
@@ -695,7 +705,8 @@ public abstract class MeterRegistry {
     @Incubating(since = "1.3.16")
     @Nullable
     public Meter removeByPreFilterId(Meter.Id preFilterId) {
-        return remove(getMappedId(preFilterId));
+        final Meter meterToRemove = preFilterIdToMeterMap.get(preFilterId);
+        return meterToRemove == null ? null : remove(meterToRemove);
     }
 
     /**
@@ -710,12 +721,11 @@ public abstract class MeterRegistry {
     @Incubating(since = "1.1.0")
     @Nullable
     public Meter remove(Meter.Id mappedId) {
-        Meter m = meterMap.get(mappedId);
-
-        if (m != null) {
+        if (meterMap.containsKey(mappedId)) {
             synchronized (meterMapLock) {
-                m = meterMap.remove(mappedId);
-                if (m != null) {
+                final Meter removedMeter = meterMap.remove(mappedId);
+                preFilterIdToMeterMap.values().removeIf(meter -> meter.equals(removedMeter));
+                if (removedMeter != null) {
                     Set<Id> synthetics = syntheticAssociations.remove(mappedId);
                     if (synthetics != null) {
                         for (Id synthetic : synthetics) {
@@ -724,10 +734,10 @@ public abstract class MeterRegistry {
                     }
 
                     for (Consumer<Meter> onRemove : meterRemovedListeners) {
-                        onRemove.accept(m);
+                        onRemove.accept(removedMeter);
                     }
 
-                    return m;
+                    return removedMeter;
                 }
             }
         }
@@ -752,6 +762,10 @@ public abstract class MeterRegistry {
         /**
          * Append a list of common tags to apply to all metrics reported to the monitoring
          * system.
+         * <p>
+         * </p>
+         * <strong>NOTE: A no-op operation if meters are already registered to the
+         * registry.</strong>
          * @param tags Tags to add to every metric.
          * @return This configuration instance.
          */
@@ -763,6 +777,10 @@ public abstract class MeterRegistry {
          * Append a list of common tags to apply to all metrics reported to the monitoring
          * system. Must be an even number of arguments representing key/value pairs of
          * tags.
+         * <p>
+         * </p>
+         * <strong>NOTE: A no-op operation if meters are already registered to the
+         * registry.</strong>
          * @param tags MUST be an even number of arguments representing key/value pairs of
          * tags.
          * @return This configuration instance.
@@ -774,6 +792,10 @@ public abstract class MeterRegistry {
         /**
          * Add a meter filter to the registry. Filters are applied in the order in which
          * they are added.
+         * <p>
+         * </p>
+         * <strong>NOTE: A no-op operation if meters are already registered to the
+         * registry.</strong>
          * @param filter The filter to add to the registry.
          * @return This configuration instance.
          */

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,6 +42,7 @@ include 'micrometer-test', 'micrometer-observation-test'
     project(":micrometer-benchmarks-$benchmark").projectDir = new File(rootProject.projectDir, "benchmarks/benchmarks-$benchmark")
 }
 
+include 'concurrency-tests'
 include 'micrometer-bom'
 include 'micrometer-jakarta9'
 include 'micrometer-java11'


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/micrometer/issues/4856,

This PR introduces the following changes,
* Keeps a map to do the look-up between 'Id` without meter filters to the actual meter. When create is called on a meter, we first check if a mapping exists and immediately return the mapped meter from the actual map that holds the meters.
* When meter filters are added to the registry, the meters registered until this point are maintained in the set and when the create operation happens on these meters, we re-compute the mapping similarly to keep the existing behavior.

TODO:

- [x] Add additional tests to MeterRegistryTest