### PR TITLE
Catch runtime exception thrown from pjp function in aspects

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -17,6 +17,7 @@ package io.micrometer.core.aop;
 
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.*;
@@ -82,6 +83,8 @@ import java.util.function.Predicate;
 @NonNullApi
 @Incubating(since = "1.0.0")
 public class TimedAspect {
+
+    private static final WarnThenDebugLogger joinPointTagsFunctionLogger = new WarnThenDebugLogger(TimedAspect.class);
 
     private static final Predicate<ProceedingJoinPoint> DONT_SKIP_ANYTHING = pjp -> false;
 
@@ -156,8 +159,22 @@ public class TimedAspect {
     public TimedAspect(MeterRegistry registry, Function<ProceedingJoinPoint, Iterable<Tag>> tagsBasedOnJoinPoint,
             Predicate<ProceedingJoinPoint> shouldSkip) {
         this.registry = registry;
-        this.tagsBasedOnJoinPoint = tagsBasedOnJoinPoint;
+        this.tagsBasedOnJoinPoint = makeSafe(tagsBasedOnJoinPoint);
         this.shouldSkip = shouldSkip;
+    }
+
+    private Function<ProceedingJoinPoint, Iterable<Tag>> makeSafe(
+            Function<ProceedingJoinPoint, Iterable<Tag>> function) {
+        return pjp -> {
+            try {
+                return function.apply(pjp);
+            }
+            catch (Throwable t) {
+                joinPointTagsFunctionLogger
+                    .log("Exception thrown from the tagsBasedOnJoinPoint function configured on TimedAspect.", t);
+                return Tags.empty();
+            }
+        };
     }
 
     @Around("@within(io.micrometer.core.annotation.Timed)")

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/CountedAspectTest.java
@@ -15,9 +15,11 @@
  */
 package io.micrometer.core.aop;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.annotation.Counted;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -25,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
@@ -191,6 +194,21 @@ class CountedAspectTest {
         assertThat(meterRegistry.get("method.counted").counters()).hasSize(2);
         assertThat(meterRegistry.get("method.counted").tag("result", "success").counter().count()).isOne();
         assertThat(meterRegistry.get("method.counted").tag("result", "failure").counter().count()).isOne();
+    }
+
+    @Test
+    @Issue("#5584")
+    void pjpFunctionThrows() {
+        CountedService countedService = getAdvisedService(new CountedService(),
+                new CountedAspect(meterRegistry, (Function<ProceedingJoinPoint, Iterable<Tag>>) jp -> {
+                    throw new RuntimeException("test");
+                }));
+        countedService.succeedWithMetrics();
+
+        Counter counter = meterRegistry.get("metric.success").tag("extra", "tag").tag("result", "success").counter();
+
+        assertThat(counter.count()).isOne();
+        assertThat(counter.getId().getDescription()).isNull();
     }
 
     static class CountedService {

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -18,11 +18,10 @@ package io.micrometer.core.aop;
 import io.micrometer.common.annotation.ValueExpressionResolver;
 import io.micrometer.common.annotation.ValueResolver;
 import io.micrometer.common.lang.NonNull;
+import io.micrometer.core.Issue;
 import io.micrometer.core.annotation.Timed;
-import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.Meter.Id;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -36,6 +35,7 @@ import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import static java.util.concurrent.CompletableFuture.supplyAsync;
@@ -375,6 +375,23 @@ class TimedAspectTest {
         service.call();
 
         assertThat(failingRegistry.getMeters()).isEmpty();
+    }
+
+    @Test
+    @Issue("#5584")
+    void pjpFunctionThrows() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AspectJProxyFactory pf = new AspectJProxyFactory(new TimedService());
+        pf.addAspect(new TimedAspect(registry, (Function<ProceedingJoinPoint, Iterable<Tag>>) jp -> {
+            throw new RuntimeException("test");
+        }));
+
+        TimedService service = pf.getProxy();
+
+        service.call();
+
+        assertThat(registry.get("call").tag("extra", "tag").timer().count()).isEqualTo(1);
     }
 
     @Nested


### PR DESCRIPTION
Before, this would result in an exception bubbling up to user code (CountedAspect) or the metric recording not happening (TimedAspect). This changes the behavior to consistently record the metric without the tags from the pjp function if it throws. This aligns the behavior between the two and is safer (in the case of CountedAspect). An alternative that would also be safe and consistent would be to align to the existing behavior of TimedAspect - not recording any metric when an exception is thrown.

Resolves gh-5584