### PR TITLE
Add Javadoc since for PushMeterRegistry.startMessage()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/push/PushMeterRegistry.java
@@ -123,6 +123,7 @@ public abstract class PushMeterRegistry extends MeterRegistry {
      * registry implementation that may be helpful in troubleshooting. By default, the
      * registry class name and step interval are included.
      * @return message to log on registry start
+     * @since 1.13.0
      */
     protected String startMessage() {
         return "publishing metrics for " + getClass().getSimpleName() + " every " + TimeUtils.format(config.step());


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `PushMeterRegistry.startMessage()`.

See gh-4848