### PR TITLE
Restore handling for Timed.percentiles() in TimedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -258,6 +258,7 @@ public class TimedAspect {
             .tags(EXCEPTION_TAG, exceptionClass)
             .tags(tagsBasedOnJoinPoint.apply(pjp))
             .publishPercentileHistogram(timed.histogram())
+            .publishPercentiles(timed.percentiles().length == 0 ? null : timed.percentiles())
             .serviceLevelObjectives(
                     timed.serviceLevelObjectives().length > 0 ? Arrays.stream(timed.serviceLevelObjectives())
                         .mapToObj(s -> Duration.ofNanos((long) TimeUtils.secondsToUnit(s, TimeUnit.NANOSECONDS)))


### PR DESCRIPTION
This PR restores handling for the `Timed.percentiles()` in the `TimedAspect` as it seems to have been removed accidentally in https://github.com/micrometer-metrics/micrometer/commit/10614998cf0779b3d6bbd33a822b96a10695572e#diff-b55b9ffafa609bfca1d0c14d92b061277165d6da05444010f8c9c161380b2d29L257.

See gh-5145