### PR TITLE
Warn about Prometheus meter registration failure

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -16,6 +16,7 @@
 package io.micrometer.prometheusmetrics;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
@@ -67,6 +68,8 @@ import static java.util.stream.StreamSupport.stream;
  * @since 1.13.0
  */
 public class PrometheusMeterRegistry extends MeterRegistry {
+
+    private static final WarnThenDebugLogger log = new WarnThenDebugLogger(PrometheusMeterRegistry.class);
 
     private final PrometheusConfig prometheusConfig;
 
@@ -609,6 +612,24 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         });
 
         return this;
+    }
+
+    @Override
+    protected void meterRegistrationFailed(Meter.Id id, String reason) {
+        super.meterRegistrationFailed(id, reason);
+
+        log.log(() -> createMeterRegistrationFailureMessage(id, reason));
+    }
+
+    private static String createMeterRegistrationFailureMessage(Meter.Id id, String reason) {
+        String message = String.format("The meter (%s) registration has failed", id);
+        if (reason != null) {
+            message += ": " + reason;
+        }
+        else {
+            message += ".";
+        }
+        return message;
     }
 
     private enum Format {


### PR DESCRIPTION
A meter registration failure seems to be an important event for users, but it's not easy for the users to be aware of the failure unless they register a callback for it.

It would be better to make the users easily aware of the failures by default.

See gh-5192