### PR TITLE
Sanitize metric names for the Prometheus client

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.prometheusmetrics;
 
-import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
@@ -536,20 +535,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricMetadata getMetadata(Meter.Id id, String suffix) {
         String name = config().namingConvention().name(id.getName(), id.getType(), id.getBaseUnit()) + suffix;
-        String sanitizedName = sanitize(name);
         String help = prometheusConfig.descriptions() ? Optional.ofNullable(id.getDescription()).orElse(" ") : " ";
         Unit unit = id.getBaseUnit() != null ? new Unit(id.getBaseUnit()) : null;
-        return new MetricMetadata(sanitizedName, help, unit);
-    }
-
-    private String sanitize(@NonNull String name) {
-        if (name.endsWith("_info") || name.endsWith("_total") || name.endsWith("_created")
-                || name.endsWith("_bucket")) {
-            return name.substring(0, name.lastIndexOf('_'));
-        }
-        else {
-            return name;
-        }
+        return new MetricMetadata(name, help, unit);
     }
 
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusNamingConvention.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusNamingConvention.java
@@ -18,8 +18,7 @@ package io.micrometer.prometheusmetrics;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.NamingConvention;
-
-import java.util.regex.Pattern;
+import io.prometheus.metrics.model.snapshots.PrometheusNaming;
 
 /**
  * See https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels for a
@@ -28,10 +27,6 @@ import java.util.regex.Pattern;
  * @author Jon Schneider
  */
 public class PrometheusNamingConvention implements NamingConvention {
-
-    private static final Pattern nameChars = Pattern.compile("[^a-zA-Z0-9_:]");
-
-    private static final Pattern tagKeyChars = Pattern.compile("[^a-zA-Z0-9_]");
 
     private final String timerSuffix;
 
@@ -45,9 +40,6 @@ public class PrometheusNamingConvention implements NamingConvention {
 
     /**
      * Names are snake-cased. They contain a base unit suffix when applicable.
-     * <p>
-     * Names may contain ASCII letters and digits, as well as underscores and colons. They
-     * must match the regex [a-zA-Z_:][a-zA-Z0-9_:]*
      */
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
@@ -81,11 +73,7 @@ public class PrometheusNamingConvention implements NamingConvention {
                 break;
         }
 
-        String sanitized = nameChars.matcher(conventionName).replaceAll("_");
-        if (!Character.isLetter(sanitized.charAt(0))) {
-            sanitized = "m_" + sanitized;
-        }
-        return sanitized;
+        return PrometheusNaming.sanitizeMetricName(conventionName);
     }
 
     /**
@@ -95,13 +83,7 @@ public class PrometheusNamingConvention implements NamingConvention {
      */
     @Override
     public String tagKey(String key) {
-        String conventionKey = NamingConvention.snakeCase.tagKey(key);
-
-        String sanitized = tagKeyChars.matcher(conventionKey).replaceAll("_");
-        if (!Character.isLetter(sanitized.charAt(0))) {
-            sanitized = "m_" + sanitized;
-        }
-        return sanitized;
+        return PrometheusNaming.sanitizeLabelName(key);
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusNamingConventionTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusNamingConventionTest.java
@@ -30,12 +30,12 @@ class PrometheusNamingConventionTest {
 
     @Test
     void formatName() {
-        assertThat(convention.name("123abc/{:id}水", Meter.Type.GAUGE)).startsWith("m_123abc__:id__");
+        assertThat(convention.name("123abc/{:id}水", Meter.Type.GAUGE)).startsWith("_23abc__:id__");
     }
 
     @Test
     void formatTagKey() {
-        assertThat(convention.tagKey("123abc/{:id}水")).startsWith("m_123abc___id__");
+        assertThat(convention.tagKey("123abc/{:id}水")).startsWith("_23abc___id__");
     }
 
     @Test


### PR DESCRIPTION
We need to sanitize metric names for the Prometheus client otherwise it fails with something like this:
```
java.lang.IllegalArgumentException: 'jvm_info': Illegal metric name. The metric name must not include the '_info' suffix.
```

This can be reproduced with:
```java
Gauge.builder("test.info", () -> 1).register(registry);
```
The name of this `Gauge` will be `test_info` in Prometheus that is invalid according to the new client, see [`PrometheusNaming`](https://github.com/prometheus/client_java/blob/8bb75446c6dca2a4e2c074e39fe34c1b061b028a/prometheus-metrics-model/src/main/java/io/prometheus/metrics/model/snapshots/PrometheusNaming.java#L37-L40).

We have built-in instrumentation that fails this validation too (see [`JvmInfoMetrics`](https://github.com/micrometer-metrics/micrometer/blob/966f5fe953a69c315b44bf4f63adf101a060bbfb/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmInfoMetrics.java#L32)):
```java
new JvmInfoMetrics().bindTo(registry);
```
If we don't want to break this, we need to sanitize the invalid suffixes.

Please check the tests because the behavior can be unexpected sometimes:
- If you create a Micrometer `Gauge` named `test.info`, the name of Prometheus gauge will be `test_info` (since the registry removes but the Prometheus client adds back the `_info` suffix).
- If you create a Micrometer `Counter` named `test.total`, the name of the Prometheus counter will be `test_total` (since the registry removes but the Prometheus client adds back the `_total` suffix).
- If you create a Micrometer `Counter` named `test.info`, the name of the Prometheus counter will be `test_total` (since the registry removes the `_info` suffix and the Prometheus client adds the `_total` suffix for counters).
- If you create a Micrometer `Gauge` named `test.total`, the name of the Prometheus counter will be `test` (since the registry removes the `_total` suffix and the Prometheus client does not add `_info` suffix for gauges).
- Similarly, `_created` and `_bucket` will be removed otherwise the Prometheus client will fail.