### PR TITLE
Deprecate DefaultUriMapper and PoolingHttpClientConnectionManagerMetricsBinder in httpcomponents

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultUriMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/DefaultUriMapper.java
@@ -29,7 +29,12 @@ import java.util.function.Function;
  *
  * @author Benjamin Hubert
  * @since 1.4.0
+ * @deprecated as of 1.12.5 in favor of an
+ * {@link org.apache.hc.client5.http.protocol.HttpClientContext} value with
+ * {@link io.micrometer.core.instrument.binder.httpcomponents.hc5.ApacheHttpClientObservationConvention#URI_TEMPLATE_ATTRIBUTE}
+ * as key name.
  */
+@Deprecated
 public class DefaultUriMapper implements Function<HttpRequest, String> {
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -43,7 +43,10 @@ import org.apache.http.pool.ConnPoolControl;
  *
  * @author Benjamin Hubert (benjamin.hubert@willhaben.at)
  * @since 1.3.0
+ * @deprecated as of 1.12.5 in favor of HttpComponents 5.x and
+ * {@link io.micrometer.core.instrument.binder.httpcomponents.hc5.PoolingHttpClientConnectionManagerMetricsBinder}.
  */
+@Deprecated
 public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBinder {
 
     private final ConnPoolControl<HttpRoute> connPoolControl;


### PR DESCRIPTION
This PR deprecates the `DefaultUriMapper` and the `PoolingHttpClientConnectionManagerMetricsBinder` in the `httpcomponents` package as they seem to have been missed when deprecating the other classes in the same package.