### PR TITLE
Add Javadoc since for PrometheusConfig.prometheusProperties()

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusConfig.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusConfig.java
@@ -68,6 +68,7 @@ public interface PrometheusConfig extends MeterRegistryConfig {
      * {@code io.prometheus.exporter.exemplarsOnAllMetricTypes=true}.
      * @see <a href="https://prometheus.github.io/client_java/config/config/">Prometheus
      * docs</a>
+     * @since 1.13.0
      */
     @Nullable
     default Properties prometheusProperties() {


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `PrometheusConfig.prometheusProperties()`.

See gh-4875