### PR TITLE
Add "cancelled" event to the gRPC observation instrumentation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationDocumentation.java
@@ -121,6 +121,12 @@ public enum GrpcObservationDocumentation implements ObservationDocumentation {
                 return "sent";
             }
 
+        },
+        CANCELLED {
+            @Override
+            public String getName() {
+                return "cancelled";
+            }
         }
 
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCallListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCallListener.java
@@ -49,6 +49,7 @@ class ObservationGrpcServerCallListener<RespT> extends SimpleForwardingServerCal
 
     @Override
     public void onCancel() {
+        this.observation.event(GrpcServerEvents.CANCELLED);
         try (Scope scope = this.observation.openScope()) {
             super.onCancel();
         }


### PR DESCRIPTION
When the gRPC server detects a cancelation of the client request, add `cancelled` event to the observation.


Closes #5109