### PR TITLE
Fixed @Timed for methods raising Error

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -221,9 +221,9 @@ public class TimedAspect {
                 return ((CompletionStage<?>) pjp.proceed()).whenComplete(
                         (result, throwable) -> record(pjp, timed, metricName, sample, getExceptionTag(throwable)));
             }
-            catch (Exception ex) {
-                record(pjp, timed, metricName, sample, ex.getClass().getSimpleName());
-                throw ex;
+            catch (Throwable e) {
+                record(pjp, timed, metricName, sample, e.getClass().getSimpleName());
+                throw e;
             }
         }
 
@@ -231,9 +231,9 @@ public class TimedAspect {
         try {
             return pjp.proceed();
         }
-        catch (Exception ex) {
-            exceptionClass = ex.getClass().getSimpleName();
-            throw ex;
+        catch (Throwable e) {
+            exceptionClass = e.getClass().getSimpleName();
+            throw e;
         }
         finally {
             record(pjp, timed, metricName, sample, exceptionClass);

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -260,7 +260,7 @@ class TimedAspectTest {
 
         CompletableFuture<?> completableFuture = service.callRaisingError();
 
-        assertThatThrownBy(completableFuture::join).isInstanceOf(CompletionException.class) ;
+        assertThatThrownBy(completableFuture::join).isInstanceOf(CompletionException.class);
 
         assertThat(registry.get("callRaisingError")
             .tag("class", getClass().getName() + "$AsyncTimedService")
@@ -270,7 +270,6 @@ class TimedAspectTest {
             .timer()
             .count()).isEqualTo(1);
     }
-
 
     @Test
     void timeMethodWithLongTaskTimerWhenCompleted() {


### PR DESCRIPTION
When a method is annotated with `@Timed` and failed its execution with any Exception exception tag is populated with class name of exception.
BUT
If the same method is failed with any error (StackOverflowError for example) metrics are counted as if method was executed without issues.
At the same time `@Counted` annotation and http_server_requests_seconds metrics are correctly detect error.

Below are examples of /actuator/metrics produced for `@Timed` method in Spring Boot Application
Notice that 

- for `@Timed("timed_with_error")` metric exception="none" and 
- for http_server_requests_seconds metric exception="StackOverflowError"

```
# HELP timed_with_error_seconds  
# TYPE timed_with_error_seconds summary
timed_with_error_seconds_count{class="com.twj.provided.observations.TimedController",exception="none",method="timedMethod"} 1
timed_with_error_seconds_sum{class="com.twj.provided.observations.TimedController",exception="none",method="timedMethod"} 0.0089739
# HELP timed_with_error_seconds_max  
# TYPE timed_with_error_seconds_max gauge
timed_with_error_seconds_max{class="com.twj.provided.observations.TimedController",exception="none",method="timedMethod"} 0.0089739
# HELP http_server_requests_seconds  
# TYPE http_server_requests_seconds summary
http_server_requests_seconds_count{error="StackOverflowError",exception="StackOverflowError",method="GET",outcome="SERVER_ERROR",status="500",uri="/timed"} 1
http_server_requests_seconds_sum{error="StackOverflowError",exception="StackOverflowError",method="GET",outcome="SERVER_ERROR",status="500",uri="/timed"} 0.0532252
```