### PR TITLE
Support assertions on Observation events

### DIFF
--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
@@ -88,11 +88,13 @@ class ObservationTestingTests {
         }
 
         void run() {
-            Observation.createNotStarted("foo", registry)
+            final Observation observation = Observation.createNotStarted("foo", registry)
                     .lowCardinalityKeyValue("lowTag", "lowTagValue")
-                    .highCardinalityKeyValue("highTag", "highTagValue")
-                    .event(Observation.Event.of("event1"))
-                    .observe(() -> System.out.println("Hello"));
+                    .highCardinalityKeyValue("highTag", "highTagValue");
+            observation.observe(() -> {
+                observation.event(Observation.Event.of("event1"));
+                System.out.println("Hello");
+            });
         }
 
     }

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationTestingTests.java
@@ -44,6 +44,7 @@ class ObservationTestingTests {
                 .that()
                 .hasHighCardinalityKeyValue("highTag", "highTagValue")
                 .hasLowCardinalityKeyValue("lowTag", "lowTagValue")
+                .hasEvent("event1")
                 .hasBeenStarted()
                 .hasBeenStopped();
     }
@@ -90,6 +91,7 @@ class ObservationTestingTests {
             Observation.createNotStarted("foo", registry)
                     .lowCardinalityKeyValue("lowTag", "lowTagValue")
                     .highCardinalityKeyValue("highTag", "highTagValue")
+                    .event(Observation.Event.of("event1"))
                     .observe(() -> System.out.println("Hello"));
         }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -19,8 +19,10 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.assertj.core.api.AssertProvider;
@@ -118,6 +120,14 @@ public final class TestObservationRegistry
             return true;
         }
 
+        @Override
+        public void onEvent(final Observation.Event event, final Observation.Context context) {
+            this.contexts.stream()
+                .filter(testContext -> testContext.getContext() == context)
+                .findFirst()
+                .ifPresent(testContext -> testContext.addEvent(event));
+        }
+
     }
 
     static class TestObservationContext {
@@ -127,6 +137,8 @@ public final class TestObservationRegistry
         private boolean observationStarted;
 
         private boolean observationStopped;
+
+        private final Set<Observation.Event> contextEvents = new HashSet<>();
 
         TestObservationContext(Observation.Context context) {
             this.context = context;
@@ -179,6 +191,32 @@ public final class TestObservationRegistry
             return this.context;
         }
 
+        /**
+         * Stores an {@link Observation.Event} in this context.
+         * @param event the event to store
+         */
+        public void addEvent(Observation.Event event) {
+            this.contextEvents.add(event);
+        }
+
+        /**
+         * Check if an {@link Observation.Event} with the given name was stored in this context.
+         * @param name name of the event to check
+         * @return {@code true} if an event was stored under the given name
+         */
+        public boolean hasEvent(String name) {
+            return this.contextEvents.stream().anyMatch(event -> event.getName().equals(name));
+        }
+
+        /**
+         * Check if an {@link Observation.Event} with the given name and contextual name was stored in this context.
+         * @param name name of the event to check
+         * @param contextualName contextual name of the event to check
+         * @return {@code true} if an event was stored under the given name and contextual name
+         */
+        public boolean hasEvent(String name, String contextualName) {
+            return this.contextEvents.stream().anyMatch(event -> event.getName().equals(name) && event.getContextualName().equals(contextualName));
+        }
     }
 
 }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -195,7 +195,7 @@ public final class TestObservationRegistry
          * Stores an {@link Observation.Event} in this context.
          * @param event the event to store
          */
-        public void addEvent(Observation.Event event) {
+        void addEvent(Observation.Event event) {
             this.contextEvents.add(event);
         }
 
@@ -205,7 +205,7 @@ public final class TestObservationRegistry
          * @param name name of the event to check
          * @return {@code true} if an event was stored under the given name
          */
-        public boolean hasEvent(String name) {
+        boolean hasEvent(String name) {
             return this.contextEvents.stream().anyMatch(event -> event.getName().equals(name));
         }
 
@@ -217,7 +217,7 @@ public final class TestObservationRegistry
          * @return {@code true} if an event was stored under the given name and contextual
          * name
          */
-        public boolean hasEvent(String name, String contextualName) {
+        boolean hasEvent(String name, String contextualName) {
             return this.contextEvents.stream()
                 .anyMatch(event -> event.getName().equals(name) && event.getContextualName().equals(contextualName));
         }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -200,7 +200,8 @@ public final class TestObservationRegistry
         }
 
         /**
-         * Check if an {@link Observation.Event} with the given name was stored in this context.
+         * Check if an {@link Observation.Event} with the given name was stored in this
+         * context.
          * @param name name of the event to check
          * @return {@code true} if an event was stored under the given name
          */
@@ -209,14 +210,18 @@ public final class TestObservationRegistry
         }
 
         /**
-         * Check if an {@link Observation.Event} with the given name and contextual name was stored in this context.
+         * Check if an {@link Observation.Event} with the given name and contextual name
+         * was stored in this context.
          * @param name name of the event to check
          * @param contextualName contextual name of the event to check
-         * @return {@code true} if an event was stored under the given name and contextual name
+         * @return {@code true} if an event was stored under the given name and contextual
+         * name
          */
         public boolean hasEvent(String name, String contextualName) {
-            return this.contextEvents.stream().anyMatch(event -> event.getName().equals(name) && event.getContextualName().equals(contextualName));
+            return this.contextEvents.stream()
+                .anyMatch(event -> event.getName().equals(name) && event.getContextualName().equals(contextualName));
         }
+
     }
 
 }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -577,7 +577,8 @@ public class TestObservationRegistryAssert
          * Verifies that the {@link Observation} has an event with the given name.
          * @param name event name
          * @return this
-         * @throws AssertionError if the {@link Observation} does not have an event with the given name
+         * @throws AssertionError if the {@link Observation} does not have an event with
+         * the given name
          */
         public TestObservationRegistryAssertReturningObservationContextAssert hasEvent(String name) {
             isNotNull();
@@ -588,25 +589,31 @@ public class TestObservationRegistryAssert
         }
 
         /**
-         * Verifies that the {@link Observation} has an event with the given name and contextual name.
+         * Verifies that the {@link Observation} has an event with the given name and
+         * contextual name.
          * @param name event name
          * @param contextualName contextual name
          * @return this
-         * @throws AssertionError if the {@link Observation} does not have an event with the given name and contextual name
+         * @throws AssertionError if the {@link Observation} does not have an event with
+         * the given name and contextual name
          */
-        public TestObservationRegistryAssertReturningObservationContextAssert hasEvent(String name, String contextualName) {
+        public TestObservationRegistryAssertReturningObservationContextAssert hasEvent(String name,
+                String contextualName) {
             isNotNull();
             if (!this.testContext.hasEvent(name, contextualName)) {
-                failWithMessage("Observation should have an event with name <%s> and contextual name <%s>", name, contextualName);
+                failWithMessage("Observation should have an event with name <%s> and contextual name <%s>", name,
+                        contextualName);
             }
             return this;
         }
 
         /**
-         * Verifies that the {@link Observation} does not have an event with the given name.
+         * Verifies that the {@link Observation} does not have an event with the given
+         * name.
          * @param name event name
          * @return this
-         * @throws AssertionError if the {@link Observation} has an event with the given name
+         * @throws AssertionError if the {@link Observation} has an event with the given
+         * name
          */
         public TestObservationRegistryAssertReturningObservationContextAssert doesNotHaveEvent(String name) {
             isNotNull();
@@ -617,16 +624,20 @@ public class TestObservationRegistryAssert
         }
 
         /**
-         * Verifies that the {@link Observation} does not have an event with the given name and contextual name.
+         * Verifies that the {@link Observation} does not have an event with the given
+         * name and contextual name.
          * @param name event name
          * @param contextualName contextual name@
          * @return this
-         * @throws AssertionError if the {@link Observation} has an event with the given name and contextual name
+         * @throws AssertionError if the {@link Observation} has an event with the given
+         * name and contextual name
          */
-        public TestObservationRegistryAssertReturningObservationContextAssert doesNotHaveEvent(String name, String contextualName) {
+        public TestObservationRegistryAssertReturningObservationContextAssert doesNotHaveEvent(String name,
+                String contextualName) {
             isNotNull();
             if (this.testContext.hasEvent(name, contextualName)) {
-                failWithMessage("Observation should not have an event with name <%s> and contextual name <%s>", name, contextualName);
+                failWithMessage("Observation should not have an event with name <%s> and contextual name <%s>", name,
+                        contextualName);
             }
             return this;
         }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -573,6 +573,64 @@ public class TestObservationRegistryAssert
             return this.originalAssert;
         }
 
+        /**
+         * Verifies that the {@link Observation} has an event with the given name.
+         * @param name event name
+         * @return this
+         * @throws AssertionError if the {@link Observation} does not have an event with the given name
+         */
+        public TestObservationRegistryAssertReturningObservationContextAssert hasEvent(String name) {
+            isNotNull();
+            if (!this.testContext.hasEvent(name)) {
+                failWithMessage("Observation should have an event with name <%s>", name);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies that the {@link Observation} has an event with the given name and contextual name.
+         * @param name event name
+         * @param contextualName contextual name
+         * @return this
+         * @throws AssertionError if the {@link Observation} does not have an event with the given name and contextual name
+         */
+        public TestObservationRegistryAssertReturningObservationContextAssert hasEvent(String name, String contextualName) {
+            isNotNull();
+            if (!this.testContext.hasEvent(name, contextualName)) {
+                failWithMessage("Observation should have an event with name <%s> and contextual name <%s>", name, contextualName);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies that the {@link Observation} does not have an event with the given name.
+         * @param name event name
+         * @return this
+         * @throws AssertionError if the {@link Observation} has an event with the given name
+         */
+        public TestObservationRegistryAssertReturningObservationContextAssert doesNotHaveEvent(String name) {
+            isNotNull();
+            if (this.testContext.hasEvent(name)) {
+                failWithMessage("Observation should not have an event with name <%s>", name);
+            }
+            return this;
+        }
+
+        /**
+         * Verifies that the {@link Observation} does not have an event with the given name and contextual name.
+         * @param name event name
+         * @param contextualName contextual name@
+         * @return this
+         * @throws AssertionError if the {@link Observation} has an event with the given name and contextual name
+         */
+        public TestObservationRegistryAssertReturningObservationContextAssert doesNotHaveEvent(String name, String contextualName) {
+            isNotNull();
+            if (this.testContext.hasEvent(name, contextualName)) {
+                failWithMessage("Observation should not have an event with name <%s> and contextual name <%s>", name, contextualName);
+            }
+            return this;
+        }
+
     }
 
 }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -387,56 +387,58 @@ class TestObservationRegistryAssertTests {
     void should_not_fail_when_event_matched_on_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
+        thenNoException()
+            .isThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
     }
 
     @Test
     void should_not_fail_when_contextual_event_matched_on_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
+        thenNoException()
+            .isThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
     }
 
     @Test
     void should_not_fail_when_event_matched_on_name_and_contextual_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1", "ctx1"));
+        thenNoException().isThrownBy(
+                () -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event1", "ctx1"));
     }
 
     @Test
     void should_not_fail_when_event_not_matched_on_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
+        thenNoException().isThrownBy(
+                () -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
     }
 
     @Test
     void should_not_fail_when_contextual_event_not_matched_on_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
+        thenNoException().isThrownBy(
+                () -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
     }
 
     @Test
     void should_not_fail_when_event_not_matched_on_name_and_contextual_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2", "ctx1"));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO")
+            .that()
+            .doesNotHaveEvent("event2", "ctx1"));
     }
 
     @Test
     void should_not_fail_when_contextual_event_not_matched_on_name_and_contextual_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
-        thenNoException().isThrownBy(() -> assertThat(registry)
-            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2", "ctx1"));
+        thenNoException().isThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO")
+            .that()
+            .doesNotHaveEvent("event2", "ctx1"));
     }
 
     @Test
@@ -444,15 +446,18 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
 
         thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event1"))
-            .isInstanceOf(AssertionError.class).hasMessage("Observation should not have an event with name <event1>");
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("Observation should not have an event with name <event1>");
     }
 
     @Test
     void should_fail_when_event_matched_on_name_and_contextual_name() {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
-        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event1", "ctx1"))
-            .isInstanceOf(AssertionError.class).hasMessage("Observation should not have an event with name <event1> and contextual name <ctx1>");
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO")
+            .that()
+            .doesNotHaveEvent("event1", "ctx1")).isInstanceOf(AssertionError.class)
+            .hasMessage("Observation should not have an event with name <event1> and contextual name <ctx1>");
     }
 
     @Test
@@ -460,7 +465,8 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
 
         thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2"))
-            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2>");
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("Observation should have an event with name <event2>");
     }
 
     @Test
@@ -468,7 +474,8 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
         thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2"))
-            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2>");
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("Observation should have an event with name <event2>");
     }
 
     @Test
@@ -476,7 +483,8 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
 
         thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2", "ctx2"))
-            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2> and contextual name <ctx2>");
+            .isInstanceOf(AssertionError.class)
+            .hasMessage("Observation should have an event with name <event2> and contextual name <ctx2>");
     }
 
     static class Example {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -383,6 +383,102 @@ class TestObservationRegistryAssertTests {
             .doesNotHaveAnyRemainingCurrentObservation());
     }
 
+    @Test
+    void should_not_fail_when_event_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
+    }
+
+    @Test
+    void should_not_fail_when_contextual_event_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1"));
+    }
+
+    @Test
+    void should_not_fail_when_event_matched_on_name_and_contextual_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().hasEvent("event1", "ctx1"));
+    }
+
+    @Test
+    void should_not_fail_when_event_not_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
+    }
+
+    @Test
+    void should_not_fail_when_contextual_event_not_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2"));
+    }
+
+    @Test
+    void should_not_fail_when_event_not_matched_on_name_and_contextual_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2", "ctx1"));
+    }
+
+    @Test
+    void should_not_fail_when_contextual_event_not_matched_on_name_and_contextual_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenNoException().isThrownBy(() -> assertThat(registry)
+            .hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event2", "ctx1"));
+    }
+
+    @Test
+    void should_fail_when_event_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
+
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event1"))
+            .isInstanceOf(AssertionError.class).hasMessage("Observation should not have an event with name <event1>");
+    }
+
+    @Test
+    void should_fail_when_event_matched_on_name_and_contextual_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().doesNotHaveEvent("event1", "ctx1"))
+            .isInstanceOf(AssertionError.class).hasMessage("Observation should not have an event with name <event1> and contextual name <ctx1>");
+    }
+
+    @Test
+    void should_fail_when_event_not_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1")).stop();
+
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2"))
+            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2>");
+    }
+
+    @Test
+    void should_fail_when_contextual_event_not_matched_on_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2"))
+            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2>");
+    }
+
+    @Test
+    void should_fail_when_event_not_matched_on_name_and_contextual_name() {
+        Observation.createNotStarted("FOO", registry).start().event(Observation.Event.of("event1", "ctx1")).stop();
+
+        thenThrownBy(() -> assertThat(registry).hasObservationWithNameEqualTo("FOO").that().hasEvent("event2", "ctx2"))
+            .isInstanceOf(AssertionError.class).hasMessage("Observation should have an event with name <event2> and contextual name <ctx2>");
+    }
+
     static class Example {
 
         private final ObservationRegistry registry;


### PR DESCRIPTION
Adds the ability to assert that Events have been raised on Observations; matching can be done against event name only, or event name and contextual name.

Resolves #5576