### PR TITLE
[DynatraceV2] Log simple counts for exported data points

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -453,7 +453,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
                 .send()
                 .onSuccess(response -> handleSuccess(lineCount, response, cntLinesOk, cntLinesFailed))
                 .onError(response -> {
-                    logger.info("Failed metric ingestion: Error Code={}, Response Body={}", response.code(),
+                    logger.error("Failed metric ingestion: Error Code={}, Response Body={}", response.code(),
                             getTruncatedBody(response));
                     cntLinesFailed.getAndAdd(lineCount);
                 });


### PR DESCRIPTION
This PR adds some basic status reporting on `INFO` log level. We have debug logs for the number of accepted and rejected items for each request. However, we have seen cases where many requests must be sent, and these logs can get very verbose. Additionally, they are DEBUG logs, so by definition, they are not expected to be available in a production system. 

In order to get a general heartbeat on the health of the export, I would like to add this log line. It will be written once per export (so usually once a minute) and looks something like this:

```
:46:17 dynatrace-metrics-publisher INFO i.m.d.v.DynatraceExporterV2 - Export finished. Generated 3 request(s) totaling 1706 metric lines and 1204 metadata lines. Of those, 2910 lines were successfully ingested, 0 lines failed to ingest. Target URI: https://{your-environment-id}.live.dynatrace.com/api/v2/metrics/ingest
```

(The `{your-environment-id}` part would obviously be replaced with the actual URI)