### PR TITLE
Log warning message with WARN level in logWarningAboutLateFilter() when DEBUG level is enabled

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -841,10 +841,12 @@ public abstract class MeterRegistry {
             InternalLogger logger = InternalLoggerFactory.getInstance(MeterRegistry.this.getClass());
             String baseMessage = "A MeterFilter is being configured after a Meter has been registered to this registry. All MeterFilters should be configured before any Meters are registered. If that is not possible or you have a use case where it should be allowed, let the Micrometer maintainers know at https://github.com/micrometer-metrics/micrometer/issues/4920.";
             if (logger.isDebugEnabled()) {
+                logger.warn(baseMessage);
+
                 String stackTrace = Arrays.stream(Thread.currentThread().getStackTrace())
                     .map(StackTraceElement::toString)
                     .collect(Collectors.joining("\n\tat "));
-                logger.debug(baseMessage + "\n" + stackTrace);
+                logger.debug(stackTrace);
             }
             else {
                 logger.warn(baseMessage

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryLoggingTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryLoggingTest.java
@@ -55,10 +55,11 @@ class MeterRegistryLoggingTest {
         try {
             registerMetricsAndConfigure();
 
-            assertThat(logEvents.withLevel(Level.WARN)).isEmpty();
+            assertThat(logEvents.withLevel(Level.WARN)).singleElement()
+                .extracting(ILoggingEvent::getFormattedMessage, as(InstanceOfAssertFactories.STRING))
+                .contains("A MeterFilter is being configured after a Meter has been registered to this registry.");
             assertThat(logEvents.withLevel(Level.DEBUG)).singleElement()
                 .extracting(ILoggingEvent::getFormattedMessage, as(InstanceOfAssertFactories.STRING))
-                .contains("A MeterFilter is being configured after a Meter has been registered to this registry.")
                 .containsPattern(
                         "io.micrometer.core.instrument.MeterRegistryLoggingTest.configureCommonTags\\(MeterRegistryLoggingTest.java:\\d+\\)\n"
                                 + "\tat io.micrometer.core.instrument.MeterRegistryLoggingTest.registerMetricsAndConfigure\\(MeterRegistryLoggingTest.java:\\d+\\)\n"


### PR DESCRIPTION
Lowering log level for the warning message when DEBUG level is enabled seems to be inconsistent.

See gh-4917