### PR TITLE
Replace aspectjweaver with aspectjrt in micrometer-commons

### DIFF
--- a/micrometer-commons/build.gradle
+++ b/micrometer-commons/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     optionalApi 'ch.qos.logback:logback-classic'
 
     // Aspects
-    optionalApi 'org.aspectj:aspectjweaver'
+    optionalApi libs.aspectjrt
 
     // JUnit 5
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
This PR replaces `org.aspectj:aspectjweaver` with `org.aspectj:aspectjrt` in the `micrometer-commons` as suggested in https://github.com/micrometer-metrics/micrometer/issues/1149#issuecomment-1867109246.

For the `micrometer-core`, it has been replaced already in https://github.com/micrometer-metrics/micrometer/pull/5059/files#diff-3cdfc8c41dedcdeda3217e7742a3c34142e0364d203212cc7930d59561fd94d3L84-R85.