### PR TITLE
Fix log to include stack trace in OtlpMeterRegistry.publish()

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -172,7 +172,8 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                 }
             }
             catch (Throwable e) {
-                logger.warn("Failed to publish metrics to OTLP receiver (context: {})", getConfigurationContext(), e);
+                logger.warn(String.format("Failed to publish metrics to OTLP receiver (context: %s)",
+                        getConfigurationContext()), e);
             }
         }
     }


### PR DESCRIPTION
This PR fixes log to include stack trace in `OtlpMeterRegistry.publish()`.

See gh-4829