### PR TITLE
Use failure with actual and expected message to improve IDE experience for ObservationContextAssert

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -71,7 +71,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         String actualName = this.actual.getName();
         if (!Objects.equals(name, actualName)) {
-            failWithMessage("Observation should have name equal to <%s> but has <%s>", name, actualName);
+            failWithActualExpectedAndMessage(actualName, name,
+                    "Observation should have name equal to <%s> but has <%s>", name, actualName);
         }
         return (SELF) this;
     }
@@ -89,7 +90,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         String actualName = this.actual.getName();
         if (!name.equalsIgnoreCase(actualName)) {
-            failWithMessage("Observation should have name equal to ignoring case <%s> but has <%s>", name, actualName);
+            failWithActualExpectedAndMessage(actualName, name,
+                    "Observation should have name equal to ignoring case <%s> but has <%s>", name, actualName);
         }
         return (SELF) this;
     }
@@ -107,7 +109,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         String actualName = this.actual.getContextualName();
         if (!Objects.equals(name, actualName)) {
-            failWithMessage("Observation should have contextual name equal to <%s> but has <%s>", name, actualName);
+            failWithActualExpectedAndMessage(actualName, name,
+                    "Observation should have contextual name equal to <%s> but has <%s>", name, actualName);
         }
         return (SELF) this;
     }
@@ -125,7 +128,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         String actualName = this.actual.getContextualName();
         if (!name.equalsIgnoreCase(actualName)) {
-            failWithMessage("Observation should have contextual name equal to ignoring case <%s> but has <%s>", name,
+            failWithActualExpectedAndMessage(actualName, name,
+                    "Observation should have contextual name equal to ignoring case <%s> but has <%s>", name,
                     actualName);
         }
         return (SELF) this;
@@ -251,7 +255,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
             .get()
             .getValue();
         if (!Objects.equals(tagValue, value)) {
-            failWithMessage(
+            failWithActualExpectedAndMessage(tagValue, value,
                     "Observation should have a low cardinality tag with key <%s> and value <%s>. The key is correct but the value is <%s>",
                     key, value, tagValue);
         }
@@ -328,7 +332,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
             .get()
             .getValue();
         if (!Objects.equals(tagValue, value)) {
-            failWithMessage(
+            failWithActualExpectedAndMessage(tagValue, value,
                     "Observation should have a high cardinality tag with key <%s> and value <%s>. The key is correct but the value is <%s>",
                     key, value, tagValue);
         }
@@ -462,7 +466,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
             failWithMessage("Observation should have parent <%s> but has none", expectedParent);
         }
         if (!realParent.equals(expectedParent)) {
-            failWithMessage("Observation should have parent <%s> but has <%s>", expectedParent, realParent);
+            failWithActualExpectedAndMessage(realParent, expectedParent,
+                    "Observation should have parent <%s> but has <%s>", expectedParent, realParent);
         }
         return (SELF) this;
     }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -21,10 +21,12 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 import java.util.function.Supplier;
 
 import static io.micrometer.observation.tck.ObservationContextAssert.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.Mockito.spy;
@@ -63,7 +65,11 @@ class ObservationContextAssertTests {
     void should_throw_exception_when_name_incorrect() {
         context.setName("foo");
 
-        thenThrownBy(() -> assertThat(context).hasNameEqualTo("bar")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(context).hasNameEqualTo("bar")).isInstanceOfSatisfying(AssertionFailedError.class,
+                error -> {
+                    then(error.getActual().getStringRepresentation()).isEqualTo("foo");
+                    then(error.getExpected().getStringRepresentation()).isEqualTo("bar");
+                });
     }
 
     @Test
@@ -91,7 +97,11 @@ class ObservationContextAssertTests {
     void should_throw_exception_when_contextual_name_incorrect() {
         context.setContextualName("foo");
 
-        thenThrownBy(() -> assertThat(context).hasContextualNameEqualTo("bar")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(context).hasContextualNameEqualTo("bar"))
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("foo");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("bar");
+            });
     }
 
     @Test
@@ -120,7 +130,11 @@ class ObservationContextAssertTests {
     void should_throw_exception_when_name_ignore_case_incorrect() {
         context.setName("foo");
 
-        thenThrownBy(() -> assertThat(context).hasNameEqualToIgnoringCase("bar")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(context).hasNameEqualToIgnoringCase("bar"))
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("foo");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("bar");
+            });
     }
 
     @Test
@@ -150,7 +164,10 @@ class ObservationContextAssertTests {
         context.setContextualName("foo");
 
         thenThrownBy(() -> assertThat(context).hasContextualNameEqualToIgnoringCase("bar"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("foo");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("bar");
+            });
     }
 
     @Test
@@ -248,7 +265,10 @@ class ObservationContextAssertTests {
         observation.lowCardinalityKeyValue("foo", "bar");
 
         thenThrownBy(() -> assertThat(context).hasLowCardinalityKeyValue("foo", "baz"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("bar");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("baz");
+            });
         thenThrownBy(() -> assertThat(context).hasLowCardinalityKeyValueWithKey("bar"))
             .isInstanceOf(AssertionError.class);
     }
@@ -284,7 +304,10 @@ class ObservationContextAssertTests {
         observation.highCardinalityKeyValue("foo", "bar");
 
         thenThrownBy(() -> assertThat(context).hasHighCardinalityKeyValue("foo", "baz"))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("bar");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("baz");
+            });
         thenThrownBy(() -> assertThat(context).hasHighCardinalityKeyValueWithKey("bar"))
             .isInstanceOf(AssertionError.class);
     }


### PR DESCRIPTION
The goal of this PR is to improve the user experience when an assertion fails in an IDE.

e.g. the error messages prior this PR in IntelliJ look like:

![old_hasContextualNameEqualToIgnoringCase](https://github.com/user-attachments/assets/21800cb2-fa72-45e0-91bc-bfee002d78f6)
![old_hasHighCardinalityKeyValue](https://github.com/user-attachments/assets/b9ee9725-f68c-408d-bc12-24c58568800d)
![old_hasNameEqualToIgnoringCase](https://github.com/user-attachments/assets/cebe6edd-ebb1-464b-be2d-f2f121de7079)
![old_hasLowCardinalityKeyValue](https://github.com/user-attachments/assets/2e70a51e-d7b5-477c-9a7a-fa3f4c9572a7)
![old_hasNameEqualTo](https://github.com/user-attachments/assets/ba935594-7358-49f3-a8be-5f0a45eb1351)
![old_hasContextualNameEqualTo](https://github.com/user-attachments/assets/f12a7abd-5157-4f32-8cbd-0d09d6dc719e)


After this PR they look like:

![new_hasContextualNameEqualToIgnoringCase](https://github.com/user-attachments/assets/47492306-40e6-45c8-92d3-a46273a8dc88)
![new_hasHighCardinalityKeyValue](https://github.com/user-attachments/assets/1d638fc7-c479-48eb-ad09-c1106ad1ac04)
![new_hasNameEqualToIgnoringCase](https://github.com/user-attachments/assets/21731a17-3967-4b29-8b97-ecf820e5db7d)
![new_hasLowCardinalityKeyValue](https://github.com/user-attachments/assets/9766716c-14a6-4ab6-91f4-4ea2b693f5eb)
![new_hasNameEqualTo](https://github.com/user-attachments/assets/76e6d176-7332-4c1c-8f73-f5ad351277d8)
![new_hasContextualNameEqualTo](https://github.com/user-attachments/assets/18bf7031-a98f-4d9b-945e-d4a293bc3556)


The difference is that Intellij knows how to handle the `AssertionFailedError` and display the nice "Click to see difference" in the UI. The AssertJ library will handle `failWithActualExpectedAndMessage` properly and fallback to `AssertionError` in case the `AssertionFailedError` from opentest4j is not available.