### PR TITLE
#5140: Tags merge optimization

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsBenchmark.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.benchmark.core;
 
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
@@ -31,13 +32,59 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class TagsBenchmark {
 
-    @Threads(16)
+    static final Tag[] orderedTagsSet10 = new Tag[] { Tag.of("key0", "value"), Tag.of("key1", "value"),
+            Tag.of("key2", "value"), Tag.of("key3", "value"), Tag.of("key4", "value"), Tag.of("key5", "value"),
+            Tag.of("key6", "value"), Tag.of("key7", "value"), Tag.of("key8", "value"), Tag.of("key9", "value") };
+
+    static final Tag[] orderedTagsSet4 = new Tag[] { Tag.of("key0", "value"), Tag.of("key1", "value"),
+            Tag.of("key2", "value"), Tag.of("key3", "value"), };
+
+    static final Tag[] orderedTagsSet2 = new Tag[] { Tag.of("key0", "value"), Tag.of("key1", "value"), };
+
+    static final Tag[] unorderedTagsSet10 = new Tag[] { Tag.of("key1", "value"), Tag.of("key2", "value"),
+            Tag.of("key3", "value"), Tag.of("key4", "value"), Tag.of("key5", "value"), Tag.of("key6", "value"),
+            Tag.of("key7", "value"), Tag.of("key8", "value"), Tag.of("key9", "value"), Tag.of("key0", "value") };
+
+    static final Tag[] unorderedTagsSet4 = new Tag[] { Tag.of("key1", "value"), Tag.of("key2", "value"),
+            Tag.of("key3", "value"), Tag.of("key0", "value"), };
+
+    static final Tag[] unorderedTagsSet2 = new Tag[] { Tag.of("key1", "value"), Tag.of("key0", "value") };
+
+    @Benchmark
+    public Tags tagsOfOrderedTagsSet10() {
+        return Tags.of(orderedTagsSet10);
+    }
+
+    @Benchmark
+    public Tags tagsOfOrderedTagsSet4() {
+        return Tags.of(orderedTagsSet4);
+    }
+
+    @Benchmark
+    public Tags tagsOfOrderedTagsSet2() {
+        return Tags.of(orderedTagsSet2);
+    }
+
+    @Benchmark
+    public Tags tagsOfUnorderedTagsSet10() {
+        return Tags.of(unorderedTagsSet10);
+    }
+
+    @Benchmark
+    public Tags tagsOfUnorderedTagsSet4() {
+        return Tags.of(unorderedTagsSet4);
+    }
+
+    @Benchmark
+    public Tags tagsOfUnorderedTagsSet2() {
+        return Tags.of(unorderedTagsSet2);
+    }
+
     @Benchmark
     public void of() {
         Tags.of("key", "value", "key2", "value2", "key3", "value3", "key4", "value4", "key5", "value5");
     }
 
-    @Threads(16)
     @Benchmark
     public void dotAnd() {
         Tags.of("key", "value").and("key2", "value2", "key3", "value3", "key4", "value4", "key5", "value5");

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsMergeBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsMergeBenchmark.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core;
+
+import io.micrometer.core.instrument.Tags;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Measurement(iterations = 2)
+@Warmup(iterations = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class TagsMergeBenchmark {
+
+    static final Tags left = Tags.of("key", "value", "key2", "value2", "key6", "value6", "key7", "value7", "key8",
+            "value8", "keyA", "valueA", "keyC", "valueC", "keyE", "valueE", "keyF", "valueF", "keyG", "valueG", "keyG",
+            "valueG", "keyG", "valueG", "keyH", "valueH");
+
+    static final Tags right = Tags.of("key", "value", "key1", "value1", "key2", "value2", "key3", "value3", "key4",
+            "value4", "key5", "value5", "keyA", "valueA", "keyB", "valueB", "keyD", "valueD");
+
+    @Benchmark
+    public Tags mergeTags() {
+        return left.and(right);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(TagsMergeBenchmark.class.getSimpleName()).build();
+        new Runner(opt).run();
+    }
+
+}


### PR DESCRIPTION
I've observed unexpectedly significant CPU time spent in Tags merge function in one of the production services which rely on micrometer:
<img width="542" alt="image" src="https://github.com/micrometer-metrics/micrometer/assets/385639/4ed8fd39-120b-4773-a300-6235ecaa7b73">
<img width="707" alt="image" src="https://github.com/micrometer-metrics/micrometer/assets/385639/f46e84d4-f728-4a5f-9018-303620b9526b">

I've slightly refactored internals of `Tags` class to take advantage of tags set is being already sorted array, which could be then combined with other sorted set in linear time.

I've also added microbenchmark for tags concat operation to see the performance gain before I can test this change in production. 

Below I'm providing results from `Apple M2 Pro` + `JDK 21` machine:

Updated benchmark results:
Baseline (b410174db680401423659955581bd03009113908 + ac33ae9344f630eedbd0981073d56d2dd12c6d5e):
```
Benchmark                               Mode  Cnt   Score   Error  Units
TagsBenchmark.dotAnd                    avgt    2  98.417          ns/op
TagsBenchmark.of                        avgt    2  45.250          ns/op
TagsBenchmark.tagsOfOrderedTagsSet10    avgt    2  69.997          ns/op
TagsBenchmark.tagsOfOrderedTagsSet2     avgt    2  22.632          ns/op
TagsBenchmark.tagsOfOrderedTagsSet4     avgt    2  32.953          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet10  avgt    2  90.041          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet2   avgt    2  23.264          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet4   avgt    2  47.629          ns/op
```
<details>
<summary>Full JMH output</summary>

```
> Task :micrometer-benchmarks-core:io.micrometer.benchmark.core.TagsBenchmark.main()
# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.dotAnd

# Run progress: 0.00% complete, ETA 00:05:20
# Fork: 1 of 1
# Warmup Iteration   1: 90.438 ns/op
# Warmup Iteration   2: 87.639 ns/op
Iteration   1: 87.696 ns/op
Iteration   2: 109.139 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.dotAnd":
  98.417 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.of

# Run progress: 12.50% complete, ETA 00:04:41
# Fork: 1 of 1
# Warmup Iteration   1: 46.801 ns/op
# Warmup Iteration   2: 46.672 ns/op
Iteration   1: 45.042 ns/op
Iteration   2: 45.459 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.of":
  45.250 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet10

# Run progress: 25.00% complete, ETA 00:04:01
# Fork: 1 of 1
# Warmup Iteration   1: 70.377 ns/op
# Warmup Iteration   2: 70.155 ns/op
Iteration   1: 70.001 ns/op
Iteration   2: 69.993 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet10":
  69.997 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet2

# Run progress: 37.50% complete, ETA 00:03:21
# Fork: 1 of 1
# Warmup Iteration   1: 22.845 ns/op
# Warmup Iteration   2: 22.739 ns/op
Iteration   1: 22.661 ns/op
Iteration   2: 22.604 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet2":
  22.632 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet4

# Run progress: 50.00% complete, ETA 00:02:40
# Fork: 1 of 1
# Warmup Iteration   1: 34.573 ns/op
# Warmup Iteration   2: 32.922 ns/op
Iteration   1: 32.926 ns/op
Iteration   2: 32.979 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet4":
  32.953 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet10

# Run progress: 62.50% complete, ETA 00:02:00
# Fork: 1 of 1
# Warmup Iteration   1: 96.586 ns/op
# Warmup Iteration   2: 90.373 ns/op
Iteration   1: 90.258 ns/op
Iteration   2: 89.825 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet10":
  90.041 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet2

# Run progress: 75.00% complete, ETA 00:01:20
# Fork: 1 of 1
# Warmup Iteration   1: 21.841 ns/op
# Warmup Iteration   2: 23.070 ns/op
Iteration   1: 23.304 ns/op
Iteration   2: 23.225 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet2":
  23.264 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet4

# Run progress: 87.50% complete, ETA 00:00:40
# Fork: 1 of 1
# Warmup Iteration   1: 48.443 ns/op
# Warmup Iteration   2: 47.487 ns/op
Iteration   1: 47.721 ns/op
Iteration   2: 47.536 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet4":
  47.629 ns/op


# Run complete. Total time: 00:05:21

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise
extra caution when trusting the results, look into the generated code to check the benchmark still
works, and factor in a small probability of new VM bugs. Additionally, while comparisons between
different JVMs are already problematic, the performance difference caused by different Blackhole
modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.

Benchmark                               Mode  Cnt   Score   Error  Units
TagsBenchmark.dotAnd                    avgt    2  98.417          ns/op
TagsBenchmark.of                        avgt    2  45.250          ns/op
TagsBenchmark.tagsOfOrderedTagsSet10    avgt    2  69.997          ns/op
TagsBenchmark.tagsOfOrderedTagsSet2     avgt    2  22.632          ns/op
TagsBenchmark.tagsOfOrderedTagsSet4     avgt    2  32.953          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet10  avgt    2  90.041          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet2   avgt    2  23.264          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet4   avgt    2  47.629          ns/op

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```
</details>

```
Benchmark                     Mode  Cnt    Score   Error  Units
TagsMergeBenchmark.mergeTags  avgt    2  275.544          ns/op
```

<details>
<summary>Full JMH output:</summary>

```
> Task :micrometer-benchmarks-core:io.micrometer.benchmark.core.TagsMergeBenchmark.main()
# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsMergeBenchmark.mergeTags

# Run progress: 0.00% complete, ETA 00:00:40
# Fork: 1 of 1
# Warmup Iteration   1: 276.906 ns/op
# Warmup Iteration   2: 275.613 ns/op
Iteration   1: 275.369 ns/op
Iteration   2: 275.719 ns/op


Result "io.micrometer.benchmark.core.TagsMergeBenchmark.mergeTags":
  275.544 ns/op


# Run complete. Total time: 00:00:40

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise
extra caution when trusting the results, look into the generated code to check the benchmark still
works, and factor in a small probability of new VM bugs. Additionally, while comparisons between
different JVMs are already problematic, the performance difference caused by different Blackhole
modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.

Benchmark                     Mode  Cnt    Score   Error  Units
TagsMergeBenchmark.mergeTags  avgt    2  275.544          ns/op

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```
</details>

With optimisations (05512c2d254912c857db61e02b67e6d650fa0f84): 
```
Benchmark                               Mode  Cnt   Score   Error  Units
TagsBenchmark.dotAnd                    avgt    2  40.889          ns/op
TagsBenchmark.of                        avgt    2  36.411          ns/op
TagsBenchmark.tagsOfOrderedTagsSet10    avgt    2  31.092          ns/op
TagsBenchmark.tagsOfOrderedTagsSet2     avgt    2   3.885          ns/op
TagsBenchmark.tagsOfOrderedTagsSet4     avgt    2   9.395          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet10  avgt    2  31.206          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet2   avgt    2   3.872          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet4   avgt    2   9.486          ns/op
```

<details>
<summary>Full JMH output:</summary>

```
> Task :micrometer-benchmarks-core:io.micrometer.benchmark.core.TagsBenchmark.main()
# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.dotAnd

# Run progress: 0.00% complete, ETA 00:05:20
# Fork: 1 of 1
# Warmup Iteration   1: 41.712 ns/op
# Warmup Iteration   2: 41.486 ns/op
Iteration   1: 40.870 ns/op
Iteration   2: 40.907 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.dotAnd":
  40.889 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.of

# Run progress: 12.50% complete, ETA 00:04:41
# Fork: 1 of 1
# Warmup Iteration   1: 31.779 ns/op
# Warmup Iteration   2: 31.810 ns/op
Iteration   1: 31.638 ns/op
Iteration   2: 41.185 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.of":
  36.411 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet10

# Run progress: 25.00% complete, ETA 00:04:01
# Fork: 1 of 1
# Warmup Iteration   1: 31.355 ns/op
# Warmup Iteration   2: 31.382 ns/op
Iteration   1: 31.102 ns/op
Iteration   2: 31.083 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet10":
  31.092 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet2

# Run progress: 37.50% complete, ETA 00:03:21
# Fork: 1 of 1
# Warmup Iteration   1: 3.997 ns/op
# Warmup Iteration   2: 4.002 ns/op
Iteration   1: 3.895 ns/op
Iteration   2: 3.875 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet2":
  3.885 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet4

# Run progress: 50.00% complete, ETA 00:02:40
# Fork: 1 of 1
# Warmup Iteration   1: 10.041 ns/op
# Warmup Iteration   2: 9.914 ns/op
Iteration   1: 9.432 ns/op
Iteration   2: 9.357 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfOrderedTagsSet4":
  9.395 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet10

# Run progress: 62.50% complete, ETA 00:02:00
# Fork: 1 of 1
# Warmup Iteration   1: 31.330 ns/op
# Warmup Iteration   2: 31.318 ns/op
Iteration   1: 31.111 ns/op
Iteration   2: 31.302 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet10":
  31.206 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet2

# Run progress: 75.00% complete, ETA 00:01:20
# Fork: 1 of 1
# Warmup Iteration   1: 4.043 ns/op
# Warmup Iteration   2: 4.025 ns/op
Iteration   1: 3.880 ns/op
Iteration   2: 3.865 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet2":
  3.872 ns/op


# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet4

# Run progress: 87.50% complete, ETA 00:00:40
# Fork: 1 of 1
# Warmup Iteration   1: 9.849 ns/op
# Warmup Iteration   2: 9.861 ns/op
Iteration   1: 9.545 ns/op
Iteration   2: 9.426 ns/op


Result "io.micrometer.benchmark.core.TagsBenchmark.tagsOfUnorderedTagsSet4":
  9.486 ns/op


# Run complete. Total time: 00:05:21

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise
extra caution when trusting the results, look into the generated code to check the benchmark still
works, and factor in a small probability of new VM bugs. Additionally, while comparisons between
different JVMs are already problematic, the performance difference caused by different Blackhole
modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.

Benchmark                               Mode  Cnt   Score   Error  Units
TagsBenchmark.dotAnd                    avgt    2  40.889          ns/op
TagsBenchmark.of                        avgt    2  36.411          ns/op
TagsBenchmark.tagsOfOrderedTagsSet10    avgt    2  31.092          ns/op
TagsBenchmark.tagsOfOrderedTagsSet2     avgt    2   3.885          ns/op
TagsBenchmark.tagsOfOrderedTagsSet4     avgt    2   9.395          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet10  avgt    2  31.206          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet2   avgt    2   3.872          ns/op
TagsBenchmark.tagsOfUnorderedTagsSet4   avgt    2   9.486          ns/op

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```
</details>

```
Benchmark                     Mode  Cnt   Score   Error  Units
TagsMergeBenchmark.mergeTags  avgt    2  77.791          ns/op
```

<details>
<summary>Full JMH output:</summary>

```
> Task :micrometer-benchmarks-core:io.micrometer.benchmark.core.TagsMergeBenchmark.main()
# JMH version: 1.37
# VM version: JDK 21.0.1, OpenJDK 64-Bit Server VM, 21.0.1+12-LTS
# VM invoker: /Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=PL -Duser.language=en -Duser.variant
# Blackhole mode: compiler (auto-detected, use -Djmh.blackhole.autoDetect=false to disable)
# Warmup: 2 iterations, 10 s each
# Measurement: 2 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: io.micrometer.benchmark.core.TagsMergeBenchmark.mergeTags

# Run progress: 0.00% complete, ETA 00:00:40
# Fork: 1 of 1
# Warmup Iteration   1: 78.302 ns/op
# Warmup Iteration   2: 77.982 ns/op
Iteration   1: 77.720 ns/op
Iteration   2: 77.862 ns/op


Result "io.micrometer.benchmark.core.TagsMergeBenchmark.mergeTags":
  77.791 ns/op


# Run complete. Total time: 00:00:40

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

NOTE: Current JVM experimentally supports Compiler Blackholes, and they are in use. Please exercise
extra caution when trusting the results, look into the generated code to check the benchmark still
works, and factor in a small probability of new VM bugs. Additionally, while comparisons between
different JVMs are already problematic, the performance difference caused by different Blackhole
modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.

Benchmark                     Mode  Cnt   Score   Error  Units
TagsMergeBenchmark.mergeTags  avgt    2  77.791          ns/op

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.
```
</details>
Part of #5140.