### PR TITLE
Bump io.netty:netty-bom to 4.1.115.Final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ maven-resolver = "1.9.22"
 mockito4 = "4.11.0"
 mockito5 = "5.11.0"
 mongo = "4.11.4"
-netty = "4.1.114.Final"
+netty = "4.1.115.Final"
 newrelic-api = "5.14.0"
 # Kotlin 1.7 sample will fail from OkHttp 4.12.0 due to okio dependency being a Kotlin 1.9 module
 okhttp = "4.11.0"


### PR DESCRIPTION
Mitigates https://github.com/advisories/GHSA-xq3w-v528-46rv in Netty dependency.