### PR TITLE
Added constructor to MeterRegistry to enable percentile publish

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -483,6 +483,29 @@ public abstract class MeterRegistry {
     }
 
     /**
+     * Measures the time taken for short tasks and the count of these tasks.
+     * @param name The base metric name
+     * @param tags Sequence of dimensions for breaking down the name.
+     * @param publishPercentileHistogram If this timer publishes percentile histogram
+     * @return A new or existing timer.
+     */
+    public Timer timer(String name, boolean publishPercentileHistogram, Iterable<Tag> tags) {
+        return Timer.builder(name).tags(tags).publishPercentileHistogram(publishPercentileHistogram).register(this);
+    }
+
+    /**
+     * Measures the time taken for short tasks and the count of these tasks.
+     * @param name The base metric name
+     * @param tags MUST be an even number of arguments representing key/value pairs of
+     * tags.
+     * @param publishPercentileHistogram If this timer publishes percentile histogram
+     * @return A new or existing timer.
+     */
+    public Timer timer(String name, boolean publishPercentileHistogram, String... tags) {
+        return timer(name, publishPercentileHistogram, Tags.of(tags));
+    }
+
+    /**
      * Access to less frequently used meter types and patterns.
      * @return Access to additional meter types and patterns.
      */

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -75,6 +75,25 @@ class MeterRegistryTest {
     }
 
     @Test
+    void histogramTimerConstructor() {
+        MeterRegistry registry = new SimpleMeterRegistry() {
+            @Override
+            protected Timer newTimer(@Nonnull Meter.Id id, DistributionStatisticConfig histogramConfig,
+                    PauseDetector pauseDetector) {
+                if (id.getName().equals("timerWithHistogram")) {
+                    assertThat(histogramConfig.isPublishingHistogram()).isTrue();
+                }
+                else if (id.getName().equals("timerWithoutHistogram")) {
+                    assertThat(histogramConfig.isPublishingHistogram()).isFalse();
+                }
+                return super.newTimer(id, histogramConfig, pauseDetector);
+            }
+        };
+        registry.timer("timerWithHistogram", true);
+        registry.timer("timerWithoutHistogram", false);
+    }
+
+    @Test
     void histogramConfigTransformingMeterFilter() {
         MeterRegistry registry = new SimpleMeterRegistry() {
             @Override


### PR DESCRIPTION
Added a handy constructor that takes `publishPercentileHistogram` as parameter given the default value is `false`. This provides an easy way to enable a useful feature with little code.