### PR TITLE
[Dynatrace] debug log in exporter when no meters are registered

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -148,6 +148,11 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
             return;
         }
 
+        if (meters.isEmpty()) {
+            logger.debug("Meter list is empty, nothing to export. Did you create any meters?");
+            return;
+        }
+
         Map<String, String> seenMetadata = null;
         if (config.exportMeterMetadata()) {
             seenMetadata = new HashMap<>();


### PR DESCRIPTION
Adds a debug log for when no meters are passed to `DynatraceExporterV2#export()` and returns early as any code after this is a no-op.

Currently, when no meters are passed to export, we don't send any requests nor do we do any other operations that would indicate that the exporter being called on any log-level, thus making it harder for users and/or support engineers to diagnose this trivial case.

cc @pirgeo

 