### PR TITLE
Add warning logs for deprecated classes in httpcomponents

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpClientInterceptor.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.httpcomponents;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -57,6 +59,8 @@ import java.util.function.Function;
 @Deprecated
 public class MicrometerHttpClientInterceptor {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(MicrometerHttpClientInterceptor.class);
+
     private static final String METER_NAME = "httpcomponents.httpclient.request";
 
     private final Map<HttpContext, Timer.ResourceSample> timerByHttpContext = new ConcurrentHashMap<>();
@@ -74,6 +78,9 @@ public class MicrometerHttpClientInterceptor {
      */
     public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry, Function<HttpRequest, String> uriMapper,
             Iterable<Tag> extraTags, boolean exportTagsForRoute) {
+        log.warn(
+                "This class has been deprecated. Please use ObservationExecChainHandler for Apache HTTP client 5 support instead.");
+
         this.requestInterceptor = (request, context) -> timerByHttpContext.put(context,
                 Timer.resource(meterRegistry, METER_NAME)
                     .tags("method", request.getRequestLine().getMethod(), "uri", uriMapper.apply(request)));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutor.java
@@ -16,6 +16,8 @@
 package io.micrometer.core.instrument.binder.httpcomponents;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -63,6 +65,8 @@ import java.util.function.Function;
 @Deprecated
 public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(MicrometerHttpRequestExecutor.class);
+
     /**
      * Default header name for URI pattern.
      * @deprecated use {@link DefaultUriMapper#URI_PATTERN_HEADER} since 1.4.0
@@ -92,6 +96,10 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
             Function<HttpRequest, String> uriMapper, Iterable<Tag> extraTags, boolean exportTagsForRoute,
             ObservationRegistry observationRegistry, @Nullable ApacheHttpClientObservationConvention convention) {
         super(waitForContinue);
+
+        log.warn(
+                "This class has been deprecated. Please use ObservationExecChainHandler for Apache HTTP client 5 support instead.");
+
         this.registry = Optional.ofNullable(registry)
             .orElseThrow(() -> new IllegalArgumentException("registry is required but has been initialized with null"));
         this.uriMapper = Optional.ofNullable(uriMapper)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpClientInterceptor.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.httpcomponents.hc5;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -51,6 +53,8 @@ import java.util.function.Function;
 @Deprecated
 public class MicrometerHttpClientInterceptor {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(MicrometerHttpClientInterceptor.class);
+
     private static final String METER_NAME = "httpcomponents.httpclient.request";
 
     private final Map<HttpContext, Timer.ResourceSample> timerByHttpContext = new ConcurrentHashMap<>();
@@ -68,6 +72,9 @@ public class MicrometerHttpClientInterceptor {
      */
     public MicrometerHttpClientInterceptor(MeterRegistry meterRegistry, Function<HttpRequest, String> uriMapper,
             Iterable<Tag> extraTags, boolean exportTagsForRoute) {
+        log.warn(
+                "This class has been deprecated. Please use ObservationExecChainHandler for Apache HTTP client 5 support instead.");
+
         this.requestInterceptor = (request, entityDetails, context) -> timerByHttpContext.put(context,
                 Timer.resource(meterRegistry, METER_NAME)
                     .tags("method", request.getMethod(), "uri", uriMapper.apply(request)));

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutor.java
@@ -16,6 +16,8 @@
 package io.micrometer.core.instrument.binder.httpcomponents.hc5;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -58,6 +60,8 @@ import java.util.function.Function;
 @Deprecated
 public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(MicrometerHttpRequestExecutor.class);
+
     static final String METER_NAME = "httpcomponents.httpclient.request";
 
     private final MeterRegistry registry;
@@ -80,6 +84,10 @@ public class MicrometerHttpRequestExecutor extends HttpRequestExecutor {
             Function<HttpRequest, String> uriMapper, Iterable<Tag> extraTags, boolean exportTagsForRoute,
             ObservationRegistry observationRegistry, @Nullable ApacheHttpClientObservationConvention convention) {
         super(waitForContinue, null, null);
+
+        log.warn(
+                "This class has been deprecated. Please use ObservationExecChainHandler for Apache HTTP client 5 support instead.");
+
         this.registry = Optional.ofNullable(registry)
             .orElseThrow(() -> new IllegalArgumentException("registry is required but has been initialized with null"));
         this.uriMapper = Optional.ofNullable(uriMapper)


### PR DESCRIPTION
This PR adds warning logs for deprecated classes in the `httpcomponents` package.

Closes gh-4576