### PR TITLE
Add "grpc.canceled" tag for gRPC observation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcServerObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/DefaultGrpcServerObservationConvention.java
@@ -50,6 +50,7 @@ public class DefaultGrpcServerObservationConvention implements GrpcServerObserva
         if (context.getStatusCode() != null) {
             keyValues.add(LowCardinalityKeyNames.STATUS_CODE.withValue(context.getStatusCode().name()));
         }
+        keyValues.add(LowCardinalityKeyNames.CANCELLED.withValue(Boolean.toString(context.isCancelled())));
         return KeyValues.of(keyValues);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
@@ -83,6 +83,12 @@ public enum GrpcObservationDocumentation implements ObservationDocumentation {
             public String asString() {
                 return "grpc.status_code";
             }
+        },
+        CANCELLED {
+            @Override
+            public String asString() {
+                return "grpc.cancelled";
+            }
         }
 
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
@@ -50,6 +50,8 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
 
     private Metadata trailers;
 
+    private boolean cancelled;
+
     public GrpcServerObservationContext(Getter<Metadata> getter) {
         super(getter);
     }
@@ -138,6 +140,23 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
      */
     public void setTrailers(Metadata trailers) {
         this.trailers = trailers;
+    }
+
+    /**
+     * Indicate whether the request is cancelled or not.
+     * @return {@code true} if the request is cancelled
+     * @since 1.14
+     */
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Set {@code true} when the request is cancelled.
+     * @since 1.14
+     */
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
@@ -67,6 +67,7 @@ class ObservationGrpcServerCall<ReqT, RespT> extends SimpleForwardingServerCall<
         GrpcServerObservationContext context = (GrpcServerObservationContext) this.observation.getContext();
         context.setStatusCode(status.getCode());
         context.setTrailers(trailersToKeep);
+        context.setCancelled(isCancelled());
         super.close(status, trailers);
     }
 


### PR DESCRIPTION
When the gRPC server detects a cancelation of the client request, add the `grpc.canceled` tag to the observation.

Cloese #5109