### PR TITLE
Add default factoryType tag in CommonsObjectPool2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -129,12 +129,16 @@ public class CommonsObjectPool2Metrics implements MeterBinder, AutoCloseable {
 
     private Iterable<Tag> nameTag(ObjectName name, String type)
             throws AttributeNotFoundException, MBeanException, ReflectionException, InstanceNotFoundException {
+
         Tags tags = Tags.of("name", name.getKeyProperty("name"), "type", type);
+        String factoryType = "none"; // Default value for factoryType if not available
+
         if (Objects.equals(type, "GenericObjectPool")) {
             // for GenericObjectPool, we want to include the name and factoryType as tags
-            String factoryType = mBeanServer.getAttribute(name, "FactoryType").toString();
-            tags = Tags.concat(tags, "factoryType", factoryType);
+            factoryType = mBeanServer.getAttribute(name, "FactoryType").toString();
         }
+
+        tags = Tags.concat(tags, "factoryType", factoryType);
         return tags;
     }
 


### PR DESCRIPTION
## Overview

~~This PR addresses the issue of Prometheus tag collision by introducing distinct metric name prefixes for different pool types in the `CommonsObjectPool2Metrics` class. This change ensures that metrics from `GenericObjectPool` and `GenericKeyedObjectPool` have unique names, preventing conflicts caused by differing tag sets.~~

This PR addresses the issue of Prometheus tag collision by ensuring that all metrics have a consistent set of tags. For `GenericObjectPool`, a `factoryType` tag is added, and for other pool types, a default value of `factoryType=none` is used. This approach resolves the conflict caused by differing tag sets between `GenericObjectPool` and other pool types.

## Changes

~~- Introduced distinct metric name prefixes: `objectpool.` for `GenericObjectPool` and `keyedobjectpool.` for `GenericKeyedObjectPool`.~~
~~- Updated the `registerMetricsEventually` method to apply the appropriate prefix based on the pool type.~~
~~- Adjusted metric registration methods (`registerGaugeForObject`, `registerFunctionCounterForObject`, `registerTimeGaugeForObject`) to use the new prefixes.~~

- Added a default `factoryType=none` tag for all pool types except `GenericObjectPool`.

## Reasoning

Prometheus requires that all meters with the same name have the same set of tag keys. The previous implementation violated this rule by adding a `factoryType` tag for `GenericObjectPool`, which was not present in other pool types. This caused registration failures in `PrometheusMeterRegistry` at [this line](https://github.com/micrometer-metrics/micrometer/blob/main/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java#L594). By ensuring that all metrics include a consistent set of tags, we eliminate tag collisions and comply with Prometheus' requirements.