### PR TITLE
Warn when a MeterFilter is configured after a meter is registered

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -19,6 +19,7 @@
 	<suppress id="SLF4JIllegalImportCheck" files="implementations[\\/].+" />
 	<suppress id="SLF4JIllegalImportCheck" files="benchmarks[\\/].+" />
 	<suppress id="SLF4JIllegalImportCheck" files="micrometer-osgi-test" />
+	<suppress id="SLF4JIllegalImportCheck" files="MeterRegistryLoggingTest" />
 
 	<suppress id="sysout" files="ClearCustomMetricDescriptors.java"/>
 	<suppress id="sysout" files="HttpSender.java"/>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -164,6 +164,7 @@ jsr107 = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "jsr107" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 junitBom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junitLoggingExtention = "com.innoq:junit5-logging-extension:0.2.0"
 junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }
 kafkaClients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }
 kafkaStreams = { module = "org.apache.kafka:kafka-streams", version.ref = "kafka" }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -156,6 +156,7 @@ dependencies {
     }
     // Needed for LogbackMetrics tests
     testImplementation libs.slf4jApi
+    testImplementation(libs.junitLoggingExtention)
 
     testImplementation 'org.mockito:mockito-core'
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryLoggingTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryLoggingTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.innoq.junit.jupiter.logging.Logging;
+import com.innoq.junit.jupiter.logging.LoggingEvents;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for expected logging from {@link MeterRegistry}.
+ */
+@Logging
+class MeterRegistryLoggingTest {
+
+    MeterRegistry registry = new SimpleMeterRegistry();
+
+    @Test
+    void meterRegistrationBeforeMeterFilterConfig(LoggingEvents logEvents) {
+        registerMetricsAndConfigure();
+
+        assertThat(logEvents.withLevel(Level.DEBUG)).isEmpty();
+        assertThat(logEvents.withLevel(Level.WARN)).singleElement()
+            .extracting(ILoggingEvent::getFormattedMessage, as(InstanceOfAssertFactories.STRING))
+            .contains("A MeterFilter is being configured after a Meter has been registered to this registry.")
+            .doesNotContain("meterRegistrationBeforeMeterFilterConfig")
+            .doesNotContain("\tat ");
+    }
+
+    @Test
+    void meterRegistrationBeforeMeterFilterConfigWithDebugLogging(LoggingEvents logEvents) {
+        Level priorLevel = ((Logger) LoggerFactory.getLogger(SimpleMeterRegistry.class)).getLevel();
+        ((Logger) LoggerFactory.getLogger(SimpleMeterRegistry.class)).setLevel(Level.DEBUG);
+        try {
+            registerMetricsAndConfigure();
+
+            assertThat(logEvents.withLevel(Level.WARN)).isEmpty();
+            assertThat(logEvents.withLevel(Level.DEBUG)).singleElement()
+                .extracting(ILoggingEvent::getFormattedMessage, as(InstanceOfAssertFactories.STRING))
+                .contains("A MeterFilter is being configured after a Meter has been registered to this registry.")
+                .containsPattern(
+                        "io.micrometer.core.instrument.MeterRegistryLoggingTest.configureCommonTags\\(MeterRegistryLoggingTest.java:\\d+\\)\n"
+                                + "\tat io.micrometer.core.instrument.MeterRegistryLoggingTest.registerMetricsAndConfigure\\(MeterRegistryLoggingTest.java:\\d+\\)\n"
+                                + "\tat io.micrometer.core.instrument.MeterRegistryLoggingTest.meterRegistrationBeforeMeterFilterConfigWithDebugLogging\\(MeterRegistryLoggingTest.java:\\d+\\)");
+        }
+        finally {
+            ((Logger) LoggerFactory.getLogger(SimpleMeterRegistry.class)).setLevel(priorLevel);
+        }
+    }
+
+    // intentionally nest method calls to assert on a more realistic stack trace
+    void registerMetricsAndConfigure() {
+        registry.counter("counter");
+        configureCommonTags();
+    }
+
+    void configureCommonTags() {
+        registry.config().commonTags("common", "tag");
+    }
+
+}


### PR DESCRIPTION
In normal usage we would expect this should not happen, but there is nothing enforcing or encouraging it to not happen. This warns users via logging that it is happening and advises to correct it, if possible. Otherwise, we want to learn about why it is not fixable. The problem with configuring MeterFilters after a Meter has been registered is that such filters will not be applied to previously registered meters. This can result in a mix of metrics with all filters applied and only some filters applied, which is potentially hard to notice.