### PR TITLE
Add "cancelled" information to the GrpcServerObservationContext

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/GrpcServerObservationContext.java
@@ -50,6 +50,8 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
 
     private Metadata trailers;
 
+    private boolean cancelled;
+
     public GrpcServerObservationContext(Getter<Metadata> getter) {
         super(getter);
     }
@@ -138,6 +140,23 @@ public class GrpcServerObservationContext extends RequestReplyReceiverContext<Me
      */
     public void setTrailers(Metadata trailers) {
         this.trailers = trailers;
+    }
+
+    /**
+     * Indicate whether the request is cancelled or not.
+     * @return {@code true} if the request is cancelled
+     * @since 1.14
+     */
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Set {@code true} when the request is cancelled.
+     * @since 1.14
+     */
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcServerCall.java
@@ -67,6 +67,7 @@ class ObservationGrpcServerCall<ReqT, RespT> extends SimpleForwardingServerCall<
         GrpcServerObservationContext context = (GrpcServerObservationContext) this.observation.getContext();
         context.setStatusCode(status.getCode());
         context.setTrailers(trailersToKeep);
+        context.setCancelled(isCancelled());
         super.close(status, trailers);
     }
 


### PR DESCRIPTION
Add gRPC cancellation information to the `GrpcServerObservationContext`.
Also, improve gRPC unit test reliability by adding proper wait mechanisms.

See gh-5301