### PR TITLE
Upgrade CI machine image to ubuntu-2204:2024.05.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ executors:
   machine-executor:
     working_directory: ~/micrometer
     machine:
-      image: ubuntu-2204:2024.01.2
+      image: ubuntu-2204:2024.05.1
 
 commands:
   gradlew-build:


### PR DESCRIPTION
This PR upgrades CI machine image to ubuntu-2204:2024.05.1.