### PR TITLE
Add benchmarks for DefaultLTT start/stop

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+public class DefaultLongTaskTimerBenchmark {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(DefaultLongTaskTimerBenchmark.class.getSimpleName()).build();
+
+        new Runner(opt).run();
+    }
+
+    private static final int sampleCount = 10_000;
+
+    private MockClock clock;
+
+    private DefaultLongTaskTimer longTaskTimer;
+
+    private LongTaskTimer.Sample middleSample;
+
+    @Setup(Level.Invocation)
+    public void setup() {
+        clock = new MockClock();
+        longTaskTimer = new DefaultLongTaskTimer(
+                new Meter.Id("ltt", Tags.empty(), TimeUnit.MILLISECONDS.toString().toLowerCase(), null,
+                        Meter.Type.LONG_TASK_TIMER),
+                clock, TimeUnit.MILLISECONDS, DistributionStatisticConfig.DEFAULT, false);
+        // start some samples for benchmarking start/stop with active samples
+        IntStream.range(0, sampleCount).forEach(offset -> {
+            clock.add(offset, TimeUnit.MILLISECONDS);
+            LongTaskTimer.Sample sample = longTaskTimer.start();
+            if (offset == sampleCount / 2)
+                middleSample = sample;
+        });
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() {
+        longTaskTimer = null;
+    }
+
+    @Benchmark
+    @Warmup(iterations = 20)
+    @Measurement(iterations = 200)
+    @BenchmarkMode(Mode.SingleShotTime)
+    public LongTaskTimer.Sample start() {
+        return longTaskTimer.start();
+    }
+
+    @Benchmark
+    @Warmup(iterations = 20)
+    @Measurement(iterations = 200)
+    @BenchmarkMode(Mode.SingleShotTime)
+    public long stop() {
+        return middleSample.stop();
+    }
+
+    @Benchmark
+    @Warmup(iterations = 20)
+    @Measurement(iterations = 200)
+    @BenchmarkMode(Mode.SingleShotTime)
+    public long startAndStop() {
+        start();
+        return stop();
+    }
+
+}


### PR DESCRIPTION
Start and stop are called on the critical path. We should have benchmarks for them to evaluate changes that may affect their performance.

The benchmark is done differently than most other benchmarks because we want to isolate the time taken by starting a sample with a fixed number of existing samples and stopping a sample that hasn't been stopped. These both require specific states before the benchmarked code runs and that state will be altered by running the benchmark. If the state is not reset between benchmark invocations, we are measuring the time to start a new sample with increasingly more samples present, which we expect to take increasingly longer. That did not seem like the right approach. Likewise, the stop benchmark would result in stopping an already stopped sample if multiple invocations are made without resetting the state, which we expect to be substantially faster than stopping an unstopped sample. Suggestions are welcome on any better way to handle this.

See #5591 