### PR TITLE
Add Exemplars support to Prometheus 1.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ newrelic-api = "5.14.0"
 # Kotlin 1.7 sample will fail from OkHttp 4.12.0 due to okio dependency being a Kotlin 1.9 module
 okhttp = "4.11.0"
 postgre = "42.7.2"
-prometheus = "1.1.0"
+prometheus = "1.2.0"
 prometheusSimpleClient = "0.16.0"
 reactor = "2022.0.16"
 rest-assured = "5.4.0"

--- a/implementations/micrometer-registry-prometheus/build.gradle
+++ b/implementations/micrometer-registry-prometheus/build.gradle
@@ -4,10 +4,11 @@ dependencies {
     api project(':micrometer-core')
 
     api('io.prometheus:prometheus-metrics-core') {
-        // We don't need this nor some of its dependencies:
-        // io.prometheus:prometheus-metrics-tracer-otel
-        // io.prometheus:prometheus-metrics-tracer-otel-agent
-        exclude(group: 'io.prometheus', module: 'prometheus-metrics-tracer-initializer')
+        // We only need SpanContext from prometheus-metrics-tracer-common so we should
+        // exclude(group: 'io.prometheus', module: 'prometheus-metrics-tracer-initializer')
+        // But right now we cannot since ExemplarSampler imports SpanContextSupplier
+        exclude(group: 'io.prometheus', module: 'prometheus-metrics-tracer-otel')
+        exclude(group: 'io.prometheus', module: 'prometheus-metrics-tracer-otel-agent')
     }
     implementation 'io.prometheus:prometheus-metrics-exposition-formats'
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -16,6 +16,7 @@
 package io.micrometer.prometheusmetrics;
 
 import io.prometheus.metrics.config.ExemplarsProperties;
+import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.core.exemplars.ExemplarSampler;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfig;
 import io.prometheus.metrics.tracer.common.SpanContext;
@@ -29,9 +30,9 @@ import java.util.concurrent.ConcurrentMap;
  * @author Jonatan Ivanov
  * @since 1.13.0
  */
-public class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
+class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
 
-    private final ExemplarsProperties properties = ExemplarsProperties.builder().build();
+    private final ExemplarsProperties exemplarProperties = PrometheusProperties.get().getExemplarProperties();
 
     private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
 
@@ -46,14 +47,15 @@ public class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
     @Override
     public ExemplarSampler createExemplarSampler(int numberOfExemplars) {
         ExemplarSamplerConfig config = exemplarSamplerConfigsByNumberOfExemplars.computeIfAbsent(numberOfExemplars,
-                key -> new ExemplarSamplerConfig(properties, numberOfExemplars));
+                key -> new ExemplarSamplerConfig(exemplarProperties, numberOfExemplars));
         return new ExemplarSampler(config, spanContext);
     }
 
     @Override
     public ExemplarSampler createExemplarSampler(double[] histogramClassicUpperBounds) {
         ExemplarSamplerConfig config = exemplarSamplerConfigsByHistogramUpperBounds.computeIfAbsent(
-                histogramClassicUpperBounds, key -> new ExemplarSamplerConfig(properties, histogramClassicUpperBounds));
+                histogramClassicUpperBounds,
+                key -> new ExemplarSamplerConfig(exemplarProperties, histogramClassicUpperBounds));
         return new ExemplarSampler(config, spanContext);
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheusmetrics;
+
+import io.prometheus.metrics.config.ExemplarsProperties;
+import io.prometheus.metrics.core.exemplars.ExemplarSampler;
+import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfig;
+import io.prometheus.metrics.tracer.common.SpanContext;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation of {@link ExemplarSamplerFactory}.
+ *
+ * @author Jonatan Ivanov
+ * @since 1.13.0
+ */
+public class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
+
+    // TODO: Should we expose ExemplarsProperties and let users inject it through a ctor?
+    private final ExemplarsProperties properties = ExemplarsProperties.builder().build();
+
+    private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
+
+    // TODO: double[] as the key of a map? :|
+    private final ConcurrentMap<double[], ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
+
+    private final SpanContext spanContext;
+
+    public DefaultExemplarSamplerFactory(SpanContext spanContext) {
+        this.spanContext = spanContext;
+    }
+
+    @Override
+    public ExemplarSampler createExemplarSampler(int numberOfExemplars) {
+        ExemplarSamplerConfig config = exemplarSamplerConfigsByNumberOfExemplars.computeIfAbsent(numberOfExemplars,
+                key -> new ExemplarSamplerConfig(properties, numberOfExemplars));
+        return new ExemplarSampler(config, spanContext);
+    }
+
+    @Override
+    public ExemplarSampler createExemplarSampler(double[] histogramClassicUpperBounds) {
+        ExemplarSamplerConfig config = exemplarSamplerConfigsByHistogramUpperBounds.computeIfAbsent(
+                histogramClassicUpperBounds, key -> new ExemplarSamplerConfig(properties, histogramClassicUpperBounds));
+        return new ExemplarSampler(config, spanContext);
+    }
+
+}

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -31,12 +31,10 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
 
-    // TODO: Should we expose ExemplarsProperties and let users inject it through a ctor?
     private final ExemplarsProperties properties = ExemplarsProperties.builder().build();
 
     private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
 
-    // TODO: double[] as the key of a map? :|
     private final ConcurrentMap<double[], ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
 
     private final SpanContext spanContext;

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/ExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/ExemplarSamplerFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheusmetrics;
+
+import io.prometheus.metrics.core.exemplars.ExemplarSampler;
+
+/**
+ * A factory that creates {@link ExemplarSampler} instances with the desired properties.
+ *
+ * @author Jonatan Ivanov
+ * @since 1.13.0
+ */
+public interface ExemplarSamplerFactory {
+
+    /**
+     * Creates an {@link ExemplarSampler} that stores the defined amount of exemplars.
+     * @param numberOfExemplars the amount of exemplars stored by the sampler.
+     * @return a new {@link ExemplarSampler} instance.
+     */
+    ExemplarSampler createExemplarSampler(int numberOfExemplars);
+
+    /**
+     * Creates an {@link ExemplarSampler} that stores exemplars for the defined histogram
+     * buckets. This means as many exemplars as many buckets are defined.
+     * @param histogramUpperBounds histogram buckets to store exemplars for.
+     * @return a new {@link ExemplarSampler} instance.
+     */
+    ExemplarSampler createExemplarSampler(double[] histogramUpperBounds);
+
+}

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/ExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/ExemplarSamplerFactory.java
@@ -23,7 +23,7 @@ import io.prometheus.metrics.core.exemplars.ExemplarSampler;
  * @author Jonatan Ivanov
  * @since 1.13.0
  */
-public interface ExemplarSamplerFactory {
+interface ExemplarSamplerFactory {
 
     /**
      * Creates an {@link ExemplarSampler} that stores the defined amount of exemplars.

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusHistogram.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusHistogram.java
@@ -61,14 +61,10 @@ class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
         }
     }
 
-    boolean isExemplarsEnabled() {
-        return exemplarSampler != null;
-    }
-
     @Override
     public void recordDouble(double value) {
         super.recordDouble(value);
-        if (isExemplarsEnabled()) {
+        if (exemplarSampler != null) {
             exemplarSampler.observe(value);
         }
     }
@@ -76,18 +72,13 @@ class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
     @Override
     public void recordLong(long value) {
         super.recordLong(value);
-        if (isExemplarsEnabled()) {
+        if (exemplarSampler != null) {
             exemplarSampler.observe(value);
         }
     }
 
     Exemplars exemplars() {
-        return isExemplarsEnabled() ? this.exemplarSampler.collect() : Exemplars.EMPTY;
-    }
-
-    @Nullable
-    Exemplar lastExemplar() {
-        return isExemplarsEnabled() ? exemplarSampler.collect().getLatest() : null;
+        return exemplarSampler != null ? this.exemplarSampler.collect() : Exemplars.EMPTY;
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusHistogram.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusHistogram.java
@@ -23,15 +23,10 @@ import io.micrometer.core.instrument.distribution.Histogram;
 import io.micrometer.core.instrument.distribution.TimeWindowFixedBoundaryHistogram;
 import io.prometheus.metrics.core.exemplars.ExemplarSampler;
 import io.prometheus.metrics.model.snapshots.Exemplar;
+import io.prometheus.metrics.model.snapshots.Exemplars;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.atomic.AtomicReferenceArray;
-
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Internal {@link Histogram} implementation for Prometheus that handles {@link Exemplar
@@ -42,18 +37,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
 
     @Nullable
-    private final double[] buckets;
-
-    @Nullable
-    private final AtomicReferenceArray<Exemplar> exemplars;
-
-    @Nullable
-    private final AtomicReference<Exemplar> lastExemplar;
-
-    @Nullable
     private final ExemplarSampler exemplarSampler;
 
-    PrometheusHistogram(Clock clock, DistributionStatisticConfig config, @Nullable ExemplarSampler exemplarSampler) {
+    PrometheusHistogram(Clock clock, DistributionStatisticConfig config,
+            @Nullable ExemplarSamplerFactory exemplarSamplerFactory) {
         super(clock, DistributionStatisticConfig.builder()
             // effectively never rolls over
             .expiry(Duration.ofDays(1825))
@@ -61,23 +48,16 @@ class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
             .build()
             .merge(config), true);
 
-        this.exemplarSampler = exemplarSampler;
-        if (isExemplarsEnabled()) {
-            double[] originalBuckets = getBuckets();
-            if (originalBuckets[originalBuckets.length - 1] != Double.POSITIVE_INFINITY) {
-                this.buckets = Arrays.copyOf(originalBuckets, originalBuckets.length + 1);
-                this.buckets[buckets.length - 1] = Double.POSITIVE_INFINITY;
+        if (exemplarSamplerFactory != null) {
+            double[] buckets = getBuckets();
+            if (buckets[buckets.length - 1] != Double.POSITIVE_INFINITY) {
+                buckets = Arrays.copyOf(buckets, buckets.length + 1);
+                buckets[buckets.length - 1] = Double.POSITIVE_INFINITY;
             }
-            else {
-                this.buckets = originalBuckets;
-            }
-            this.exemplars = new AtomicReferenceArray<>(this.buckets.length);
-            this.lastExemplar = new AtomicReference<>();
+            this.exemplarSampler = exemplarSamplerFactory.createExemplarSampler(buckets);
         }
         else {
-            this.buckets = null;
-            this.exemplars = null;
-            this.lastExemplar = null;
+            this.exemplarSampler = null;
         }
     }
 
@@ -89,7 +69,7 @@ class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
     public void recordDouble(double value) {
         super.recordDouble(value);
         if (isExemplarsEnabled()) {
-            updateExemplar(value, null, null);
+            exemplarSampler.observe(value);
         }
     }
 
@@ -97,76 +77,17 @@ class PrometheusHistogram extends TimeWindowFixedBoundaryHistogram {
     public void recordLong(long value) {
         super.recordLong(value);
         if (isExemplarsEnabled()) {
-            updateExemplar(value, NANOSECONDS, SECONDS);
+            exemplarSampler.observe(value);
         }
     }
 
-    private void updateExemplar(double value, @Nullable TimeUnit sourceUnit, @Nullable TimeUnit destinationUnit) {
-        int index = leastLessThanOrEqualTo(value);
-        index = (index == -1) ? exemplars.length() - 1 : index;
-        updateExemplar(value, sourceUnit, destinationUnit, index);
-    }
-
-    private void updateExemplar(double value, @Nullable TimeUnit sourceUnit, @Nullable TimeUnit destinationUnit,
-            int index) {
-        // double bucketFrom = (index == 0) ? Double.NEGATIVE_INFINITY : buckets[index -
-        // 1];
-        // double bucketTo = buckets[index];
-        // Exemplar previusBucketExemplar;
-        // Exemplar previousLastExemplar;
-        // Exemplar nextExemplar;
-        //
-        // double exemplarValue = (sourceUnit != null && destinationUnit != null)
-        // ? TimeUtils.convert(value, sourceUnit, destinationUnit) : value;
-        // do {
-        // previusBucketExemplar = exemplars.get(index);
-        // previousLastExemplar = lastExemplar.get();
-        // nextExemplar = exemplarSampler.sample(exemplarValue, bucketFrom, bucketTo,
-        // previusBucketExemplar);
-        // }
-        // while (nextExemplar != null && nextExemplar != previusBucketExemplar
-        // && !(exemplars.compareAndSet(index, previusBucketExemplar, nextExemplar)
-        // && lastExemplar.compareAndSet(previousLastExemplar, nextExemplar)));
-    }
-
-    @Nullable
-    Exemplar[] exemplars() {
-        if (isExemplarsEnabled()) {
-            Exemplar[] exemplarsArray = new Exemplar[this.exemplars.length()];
-            for (int i = 0; i < this.exemplars.length(); i++) {
-                exemplarsArray[i] = this.exemplars.get(i);
-            }
-
-            return exemplarsArray;
-        }
-        else {
-            return null;
-        }
+    Exemplars exemplars() {
+        return isExemplarsEnabled() ? this.exemplarSampler.collect() : Exemplars.EMPTY;
     }
 
     @Nullable
     Exemplar lastExemplar() {
-        return this.lastExemplar.get();
-    }
-
-    /**
-     * The least bucket that is less than or equal to a sample.
-     */
-    private int leastLessThanOrEqualTo(double key) {
-        int low = 0;
-        int high = buckets.length - 1;
-
-        while (low <= high) {
-            int mid = (low + high) >>> 1;
-            if (buckets[mid] < key)
-                low = mid + 1;
-            else if (buckets[mid] > key)
-                high = mid - 1;
-            else
-                return mid; // exact match
-        }
-
-        return low < buckets.length ? low : -1;
+        return isExemplarsEnabled() ? exemplarSampler.collect().getLatest() : null;
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -27,6 +27,7 @@ import io.micrometer.core.instrument.internal.DefaultGauge;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.prometheus.metrics.config.ExporterProperties;
+import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.expositionformats.ExpositionFormats;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.*;
@@ -66,9 +67,7 @@ import static java.util.stream.StreamSupport.stream;
  */
 public class PrometheusMeterRegistry extends MeterRegistry {
 
-    private final ExporterProperties exporterProperties = ExporterProperties.builder()
-        .exemplarsOnAllMetricTypes(true)
-        .build();
+    private final ExporterProperties exporterProperties = PrometheusProperties.get().getExporterProperties();
 
     private final ExpositionFormats expositionFormats = ExpositionFormats.init(exporterProperties);
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -35,6 +35,7 @@ import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapsho
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot.HistogramDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot.InfoDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
+import io.prometheus.metrics.tracer.common.SpanContext;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -93,17 +94,17 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * @param config configuration
      * @param registry prometheus registry
      * @param clock clock
-     * @param exemplarSamplerFactory exemplar sampler factory
+     * @param spanContext span context that interacts with the used tracing library
      */
     public PrometheusMeterRegistry(PrometheusConfig config, PrometheusRegistry registry, Clock clock,
-            @Nullable ExemplarSamplerFactory exemplarSamplerFactory) {
+            @Nullable SpanContext spanContext) {
         super(clock);
 
         config.requireValid();
 
         this.prometheusConfig = config;
         this.registry = registry;
-        this.exemplarSamplerFactory = exemplarSamplerFactory;
+        this.exemplarSamplerFactory = spanContext != null ? new DefaultExemplarSamplerFactory(spanContext) : null;
 
         config().namingConvention(new PrometheusNamingConvention());
         config().onMeterRemoved(this::onMeterRemoved);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -66,11 +66,11 @@ import static java.util.stream.StreamSupport.stream;
  */
 public class PrometheusMeterRegistry extends MeterRegistry {
 
-    private static final ExporterProperties EXPORTER_PROPERTIES = ExporterProperties.builder()
+    private final ExporterProperties exporterProperties = ExporterProperties.builder()
         .exemplarsOnAllMetricTypes(true)
         .build();
 
-    private static final ExpositionFormats EXPOSITION_FORMATS = ExpositionFormats.init(EXPORTER_PROPERTIES);
+    private final ExpositionFormats expositionFormats = ExpositionFormats.init(exporterProperties);
 
     private final PrometheusConfig prometheusConfig;
 
@@ -163,7 +163,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private void scrape(OutputStream outputStream, String contentType, MetricSnapshots snapshots) throws IOException {
-        EXPOSITION_FORMATS.findWriter(contentType).write(outputStream, snapshots);
+        expositionFormats.findWriter(contentType).write(outputStream, snapshots);
     }
 
     /**

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusTimer.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusTimer.java
@@ -95,7 +95,7 @@ public class PrometheusTimer extends AbstractTimer {
         }
 
         if (!histogramExemplarsEnabled && exemplarSampler != null) {
-            exemplarSampler.observe(TimeUtils.nanosToUnit(nanoAmount, baseTimeUnit()));
+            exemplarSampler.observe(nanoAmount);
         }
     }
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -271,9 +271,8 @@ class PrometheusMeterRegistryTest {
 
     @Test
     void percentileHistogramWithUpperBoundContainsExactlyOneInf() {
-
-        DistributionSummary s = DistributionSummary.builder("ds") // single character
-                                                                  // names no longer valid
+        // single character names no longer valid
+        DistributionSummary s = DistributionSummary.builder("ds")
             .publishPercentileHistogram()
             .maximumExpectedValue(3.0)
             .register(registry);
@@ -505,8 +504,8 @@ class PrometheusMeterRegistryTest {
     @Issue("#1883")
     @Test
     void filteredMetricFamilySamplesWithCounter() {
-        String[] names = { "my_count" }; // fails with my_count_total since Prometheus
-                                         // client 1.x
+        // fails with my_count_total since Prometheus client 1.x
+        String[] names = { "my_count" };
 
         Counter.builder("my.count").register(registry);
         assertFilteredMetricSnapshots(names, names);
@@ -533,9 +532,8 @@ class PrometheusMeterRegistryTest {
     @Issue("#1883")
     @Test
     void filteredMetricFamilySamplesWithTimer() {
-        String[] names = { "my_timer_seconds", "my_timer_seconds_max" }; // not individual
-                                                                         // time series
-                                                                         // name
+        // not individual time series name
+        String[] names = { "my_timer_seconds", "my_timer_seconds_max" };
 
         Timer.builder("my.timer").register(registry);
         assertFilteredMetricSnapshots(names, names);
@@ -590,9 +588,8 @@ class PrometheusMeterRegistryTest {
     void scrapeWithLongTaskTimer() {
         LongTaskTimer.builder("my.long.task.timer").register(registry);
         assertThat(registry.scrape()).contains("my_long_task_timer_seconds_max")
-            .contains("my_long_task_timer_seconds_count") // since Prometheus client 1.x,
-                                                          // suffix _active_count =>
-                                                          // _count
+            // since Prometheus client 1.x, suffix _active_count => _count
+            .contains("my_long_task_timer_seconds_count")
             .contains("my_long_task_timer_seconds_sum");
     }
 
@@ -639,95 +636,83 @@ class PrometheusMeterRegistryTest {
             .endsWith("# EOF\n");
     }
 
-    // @Test
-    // void openMetricsScrapeWithExemplars() {
-    // DefaultExemplarSampler exemplarSampler = new DefaultExemplarSampler(new
-    // TestSpanContextSupplier());
-    // PrometheusMeterRegistry registry = new
-    // PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry,
-    // clock, exemplarSampler);
-    //
-    // Counter counter = Counter.builder("my.counter").register(registry);
-    // counter.increment();
-    //
-    // Timer timer = Timer.builder("timer.noHistogram").register(registry);
-    // timer.record(Duration.ofMillis(100));
-    // timer.record(Duration.ofMillis(200));
-    // timer.record(Duration.ofMillis(150));
-    //
-    // Timer timerWithHistogram = Timer.builder("timer.withHistogram")
-    // .serviceLevelObjectives(Duration.ofMillis(100), Duration.ofMillis(200),
-    // Duration.ofMillis(300))
-    // .register(registry);
-    // timerWithHistogram.record(Duration.ofMillis(15));
-    // timerWithHistogram.record(Duration.ofMillis(1_500));
-    // timerWithHistogram.record(Duration.ofMillis(150));
-    //
-    // DistributionSummary summary =
-    // DistributionSummary.builder("summary.noHistogram").register(registry);
-    // summary.record(0.10);
-    // summary.record(1E18);
-    // summary.record(20);
-    //
-    // DistributionSummary summaryWithHistogram =
-    // DistributionSummary.builder("summary.withHistogram")
-    // .publishPercentileHistogram()
-    // .register(registry);
-    // summaryWithHistogram.record(0.15);
-    // summaryWithHistogram.record(5E18);
-    // summaryWithHistogram.record(15);
-    //
-    // DistributionSummary slos = DistributionSummary.builder("summary.withSlos")
-    // .serviceLevelObjectives(100, 200, 300)
-    // .register(registry);
-    // slos.record(10);
-    // slos.record(1_000);
-    // slos.record(250);
-    //
-    // String scraped = registry.scrape(TextFormat.CONTENT_TYPE_OPENMETRICS_100);
-    // assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"}
-    // 1.0 ");
-    //
-    // assertThat(scraped).contains("timer_noHistogram_seconds_count 3.0 #
-    // {span_id=\"3\",trace_id=\"4\"} 1.0 ");
-    //
-    // assertThat(scraped)
-    // .contains("timer_withHistogram_seconds_bucket{le=\"0.1\"} 1.0 #
-    // {span_id=\"5\",trace_id=\"6\"} 0.015 ")
-    // .contains("timer_withHistogram_seconds_bucket{le=\"0.2\"} 2.0 #
-    // {span_id=\"9\",trace_id=\"10\"} 0.15 ")
-    // .contains("timer_withHistogram_seconds_bucket{le=\"0.3\"} 2.0\n")
-    // .contains("timer_withHistogram_seconds_bucket{le=\"+Inf\"} 3.0 #
-    // {span_id=\"7\",trace_id=\"8\"} 1.5 ");
-    // assertThat(scraped).contains("timer_withHistogram_seconds_count 3.0 #
-    // {span_id=\"9\",trace_id=\"10\"} 1.0 ");
-    //
-    // assertThat(scraped).contains("summary_noHistogram_count 3.0 #
-    // {span_id=\"11\",trace_id=\"12\"} 1.0 ");
-    //
-    // assertThat(scraped)
-    // .contains("summary_withHistogram_bucket{le=\"1.0\"} 1.0 #
-    // {span_id=\"13\",trace_id=\"14\"} 0.15 ")
-    // .contains("summary_withHistogram_bucket{le=\"16.0\"} 2.0 #
-    // {span_id=\"17\",trace_id=\"18\"} 15.0 ")
-    // .contains("summary_withHistogram_bucket{le=\"+Inf\"} 3.0 #
-    // {span_id=\"15\",trace_id=\"16\"} 5.0E18 ");
-    // assertThat(scraped).contains("summary_withHistogram_count 3.0 #
-    // {span_id=\"17\",trace_id=\"18\"} 1.0 ");
-    //
-    // assertThat(scraped)
-    // .contains("summary_withSlos_bucket{le=\"100.0\"} 1.0 #
-    // {span_id=\"19\",trace_id=\"20\"} 10.0 ")
-    // .contains("summary_withSlos_bucket{le=\"200.0\"} 1.0\n")
-    // .contains("summary_withSlos_bucket{le=\"300.0\"} 2.0 #
-    // {span_id=\"23\",trace_id=\"24\"} 250.0 ")
-    // .contains("summary_withSlos_bucket{le=\"+Inf\"} 3.0 #
-    // {span_id=\"21\",trace_id=\"22\"} 1000.0 ");
-    // assertThat(scraped).contains("summary_withSlos_count 3.0 #
-    // {span_id=\"23\",trace_id=\"24\"} 1.0 ");
-    //
-    // assertThat(scraped).endsWith("# EOF\n");
-    // }
+    @Test
+    void openMetricsScrapeWithExemplars() throws InterruptedException {
+        ExemplarSamplerFactory exemplarSamplerFactory = new DefaultExemplarSamplerFactory(new TestSpanContex());
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry,
+                clock, exemplarSamplerFactory);
+
+        Counter counter = Counter.builder("my.counter").register(registry);
+        counter.increment();
+
+        Timer timer = Timer.builder("timer.noHistogram").register(registry);
+        timer.record(Duration.ofMillis(100));
+        timer.record(Duration.ofMillis(200));
+        timer.record(Duration.ofMillis(150));
+
+        Timer timerWithHistogram = Timer.builder("timer.withHistogram")
+            .serviceLevelObjectives(Duration.ofMillis(100), Duration.ofMillis(200), Duration.ofMillis(300))
+            .register(registry);
+        timerWithHistogram.record(Duration.ofMillis(15));
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        timerWithHistogram.record(Duration.ofMillis(1_500));
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        timerWithHistogram.record(Duration.ofMillis(150));
+
+        DistributionSummary summary = DistributionSummary.builder("summary.noHistogram").register(registry);
+        summary.record(0.10);
+        summary.record(1E18);
+        summary.record(20);
+
+        DistributionSummary summaryWithHistogram = DistributionSummary.builder("summary.withHistogram")
+            .publishPercentileHistogram()
+            .register(registry);
+        summaryWithHistogram.record(0.15);
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        summaryWithHistogram.record(5E18);
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        summaryWithHistogram.record(15);
+
+        DistributionSummary slos = DistributionSummary.builder("summary.withSlos")
+            .serviceLevelObjectives(100, 200, 300)
+            .register(registry);
+        slos.record(10);
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        slos.record(1_000);
+        Thread.sleep(100); // sleeping 100ms since the sample interval limit is 90ms
+        slos.record(250);
+
+        String scraped = registry.scrape("application/openmetrics-text");
+        assertThat(scraped).contains("my_counter_total 1.0 # {span_id=\"1\",trace_id=\"2\"} 1.0 ");
+
+        assertThat(scraped).contains("timer_noHistogram_seconds_count 3 # {span_id=\"3\",trace_id=\"4\"} 1.0 ");
+
+        assertThat(scraped)
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.1\"} 1 # {span_id=\"5\",trace_id=\"6\"} 0.015 ")
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.2\"} 2 # {span_id=\"9\",trace_id=\"10\"} 0.15 ")
+            .contains("timer_withHistogram_seconds_bucket{le=\"0.3\"} 2\n")
+            .contains("timer_withHistogram_seconds_bucket{le=\"+Inf\"} 3 # {span_id=\"7\",trace_id=\"8\"} 1.5 ");
+        // Should the value be 1.0 instead of 0.15 in case of _count?
+        assertThat(scraped).contains("timer_withHistogram_seconds_count 3 # {span_id=\"9\",trace_id=\"10\"} 0.15 ");
+
+        assertThat(scraped).contains("summary_noHistogram_count 3 # {span_id=\"11\",trace_id=\"12\"} 1.0 ");
+
+        assertThat(scraped)
+            .contains("summary_withHistogram_bucket{le=\"1.0\"} 1 # {span_id=\"13\",trace_id=\"14\"} 0.15 ")
+            .contains("summary_withHistogram_bucket{le=\"16.0\"} 2 # {span_id=\"17\",trace_id=\"18\"} 15.0 ")
+            .contains("summary_withHistogram_bucket{le=\"+Inf\"} 3 # {span_id=\"15\",trace_id=\"16\"} 5.0E18 ");
+        // Should the value be 1.0 instead of 15.0 in case of _count?
+        assertThat(scraped).contains("summary_withHistogram_count 3 # {span_id=\"17\",trace_id=\"18\"} 15.0");
+
+        assertThat(scraped).contains("summary_withSlos_bucket{le=\"100.0\"} 1 # {span_id=\"19\",trace_id=\"20\"} 10.0 ")
+            .contains("summary_withSlos_bucket{le=\"200.0\"} 1\n")
+            .contains("summary_withSlos_bucket{le=\"300.0\"} 2 # {span_id=\"23\",trace_id=\"24\"} 250.0 ")
+            .contains("summary_withSlos_bucket{le=\"+Inf\"} 3 # {span_id=\"21\",trace_id=\"22\"} 1000.0 ");
+        // Should the value be 1.0 instead of 250.0 in case of _count?
+        assertThat(scraped).contains("summary_withSlos_count 3 # {span_id=\"23\",trace_id=\"24\"} 250.0 ");
+
+        assertThat(scraped).endsWith("# EOF\n");
+    }
 
     @Test
     void noExemplarsIfNoSampler() {
@@ -763,10 +748,7 @@ class PrometheusMeterRegistryTest {
         assertThat(scraped).contains("test_timer_seconds_bucket{le=\"0.1\"} 1\n")
             .contains("test_timer_seconds_bucket{le=\"0.2\"} 2\n")
             .contains("test_timer_seconds_bucket{le=\"0.3\"} 2\n")
-            .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3\n"); // fails with a count
-                                                                     // of 5 despite only
-                                                                     // 3 calls to
-                                                                     // record...
+            .contains("test_timer_seconds_bucket{le=\"+Inf\"} 3\n");
         assertThat(scraped).contains("test_histogram_bucket{le=\"1.0\"} 1\n")
             .contains("test_histogram_bucket{le=\"16.0\"} 2\n")
             .contains("test_histogram_bucket{le=\"+Inf\"} 3\n");
@@ -778,7 +760,7 @@ class PrometheusMeterRegistryTest {
         assertThat(scraped).endsWith("# EOF\n");
     }
 
-    static class TestSpanContextSupplier implements SpanContext {
+    static class TestSpanContex implements SpanContext {
 
         private final AtomicLong count = new AtomicLong();
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -638,9 +638,8 @@ class PrometheusMeterRegistryTest {
 
     @Test
     void openMetricsScrapeWithExemplars() throws InterruptedException {
-        ExemplarSamplerFactory exemplarSamplerFactory = new DefaultExemplarSamplerFactory(new TestSpanContex());
         PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT, prometheusRegistry,
-                clock, exemplarSamplerFactory);
+                clock, new TestSpanContex());
 
         Counter counter = Counter.builder("my.counter").register(registry);
         counter.increment();

--- a/implementations/micrometer-registry-prometheus/src/test/resources/prometheus.properties
+++ b/implementations/micrometer-registry-prometheus/src/test/resources/prometheus.properties
@@ -1,0 +1,1 @@
+io.prometheus.exporter.exemplarsOnAllMetricTypes=true

--- a/implementations/micrometer-registry-prometheus/src/test/resources/prometheus.properties
+++ b/implementations/micrometer-registry-prometheus/src/test/resources/prometheus.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2024 VMware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 io.prometheus.exporter.exemplarsOnAllMetricTypes=true

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
@@ -19,7 +19,6 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.prometheusmetrics.DefaultExemplarSamplerFactory;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
@@ -33,7 +32,7 @@ import static io.prometheus.client.exporter.common.TextFormat.CONTENT_TYPE_OPENM
 public class PrometheusExemplarsSample {
 
     private static final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT,
-            new PrometheusRegistry(), Clock.SYSTEM, new DefaultExemplarSamplerFactory(new TestSpanContext()));
+            new PrometheusRegistry(), Clock.SYSTEM, new TestSpanContext());
 
     public static void main(String[] args) throws InterruptedException {
         Counter counter = registry.counter("test.counter");

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/PrometheusExemplarsSample.java
@@ -19,13 +19,11 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheusmetrics.DefaultExemplarSamplerFactory;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
-import io.prometheus.client.exemplars.tracer.common.SpanContextSupplier;
-import io.prometheus.metrics.config.ExemplarsProperties;
-import io.prometheus.metrics.core.exemplars.ExemplarSampler;
-import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfig;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.tracer.common.SpanContext;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
@@ -35,8 +33,7 @@ import static io.prometheus.client.exporter.common.TextFormat.CONTENT_TYPE_OPENM
 public class PrometheusExemplarsSample {
 
     private static final PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT,
-            new PrometheusRegistry(), Clock.SYSTEM,
-            new ExemplarSampler(new ExemplarSamplerConfig(ExemplarsProperties.builder().builder(), 1)));
+            new PrometheusRegistry(), Clock.SYSTEM, new DefaultExemplarSamplerFactory(new TestSpanContext()));
 
     public static void main(String[] args) throws InterruptedException {
         Counter counter = registry.counter("test.counter");
@@ -44,37 +41,56 @@ public class PrometheusExemplarsSample {
 
         Timer timer = Timer.builder("test.timer").publishPercentileHistogram().register(registry);
         timer.record(Duration.ofNanos(1_000 * 100));
+        sleep(); // sleeping to avoid rate-limiting
         timer.record(Duration.ofMillis(2));
+        sleep(); // sleeping to avoid rate-limiting
         timer.record(Duration.ofMillis(100));
+        sleep(); // sleeping to avoid rate-limiting
         timer.record(Duration.ofSeconds(60));
 
         DistributionSummary distributionSummary = DistributionSummary.builder("test.distribution")
             .publishPercentileHistogram()
             .register(registry);
         distributionSummary.record(0.15);
+        sleep(); // sleeping to avoid rate-limiting
         distributionSummary.record(15);
+        sleep(); // sleeping to avoid rate-limiting
         distributionSummary.record(5E18);
 
         System.out.println(registry.scrape(CONTENT_TYPE_OPENMETRICS_100));
     }
 
-    static class TestSpanContextSupplier implements SpanContextSupplier {
+    static void sleep() {
+        try {
+            // sleeping 100ms since the sample interval limit is 90ms
+            Thread.sleep(100);
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static class TestSpanContext implements SpanContext {
 
         private final AtomicLong count = new AtomicLong();
 
         @Override
-        public String getTraceId() {
+        public String getCurrentTraceId() {
+            return "42";
+        }
+
+        @Override
+        public String getCurrentSpanId() {
             return String.valueOf(count.incrementAndGet());
         }
 
         @Override
-        public String getSpanId() {
-            return String.valueOf(count.incrementAndGet());
-        }
-
-        @Override
-        public boolean isSampled() {
+        public boolean isCurrentSpanSampled() {
             return true;
+        }
+
+        @Override
+        public void markCurrentSpanAsExemplar() {
         }
 
     }


### PR DESCRIPTION
Issues:

1. prometheus-metrics-tracer-initializer is needed:
We would only need SpanContext from prometheus-metrics-tracer-common
but ExemplarSampler imports SpanContextSupplier so that is also needed
from prometheus-metrics-tracer-initializer.

2. Testing is not easy because of the rate limiter since the Prometheus
Java Client does not have a clock abstraction that we could mock/fake.