### PR TITLE
Enable Gauge builders to take a subclass of Number

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
@@ -53,7 +53,7 @@ public interface Gauge extends Meter {
      * @since 1.1.0
      */
     @Incubating(since = "1.1.0")
-    static Builder<Supplier<Number>> builder(String name, Supplier<Number> f) {
+    static <T extends Number> Builder<Supplier<T>> builder(String name, Supplier<T> f) {
         return new Builder<>(name, f, f2 -> {
             Number val = f2.get();
             return val == null ? Double.NaN : val.doubleValue();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
@@ -112,7 +112,7 @@ public class MultiGauge {
             return new Row<>(uniqueTags, number, Number::doubleValue);
         }
 
-        public static Row<Supplier<Number>> of(Tags uniqueTags, Supplier<Number> valueFunction) {
+        public static <T extends Number> Row<Supplier<T>> of(Tags uniqueTags, Supplier<T> valueFunction) {
             return new Row<>(uniqueTags, valueFunction, f -> {
                 Number value = valueFunction.get();
                 return value == null ? Double.NaN : value.doubleValue();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
@@ -46,7 +46,7 @@ public interface TimeGauge extends Gauge {
      * @since 1.7.0
      */
     @Incubating(since = "1.7.0")
-    static Builder<Supplier<Number>> builder(String name, Supplier<Number> f, TimeUnit fUnits) {
+    static <T extends Number> Builder<Supplier<T>> builder(String name, Supplier<T> f, TimeUnit fUnits) {
         return new Builder<>(name, f, fUnits, f2 -> {
             Number val = f2.get();
             return val == null ? Double.NaN : val.doubleValue();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -89,6 +90,14 @@ class MultiGaugeTest {
         colorGauges.register(Collections.singletonList(Row.of(Tags.of("color", "red"), () -> 1)));
 
         System.gc();
+
+        assertThat(registry.get("colors").tag("color", "red").gauge().value()).isEqualTo(1);
+    }
+
+    @Test
+    void rowGaugesCanTakeSubClassOfNumberSuppliers() {
+        final Supplier<Long> supplier = () -> 1L;
+        colorGauges.register(Collections.singletonList(Row.of(Tags.of("color", "red"), supplier)));
 
         assertThat(registry.get("colors").tag("color", "red").gauge().value()).isEqualTo(1);
     }


### PR DESCRIPTION
This is an idea to make the various `Gauge.builder(..)` methods more flexible. Currently, due to Java's type erasure, if you want to instantiate a gauge using a `Supplier<Integer>`, you need to cast this to a `Supplier<Number>`, weakening your type safety.

You can extend the signature in a backward-compatible way and allow usage, as demonstrated in the tests I've added. I tried fitting the tests into appropriate places, but if this isn't where they should be, I'd be happy to move/refactor them.

I tried to look into issues and PRs to see if something similar had been proposed before, but I couldn't find anything, so I thought of sharing an idea as a PR. In any case, if you believe this is not useful for the project, please reject the PR.