### PR TITLE
Implement a CloudWatch EmbeddedMetricFormat (EMF) registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,7 +343,7 @@ subprojects {
 
             check.dependsOn("testModules")
 
-            if (!(project.name in ['micrometer-test-aspectj-ltw', 'micrometer-test-aspectj-ctw'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
+            if (!(project.name in ['micrometer-test-aspectj-ltw', 'micrometer-test-aspectj-ctw', 'micrometer-registry-cloudwatch-embedded-metrics'])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/build.gradle
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    api project(':micrometer-core')
+
+    api 'software.amazon.cloudwatchlogs:aws-embedded-metrics:4.1.1'
+    implementation 'org.slf4j:slf4j-api'
+
+    testImplementation libs.mockitoCore5
+    testImplementation project(':micrometer-test')
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsConfig.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsConfig.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.annotation.Incubating;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.validate.Validated;
+import io.micrometer.core.instrument.step.StepRegistryConfig;
+
+import java.time.Duration;
+import java.util.function.Predicate;
+
+import software.amazon.cloudwatchlogs.emf.config.Configuration;
+import software.amazon.cloudwatchlogs.emf.config.EnvironmentConfigurationProvider;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+
+import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;
+import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
+
+/**
+ * Configuration for CloudWatch Embedded Metric Format exporting.
+ *
+ * @author Kyle Sletmoe
+ * @author Dawid Kublik
+ * @since 1.14.0
+ *
+ * Any value found with {@link CloudWatchEmbeddedMetricsConfig::get} will be used,
+ * otherwise we will fall back to the EMF environment configuration mechanism. Lastly, if
+ * not found in the environment, the configuration option will not be set.
+ *
+ * <a href=
+ * "https://github.com/awslabs/aws-embedded-metrics-java/tree/master#configuration">EMF
+ * Configuration</a>
+ */
+public interface CloudWatchEmbeddedMetricsConfig extends StepRegistryConfig {
+
+    /*
+     * This is to aid in testing and probably should not be overridden in a production
+     * environment
+     */
+    default Configuration emfConfiguration() {
+        return EnvironmentConfigurationProvider.getConfig();
+    }
+
+    @Override
+    default String prefix() {
+        return "cloudwatchemf";
+    }
+
+    /*
+     * For much of our config, we want to take any values explicitly set on this config
+     * object, and if those aren't set, utilize any pulled from the environment by EMF.
+     */
+    @Nullable
+    default String logGroupName() {
+        return ConfigFetcher.getOptionalConfig(this, "logGroupName", emfConfiguration().getLogGroupName().orElse(null));
+    }
+
+    @Nullable
+    default String logStreamName() {
+        return ConfigFetcher.getOptionalConfig(this, "logStreamName",
+                emfConfiguration().getLogStreamName().orElse(null));
+    }
+
+    @Nullable
+    default String serviceType() {
+        return ConfigFetcher.getOptionalConfig(this, "serviceType", emfConfiguration().getServiceType().orElse(null));
+    }
+
+    @Nullable
+    default String serviceName() {
+        return ConfigFetcher.getOptionalConfig(this, "serviceName", emfConfiguration().getServiceName().orElse(null));
+    }
+
+    @Nullable
+    default String namespace() {
+        return getString(this, "namespace").orElse(null);
+    }
+
+    @Nullable
+    default String agentEndpoint() {
+        return ConfigFetcher.getOptionalConfig(this, "agentEndpoint",
+                emfConfiguration().getAgentEndpoint().orElse(null));
+    }
+
+    default Integer asyncBufferSize() {
+        Integer configuredValue = getInteger(this, "asyncBufferSize").orElse(null);
+
+        return configuredValue != null ? configuredValue : emfConfiguration().getAsyncBufferSize();
+    }
+
+    /**
+     * Whether we want to emit default dimensions. Defaults to true.
+     * @return The decision about whether to use default dimensions
+     */
+    default boolean useDefaultDimensions() {
+        return getBoolean(this, "useDefaultDimensions").orElse(true);
+    }
+
+    /**
+     * Whether to ship high-resolution metrics to CloudWatch at a higher cost. By default,
+     * if the step interval is less than one minute, we assume that high-resolution
+     * metrics are also desired.
+     * <p>
+     * This is incubating because CloudWatch supports making this decision on a per-metric
+     * level. It's believed that deciding on a per-registry level leads to simpler
+     * configuration and will be satisfactory in most cases. To only ship a certain subset
+     * of metrics at high resolution, two {@link CloudWatchEmbeddedMetricsMeterRegistry}
+     * instances can be configured. One is configured with high-resolution and a
+     * {@link MeterFilter#denyUnless(Predicate)} filter. The other is configured with
+     * low-resolution and a {@link MeterFilter#deny(Predicate)} filter. Both use the same
+     * predicate.
+     * @return The decision about whether to accept higher cost high-resolution metrics.
+     * @since 1.13.0
+     */
+    @Incubating(since = "1.13.0")
+    default StorageResolution storageResolution() {
+        return step().compareTo(Duration.ofMinutes(1)) < 0 ? StorageResolution.HIGH : StorageResolution.STANDARD;
+    }
+
+    @Override
+    default Validated<?> validate() {
+        return checkAll(this, (CloudWatchEmbeddedMetricsConfig c) -> StepRegistryConfig.validate(c));
+    }
+
+    class ConfigFetcher {
+
+        static String getOptionalConfig(CloudWatchEmbeddedMetricsConfig config, String property,
+                @Nullable String environmentConfigValue) {
+            String configuredValue = getString(config, property).orElse(null);
+
+            return configuredValue != null ? configuredValue : environmentConfigValue;
+        }
+
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistry.java
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.step.StepMeterRegistry;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.cloudwatchlogs.emf.Constants;
+import software.amazon.cloudwatchlogs.emf.config.Configuration;
+import software.amazon.cloudwatchlogs.emf.exception.*;
+import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * {@link StepMeterRegistry} for Amazon CloudWatch Embedded Metrics Format (EMF).
+ *
+ * @author Kyle Sletmoe
+ * @author Dawid Kublik
+ * @author Jon Schneider
+ * @author Johnny Lim
+ * @author Pierre-Yves B.
+ * @since 1.14.0
+ */
+public class CloudWatchEmbeddedMetricsMeterRegistry extends StepMeterRegistry {
+
+    private static final Map<String, Unit> UNIT_BY_LOWERCASE_VALUE;
+
+    static {
+        Map<String, Unit> unitByLowercaseValue = new HashMap<>();
+        for (Unit unit : Unit.values()) {
+            if (unit != Unit.UNKNOWN_TO_SDK_VERSION) {
+                unitByLowercaseValue.put(unit.toString().toLowerCase(), unit);
+            }
+        }
+        UNIT_BY_LOWERCASE_VALUE = Collections.unmodifiableMap(unitByLowercaseValue);
+    }
+
+    private final CloudWatchEmbeddedMetricsConfig config;
+
+    private final Configuration metricsLoggerConfig;
+
+    private final MetricsLogger metricsLogger;
+
+    private final Logger logger = LoggerFactory.getLogger(CloudWatchEmbeddedMetricsMeterRegistry.class);
+
+    private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(
+            CloudWatchEmbeddedMetricsMeterRegistry.class);
+
+    public CloudWatchEmbeddedMetricsMeterRegistry(CloudWatchEmbeddedMetricsConfig config, Clock clock) {
+        this(config, clock, new NamedThreadFactory("cloudwatch-embedded-metrics-publisher"));
+    }
+
+    public CloudWatchEmbeddedMetricsMeterRegistry(CloudWatchEmbeddedMetricsConfig config, Clock clock,
+            ThreadFactory threadFactory) {
+        super(config, clock);
+        this.config = config;
+        this.metricsLoggerConfig = CloudWatchEmbeddedMetricsMeterRegistry.buildMetricsLoggerConfig(config);
+
+        this.metricsLogger = new MetricsLogger();
+        this.metricsLogger.setFlushPreserveDimensions(false); // only default dimensions
+                                                              // will remain after a flush
+        String namespace = config.namespace();
+        if (namespace != null) {
+            try {
+                this.metricsLogger.setNamespace(namespace);
+            }
+            catch (InvalidNamespaceException e) {
+                logger.warn("Invalid namespace '" + namespace + "'; using default namespace. " + e);
+            }
+        }
+
+        config().namingConvention(new CloudWatchEmbeddedMetricsNamingConvention());
+        start(threadFactory);
+    }
+
+    private static Configuration buildMetricsLoggerConfig(CloudWatchEmbeddedMetricsConfig config) {
+        Configuration metricsLoggerConfig = new Configuration();
+
+        String logGroupName = config.logGroupName();
+        if (logGroupName != null) {
+            metricsLoggerConfig.setLogGroupName(logGroupName);
+        }
+
+        String logStreamName = config.logStreamName();
+        if (logStreamName != null) {
+            metricsLoggerConfig.setLogStreamName(logStreamName);
+        }
+
+        String serviceType = config.serviceType();
+        if (serviceType != null) {
+            metricsLoggerConfig.setServiceType(serviceType);
+        }
+
+        String serviceName = config.serviceName();
+        if (serviceName != null) {
+            metricsLoggerConfig.setServiceName(serviceName);
+        }
+
+        String agentEndpoint = config.agentEndpoint();
+        if (agentEndpoint != null) {
+            metricsLoggerConfig.setAgentEndpoint(agentEndpoint);
+        }
+
+        metricsLoggerConfig.setAsyncBufferSize(config.asyncBufferSize());
+
+        return metricsLoggerConfig;
+    }
+
+    @Override
+    protected void publish() {
+        boolean interrupted = false;
+        Instant timestamp = getTimestamp();
+        try {
+            sendMetricData(timestamp, metricData());
+        }
+        catch (InterruptedException ex) {
+            interrupted = true;
+        }
+        finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    // VisibleForTesting
+    void sendMetricData(Instant timestamp, List<MetricDatum> metricData) throws InterruptedException {
+        metricsLogger.resetDimensions(config.useDefaultDimensions());
+
+        try {
+            metricsLogger.setTimestamp(timestamp);
+        }
+        catch (InvalidTimestampException e) {
+            logger.warn("Could not set timestamp for metrics step; defaulting to standard timestamp behavior " + e);
+        }
+
+        for (MetricDatum metricDatum : metricData) {
+            if (metricDatum.dimensions != null) {
+                metricsLogger.putDimensions(metricDatum.dimensions);
+            }
+
+            try {
+                metricsLogger.putMetric(metricDatum.metricName, metricDatum.value, metricDatum.unit,
+                        metricDatum.storageResolution);
+            }
+            catch (InvalidMetricException e) {
+                logger.error("Could not publish metric " + metricDatum + "; " + e);
+            }
+        }
+
+        metricsLogger.flush();
+    }
+
+    // VisibleForTesting
+    List<MetricDatum> metricData() {
+        Step step = new Step();
+        // @formatter:off
+        return getMeters().stream()
+            .flatMap(m -> m.match(
+                    step::gaugeData,
+                    step::counterData,
+                    step::timerData,
+                    step::summaryData,
+                    step::longTaskTimerData,
+                    step::timeGaugeData,
+                    step::functionCounterData,
+                    step::functionTimerData,
+                    step::metricData))
+            .collect(toList());
+        // @formatter:on
+    }
+
+    private Instant getTimestamp() {
+        return Instant.ofEpochMilli(clock.wallTime());
+    }
+
+    // VisibleForTesting
+    class Step {
+
+        private Stream<MetricDatum> gaugeData(Gauge gauge) {
+            MetricDatum metricDatum = metricDatum(gauge.getId(), "value", gauge.value());
+            if (metricDatum == null) {
+                return Stream.empty();
+            }
+            return Stream.of(metricDatum);
+        }
+
+        private Stream<MetricDatum> counterData(Counter counter) {
+            return Stream.of(metricDatum(counter.getId(), "count", Unit.COUNT, counter.count()));
+        }
+
+        // VisibleForTesting
+        Stream<MetricDatum> timerData(Timer timer) {
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            metrics
+                .add(metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
+            long count = timer.count();
+            metrics.add(metricDatum(timer.getId(), "count", Unit.COUNT, count));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
+                metrics.add(metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
+            }
+            return metrics.build();
+        }
+
+        // VisibleForTesting
+        Stream<MetricDatum> summaryData(DistributionSummary summary) {
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            metrics.add(metricDatum(summary.getId(), "sum", summary.totalAmount()));
+            long count = summary.count();
+            metrics.add(metricDatum(summary.getId(), "count", Unit.COUNT, count));
+            if (count > 0) {
+                metrics.add(metricDatum(summary.getId(), "avg", summary.mean()));
+                metrics.add(metricDatum(summary.getId(), "max", summary.max()));
+            }
+            return metrics.build();
+        }
+
+        private Stream<MetricDatum> longTaskTimerData(LongTaskTimer longTaskTimer) {
+            return Stream.of(metricDatum(longTaskTimer.getId(), "activeTasks", longTaskTimer.activeTasks()),
+                    metricDatum(longTaskTimer.getId(), "duration", longTaskTimer.duration(getBaseTimeUnit())));
+        }
+
+        private Stream<MetricDatum> timeGaugeData(TimeGauge gauge) {
+            MetricDatum metricDatum = metricDatum(gauge.getId(), "value", gauge.value(getBaseTimeUnit()));
+            if (metricDatum == null) {
+                return Stream.empty();
+            }
+            return Stream.of(metricDatum);
+        }
+
+        // VisibleForTesting
+        Stream<MetricDatum> functionCounterData(FunctionCounter counter) {
+            MetricDatum metricDatum = metricDatum(counter.getId(), "count", Unit.COUNT, counter.count());
+            if (metricDatum == null) {
+                return Stream.empty();
+            }
+            return Stream.of(metricDatum);
+        }
+
+        // VisibleForTesting
+        Stream<MetricDatum> functionTimerData(FunctionTimer timer) {
+            // we can't know anything about max and percentiles originating from a
+            // function timer
+            double sum = timer.totalTime(getBaseTimeUnit());
+            if (!Double.isFinite(sum)) {
+                return Stream.empty();
+            }
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            double count = timer.count();
+            metrics.add(metricDatum(timer.getId(), "count", Unit.COUNT, count));
+            metrics.add(metricDatum(timer.getId(), "sum", sum));
+            if (count > 0) {
+                metrics.add(metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+            }
+            return metrics.build();
+        }
+
+        // VisibleForTesting
+        Stream<MetricDatum> metricData(Meter m) {
+            return stream(m.measure().spliterator(), false)
+                .map(ms -> metricDatum(m.getId().withTag(ms.getStatistic()), ms.getValue()))
+                .filter(Objects::nonNull);
+        }
+
+        @Nullable
+        private MetricDatum metricDatum(Meter.Id id, double value) {
+            return metricDatum(id, null, id.getBaseUnit(), value);
+        }
+
+        @Nullable
+        private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, double value) {
+            return metricDatum(id, suffix, id.getBaseUnit(), value);
+        }
+
+        @Nullable
+        private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, @Nullable String unit, double value) {
+            return metricDatum(id, suffix, toUnit(unit), value);
+        }
+
+        @Nullable
+        private MetricDatum metricDatum(Meter.Id id, @Nullable String suffix, Unit unit, double value) {
+            if (Double.isNaN(value)) {
+                return null;
+            }
+
+            List<Tag> tags = id.getConventionTags(config().namingConvention());
+            if (tags.size() > Constants.MAX_DIMENSION_SET_SIZE) {
+                warnThenDebugLogger.log(() -> "Meter " + id.getName() + " has more tags (" + tags.size()
+                        + ") than the max supported by CloudWatch (" + Constants.MAX_DIMENSION_SET_SIZE
+                        + "). Some tags will be dropped.");
+            }
+
+            return new MetricDatum(getMetricName(id, suffix), toDimensions(tags),
+                    CloudWatchUtils.clampMetricValue(value), unit, config.storageResolution());
+        }
+
+        // VisibleForTesting
+        String getMetricName(Meter.Id id, @Nullable String suffix) {
+            String name = suffix != null ? id.getName() + "." + suffix : id.getName();
+            return config().namingConvention().name(name, id.getType(), id.getBaseUnit());
+        }
+
+        // VisibleForTesting
+        Unit toUnit(@Nullable String unit) {
+            if (unit == null) {
+                return Unit.NONE;
+            }
+            Unit unitEnum = UNIT_BY_LOWERCASE_VALUE.get(unit.toLowerCase());
+            return unitEnum != null ? unitEnum : Unit.NONE;
+        }
+
+        private @Nullable DimensionSet toDimensions(List<Tag> tags) {
+            DimensionSet dimensionSet = null;
+
+            List<Tag> limitedTags = tags.stream()
+                .filter(this::isAcceptableTag)
+                .limit(Constants.MAX_DIMENSION_SET_SIZE)
+                .collect(toList());
+
+            for (Tag tag : limitedTags) {
+                try {
+                    if (dimensionSet == null) {
+                        dimensionSet = DimensionSet.of(tag.getKey(), tag.getValue());
+                    }
+                }
+                catch (InvalidDimensionException e) {
+                    warnThenDebugLogger.log(() -> "Dropping a tag with key '" + tag.getKey() + "' and value '"
+                            + tag.getValue() + "' because it is an invalid dimension: " + e);
+                }
+                catch (DimensionSetExceededException e) {
+                    // Even though we limited the number of tags above, if default
+                    // dimensions are used, we could
+                    // exceed the allowed value. If this happens, set useDefaultDimensions
+                    // to false on the
+                    // CloudWatchEmbeddedMetricsConfig object.
+                    warnThenDebugLogger
+                        .log(() -> "Dropping a tag with key '" + tag.getKey() + "' and value '" + tag.getValue()
+                                + "' because the maximum number of dimensions is exceeded. You may need to disable "
+                                + "default dimensions: " + e);
+                }
+            }
+
+            return dimensionSet;
+        }
+
+        private boolean isAcceptableTag(Tag tag) {
+            if (StringUtils.isBlank(tag.getValue())) {
+                warnThenDebugLogger
+                    .log(() -> "Dropping a tag with key '" + tag.getKey() + "' because its value is blank.");
+                return false;
+            }
+            return true;
+        }
+
+    }
+
+    @Override
+    protected TimeUnit getBaseTimeUnit() {
+        return TimeUnit.MILLISECONDS;
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsNamingConvention.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsNamingConvention.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.StringUtils;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.NamingConvention;
+
+/**
+ * {@link NamingConvention} for CloudWatch Embedded Metrics Format (EMF).
+ *
+ * @author Kyle Sletmoe
+ * @author Klaus Hartl
+ * @since 1.14.0
+ */
+public class CloudWatchEmbeddedMetricsNamingConvention implements NamingConvention {
+
+    // https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_Dimension.html
+    private static final int MAX_TAG_KEY_LENGTH = 255;
+
+    private static final int MAX_TAG_VALUE_LENGTH = 1024;
+
+    private final NamingConvention delegate;
+
+    public CloudWatchEmbeddedMetricsNamingConvention() {
+        this(NamingConvention.identity);
+    }
+
+    public CloudWatchEmbeddedMetricsNamingConvention(NamingConvention delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String name(String name, Meter.Type type, @Nullable String baseUnit) {
+        return delegate.name(name, type, baseUnit);
+    }
+
+    @Override
+    public String tagKey(String key) {
+        return StringUtils.truncate(delegate.tagKey(key), MAX_TAG_KEY_LENGTH);
+    }
+
+    @Override
+    public String tagValue(String value) {
+        return StringUtils.truncate(delegate.tagValue(value), MAX_TAG_VALUE_LENGTH);
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchUtils.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+/**
+ * Utilities for CloudWatchEmbeddedMetrics registry
+ */
+final class CloudWatchUtils {
+
+    /**
+     * Minimum allowed value as specified by <a href=
+     * "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html">CloudWatch
+     * MetricDatum</a>
+     */
+    private static final double MINIMUM_ALLOWED_VALUE = 8.515920e-109;
+
+    /**
+     * Maximum allowed value as specified by <a href=
+     * "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html">CloudWatch
+     * MetricDatum</a>
+     */
+    private static final double MAXIMUM_ALLOWED_VALUE = 1.174271e+108;
+
+    private CloudWatchUtils() {
+    }
+
+    /**
+     * Clean up metric to be within the allowable range as specified in <a href=
+     * "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html">CloudWatch
+     * MetricDatum</a>
+     * @param value unsanitized value
+     * @return value clamped to allowable range
+     */
+    static double clampMetricValue(double value) {
+        // Leave as is and let the SDK reject it
+        if (Double.isNaN(value)) {
+            return value;
+        }
+        double magnitude = Math.abs(value);
+        if (magnitude == 0) {
+            // Leave zero as zero
+            return 0;
+        }
+        // Non-zero magnitude, clamp to allowed range
+        double clampedMag = Math.min(Math.max(magnitude, MINIMUM_ALLOWED_VALUE), MAXIMUM_ALLOWED_VALUE);
+        return Math.copySign(clampedMag, value);
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/MetricDatum.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/MetricDatum.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+
+/**
+ * @author Kyle Sletmoe
+ * @author Klaus Hartl
+ * @since 1.14.0
+ */
+public class MetricDatum {
+
+    final String metricName;
+
+    final @Nullable DimensionSet dimensions;
+
+    final double value;
+
+    final Unit unit;
+
+    final StorageResolution storageResolution;
+
+    public MetricDatum(String metricName, @Nullable DimensionSet dimensions, double value, Unit unit,
+            StorageResolution storageResolution) {
+        this.metricName = metricName;
+        this.dimensions = dimensions;
+        this.value = value;
+        this.unit = unit;
+        this.storageResolution = storageResolution;
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/package-info.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/main/java/io/micrometer/cloudwatchembeddedmetrics/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NonNullApi
+@NonNullFields
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.NonNullApi;
+import io.micrometer.common.lang.NonNullFields;

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsConfigTest.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsConfigTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.cloudwatchlogs.emf.Constants;
+import software.amazon.cloudwatchlogs.emf.config.Configuration;
+import software.amazon.cloudwatchlogs.emf.environment.Environments;
+import software.amazon.cloudwatchlogs.emf.model.StorageResolution;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudWatchEmbeddedMetricsConfigTest {
+
+    private Map<String, String> props = new HashMap<>();
+
+    private CloudWatchEmbeddedMetricsConfig config = props::get;
+
+    private CloudWatchEmbeddedMetricsConfig configurationWithEmfConfig(Configuration emfConfig) {
+        return new CloudWatchEmbeddedMetricsConfig() {
+            @Override
+            public String get(String key) {
+                return props.get(key);
+            }
+
+            @Override
+            public Configuration emfConfiguration() {
+                return emfConfig;
+            }
+        };
+    }
+
+    @BeforeEach
+    void setup() {
+        props = new HashMap<>();
+        config = props::get;
+    }
+
+    @Test
+    void logGroupName() {
+        // Without anything set, our config should return null
+        assertThat(config.logGroupName()).isNull();
+
+        // When the EMF config environment variable is set, but our config doesn't
+        // override it, we should use the
+        // value from the environment
+        config = configurationWithEmfConfig(new Configuration(null, null, "my-log-group", null, null,
+                Environments.Unknown, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        assertThat(config.logGroupName()).isEqualTo("my-log-group");
+
+        // Lastly, even if the EMF environment variable is set, we should use a value if
+        // it's configured on our config
+        // object
+        props.put("cloudwatchemf.logGroupName", "my-other-log-group");
+        assertThat(config.logGroupName()).isEqualTo("my-other-log-group");
+    }
+
+    @Test
+    void logStreamName() {
+        assertThat(config.logGroupName()).isNull();
+
+        config = configurationWithEmfConfig(new Configuration(null, null, null, "my-log-stream", null,
+                Environments.Unknown, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        assertThat(config.logStreamName()).isEqualTo("my-log-stream");
+
+        props.put("cloudwatchemf.logStreamName", "my-other-log-stream");
+        assertThat(config.logStreamName()).isEqualTo("my-other-log-stream");
+    }
+
+    @Test
+    void serviceType() {
+        assertThat(config.serviceType()).isNull();
+
+        config = configurationWithEmfConfig(new Configuration(null, "WebServer", null, null, null, Environments.Unknown,
+                Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        assertThat(config.serviceType()).isEqualTo("WebServer");
+
+        props.put("cloudwatchemf.serviceType", "MailServer");
+        assertThat(config.serviceType()).isEqualTo("MailServer");
+    }
+
+    @Test
+    void serviceName() {
+        assertThat(config.serviceName()).isNull();
+
+        config = configurationWithEmfConfig(new Configuration("my-service", null, null, null, null,
+                Environments.Unknown, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        assertThat(config.serviceName()).isEqualTo("my-service");
+
+        props.put("cloudwatchemf.serviceName", "my-other-service");
+        assertThat(config.serviceName()).isEqualTo("my-other-service");
+    }
+
+    @Test
+    void namespace() {
+        // Namespace is not settable via EMF environment variables
+        assertThat(config.namespace()).isNull();
+
+        props.put("cloudwatchemf.namespace", "my-namespace");
+        assertThat(config.namespace()).isEqualTo("my-namespace");
+    }
+
+    @Test
+    void agentEndpoint() {
+        assertThat(config.agentEndpoint()).isNull();
+
+        config = configurationWithEmfConfig(new Configuration(null, null, null, null, "https://127.0.0.1:443",
+                Environments.Unknown, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        assertThat(config.agentEndpoint()).isEqualTo("https://127.0.0.1:443");
+
+        props.put("cloudwatchemf.agentEndpoint", "https://example.com:443");
+        assertThat(config.agentEndpoint()).isEqualTo("https://example.com:443");
+    }
+
+    @Test
+    void asyncBufferSize() {
+        config = configurationWithEmfConfig(new Configuration(null, null, null, null, "https://127.0.0.1:443",
+                Environments.Unknown, Constants.DEFAULT_ASYNC_BUFFER_SIZE));
+
+        // EMF environment config fetcher will always respond with a default value
+        assertThat(config.asyncBufferSize()).isEqualTo(Constants.DEFAULT_ASYNC_BUFFER_SIZE);
+
+        props.put("cloudwatchemf.asyncBufferSize", "10");
+        assertThat(config.asyncBufferSize()).isEqualTo(10);
+    }
+
+    @Test
+    void useDefaultDimensions() {
+        // not settable via EMF environment config
+        assertThat(config.useDefaultDimensions()).isTrue();
+
+        props.put("cloudwatchemf.useDefaultDimensions", "false");
+        assertThat(config.useDefaultDimensions()).isFalse();
+    }
+
+    @Test
+    void storageResolution() {
+        props.put("cloudwatchemf.step", "1m");
+        assertThat(config.storageResolution()).isEqualTo(StorageResolution.STANDARD);
+
+        props.put("cloudwatchemf.step", "10s");
+        assertThat(config.storageResolution()).isEqualTo(StorageResolution.HIGH);
+    }
+
+    @Test
+    void valid() {
+        assertThat(config.validate().isValid()).isTrue();
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistryCompatibilityTest.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistryCompatibilityTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.tck.MeterRegistryCompatibilityKit;
+
+import java.time.Duration;
+
+class CloudWatchEmbeddedMetricsMeterRegistryCompatibilityTest extends MeterRegistryCompatibilityKit {
+
+    private final CloudWatchEmbeddedMetricsConfig config = new CloudWatchEmbeddedMetricsConfig() {
+        @Override
+        @Nullable
+        public String get(String key) {
+            return null;
+        }
+
+        @Override
+        public boolean enabled() {
+            return false;
+        }
+    };
+
+    @Override
+    public MeterRegistry registry() {
+        // noinspection ConstantConditions
+        return new CloudWatchEmbeddedMetricsMeterRegistry(config, new MockClock());
+    }
+
+    @Override
+    public Duration step() {
+        return config.step();
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistryTest.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsMeterRegistryTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.common.lang.Nullable;
+import io.micrometer.core.instrument.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+
+import static io.micrometer.core.instrument.Meter.Id;
+import static io.micrometer.core.instrument.Meter.Type;
+import static io.micrometer.core.instrument.Meter.Type.DISTRIBUTION_SUMMARY;
+import static io.micrometer.core.instrument.Meter.Type.TIMER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link CloudWatchEmbeddedMetricsMeterRegistry}.
+ *
+ * @author Kyle Sletmoe
+ * @author Johnny Lim
+ */
+class CloudWatchEmbeddedMetricsMeterRegistryTest {
+
+    private static final String METER_NAME = "test";
+
+    private final MockClock clock = new MockClock();
+
+    private final CloudWatchEmbeddedMetricsConfig config = new CloudWatchEmbeddedMetricsConfig() {
+        @Nullable
+        @Override
+        public String get(String key) {
+            return null;
+        }
+    };
+
+    private final CloudWatchEmbeddedMetricsMeterRegistry registry = spy(
+            new CloudWatchEmbeddedMetricsMeterRegistry(config, clock));
+
+    private final CloudWatchEmbeddedMetricsMeterRegistry.Step registryStep = registry.new Step();
+
+    @Test
+    void metricData() {
+        registry.gauge("gauge", 1d);
+        List<MetricDatum> metricDatumStream = registry.metricData();
+        assertThat(metricDatumStream.size()).isEqualTo(1);
+    }
+
+    @Test
+    void metricDataWhenNaNShouldNotAdd() {
+        registry.gauge("gauge", Double.NaN);
+
+        AtomicReference<Double> value = new AtomicReference<>(Double.NaN);
+        registry.more().timeGauge("time.gauge", Tags.empty(), value, TimeUnit.MILLISECONDS, AtomicReference::get);
+
+        List<MetricDatum> metricDatumStream = registry.metricData();
+        assertThat(metricDatumStream.size()).isEqualTo(0);
+    }
+
+    @Test
+    void batchGetMetricName() {
+        Id id = new Id("name", Tags.empty(), null, null, Type.COUNTER);
+        assertThat(registry.new Step().getMetricName(id, "suffix")).isEqualTo("name.suffix");
+    }
+
+    @Test
+    void batchGetMetricNameWhenSuffixIsNullShouldNotAppend() {
+        Id id = new Id("name", Tags.empty(), null, null, Type.COUNTER);
+        assertThat(registry.new Step().getMetricName(id, null)).isEqualTo("name");
+    }
+
+    @Test
+    void batchFunctionCounterData() {
+        FunctionCounter counter = FunctionCounter.builder("myCounter", 1d, Number::doubleValue).register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Step().functionCounterData(counter)).hasSize(1);
+    }
+
+    @Test
+    void batchFunctionCounterDataShouldClampInfiniteValues() {
+        FunctionCounter counter = FunctionCounter
+            .builder("my.positive.infinity", Double.POSITIVE_INFINITY, Number::doubleValue)
+            .register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Step().functionCounterData(counter).findFirst().get().value).isEqualTo(1.174271e+108);
+
+        counter = FunctionCounter.builder("my.negative.infinity", Double.NEGATIVE_INFINITY, Number::doubleValue)
+            .register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Step().functionCounterData(counter).findFirst().get().value).isEqualTo(-1.174271e+108);
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterHasOnlyNaNValuesShouldNotBeWritten() {
+        Measurement measurement = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        List<Measurement> measurements = List.of(measurement);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.new Step().metricData(meter)).isEmpty();
+    }
+
+    @Test
+    void writeMeterWhenCustomMeterHasMixedNaNAndNonNaNValuesShouldSkipOnlyNaNValues() {
+        Measurement measurement1 = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        Measurement measurement2 = new Measurement(() -> 1d, Statistic.VALUE);
+        Measurement measurement3 = new Measurement(() -> 2d, Statistic.VALUE);
+        List<Measurement> measurements = Arrays.asList(measurement1, measurement2, measurement3);
+        Meter meter = Meter.builder("my.meter", Meter.Type.GAUGE, measurements).register(this.registry);
+        assertThat(registry.new Step().metricData(meter)).hasSize(2);
+    }
+
+    @Test
+    void writeShouldDropTagWithBlankValue() {
+        registry.gauge("my.gauge", Tags.of("accepted", "foo").and("empty", ""), 1d);
+        assertThat(registry.metricData()).hasSize(1)
+            .allSatisfy(
+                    datum -> assertThat(datum.dimensions.getDimensionKeys()).hasSize(1).isEqualTo(Set.of("accepted")));
+    }
+
+    @Test
+    void functionTimerData() {
+        FunctionTimer timer = FunctionTimer
+            .builder("my.function.timer", 1d, Number::longValue, Number::doubleValue, TimeUnit.MILLISECONDS)
+            .register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Step().functionTimerData(timer)).hasSize(3);
+    }
+
+    @Test
+    void functionTimerDataWhenSumIsNaNShouldReturnEmptyStream() {
+        FunctionTimer timer = FunctionTimer
+            .builder("my.function.timer", Double.NaN, Number::longValue, Number::doubleValue, TimeUnit.MILLISECONDS)
+            .register(registry);
+        clock.add(config.step());
+        assertThat(registry.new Step().functionTimerData(timer)).isEmpty();
+    }
+
+    @Test
+    void shouldAddFunctionTimerAggregateMetricWhenAtLeastOneEventHappened() {
+        FunctionTimer timer = mock(FunctionTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(2.0);
+
+        Stream<MetricDatum> metricDatumStream = registryStep.functionTimerData(timer);
+
+        assertThat(metricDatumStream.anyMatch(hasAvgMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldNotAddFunctionTimerAggregateMetricWhenNoEventHappened() {
+        FunctionTimer timer = mock(FunctionTimer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(0.0);
+
+        Stream<MetricDatum> metricDatumStream = registryStep.functionTimerData(timer);
+
+        assertThat(metricDatumStream.noneMatch(hasAvgMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldAddTimerAggregateMetricWhenAtLeastOneEventHappened() {
+        Timer timer = mock(Timer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(2L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryStep.timerData(timer);
+
+        assertThat(streamSupplier.get().anyMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().anyMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldNotAddTimerAggregateMetricWhenNoEventHappened() {
+        Timer timer = mock(Timer.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, TIMER);
+        when(timer.getId()).thenReturn(meterId);
+        when(timer.count()).thenReturn(0L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryStep.timerData(timer);
+
+        assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldAddDistributionSumAggregateMetricWhenAtLeastOneEventHappened() {
+        DistributionSummary summary = mock(DistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        when(summary.count()).thenReturn(2L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryStep.summaryData(summary);
+
+        assertThat(streamSupplier.get().anyMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().anyMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    @Test
+    void shouldNotAddDistributionSumAggregateMetricWhenNoEventHappened() {
+        DistributionSummary summary = mock(DistributionSummary.class);
+        Id meterId = new Id(METER_NAME, Tags.empty(), null, null, DISTRIBUTION_SUMMARY);
+        when(summary.getId()).thenReturn(meterId);
+        when(summary.count()).thenReturn(0L);
+
+        Supplier<Stream<MetricDatum>> streamSupplier = () -> registryStep.summaryData(summary);
+
+        assertThat(streamSupplier.get().noneMatch(hasAvgMetric(meterId))).isTrue();
+        assertThat(streamSupplier.get().noneMatch(hasMaxMetric(meterId))).isTrue();
+    }
+
+    void batchToStandardUnitWhenUnitIsUnknownShouldReturnNone() {
+        assertThat(this.registry.new Step().toUnit("unknownUnit")).isEqualTo(Unit.NONE);
+    }
+
+    private Predicate<MetricDatum> hasAvgMetric(Id id) {
+        return e -> e.metricName.equals(id.getName().concat(".avg"));
+    }
+
+    private Predicate<MetricDatum> hasMaxMetric(Id id) {
+        return e -> e.metricName.equals(id.getName().concat(".max"));
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsNamingConventionTest.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchEmbeddedMetricsNamingConventionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import io.micrometer.core.instrument.config.NamingConvention;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CloudWatchEmbeddedMetricsNamingConvention}.
+ *
+ * @author Kyle Sletmoe
+ * @author Klaus Hartl
+ * @author Johnny Lim
+ */
+class CloudWatchEmbeddedMetricsNamingConventionTest {
+
+    private final NamingConvention namingConvention = new CloudWatchEmbeddedMetricsNamingConvention();
+
+    @Test
+    void truncateTagKey() {
+        assertThat(namingConvention.tagKey(repeat("x", 256))).hasSize(255);
+    }
+
+    @Test
+    void truncateTagValue() {
+        assertThat(namingConvention.tagValue(repeat("x", 1025))).hasSize(1024);
+    }
+
+    private String repeat(String s, int repeat) {
+        return String.join("", Collections.nCopies(repeat, s));
+    }
+
+}

--- a/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchUtilsTest.java
+++ b/implementations/micrometer-registry-cloudwatch-embedded-metrics/src/test/java/io/micrometer/cloudwatchembeddedmetrics/CloudWatchUtilsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.cloudwatchembeddedmetrics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test methods in CloudWatchUtils
+ */
+class CloudWatchUtilsTest {
+
+    private static final double EXPECTED_MIN = 8.515920e-109;
+
+    private static final double EXPECTED_MAX = 1.174271e+108;
+
+    @Test
+    void testClamp() {
+        assertThat(CloudWatchUtils.clampMetricValue(Double.NaN)).as("Check NaN").isNaN();
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.MIN_VALUE)).as("Check minimum value")
+            .isEqualTo(EXPECTED_MIN);
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.NEGATIVE_INFINITY)).as("Check negative infinity")
+            .isEqualTo(-EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(Double.POSITIVE_INFINITY)).as("Check positive infinity")
+            .isEqualTo(EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-Double.MAX_VALUE)).as("Check negative max value")
+            .isEqualTo(-EXPECTED_MAX);
+
+        assertThat(CloudWatchUtils.clampMetricValue(0)).as("Check 0").isEqualTo(0);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-0)).as("Check -0").isEqualTo(0);
+
+        assertThat(CloudWatchUtils.clampMetricValue(100.1)).as("Check positive value").isEqualTo(100.1);
+
+        assertThat(CloudWatchUtils.clampMetricValue(-10.2)).as("Check negative value").isEqualTo(-10.2);
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,7 +33,7 @@ include 'micrometer-commons', 'micrometer-core', 'micrometer-observation'
 
 include 'micrometer-test', 'micrometer-observation-test', 'micrometer-test-aspectj-ltw', 'micrometer-test-aspectj-ctw'
 
-['atlas', 'prometheus', 'prometheus-simpleclient', 'datadog', 'elastic', 'ganglia', 'graphite', 'health', 'jmx', 'influx', 'otlp', 'statsd', 'new-relic', 'cloudwatch2', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver', 'opentsdb'].each { sys ->
+['atlas', 'prometheus', 'prometheus-simpleclient', 'datadog', 'elastic', 'ganglia', 'graphite', 'health', 'jmx', 'influx', 'otlp', 'statsd', 'new-relic', 'cloudwatch2', 'cloudwatch-embedded-metrics', 'signalfx', 'wavefront', 'dynatrace', 'azure-monitor', 'humio', 'appoptics', 'kairos', 'stackdriver', 'opentsdb'].each { sys ->
     include "micrometer-registry-$sys"
     project(":micrometer-registry-$sys").projectDir = new File(rootProject.projectDir, "implementations/micrometer-registry-$sys")
 }


### PR DESCRIPTION
I based this heavily off of the existing CloudWatch2 registry and tried to maintain attribution comments where it made sense. 