### PR TITLE
Pass observation to tasks

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -20,11 +20,14 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.context.ContextExecutorService;
+import io.micrometer.context.ContextSnapshotFactory;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -610,6 +613,11 @@ public interface Observation extends ObservationView {
 
     default <T, E extends Throwable> CheckedCallable<T, E> wrapChecked(CheckedCallable<T, E> checkedCallable) throws E {
         return () -> observeChecked(checkedCallable);
+    }
+
+    default ExecutorService wrap(ExecutorService executorService) {
+        return ContextExecutorService.wrap(executorService,
+                () -> ContextSnapshotFactory.builder().build().captureAll());
     }
 
     /**


### PR DESCRIPTION
As developer, I would like parallelize my code and observe subtasks (https://stackoverflow.com/questions/78746378/spring-boot-3-micrometer-tracing-in-mdc/78765658#78765658 https://stackoverflow.com/questions/78889603/traceid-propagation-to-virtual-thread).

I found solution with `ContextExecutorService`, but according to discussion https://github.com/micrometer-metrics/context-propagation/issues/295, ContextExecutorService is low level API, which should not be used by application code.

`Observation` is enough high level to be used by application code.