### PR TITLE
Update japicmp compatibleVersion to 1.12.0 for 1.13.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,7 +337,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-registry-prometheus', 'micrometer-registry-prometheus-simpleclient', 'micrometer-jakarta9', 'micrometer-java11', 'micrometer-jetty12'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
+            if (!(project.name in ['micrometer-registry-prometheus', 'micrometer-registry-prometheus-simpleclient', 'micrometer-java11', 'micrometer-jetty12'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1g
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
 
-compatibleVersion=1.11.0
+compatibleVersion=1.12.0
 
 kotlin.stdlib.default.dependency=false
 


### PR DESCRIPTION
This PR updates the `compatibleVersion` property in the `gradle.properties` to 1.12.0 for the 1.13.x branch.

This PR also removes the `micrometer-jakarta9` module from the japicmp skip list.