### PR TITLE
Fix AspectJ pointcut syntax

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -167,7 +167,7 @@ public class CountedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Counted) and not @annotation(io.micrometer.core.annotation.Counted)")
+    @Around("@within(io.micrometer.core.annotation.Counted) && !@annotation(io.micrometer.core.annotation.Counted)")
     @Nullable
     public Object countedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -161,7 +161,7 @@ public class TimedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Timed) and not @annotation(io.micrometer.core.annotation.Timed)")
+    @Around("@within(io.micrometer.core.annotation.Timed) && !@annotation(io.micrometer.core.annotation.Timed)")
     @Nullable
     public Object timedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -105,7 +105,7 @@ public class ObservedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.observation.annotation.Observed) and not @annotation(io.micrometer.observation.annotation.Observed)")
+    @Around("@within(io.micrometer.observation.annotation.Observed) && !@annotation(io.micrometer.observation.annotation.Observed)")
     @Nullable
     public Object observeClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {


### PR DESCRIPTION
AspectJ pointcuts use the `&&` and `!` operators and the alternative word form syntax with `and` and `not` operators is only allowed for load-time weaving with `aop.xml` which cannot use the symbols in the XML. This fixes compile-time weaving support which failed on the `and not` syntax.