### PR TITLE
Service level objectives support on `@Timed` annotation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/annotation/Timed.java
@@ -75,6 +75,15 @@ public @interface Timed {
     boolean histogram() default false;
 
     /**
+     * List of service level objectives to calculate client-side for the
+     * {@link io.micrometer.core.instrument.Timer} in seconds. For example, for a 100ms
+     * should be passed as {@code 0.1}.
+     * @return service level objectives to calculate
+     * @see io.micrometer.core.instrument.Timer.Builder#serviceLevelObjectives(java.time.Duration...)
+     */
+    double[] serviceLevelObjectives() default {};
+
+    /**
      * Description of the {@link io.micrometer.core.instrument.Timer}.
      * @return meter description
      * @see io.micrometer.core.instrument.Timer.Builder#description(String)

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -258,9 +258,12 @@ public class TimedAspect {
             .tags(EXCEPTION_TAG, exceptionClass)
             .tags(tagsBasedOnJoinPoint.apply(pjp))
             .publishPercentileHistogram(timed.histogram())
-            .serviceLevelObjectives((Duration[]) Arrays.stream(timed.serviceLevelObjectives())
-                .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                .toArray());
+            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0 ?
+                (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                    .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                    .toArray()
+                : null
+            );
 
         if (meterTagAnnotationHandler != null) {
             meterTagAnnotationHandler.addAnnotatedParameters(builder, pjp);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -246,7 +246,7 @@ public class TimedAspect {
             sample.stop(recordBuilder(pjp, timed, metricName, exceptionClass).register(registry));
         }
         catch (Exception e) {
-            // ignoring on purpose
+            System.out.println(e);// ignoring on purpose
         }
     }
 
@@ -258,11 +258,10 @@ public class TimedAspect {
             .tags(EXCEPTION_TAG, exceptionClass)
             .tags(tagsBasedOnJoinPoint.apply(pjp))
             .publishPercentileHistogram(timed.histogram())
-            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0
-                    ? (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+            .serviceLevelObjectives(
+                    timed.serviceLevelObjectives().length > 0 ? Arrays.stream(timed.serviceLevelObjectives())
                         .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                        .toArray()
-                    : null);
+                        .toArray(Duration[]::new) : null);
 
         if (meterTagAnnotationHandler != null) {
             meterTagAnnotationHandler.addAnnotatedParameters(builder, pjp);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -246,7 +246,7 @@ public class TimedAspect {
             sample.stop(recordBuilder(pjp, timed, metricName, exceptionClass).register(registry));
         }
         catch (Exception e) {
-            System.out.println(e);// ignoring on purpose
+            // ignoring on purpose
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -258,12 +258,11 @@ public class TimedAspect {
             .tags(EXCEPTION_TAG, exceptionClass)
             .tags(tagsBasedOnJoinPoint.apply(pjp))
             .publishPercentileHistogram(timed.histogram())
-            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0 ?
-                (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
-                    .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                    .toArray()
-                : null
-            );
+            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0
+                    ? (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                        .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                        .toArray()
+                    : null);
 
         if (meterTagAnnotationHandler != null) {
             meterTagAnnotationHandler.addAnnotatedParameters(builder, pjp);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -20,14 +20,18 @@ import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.util.TimeUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -254,7 +258,10 @@ public class TimedAspect {
             .tags(EXCEPTION_TAG, exceptionClass)
             .tags(tagsBasedOnJoinPoint.apply(pjp))
             .publishPercentileHistogram(timed.histogram())
-            .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles());
+            .serviceLevelObjectives((Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                .toArray());
+
         if (meterTagAnnotationHandler != null) {
             meterTagAnnotationHandler.addAnnotatedParameters(builder, pjp);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -102,9 +102,12 @@ public interface Timer extends Meter, HistogramSupport {
             .description(timed.description().isEmpty() ? null : timed.description())
             .publishPercentileHistogram(timed.histogram())
             .publishPercentiles(timed.percentiles().length > 0 ? timed.percentiles() : null)
-            .serviceLevelObjectives((Duration[]) Arrays.stream(timed.serviceLevelObjectives())
-                .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                .toArray());
+            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0 ?
+                (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                    .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                    .toArray()
+                : null
+            );
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -22,9 +22,12 @@ import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;
@@ -100,7 +103,10 @@ public interface Timer extends Meter, HistogramSupport {
         return new Builder(timed.value().isEmpty() ? defaultName : timed.value()).tags(timed.extraTags())
             .description(timed.description().isEmpty() ? null : timed.description())
             .publishPercentileHistogram(timed.histogram())
-            .publishPercentiles(timed.percentiles().length > 0 ? timed.percentiles() : null);
+            .publishPercentiles(timed.percentiles().length > 0 ? timed.percentiles() : null)
+            .serviceLevelObjectives((Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                .toArray());
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -102,11 +102,10 @@ public interface Timer extends Meter, HistogramSupport {
             .description(timed.description().isEmpty() ? null : timed.description())
             .publishPercentileHistogram(timed.histogram())
             .publishPercentiles(timed.percentiles().length > 0 ? timed.percentiles() : null)
-            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0
-                    ? (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+            .serviceLevelObjectives(
+                    timed.serviceLevelObjectives().length > 0 ? Arrays.stream(timed.serviceLevelObjectives())
                         .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                        .toArray()
-                    : null);
+                        .toArray(Duration[]::new) : null);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -102,12 +102,11 @@ public interface Timer extends Meter, HistogramSupport {
             .description(timed.description().isEmpty() ? null : timed.description())
             .publishPercentileHistogram(timed.histogram())
             .publishPercentiles(timed.percentiles().length > 0 ? timed.percentiles() : null)
-            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0 ?
-                (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
-                    .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
-                    .toArray()
-                : null
-            );
+            .serviceLevelObjectives(timed.serviceLevelObjectives().length > 0
+                    ? (Duration[]) Arrays.stream(timed.serviceLevelObjectives())
+                        .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))
+                        .toArray()
+                    : null);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -25,9 +25,7 @@ import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/resources/TimedResource.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jersey/server/resources/TimedResource.java
@@ -55,6 +55,13 @@ public class TimedResource {
     }
 
     @GET
+    @Path("timed-slo")
+    @Timed(value = "timedSlo", histogram = true, serviceLevelObjectives = { 0.1, 0.5 })
+    public String timedSlo() {
+        return "timed";
+    }
+
+    @GET
     @Path("multi-timed")
     @Timed("multi1")
     @Timed("multi2")


### PR DESCRIPTION
Adding the ability to specify, on `@Timed` annotations, the service level objectives.
Using seconds as the unit of time for these values.