### PR TITLE
Use same description for same meter name in Log4j2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -51,6 +51,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private static final String METER_NAME = "log4j2.events";
 
+    private static final String METER_DESCRIPTION = "Number of log events";
+
     private final Iterable<Tag> tags;
 
     private final LoggerContext loggerContext;
@@ -156,42 +158,42 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
             fatalCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "fatal")
-                .description("Number of fatal level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
             errorCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "error")
-                .description("Number of error level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
             warnCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "warn")
-                .description("Number of warn level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
             infoCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "info")
-                .description("Number of info level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
             debugCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "debug")
-                .description("Number of debug level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
 
             traceCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "trace")
-                .description("Number of trace level log events")
+                .description(METER_DESCRIPTION)
                 .baseUnit(BaseUnits.EVENTS)
                 .register(registry);
         }


### PR DESCRIPTION
This PR changes to use the same description for the same meter name in the `Log4j2Metrics`.