### PR TITLE
Fix AspectJ load-time weaving and class-level annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,7 @@ subprojects {
             ext.year = Calendar.getInstance().get(Calendar.YEAR)
             skipExistingHeaders = true
             exclude '**/*.json' // comments not supported
+            exclude '**/aop.xml'
         }
 
         spotless {
@@ -337,7 +338,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-registry-prometheus', 'micrometer-registry-prometheus-simpleclient', 'micrometer-jakarta9', 'micrometer-java11', 'micrometer-jetty12'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
+            if (!(project.name in ['micrometer-registry-prometheus', 'micrometer-registry-prometheus-simpleclient', 'micrometer-jakarta9', 'micrometer-java11', 'micrometer-jetty12', 'micrometer-test-aspectj-ltw'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -167,7 +167,7 @@ public class CountedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Counted) and not @annotation(io.micrometer.core.annotation.Counted)")
+    @Around("@within(io.micrometer.core.annotation.Counted) && !@annotation(io.micrometer.core.annotation.Counted) && execution(* *(..))")
     @Nullable
     public Object countedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {
@@ -198,15 +198,21 @@ public class CountedAspect {
      * {@link Counted#recordFailuresOnly()} is set to {@code false}, a success is
      * recorded.
      * @param pjp Encapsulates some information about the intercepted area.
-     * @param counted The annotation.
      * @return Whatever the intercepted method returns.
      * @throws Throwable When the intercepted method throws one.
      */
-    @Around(value = "@annotation(counted)", argNames = "pjp,counted")
+    @Around("execution (@io.micrometer.core.annotation.Counted * *.*(..))")
     @Nullable
-    public Object interceptAndRecord(ProceedingJoinPoint pjp, Counted counted) throws Throwable {
+    public Object interceptAndRecord(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {
             return pjp.proceed();
+        }
+
+        Method method = ((MethodSignature) pjp.getSignature()).getMethod();
+        Counted counted = method.getAnnotation(Counted.class);
+        if (counted == null) {
+            method = pjp.getTarget().getClass().getMethod(method.getName(), method.getParameterTypes());
+            counted = method.getAnnotation(Counted.class);
         }
 
         return perform(pjp, counted);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -161,7 +161,7 @@ public class TimedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.core.annotation.Timed) and not @annotation(io.micrometer.core.annotation.Timed)")
+    @Around("@within(io.micrometer.core.annotation.Timed) && !@annotation(io.micrometer.core.annotation.Timed) && execution(* *(..))")
     @Nullable
     public Object timedClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -105,7 +105,7 @@ public class ObservedAspect {
         this.shouldSkip = shouldSkip;
     }
 
-    @Around("@within(io.micrometer.observation.annotation.Observed) and not @annotation(io.micrometer.observation.annotation.Observed)")
+    @Around("@within(io.micrometer.observation.annotation.Observed) && !@annotation(io.micrometer.observation.annotation.Observed) && execution(* *.*(..))")
     @Nullable
     public Object observeClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {

--- a/micrometer-test-aspectj-ltw/build.gradle
+++ b/micrometer-test-aspectj-ltw/build.gradle
@@ -1,0 +1,25 @@
+plugins {
+    id 'java'
+}
+
+group = 'io.micrometer'
+
+repositories {
+    mavenCentral()
+}
+
+configurations {
+    agents
+}
+
+dependencies {
+    agents libs.aspectjweaver
+    implementation project(':micrometer-core')
+    testImplementation libs.junitJupiter
+    testImplementation libs.assertj
+}
+
+test {
+    useJUnitPlatform()
+    jvmArgs '-javaagent:' + configurations.agents.files.find { it.name.startsWith('aspectjweaver') }
+}

--- a/micrometer-test-aspectj-ltw/src/main/java/io/micrometer/MeasuredClass.java
+++ b/micrometer-test-aspectj-ltw/src/main/java/io/micrometer/MeasuredClass.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer;
+
+import io.micrometer.core.annotation.Counted;
+import io.micrometer.core.annotation.Timed;
+
+@Counted
+@Timed
+public class MeasuredClass {
+
+    @Timed
+    public void timedMethod() {
+    }
+
+    @Counted
+    public void countedMethod() {
+    }
+
+    public void classLevelTimedMethod() {
+    }
+
+    public void classLevelCountedMethod() {
+    }
+
+}

--- a/micrometer-test-aspectj-ltw/src/main/java/io/micrometer/package-info.java
+++ b/micrometer-test-aspectj-ltw/src/main/java/io/micrometer/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for testing.
+ */
+package io.micrometer;

--- a/micrometer-test-aspectj-ltw/src/main/resources/META-INF/aop.xml
+++ b/micrometer-test-aspectj-ltw/src/main/resources/META-INF/aop.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE aspectj PUBLIC "-//AspectJ//DTD//EN" "https://eclipse.dev/aspectj/dtd/aspectj.dtd">
+<aspectj>
+  <weaver options="-verbose -showWeaveInfo">
+    <include within="io.micrometer.core.aop.*"/>
+    <include within="io.micrometer.MeasuredClass"/>
+  </weaver>
+  <aspects>
+    <aspect name="io.micrometer.core.aop.CountedAspect"/>
+    <aspect name="io.micrometer.core.aop.TimedAspect"/>
+  </aspects>
+</aspectj>

--- a/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/MeasuredClassTest.java
+++ b/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/MeasuredClassTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.*;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MeasuredClassTest {
+
+    static MeterRegistry meterRegistry;
+
+    @BeforeAll
+    static void setUpAll() {
+        meterRegistry = new SimpleMeterRegistry();
+        Metrics.addRegistry(meterRegistry);
+    }
+
+    MeasuredClass measuredClass;
+
+    @BeforeEach
+    void setUp() {
+        measuredClass = new MeasuredClass();
+    }
+
+    @Test
+    void it_measures_timed_method() {
+        measuredClass.timedMethod();
+
+        var timer = meterRegistry.get("method.timed")
+            .tag("class", MeasuredClass.class.getName())
+            .tag("method", "timedMethod")
+            .timer();
+
+        assertThat(timer.count()).isOne();
+
+        measuredClass.timedMethod();
+        assertThat(timer.count()).isEqualTo(2);
+    }
+
+    @Test
+    void it_measures_counted_method() {
+        measuredClass.countedMethod();
+
+        var counter = meterRegistry.get("method.counted")
+            .tag("class", MeasuredClass.class.getName())
+            .tag("method", "countedMethod")
+            .counter();
+
+        assertThat(counter.count()).isOne();
+
+        measuredClass.countedMethod();
+        assertThat(counter.count()).isEqualTo(2);
+    }
+
+    @Test
+    void it_measures_class_level_timed_method() {
+        measuredClass.classLevelTimedMethod();
+
+        var timer = meterRegistry.get("method.timed")
+            .tag("class", MeasuredClass.class.getName())
+            .tag("method", "classLevelTimedMethod")
+            .timer();
+
+        assertThat(timer.count()).isOne();
+
+        measuredClass.classLevelTimedMethod();
+        assertThat(timer.count()).isEqualTo(2);
+    }
+
+    @Test
+    void it_measures_class_level_counted_method() {
+        measuredClass.classLevelCountedMethod();
+
+        var counter = meterRegistry.get("method.counted")
+            .tag("class", MeasuredClass.class.getName())
+            .tag("method", "classLevelCountedMethod")
+            .counter();
+
+        assertThat(counter.count()).isOne();
+
+        measuredClass.classLevelCountedMethod();
+        assertThat(counter.count()).isEqualTo(2);
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,7 @@ include 'micrometer-commons', 'micrometer-core', 'micrometer-observation'
     project(":micrometer-samples-$sample").projectDir = new File(rootProject.projectDir, "samples/micrometer-samples-$sample")
 }
 
-include 'micrometer-test', 'micrometer-observation-test'
+include 'micrometer-test', 'micrometer-observation-test', 'micrometer-test-aspectj-ltw'
 
 ['atlas', 'prometheus', 'prometheus-simpleclient', 'datadog', 'elastic', 'ganglia', 'graphite', 'health', 'jmx', 'influx', 'otlp', 'statsd', 'new-relic', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver', 'opentsdb'].each { sys ->
     include "micrometer-registry-$sys"


### PR DESCRIPTION
The pointcut syntax used in the aspects is not valid for the AspectJ
weaver/compiler. Replaced `and not` with `&& !` to fix it and also had
to add a condition to match only methods and not constructors which the
implementation assumed it gets.

One problem was that the aspects were only tested with Spring AOP
proxies, but AspectJ weaver/compiler bugs were going unnoticed.  The
added LTW test module will run with the `aspectjweaver` java agent to
weave the classes at load time, then tests if the aspects are applied
and metrics collected as expected.
