### PR TITLE
Remove obsolete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.lockfile linguist-generated


### PR DESCRIPTION
This PR removes the `.gitattributes` file as it only contains an obsolete entry.