### PR TITLE
Upgrade JDK for CI builds to 8.0.432, 11.0.25, and 17.0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,25 +6,25 @@ executors:
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: cimg/openjdk:20.0.2
+      - image: cimg/openjdk:20.0.2 # The version of Mockito we are using does not support 21.
   circle-jdk17-executor:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: cimg/openjdk:17.0.11
+      - image: cimg/openjdk:17.0.13
   circle-jdk8-executor:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: cimg/openjdk:8.0.402
+      - image: cimg/openjdk:8.0.432
   circle-jdk11-executor:
     working_directory: ~/micrometer
     environment:
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
     docker:
-      - image: cimg/openjdk:11.0.22
+      - image: cimg/openjdk:11.0.25
   machine-executor:
     working_directory: ~/micrometer
     machine:


### PR DESCRIPTION
This PR upgrades JDK for CI builds to 8.0.432, 11.0.25, and 17.0.13.