### PR TITLE
Use the current timestamp for otlp gauges

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -309,7 +309,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         return getMetricBuilder(gauge.getId())
             .setGauge(io.opentelemetry.proto.metrics.v1.Gauge.newBuilder()
                 .addDataPoints(NumberDataPoint.newBuilder()
-                    .setTimeUnixNano(getTimeUnixNano())
+                    .setTimeUnixNano(TimeUnit.MILLISECONDS.toNanos(clock.wallTime()))
                     .setAsDouble(gauge.value())
                     .addAllAttributes(getTagsForId(gauge.getId()))
                     .build()))

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -78,7 +78,9 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         Metric metric = writeToMetric(gauge);
         assertThat(metric.getGauge()).isNotNull();
         assertThat(metric.getGauge().getDataPoints(0).getAsDouble()).isEqualTo(5);
-        assertThat(metric.getGauge().getDataPoints(0).getTimeUnixNano()).isEqualTo(TimeUnit.MINUTES.toNanos(1));
+        assertThat(metric.getGauge().getDataPoints(0).getTimeUnixNano())
+            .describedAs("Gauges should have timestamp of the instant when data is sampled")
+            .isEqualTo(otlpConfig().step().plus(Duration.ofMillis(1)).toNanos());
     }
 
     @Test
@@ -88,7 +90,9 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         Metric metric = writeToMetric(timeGauge);
         assertThat(metric.getGauge()).isNotNull();
         assertThat(metric.getGauge().getDataPoints(0).getAsDouble()).isEqualTo(0.024);
-        assertThat(metric.getGauge().getDataPoints(0).getTimeUnixNano()).isEqualTo(TimeUnit.MINUTES.toNanos(1));
+        assertThat(metric.getGauge().getDataPoints(0).getTimeUnixNano())
+            .describedAs("Gauges should have timestamp of the instant when data is sampled")
+            .isEqualTo(otlpConfig().step().plus(Duration.ofMillis(1)).toNanos());
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/micrometer/issues/5044