### PR TITLE
Expose TestObservationRegistry as an AssertJ AssertProvider

### DIFF
--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
@@ -27,13 +27,13 @@ import io.micrometer.observation.annotation.Observed;
 import io.micrometer.observation.aop.ObservedAspect;
 import io.micrometer.observation.docs.ObservationDocumentation;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 import org.springframework.lang.Nullable;
 
 import static io.micrometer.docs.observation.ObservationHandlerTests.TaxObservationDocumentation.TaxHighCardinalityKeyNames.USER_ID;
 import static io.micrometer.docs.observation.ObservationHandlerTests.TaxObservationDocumentation.TaxLowCardinalityKeyNames.TAX_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Sources for observation-components.adoc
@@ -158,7 +158,7 @@ class ObservationHandlerTests {
         service.call();
 
         // assert that observation has been properly created
-        TestObservationRegistryAssert.assertThat(registry)
+        assertThat(registry)
                 .hasSingleObservationThat()
                 .hasBeenStopped()
                 .hasNameEqualTo("test.call")

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
@@ -18,8 +18,9 @@ package io.micrometer.docs.observation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Sources for observation-testing.adoc
@@ -37,7 +38,7 @@ class ObservationTestingTests {
         new Example(registry).run();
 
         // check your observation
-        TestObservationRegistryAssert.assertThat(registry)
+        assertThat(registry)
                 .doesNotHaveAnyRemainingCurrentObservation()
                 .hasObservationWithNameEqualTo("foo")
                 .that()

--- a/docs/src/test/java/io/micrometer/docs/observation/messaging/ObservationMessagingIntegrationTest.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/messaging/ObservationMessagingIntegrationTest.java
@@ -20,7 +20,6 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import io.micrometer.observation.transport.ReceiverContext;
 import io.micrometer.observation.transport.SenderContext;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -55,6 +54,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 @Tag("docker")
@@ -134,15 +135,13 @@ class ObservationMessagingIntegrationTest {
         // end::consumer_side[]
 
         // tag::test_assertions[]
-        TestObservationRegistryAssert.assertThat(registry)
-            .hasObservationWithNameEqualTo("kafka.send")
+        assertThat(registry).hasObservationWithNameEqualTo("kafka.send")
             .that()
             .hasBeenStarted()
             .hasBeenStopped()
             .hasLowCardinalityKeyValue("sent", "true");
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .hasObservationWithNameEqualTo("kafka.receive")
+        assertThat(registry).hasObservationWithNameEqualTo("kafka.receive")
             .that()
             .hasBeenStarted()
             .hasBeenStopped()

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -66,7 +66,6 @@ import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -170,7 +169,7 @@ class GrpcObservationTest {
             assertThat(clientHandler.getEvents()).containsExactly(GrpcClientEvents.MESSAGE_SENT,
                     GrpcClientEvents.MESSAGE_RECEIVED);
             // tag::assertion[]
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server"));
             // end::assertion[]
@@ -205,7 +204,7 @@ class GrpcObservationTest {
 
             await().until(() -> futures.stream().allMatch(Future::isDone));
             assertThat(responses).hasSize(count).containsExactlyInAnyOrderElementsOf(messages);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server"));
             verifyHeaders();
@@ -248,7 +247,7 @@ class GrpcObservationTest {
             verifyServerContext("grpc.testing.SimpleService", "ClientStreamingRpc",
                     "grpc.testing.SimpleService/ClientStreamingRpc", MethodType.CLIENT_STREAMING);
             assertThat(serverHandler.getContext().getStatusCode()).isEqualTo(Code.OK);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server"));
             verifyHeaders();
@@ -283,7 +282,7 @@ class GrpcObservationTest {
             assertThat(clientHandler.getContext().getStatusCode()).isEqualTo(Code.OK);
             assertThat(clientHandler.getEvents()).containsExactly(GrpcClientEvents.MESSAGE_SENT,
                     GrpcClientEvents.MESSAGE_RECEIVED, GrpcClientEvents.MESSAGE_RECEIVED);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server"));
             verifyHeaders();
@@ -336,7 +335,7 @@ class GrpcObservationTest {
 
             assertThat(serverHandler.getContext().getStatusCode()).isEqualTo(Code.OK);
             assertThat(clientHandler.getContext().getStatusCode()).isEqualTo(Code.OK);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server"));
             verifyHeaders();
@@ -408,9 +407,8 @@ class GrpcObservationTest {
             assertThat(clientHandler.getContext().getStatusCode()).isEqualTo(Code.UNKNOWN);
             assertThat(serverHandler.getEvents()).containsExactly(GrpcServerEvents.MESSAGE_RECEIVED);
             assertThat(clientHandler.getEvents()).containsExactly(GrpcClientEvents.MESSAGE_SENT);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
-                .hasAnObservation(
-                        observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
+            assertThat(observationRegistry).hasAnObservation(
+                    observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
         }
 
         @Test
@@ -432,9 +430,8 @@ class GrpcObservationTest {
             assertThat(serverHandler.getContext().getStatusCode()).isNull();
             assertThat(clientHandler.getEvents()).isEmpty();
             assertThat(serverHandler.getEvents()).isEmpty();
-            TestObservationRegistryAssert.assertThat(observationRegistry)
-                .hasAnObservation(
-                        observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
+            assertThat(observationRegistry).hasAnObservation(
+                    observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
         }
 
         @Test
@@ -458,9 +455,8 @@ class GrpcObservationTest {
             assertThat(serverHandler.getContext().getStatusCode()).isNull();
             assertThat(clientHandler.getEvents()).containsExactly(GrpcClientEvents.MESSAGE_SENT);
             assertThat(serverHandler.getEvents()).containsExactly(GrpcServerEvents.MESSAGE_RECEIVED);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
-                .hasAnObservation(
-                        observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
+            assertThat(observationRegistry).hasAnObservation(
+                    observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
         }
 
         @Test
@@ -483,9 +479,8 @@ class GrpcObservationTest {
             assertThat(serverHandler.getContext().getStatusCode()).isNull();
             assertThat(clientHandler.getEvents()).isEmpty();
             assertThat(serverHandler.getEvents()).isEmpty();
-            TestObservationRegistryAssert.assertThat(observationRegistry)
-                .hasAnObservation(
-                        observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
+            assertThat(observationRegistry).hasAnObservation(
+                    observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server").hasError());
         }
 
         private StreamObserver<SimpleResponse> createResponseObserver(AtomicBoolean errored) {
@@ -572,7 +567,7 @@ class GrpcObservationTest {
             this.service.requestInterrupted.set(true);
             await().until(future::isDone);
             assertThat(future.isCancelled()).isTrue();
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client")
                     .hasLowCardinalityKeyValue("grpc.status_code", "CANCELLED"))
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.server")
@@ -593,7 +588,7 @@ class GrpcObservationTest {
             this.service.requestInterrupted.set(true);
             await().until(channel::isTerminated);
             await().until(future::isDone);
-            TestObservationRegistryAssert.assertThat(observationRegistry)
+            assertThat(observationRegistry)
                 .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("grpc.client")
                     .hasLowCardinalityKeyValue("grpc.status_code", "UNAVAILABLE"));
             assertThat(serverHandler.getEvents()).contains(GrpcServerEvents.CANCELLED);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
@@ -25,7 +25,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -305,8 +304,7 @@ class MicrometerHttpRequestExecutorTest {
                 EntityUtils.consume(client.execute(new HttpCustomMethod(method, server.baseUrl())).getEntity());
                 break;
         }
-        TestObservationRegistryAssert.assertThat(observationRegistry)
-            .hasSingleObservationThat()
+        assertThat(observationRegistry).hasSingleObservationThat()
             .hasContextualNameEqualToIgnoringCase("http " + method);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -25,7 +25,6 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
@@ -318,8 +317,7 @@ class MicrometerHttpRequestExecutorTest {
                 execute(client, new HttpUriRequestBase(method, URI.create(server.baseUrl())));
                 break;
         }
-        TestObservationRegistryAssert.assertThat(observationRegistry)
-            .hasSingleObservationThat()
+        assertThat(observationRegistry).hasSingleObservationThat()
             .hasContextualNameEqualToIgnoringCase("http " + method);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static io.micrometer.core.instrument.binder.httpcomponents.hc5.ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.*;
-import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerTest.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.micrometer.core.instrument.binder.httpcomponents.hc5.ApacheHttpClientObservationDocumentation.ApacheHttpClientKeyNames.*;
-import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentationTest.java
@@ -26,7 +26,6 @@ import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.Test;
 
-import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ObservationOrTimerCompatibleInstrumentationTest {

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -23,6 +23,8 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.assertj.core.api.AssertProvider;
+
 /**
  * Implementation of {@link ObservationRegistry} used for testing.
  *
@@ -31,7 +33,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public final class TestObservationRegistry implements ObservationRegistry {
+public final class TestObservationRegistry
+        implements ObservationRegistry, AssertProvider<TestObservationRegistryAssert> {
 
     private final ObservationRegistry delegate = ObservationRegistry.create();
 
@@ -79,6 +82,18 @@ public final class TestObservationRegistry implements ObservationRegistry {
      */
     public void clear() {
         getContexts().clear();
+    }
+
+    /**
+     * Return an assert for AspectJ.
+     * @return an AspectJ assert
+     * @deprecated to prevent accidental use. Prefer standard AssertJ
+     * {@code assertThat(observationRegistry)...} calls instead.
+     */
+    @Deprecated
+    @Override
+    public TestObservationRegistryAssert assertThat() {
+        return TestObservationRegistryAssert.assertThat(this);
     }
 
     private static class StoringObservationHandler implements ObservationHandler<Observation.Context> {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.thenNoException;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
@@ -66,8 +66,7 @@ class TestObservationRegistryAssertTests {
     void should_fail_when_observation_not_started() {
         Observation.createNotStarted("foo", registry);
 
-        thenThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().hasBeenStarted())
+        thenThrownBy(() -> assertThat(registry).hasSingleObservationThat().hasBeenStarted())
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("You have forgotten to start your observation");
     }
@@ -76,16 +75,14 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_observation_started() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenNoException().isThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().hasBeenStarted());
+        thenNoException().isThrownBy(() -> assertThat(registry).hasSingleObservationThat().hasBeenStarted());
     }
 
     @Test
     void should_fail_when_observation_not_stopped() {
         Observation.createNotStarted("foo", registry).start();
 
-        thenThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().hasBeenStopped())
+        thenThrownBy(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped())
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("Observation is not stopped");
     }
@@ -94,15 +91,14 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_observation_stopped() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenNoException().isThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().hasBeenStopped());
+        thenNoException().isThrownBy(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped());
     }
 
     @Test
     void should_fail_when_observation_stopped() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().isNotStopped())
+        thenThrownBy(() -> assertThat(registry).hasSingleObservationThat().isNotStopped())
             .isInstanceOf(AssertionError.class)
             .hasMessageContaining("Observation is stopped");
     }
@@ -111,16 +107,14 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_observation_not_stopped() {
         Observation.createNotStarted("foo", registry).start();
 
-        thenNoException().isThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasSingleObservationThat().isNotStopped());
+        thenNoException().isThrownBy(() -> assertThat(registry).hasSingleObservationThat().isNotStopped());
     }
 
     @Test
     void should_fail_when_no_observation_with_name_found() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasObservationWithNameEqualTo("bar"))
-            .isInstanceOf(AssertionError.class)
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("bar")).isInstanceOf(AssertionError.class)
             .hasMessageContaining("Available names are <foo>");
     }
 
@@ -128,18 +122,16 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_observation_with_name_found() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasObservationWithNameEqualTo("foo")
-            .that()
-            .hasBeenStarted());
+        thenNoException()
+            .isThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("foo").that().hasBeenStarted());
     }
 
     @Test
     void should_fail_when_no_observation_with_name_ignoring_case_found() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasObservationWithNameEqualToIgnoringCase("bar")).isInstanceOf(AssertionError.class)
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualToIgnoringCase("bar"))
+            .isInstanceOf(AssertionError.class)
             .hasMessageContaining("Available names are <foo>");
     }
 
@@ -147,17 +139,15 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_observation_with_name_ignoring_case_found() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasObservationWithNameEqualToIgnoringCase("foo")
-            .that()
-            .hasBeenStarted());
+        thenNoException().isThrownBy(
+                () -> assertThat(registry).hasObservationWithNameEqualToIgnoringCase("foo").that().hasBeenStarted());
     }
 
     @Test
     void should_fail_when_no_contexts_satisfy_the_assertion() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
+        thenThrownBy(() -> assertThat(registry)
             .hasHandledContextsThatSatisfy(contexts -> Assertions.assertThat(contexts).hasSize(2)))
             .isInstanceOf(AssertionError.class);
     }
@@ -166,7 +156,7 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_contexts_satisfy_the_assertions() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
+        thenNoException().isThrownBy(() -> assertThat(registry)
             .hasHandledContextsThatSatisfy(contexts -> Assertions.assertThat(contexts).hasSize(1)));
     }
 
@@ -174,22 +164,20 @@ class TestObservationRegistryAssertTests {
     void should_fail_when_there_are_observations() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation())
-            .isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).doesNotHaveAnyObservation()).isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_there_are_no_observations() {
-        thenNoException()
-            .isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation());
+        thenNoException().isThrownBy(() -> assertThat(registry).doesNotHaveAnyObservation());
     }
 
     @Test
     void should_fail_when_there_is_no_observation_with_name() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualTo("bar", ObservationContextAssert::doesNotHaveError))
+        thenThrownBy(() -> assertThat(registry).forAllObservationsWithNameEqualTo("bar",
+                ObservationContextAssert::doesNotHaveError))
             .isInstanceOf(AssertionError.class);
     }
 
@@ -197,8 +185,8 @@ class TestObservationRegistryAssertTests {
     void should_fail_when_all_observations_do_not_match_the_assertion() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualTo("foo", ObservationContextAssert::hasError))
+        thenThrownBy(
+                () -> assertThat(registry).forAllObservationsWithNameEqualTo("foo", ObservationContextAssert::hasError))
             .isInstanceOf(AssertionError.class);
     }
 
@@ -206,16 +194,16 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_all_observations_match_the_assertion() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualTo("foo", ObservationContextAssert::doesNotHaveError));
+        thenNoException().isThrownBy(() -> assertThat(registry).forAllObservationsWithNameEqualTo("foo",
+                ObservationContextAssert::doesNotHaveError));
     }
 
     @Test
     void should_fail_when_there_is_no_observation_with_name_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualToIgnoreCase("bar", ObservationContextAssert::doesNotHaveError))
+        thenThrownBy(() -> assertThat(registry).forAllObservationsWithNameEqualToIgnoreCase("bar",
+                ObservationContextAssert::doesNotHaveError))
             .isInstanceOf(AssertionError.class);
     }
 
@@ -223,8 +211,8 @@ class TestObservationRegistryAssertTests {
     void should_fail_when_not_all_observations_match_the_assertion_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualToIgnoreCase("foo", ObservationContextAssert::hasError))
+        thenThrownBy(() -> assertThat(registry).forAllObservationsWithNameEqualToIgnoreCase("foo",
+                ObservationContextAssert::hasError))
             .isInstanceOf(AssertionError.class);
     }
 
@@ -232,135 +220,126 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_all_observations_match_the_assertion_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .forAllObservationsWithNameEqualToIgnoreCase("foo", ObservationContextAssert::doesNotHaveError));
+        thenNoException().isThrownBy(() -> assertThat(registry).forAllObservationsWithNameEqualToIgnoreCase("foo",
+                ObservationContextAssert::doesNotHaveError));
     }
 
     @Test
     void should_fail_when_number_of_observations_does_not_match() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasNumberOfObservationsEqualTo(0))
-            .isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsEqualTo(0)).isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_number_of_observations_matches() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenNoException()
-            .isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasNumberOfObservationsEqualTo(1));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasNumberOfObservationsEqualTo(1));
     }
 
     @Test
     void should_fail_when_names_match_but_number_is_incorrect() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualTo("foo", 0)).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualTo("foo", 0))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_fail_when_number_is_correct_but_names_do_not_match() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualTo("bar", 1)).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualTo("bar", 1))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_number_and_names_match() {
         Observation.createNotStarted("foo", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualTo("foo", 1));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualTo("foo", 1));
     }
 
     @Test
     void should_fail_when_names_match_but_number_is_incorrect_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualToIgnoreCase("foo", 0)).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualToIgnoreCase("foo", 0))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_fail_when_number_is_correct_but_names_do_not_match_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualToIgnoreCase("bar", 1)).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualToIgnoreCase("bar", 1))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_number_and_names_match_ignore_case() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasNumberOfObservationsWithNameEqualToIgnoreCase("foo", 1));
+        thenNoException()
+            .isThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualToIgnoreCase("foo", 1));
     }
 
     @Test
     void should_fail_when_key_value_not_matched() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyValue("key", "value"))
+        thenThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue("key", "value"))
             .isInstanceOf(AssertionError.class);
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasAnObservationWithAKeyValue(KeyValue.of("key", "value"))).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue(KeyValue.of("key", "value")))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_key_value_matched() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenNoException().isThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyValue("foo", "bar"));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue("foo", "bar"));
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasAnObservationWithAKeyValue(KeyValue.of("foo", "bar")));
+        thenNoException()
+            .isThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue(KeyValue.of("foo", "bar")));
     }
 
     @Test
     void should_fail_when_key_not_matched() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyName("key"))
-            .isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyName("key")).isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_key_matched() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenNoException()
-            .isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyName("foo"));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyName("foo"));
     }
 
     @Test
     void should_fail_when_key_value_not_matched_using_KeyName() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasAnObservationWithAKeyValue(MyKeyName.FOO, "value")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue(MyKeyName.FOO, "value"))
+            .isInstanceOf(AssertionError.class);
     }
 
     @Test
     void should_not_fail_when_key_value_matched_using_KeyName() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
-            .hasAnObservationWithAKeyValue(MyKeyName.FOO, "bar"));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyValue(MyKeyName.FOO, "bar"));
     }
 
     @Test
     void should_fail_when_key_not_matched_using_KeyName() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("aaa", "bar").start().stop();
 
-        thenThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyName(MyKeyName.FOO))
+        thenThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyName(MyKeyName.FOO))
             .isInstanceOf(AssertionError.class);
     }
 
@@ -368,15 +347,14 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_key_matched_using_KeyName() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenNoException().isThrownBy(
-                () -> TestObservationRegistryAssert.assertThat(registry).hasAnObservationWithAKeyName(MyKeyName.FOO));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasAnObservationWithAKeyName(MyKeyName.FOO));
     }
 
     @Test
     void should_fail_when_no_observation_matches_assertion() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("aaa", "bar").start().stop();
 
-        thenThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
+        thenThrownBy(() -> assertThat(registry)
             .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("FOO")
                 .hasLowCardinalityKeyValue("bbb", "bar")))
             .isInstanceOf(AssertionError.class);
@@ -386,7 +364,7 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_one_observation_matches_assertion() {
         Observation.createNotStarted("FOO", registry).lowCardinalityKeyValue("foo", "bar").start().stop();
 
-        thenNoException().isThrownBy(() -> TestObservationRegistryAssert.assertThat(registry)
+        thenNoException().isThrownBy(() -> assertThat(registry)
             .hasAnObservation(observationContextAssert -> observationContextAssert.hasNameEqualTo("FOO")
                 .hasLowCardinalityKeyValue("foo", "bar")));
     }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/aop/ObservedAspectTests.java
@@ -27,7 +27,6 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
 import io.micrometer.observation.annotation.Observed;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -61,8 +60,7 @@ class ObservedAspectTests {
         ObservedService service = pf.getProxy();
         service.call();
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.call")
@@ -85,8 +83,7 @@ class ObservedAspectTests {
         TestBeanInterface service = pf.getProxy();
         service.testMethod("bar");
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.method")
@@ -105,8 +102,7 @@ class ObservedAspectTests {
         ObservedService service = pf.getProxy();
         assertThatThrownBy(service::error);
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.error")
@@ -134,12 +130,9 @@ class ObservedAspectTests {
 
         assertThat(asyncResult.get()).isEqualTo("test-result");
         await().atMost(Duration.ofMillis(200))
-            .untilAsserted(() -> TestObservationRegistryAssert.assertThat(registry)
-                .hasSingleObservationThat()
-                .hasBeenStopped());
+            .untilAsserted(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped());
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasNameEqualTo("test.async")
             .hasContextualNameEqualTo("ObservedService#async")
@@ -163,12 +156,9 @@ class ObservedAspectTests {
 
         assertThatThrownBy(fakeAsyncTask::get).isEqualTo(simulatedException);
         await().atMost(Duration.ofMillis(200))
-            .untilAsserted(() -> TestObservationRegistryAssert.assertThat(registry)
-                .hasSingleObservationThat()
-                .hasBeenStopped());
+            .untilAsserted(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped());
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasNameEqualTo("test.async")
             .hasContextualNameEqualTo("ObservedService#async")
@@ -189,8 +179,7 @@ class ObservedAspectTests {
 
         ObservedService service = pf.getProxy();
         service.call();
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.call")
@@ -210,7 +199,7 @@ class ObservedAspectTests {
 
         ObservedService service = pf.getProxy();
         service.call();
-        TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation();
+        assertThat(registry).doesNotHaveAnyObservation();
     }
 
     @Test
@@ -223,8 +212,7 @@ class ObservedAspectTests {
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         service.call();
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.class")
@@ -246,8 +234,7 @@ class ObservedAspectTests {
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         assertThatThrownBy(service::error);
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.class")
@@ -277,12 +264,9 @@ class ObservedAspectTests {
 
         assertThat(asyncResult.get()).isEqualTo("test-result");
         await().atMost(Duration.ofMillis(200))
-            .untilAsserted(() -> TestObservationRegistryAssert.assertThat(registry)
-                .hasSingleObservationThat()
-                .hasBeenStopped());
+            .untilAsserted(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped());
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasNameEqualTo("test.class")
             .hasContextualNameEqualTo("test.class#call")
@@ -308,12 +292,9 @@ class ObservedAspectTests {
 
         assertThatThrownBy(fakeAsyncTask::get).isEqualTo(simulatedException);
         await().atMost(Duration.ofMillis(200))
-            .untilAsserted(() -> TestObservationRegistryAssert.assertThat(registry)
-                .hasSingleObservationThat()
-                .hasBeenStopped());
+            .untilAsserted(() -> assertThat(registry).hasSingleObservationThat().hasBeenStopped());
 
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasNameEqualTo("test.class")
             .hasContextualNameEqualTo("test.class#call")
@@ -336,8 +317,7 @@ class ObservedAspectTests {
 
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         service.call();
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.class")
@@ -357,7 +337,7 @@ class ObservedAspectTests {
 
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         service.call();
-        TestObservationRegistryAssert.assertThat(registry).doesNotHaveAnyObservation();
+        assertThat(registry).doesNotHaveAnyObservation();
     }
 
     @Test
@@ -370,8 +350,7 @@ class ObservedAspectTests {
 
         ObservedClassLevelAnnotatedService service = pf.getProxy();
         service.annotatedOnMethod();
-        TestObservationRegistryAssert.assertThat(registry)
-            .doesNotHaveAnyRemainingCurrentObservation()
+        assertThat(registry).doesNotHaveAnyRemainingCurrentObservation()
             .hasSingleObservationThat()
             .hasBeenStopped()
             .hasNameEqualTo("test.class")

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
@@ -36,7 +36,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.function.Function;
 
-import static io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationTimingVerificationTests.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.docs.ObservationDocumentation;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -78,13 +77,11 @@ abstract class InstrumentationTimingVerificationTests extends InstrumentationVer
 
         if (testType == TestType.METRICS_VIA_OBSERVATIONS_WITH_METRICS_HANDLER) {
             if (observationDocumentation.getDefaultConvention() == null) {
-                TestObservationRegistryAssert.assertThat(getObservationRegistry())
-                    .hasObservationWithNameEqualTo(observationDocumentation.getName())
+                assertThat(getObservationRegistry()).hasObservationWithNameEqualTo(observationDocumentation.getName())
                     .that()
                     .hasContextualNameEqualTo(observationDocumentation.getContextualName());
             }
-            TestObservationRegistryAssert.assertThat(getObservationRegistry())
-                .hasObservationWithNameEqualTo(timerName())
+            assertThat(getObservationRegistry()).hasObservationWithNameEqualTo(timerName())
                 .that()
                 .hasSubsetOfKeys(getAllKeyNames(observationDocumentation));
         }

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 
 import io.micrometer.jakarta9.instrument.jms.JmsInstrumentation;
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import jakarta.jms.*;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQExtension;
@@ -65,8 +64,7 @@ class JmsInstrumentationTests {
     void shouldInstrumentSendOperations(String methodName, SessionConsumer sessionConsumer) throws Exception {
         try (Session session = createInstrumentedSession()) {
             sessionConsumer.accept(session);
-            TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("jms.message.publish")
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.publish")
                 .that()
                 .hasContextualNameEqualTo("test.send publish");
         }
@@ -116,8 +114,7 @@ class JmsInstrumentationTests {
             TextMessage message = session.createTextMessage("test content");
             jmsConnection.close();
             assertThatThrownBy(() -> producer.send(message)).isInstanceOf(jakarta.jms.IllegalStateException.class);
-            TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("jms.message.publish")
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.publish")
                 .that()
                 .hasContextualNameEqualTo("test.send publish")
                 .hasLowCardinalityKeyValue("exception", "IllegalStateException");
@@ -134,8 +131,7 @@ class JmsInstrumentationTests {
             MessageProducer producer = session.createProducer(topic);
             producer.send(session.createTextMessage("test send"));
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-            TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("jms.message.process")
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
                 .that()
                 .hasContextualNameEqualTo("test.send process");
         }
@@ -154,8 +150,7 @@ class JmsInstrumentationTests {
             MessageProducer producer = session.createProducer(topic);
             producer.send(session.createTextMessage("test send"));
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-            TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("jms.message.process")
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
                 .that()
                 .hasLowCardinalityKeyValue("exception", "IllegalStateException");
         }


### PR DESCRIPTION
This is just an idea which is inspired by the way the Spring Boot [`ApplicationContextAssertProvider`](https://github.com/spring-projects/spring-boot/blob/main/spring-boot-project/spring-boot-test/src/main/java/org/springframework/boot/test/context/assertj/ApplicationContextAssertProvider.java) works. Some more information from the Spring Boot [Testing your Auto-configuration](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.testing).

The main idea is basically for people not to need to do `TestObservationRegistryAssert.assertThat`, but instead use (the most likely already exposed) `Assertions.assertThat`.

I tried to look into the issues and PRs if something like this was proposed before, but I could not find anything and I thought to share an idea as a PR. I fully understand that perhaps the idea of the `TestObservationRegistry` is not to depend on AssertJ and / or you do not like the idea at all. In any case if you think that this is not useful for the project then please go ahead and reject the PR.