### PR TITLE
@Timed should record Throwables not only Exceptions

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -210,9 +210,9 @@ public class TimedAspect {
                 return ((CompletionStage<?>) pjp.proceed()).whenComplete(
                         (result, throwable) -> record(pjp, timed, metricName, sample, getExceptionTag(throwable)));
             }
-            catch (Exception ex) {
-                record(pjp, timed, metricName, sample, ex.getClass().getSimpleName());
-                throw ex;
+            catch (Throwable e) {
+                record(pjp, timed, metricName, sample, e.getClass().getSimpleName());
+                throw e;
             }
         }
 
@@ -220,9 +220,9 @@ public class TimedAspect {
         try {
             return pjp.proceed();
         }
-        catch (Exception ex) {
-            exceptionClass = ex.getClass().getSimpleName();
-            throw ex;
+        catch (Throwable e) {
+            exceptionClass = e.getClass().getSimpleName();
+            throw e;
         }
         finally {
             record(pjp, timed, metricName, sample, exceptionClass);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -269,9 +269,9 @@ public class TimedAspect {
                 return ((CompletionStage<?>) pjp.proceed())
                     .whenComplete((result, throwable) -> sample.ifPresent(this::stopTimer));
             }
-            catch (Exception ex) {
+            catch (Throwable e) {
                 sample.ifPresent(this::stopTimer);
-                throw ex;
+                throw e;
             }
         }
 


### PR DESCRIPTION
Rebasing fix provided in [PR 5476](https://github.com/micrometer-metrics/micrometer/pull/5476) to 1.12.x branch.

Original problem:
When a method is annotated with @Timed and failed its execution with any Exception exception tag is populated with class name of exception BUT if the same method is failed with any error (StackOverflowError for example) metrics are counted as if method was executed without issues.
At the same time @Counted annotation and http_server_requests_seconds metrics are correctly detect error.