### PR TITLE
Enable japicmp task for micrometer-registry-statsd

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -67,5 +67,3 @@ publishing {
         }
     }
 }
-
-tasks.japicmp.enabled = false


### PR DESCRIPTION
This PR enables `japicmp` task for `micrometer-registry-statsd` as it seems to be disabled unintentionally.