### PR TITLE
Remove space at beginning of line in doc

### DIFF
--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -17,4 +17,4 @@ The `micrometer-core` module aims to have minimal dependencies. It does not requ
 
 Use of the xref:concepts/timers.adoc#pause-detection[pause detection] feature requires the https://github.com/LatencyUtils/LatencyUtils[LatencyUtils] dependency to be available on the classpath at runtime. If your application does not use the pause detection feature, you can exclude LatencyUtils from your runtime classpath.
 
- If you use xref:concepts/histogram-quantiles.adoc[client-side percentiles], you need https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] on the classpath at runtime. If you do not use client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.
+If you use xref:concepts/histogram-quantiles.adoc[client-side percentiles], you need https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] on the classpath at runtime. If you do not use client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.


### PR DESCRIPTION
Remove a leading space at the beginning of a line in the `Concepts` documentation page.