### PR TITLE
Apply NamingConvention to tags for OtlpMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -298,7 +298,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
     }
 
     private Iterable<? extends KeyValue> getTagsForId(Meter.Id id) {
-        return id.getTags()
+        return id.getConventionTags(config().namingConvention())
             .stream()
             .map(tag -> createKeyValue(tag.getKey(), tag.getValue()))
             .collect(Collectors.toList());


### PR DESCRIPTION
This PR applies `NamingConvention` to tags for `OtlpMeterRegistry`.

See https://github.com/micrometer-metrics/micrometer/issues/4053#issuecomment-1702959975