### PR TITLE
Consistently use baseTimeUnit in StatsD

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -258,7 +258,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     @Override
     public final void record(long amount, TimeUnit unit) {
         if (amount >= 0) {
-            histogram.recordLong(TimeUnit.NANOSECONDS.convert(amount, unit));
+            histogram.recordLong(baseTimeUnit().convert(amount, unit));
             recordNonNegative(amount, unit);
 
             if (intervalEstimator != null) {


### PR DESCRIPTION
Draft: Opening for discussion with (incomplete) proposed changes.

There is a `baseTimeUnit` for `Timer`s that appears to be inconsistently used. Given the definition "The base time unit of the timer to which all published metrics will be scaled" I'd expect that a value, eg 2000 sec, reported as the value 2000 with the unit seconds would be emitted to statsd as the value in the base time units,  2000 in this example. However, the actual value is 2,000,000. Which is the corresponding millisecond value for the seconds expected to be recorded.

As that explainer above is a challenge to read: I've included some (untested or even compiled) changes to illustrate.