### PR TITLE
Add note for a link to GitHub repository for Prometheus Grafana dashboard

### DIFF
--- a/docs/modules/ROOT/pages/implementations/prometheus.adoc
+++ b/docs/modules/ROOT/pages/implementations/prometheus.adoc
@@ -148,6 +148,8 @@ See the https://prometheus.io/docs/querying/basics[Prometheus docs] for a far mo
 
 A publicly available Grafana dashboard for Micrometer-sourced JVM and Tomcat metrics is available https://grafana.com/grafana/dashboards/4701-jvm-micrometer/[here].
 
+NOTE: The dashboard is maintained in an external GitHub repository https://github.com/mweirauch/grafana-dashboards[here], so if you have an issue, it should be created in the GitHub repository.
+
 image::implementations/prometheus-dashboard.png[Grafana dashboard for JVM and Tomcat binders]
 
 The dashboard features:


### PR DESCRIPTION
This PR adds a note for a link to the GitHub repository for the Prometheus Grafana dashboard.

By the way, while working on this, the "Grafana Dashboard" section seems to contain a copy from the contents in [the Grafana dashboard page](https://grafana.com/grafana/dashboards/4701-jvm-micrometer/), which is easily to get out of sync and is actually out of sync a bit already.

It might be better to remove the contents and have a link to the the Grafana dashboard page only. Or if the GitHub repository has a proper README file later, it would be better to link to the README instead.

See gh-5661

/cc @mweirauch 