### PR TITLE
Run concurrency tests as part of CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ jobs:
     steps:
       - gradlew-build
 
+  concurrency-tests:
+    executor: circle-jdk-executor
+    steps:
+      - gradlew-build:
+          command: jcstress
+
   docker-tests:
     executor: machine-executor
     steps:
@@ -101,12 +107,14 @@ workflows:
       - build
       - build-jdk11
       - build-jdk17
+      - concurrency-tests
       - docker-tests
       - deploy:
           requires:
             - build
             - build-jdk11
             - build-jdk17
+            - concurrency-tests
             - docker-tests
           filters:
             branches:
@@ -133,6 +141,12 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v\d+\.\d+\.\d+(-(RC|M)\d+)?$/
+      - concurrency-tests:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+(-(RC|M)\d+)?$/
       - docker-tests:
           filters:
             branches:
@@ -144,6 +158,7 @@ workflows:
             - build
             - build-jdk11
             - build-jdk17
+            - concurrency-tests
             - docker-tests
           filters:
             tags:

--- a/concurrency-tests/build.gradle
+++ b/concurrency-tests/build.gradle
@@ -13,5 +13,8 @@ dependencies {
 jcstress {
     libs.jcstressCore
 
+    // This affects how long and thorough testing will be
+    // In order of increasing stress: sanity, quick, default, tough, stress
+    mode = 'quick'
     verbose = true
 }


### PR DESCRIPTION
While we added concurrency tests, they were not being run as part of the build. In order to ensure concurrency issues aren't introduced by a change we didn't expect to affect that, we should regularly run the concurrency test suite.

The `default` mode took too long on CI, but `quick` seems to be reasonably quick.