### PR TITLE
Use add-opens for LTW aspect tests for JDK 16+

### DIFF
--- a/micrometer-test-aspectj-ltw/build.gradle
+++ b/micrometer-test-aspectj-ltw/build.gradle
@@ -19,5 +19,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    jvmArgs '-javaagent:' + configurations.agents.files.find { it.name.startsWith('aspectjweaver') }
+    jvmArgs '-javaagent:' + configurations.agents.files.find { it.name.startsWith('aspectjweaver') },
+            // needed for Java 16+, until upgrading to AspectJ 1.9.21.1, see https://github.com/eclipse-aspectj/aspectj/blob/master/docs/release/README-1.9.20.adoc#use-ltw-on-java-16
+            '--add-opens=java.base/java.lang=ALL-UNNAMED'
 }

--- a/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/test/ltw/MeasuredClassTest.java
+++ b/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/test/ltw/MeasuredClassTest.java
@@ -27,15 +27,11 @@ import io.micrometer.observation.Observations;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
 
 import java.util.Collection;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@DisabledForJreRange(min = JRE.JAVA_17,
-        disabledReason = "See https://github.com/micrometer-metrics/micrometer/pull/5401#issuecomment-2308440259")
 class MeasuredClassTest {
 
     MeterRegistry registry = new SimpleMeterRegistry();


### PR DESCRIPTION
This is needed until we upgrade past AspectJ 1.9.21.1 which we can't do as long as we are building with < JDK 17.

Resolves gh-5403