### PR TITLE
Relax Observation Scope validation

### DIFF
--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -154,56 +154,27 @@ class ObservationValidatorTests {
 
     @Test
     @SuppressWarnings("resource")
-    void scopeOpenAfterStopShouldBeInvalid() {
-        assertThatThrownBy(() -> {
-            Observation observation = Observation.start("test", registry);
-            observation.stop();
-            observation.openScope();
-        }).isExactlyInstanceOf(InvalidObservationException.class)
-            .hasNoCause()
-            .hasMessage("Invalid scope opening: Observation 'test' has already been stopped")
-            .satisfies(exception -> assertThat(exception.toString()).matches(
-                    "(?s)^io\\.micrometer\\.observation\\.tck\\.InvalidObservationException: Invalid scope opening: Observation 'test' has already been stopped\n"
-                            + "START: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeOpenAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "STOP: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeOpenAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "SCOPE_OPEN: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeOpenAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests.java:\\d+\\)$"));
+    void scopeOpenAfterStopShouldBeValid() {
+        Observation observation = Observation.start("test", registry);
+        observation.stop();
+        observation.openScope();
     }
 
     @Test
     @SuppressWarnings("resource")
-    void scopeResetAfterStopShouldBeInvalid() {
-        assertThatThrownBy(() -> {
-            Observation observation = Observation.start("test", registry);
-            Scope scope = observation.openScope();
-            observation.stop();
-            scope.reset();
-        }).isExactlyInstanceOf(InvalidObservationException.class)
-            .hasNoCause()
-            .hasMessage("Invalid scope resetting: Observation 'test' has already been stopped")
-            .satisfies(exception -> assertThat(exception.toString()).matches(
-                    "(?s)^io\\.micrometer\\.observation\\.tck\\.InvalidObservationException: Invalid scope resetting: Observation 'test' has already been stopped\n"
-                            + "START: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeResetAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "SCOPE_OPEN: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeResetAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests.java:\\d+\\)\n"
-                            + "STOP: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeResetAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "SCOPE_RESET: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeResetAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests.java:\\d+\\)$"));
+    void scopeResetAfterStopShouldBeInValid() {
+        Observation observation = Observation.start("test", registry);
+        Scope scope = observation.openScope();
+        observation.stop();
+        scope.reset();
     }
 
     @Test
-    void scopeCloseAfterStopShouldBeInvalid() {
-        assertThatThrownBy(() -> {
-            Observation observation = Observation.start("test", registry);
-            Scope scope = observation.openScope();
-            observation.stop();
-            scope.close();
-        }).isExactlyInstanceOf(InvalidObservationException.class)
-            .hasNoCause()
-            .hasMessage("Invalid scope closing: Observation 'test' has already been stopped")
-            .satisfies(exception -> assertThat(exception.toString()).matches(
-                    "(?s)^io\\.micrometer\\.observation\\.tck\\.InvalidObservationException: Invalid scope closing: Observation 'test' has already been stopped\n"
-                            + "START: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeCloseAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "SCOPE_OPEN: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeCloseAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests.java:\\d+\\)\n"
-                            + "STOP: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeCloseAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests\\.java:\\d+\\)\n"
-                            + "SCOPE_CLOSE: app//io\\.micrometer\\.observation\\.tck\\.ObservationValidatorTests\\.lambda\\$scopeCloseAfterStopShouldBeInvalid\\$\\d+\\(ObservationValidatorTests.java:\\d+\\)$"));
+    void scopeCloseAfterStopShouldBeValid() {
+        Observation observation = Observation.start("test", registry);
+        Scope scope = observation.openScope();
+        observation.stop();
+        scope.close();
     }
 
     @Test

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -162,7 +162,7 @@ class ObservationValidatorTests {
 
     @Test
     @SuppressWarnings("resource")
-    void scopeResetAfterStopShouldBeInValid() {
+    void scopeResetAfterStopShouldBeValid() {
         Observation observation = Observation.start("test", registry);
         Scope scope = observation.openScope();
         observation.stop();


### PR DESCRIPTION
In some cases it is acceptable to open, close, and reset the scope after the Observation was stopped. But it is invalid to do these if the Observation hasn't been started yet.