### PR TITLE
Ignore NullObservation in ObservationValidator

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
@@ -16,6 +16,7 @@
 package io.micrometer.observation.tck;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.observation.NullObservation.NullContext;
 import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.ObservationHandler;
@@ -47,7 +48,7 @@ class ObservationValidator implements ObservationHandler<Context> {
     }
 
     ObservationValidator(Consumer<ValidationResult> consumer) {
-        this(consumer, context -> true);
+        this(consumer, context -> !(context instanceof NullContext));
     }
 
     ObservationValidator(Consumer<ValidationResult> consumer, Predicate<Context> supportsContextPredicate) {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.observation.tck;
 
+import io.micrometer.observation.NullObservation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.Observation.Scope;
@@ -251,6 +252,11 @@ class ObservationValidatorTests {
     @Test
     void startErrorErrorStopShouldBeValid() {
         Observation.start("test", registry).error(new RuntimeException()).error(new RuntimeException()).stop();
+    }
+
+    @Test
+    void nullObservationShouldBeIgnored() {
+        new NullObservation(registry).openScope();
     }
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NullObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NullObservation.java
@@ -28,7 +28,7 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 public class NullObservation extends SimpleObservation {
 
     public NullObservation(ObservationRegistry registry) {
-        super("null", registry, new Context());
+        super("null", registry, new NullContext());
     }
 
     @Override
@@ -64,6 +64,18 @@ public class NullObservation extends SimpleObservation {
     @Override
     public Observation start() {
         return this;
+    }
+
+    /**
+     * A special {@link Observation.Context} that should be used only in
+     * {@link NullObservation} in special cases where clearing of scopes is important. Its
+     * only purpose is to make scenarios through {@link NullObservation} distinguishable
+     * from "normal" {@link Observation Observations}.
+     *
+     * @since 1.14.0
+     */
+    public static class NullContext extends Context {
+
     }
 
 }


### PR DESCRIPTION
NullObservation is a special case for context propagation. It's not fully an Observation since it is only for scope handling which can happen outside of "normal" Observations, therefore we not necessarily need to validate it.

Closes gh-5388