### PR TITLE
Warn about gauge re-registration

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/GaugeBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/GaugeBenchmark.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(1)
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class GaugeBenchmark {
+
+    private MeterRegistry registry;
+
+    private AtomicInteger stateObject;
+
+    @Setup
+    public void setup() {
+        registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        stateObject = registry.gauge("test.gauge", new AtomicInteger());
+        // emits warn because of double registration
+        stateObject = registry.gauge("test.gauge", new AtomicInteger());
+        // emits debug because of double registration and keeps emitting debug from now on
+        stateObject = registry.gauge("test.gauge", new AtomicInteger());
+    }
+
+    @Benchmark
+    public void baseline() {
+        stateObject = new AtomicInteger();
+    }
+
+    @Benchmark
+    public void gaugeReRegistrationWithoutBuilder() {
+        stateObject = registry.gauge("test.gauge", new AtomicInteger());
+    }
+
+    @Benchmark
+    public Gauge gaugeReRegistrationWithBuilder() {
+        stateObject = new AtomicInteger();
+        return Gauge.builder("test.gauge", stateObject, AtomicInteger::doubleValue).register(registry);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(GaugeBenchmark.class.getSimpleName()).build()).run();
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/resources/logback.xml
+++ b/benchmarks/benchmarks-core/src/jmh/resources/logback.xml
@@ -1,0 +1,26 @@
+<!--
+	Copyright 2024 VMware, Inc.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+-->
+<configuration>
+<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+	<encoder>
+		<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+	</encoder>
+</appender>
+
+<root level="warn">
+	<appender-ref ref="STDOUT" />
+</root>
+</configuration>


### PR DESCRIPTION
See https://github.com/micrometer-metrics/micrometer/issues/5616 and https://github.com/micrometer-metrics/micrometer/pull/5617

I added the warning log entries and benchmarks since the extra logging is on the hot path.
The benchmarks don't test the case where the `Gauge` re-registration happens indirectly (as the result of a `MeterFilter` transformation) but since the direct and the indirect cases call the same method, I think testing only the direct case is ok.

I ran the benchmarks a couple of times but they were not as stable on my laptop as I liked, the difference between them was sometimes bigger between two identical executions (e.g. without logging) than between the two different ones (with vs. without logging).

So based on this either the benchmarks are wrong or the "noise" is bigger than the difference between the two scenarios I tested. 

## Before logging
```
Benchmark                                                   Mode      Cnt     Score   Error  Units
GaugeBenchmark.baseline                                   sample  1874878     0.065 ± 0.003  us/op
GaugeBenchmark.baseline:p0.00                             sample              0.001          us/op
GaugeBenchmark.baseline:p0.50                             sample              0.041          us/op
GaugeBenchmark.baseline:p0.90                             sample              0.048          us/op
GaugeBenchmark.baseline:p0.95                             sample              0.049          us/op
GaugeBenchmark.baseline:p0.99                             sample              0.084          us/op
GaugeBenchmark.baseline:p0.999                            sample              2.295          us/op
GaugeBenchmark.baseline:p0.9999                           sample             32.624          us/op
GaugeBenchmark.baseline:p1.00                             sample           1249.280          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder             sample  1314563     0.085 ± 0.007  us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.00       sample              0.001          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.50       sample              0.046          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.90       sample              0.054          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.95       sample              0.056          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.99       sample              0.082          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.999      sample             15.680          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.9999     sample             51.722          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p1.00       sample           1472.512          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder          sample  1871879     0.081 ± 0.007  us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.00    sample              0.004          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.50    sample              0.053          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.90    sample              0.062          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.95    sample              0.065          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.99    sample              0.110          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.999   sample              4.201          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.9999  sample             37.748          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p1.00    sample           3993.600          us/op
```

## After logging
```
Benchmark                                                   Mode      Cnt     Score   Error  Units
GaugeBenchmark.baseline                                   sample  1901391     0.062 ± 0.002  us/op
GaugeBenchmark.baseline:p0.00                             sample              0.001          us/op
GaugeBenchmark.baseline:p0.50                             sample              0.040          us/op
GaugeBenchmark.baseline:p0.90                             sample              0.044          us/op
GaugeBenchmark.baseline:p0.95                             sample              0.047          us/op
GaugeBenchmark.baseline:p0.99                             sample              0.066          us/op
GaugeBenchmark.baseline:p0.999                            sample              1.829          us/op
GaugeBenchmark.baseline:p0.9999                           sample             32.220          us/op
GaugeBenchmark.baseline:p1.00                             sample            114.432          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder             sample  1568405     0.090 ± 0.003  us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.00       sample              0.008          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.50       sample              0.057          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.90       sample              0.066          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.95       sample              0.069          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.99       sample              0.093          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.999      sample             14.704          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p0.9999     sample             42.598          us/op
GaugeBenchmark.gaugeReRegistrationWithBuilder:p1.00       sample            192.000          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder          sample  1667600     0.083 ± 0.004  us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.00    sample              0.010          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.50    sample              0.055          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.90    sample              0.064          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.95    sample              0.067          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.99    sample              0.086          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.999   sample             14.080          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p0.9999  sample             32.783          us/op
GaugeBenchmark.gaugeReRegistrationWithoutBuilder:p1.00    sample           1423.360          us/op
```

/cc: @keith-turner