### PR TITLE
Avoid calling naming convention on scrape

### DIFF
--- a/implementations/micrometer-registry-prometheus-simpleclient/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus-simpleclient/src/test/java/io/micrometer/prometheus/PrometheusMeterRegistryTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.prometheus;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.*;
@@ -715,6 +716,50 @@ class PrometheusMeterRegistryTest {
             .contains("test_slos_bucket{le=\"+Inf\"} 3.0\n");
         assertThat(scraped).doesNotContain("span_id").doesNotContain("trace_id");
         assertThat(scraped).endsWith("# EOF\n");
+    }
+
+    @Test
+    @Issue("#5229")
+    void doesNotCallConventionOnScrape() {
+        CountingPrometheusNamingConvention convention = new CountingPrometheusNamingConvention();
+        registry.config().namingConvention(convention);
+
+        Timer.builder("timer").tag("k1", "v1").description("my timer").register(registry);
+        Counter.builder("counter").tag("k1", "v1").description("my counter").register(registry);
+        DistributionSummary.builder("summary").tag("k1", "v1").description("my summary").register(registry);
+        Gauge.builder("gauge", new AtomicInteger(), AtomicInteger::doubleValue)
+            .tag("k1", "v1")
+            .description("my gauge")
+            .register(registry);
+        LongTaskTimer.builder("long.task.timer").tag("k1", "v1").description("my long task timer").register(registry);
+
+        int expectedNameCount = convention.nameCount.get();
+        int expectedTagKeyCount = convention.tagKeyCount.get();
+
+        registry.scrape();
+
+        assertThat(convention.nameCount.get()).isEqualTo(expectedNameCount);
+        assertThat(convention.tagKeyCount.get()).isEqualTo(expectedTagKeyCount);
+    }
+
+    private static class CountingPrometheusNamingConvention extends PrometheusNamingConvention {
+
+        AtomicInteger nameCount = new AtomicInteger();
+
+        AtomicInteger tagKeyCount = new AtomicInteger();
+
+        @Override
+        public String name(String name, Meter.Type type, @Nullable String baseUnit) {
+            nameCount.incrementAndGet();
+            return super.name(name, type, baseUnit);
+        }
+
+        @Override
+        public String tagKey(String key) {
+            tagKeyCount.incrementAndGet();
+            return super.tagKey(key);
+        }
+
     }
 
     static class TestSpanContextSupplier implements SpanContextSupplier {


### PR DESCRIPTION
The naming convention was being called on each scrape for each metric to create the MetricMetadata. This is unnecessary because we already have the computed convention name specifically to avoid needing to call the convention again.

See #5229

The same test has been added to the micrometer-registry-prometheus module and the simpleclient module as well. The test is passing without changes to the simpleclient module, but the changes made in main code were needed for this to pass in micrometer-registry-prometheus, demonstrating the difference in behavior we want to ensure does not regress in the future.