### PR TITLE
Expose ForkJoinPool parallelism and pool size metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -59,6 +59,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
 
     private static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "";
 
+    public static final String DESCRIPTION_POOL_SIZE = "The current number of threads in the pool";
+
     @Nullable
     private final ExecutorService executorService;
 
@@ -362,7 +364,7 @@ public class ExecutorServiceMetrics implements MeterBinder {
 
         Gauge.builder(metricPrefix + "executor.pool.size", tp, ThreadPoolExecutor::getPoolSize)
             .tags(tags)
-            .description("The current number of threads in the pool")
+            .description(DESCRIPTION_POOL_SIZE)
             .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
@@ -385,32 +387,38 @@ public class ExecutorServiceMetrics implements MeterBinder {
             .description("Estimate of the total number of tasks stolen from "
                     + "one thread's work queue by another. The reported value "
                     + "underestimates the actual total number of steals when the pool " + "is not quiescent")
+            .baseUnit(BaseUnits.TASKS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.queued", fj, ForkJoinPool::getQueuedTaskCount)
             .tags(tags)
             .description("An estimate of the total number of tasks currently held in queues by worker threads")
+            .baseUnit(BaseUnits.TASKS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.active", fj, ForkJoinPool::getActiveThreadCount)
             .tags(tags)
             .description("An estimate of the number of threads that are currently stealing or executing tasks")
+            .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.running", fj, ForkJoinPool::getRunningThreadCount)
             .tags(tags)
             .description(
                     "An estimate of the number of worker threads that are not blocked waiting to join tasks or for other managed synchronization threads")
+            .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.parallelism", fj, ForkJoinPool::getParallelism)
             .tags(tags)
             .description("The targeted parallelism level of this pool")
+            .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.pool.size", fj, ForkJoinPool::getPoolSize)
             .tags(tags)
-            .description("The number of worker threads that have started but not yet terminated")
+            .description(DESCRIPTION_POOL_SIZE)
+            .baseUnit(BaseUnits.THREADS)
             .register(registry);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -407,6 +407,11 @@ public class ExecutorServiceMetrics implements MeterBinder {
             .tags(tags)
             .description("The targeted parallelism level of this pool")
             .register(registry);
+
+        Gauge.builder(metricPrefix + "executor.pool.size", fj, ForkJoinPool::getPoolSize)
+            .tags(tags)
+            .description("The number of worker threads that have started but not yet terminated")
+            .register(registry);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -59,7 +59,7 @@ public class ExecutorServiceMetrics implements MeterBinder {
 
     private static final String DEFAULT_EXECUTOR_METRIC_PREFIX = "";
 
-    public static final String DESCRIPTION_POOL_SIZE = "The current number of threads in the pool";
+    private static final String DESCRIPTION_POOL_SIZE = "The current number of threads in the pool";
 
     @Nullable
     private final ExecutorService executorService;
@@ -387,26 +387,22 @@ public class ExecutorServiceMetrics implements MeterBinder {
             .description("Estimate of the total number of tasks stolen from "
                     + "one thread's work queue by another. The reported value "
                     + "underestimates the actual total number of steals when the pool " + "is not quiescent")
-            .baseUnit(BaseUnits.TASKS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.queued", fj, ForkJoinPool::getQueuedTaskCount)
             .tags(tags)
             .description("An estimate of the total number of tasks currently held in queues by worker threads")
-            .baseUnit(BaseUnits.TASKS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.active", fj, ForkJoinPool::getActiveThreadCount)
             .tags(tags)
             .description("An estimate of the number of threads that are currently stealing or executing tasks")
-            .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.running", fj, ForkJoinPool::getRunningThreadCount)
             .tags(tags)
             .description(
                     "An estimate of the number of worker threads that are not blocked waiting to join tasks or for other managed synchronization threads")
-            .baseUnit(BaseUnits.THREADS)
             .register(registry);
 
         Gauge.builder(metricPrefix + "executor.parallelism", fj, ForkJoinPool::getParallelism)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -402,6 +402,11 @@ public class ExecutorServiceMetrics implements MeterBinder {
             .description(
                     "An estimate of the number of worker threads that are not blocked waiting to join tasks or for other managed synchronization threads")
             .register(registry);
+
+        Gauge.builder(metricPrefix + "executor.parallelism", fj, ForkJoinPool::getParallelism)
+            .tags(tags)
+            .description("The targeted parallelism level of this pool")
+            .register(registry);
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -161,6 +161,19 @@ class ExecutorServiceMetricsTest {
             .doesNotThrowAnyException();
     }
 
+    @DisplayName("ForkJoinPool is assigned with its own set of metrics")
+    @ParameterizedTest
+    @CsvSource({ "custom,custom.", "custom.,custom.", ",''", "' ',''" })
+    void forkJoinPool(String metricPrefix, String expectedMetricPrefix) {
+        var fjp = new ForkJoinPool(1);
+        monitorExecutorService("fjp", metricPrefix, fjp);
+        registry.get(expectedMetricPrefix + "executor.steals").tags(userTags).tag("name", "fjp").functionCounter();
+        registry.get(expectedMetricPrefix + "executor.queued").tags(userTags).tag("name", "fjp").gauge();
+        registry.get(expectedMetricPrefix + "executor.running").tags(userTags).tag("name", "fjp").gauge();
+        registry.get(expectedMetricPrefix + "executor.parallelism").tags(userTags).tag("name", "fjp").gauge();
+        registry.get(expectedMetricPrefix + "executor.pool.size").tags(userTags).tag("name", "fjp").gauge();
+    }
+
     @DisplayName("ScheduledExecutorService can be monitored with a default set of metrics")
     @ParameterizedTest
     @CsvSource({ "custom,custom.", "custom.,custom.", ",''", "' ',''" })


### PR DESCRIPTION
Hello, contributors,

I recently switched to using virtual threads, so became a big user of ForkJoinPool. When I looked at metrics, exposed by micrometer, I saw that parallelism isn't exposed. Is there a reason for this? Well, if not, I believe this could be a nice addition to already exposed ones.

I hesitated to add [ForkJoinPool::getPoolSize](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ForkJoinPool.html#getPoolSize()), as I'm not sure this one is important, but I could add it too. What do you think about it?