### PR TITLE
Use failWithActualExpectedAndMessage() where possible

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -166,7 +166,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         long actualSize = this.actual.getAllKeyValues().stream().count();
         if (actualSize != size) {
-            failWithMessage("Observation expected to have <%s> keys but has <%s>.", size, actualSize);
+            failWithActualExpectedAndMessage(actualSize, size, "Observation expected to have <%s> keys but has <%s>.",
+                    size, actualSize);
         }
         return (SELF) this;
     }
@@ -388,7 +389,8 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         isNotNull();
         Object mapValue = this.actual.get(key);
         if (!Objects.equals(mapValue, value)) {
-            failWithMessage("Observation should have an entry for key <%s> with value <%s>. Value was <%s>", key, value,
+            failWithActualExpectedAndMessage(mapValue, value,
+                    "Observation should have an entry for key <%s> with value <%s>. Value was <%s>", key, value,
                     mapValue);
         }
         return (SELF) this;

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryAssert.java
@@ -116,8 +116,14 @@ public class ObservationRegistryAssert<SELF extends ObservationRegistryAssert<SE
     public SELF hasRemainingCurrentObservationSameAs(Observation observation) {
         isNotNull();
         Observation current = actual.getCurrentObservation();
+        if (current == null) {
+            failWithMessage(
+                    "Expected current observation in the registry to be same as <%s> but there was no current observation",
+                    observation);
+        }
         if (current != observation) {
-            failWithMessage("Expected current observation in the registry to be same as <%s> but was <%s>", observation,
+            failWithActualExpectedAndMessage(current, observation,
+                    "Expected current observation in the registry to be same as <%s> but was <%s>", observation,
                     current);
         }
         return (SELF) this;
@@ -183,16 +189,17 @@ public class ObservationRegistryAssert<SELF extends ObservationRegistryAssert<SE
     public SELF hasRemainingCurrentScopeSameAs(Observation.Scope scope) {
         isNotNull();
         Observation.Scope current = actual.getCurrentObservationScope();
+        String expectedContextName = scope.getCurrentObservation().getContext().getName();
         if (current == null) {
             failWithMessage(
                     "Expected current Scope in the registry to be same as a provided Scope tied to observation named <%s> but there was no current scope",
-                    scope.getCurrentObservation().getContext().getName());
+                    expectedContextName);
         }
         if (current != scope) {
-            failWithMessage(
+            String actualContextName = current.getCurrentObservation().getContext().getName();
+            failWithActualExpectedAndMessage(actualContextName, expectedContextName,
                     "Expected current Scope in the registry to be same as a provided Scope tied to observation named <%s> but was a different one (tied to observation named <%s>)",
-                    scope.getCurrentObservation().getContext().getName(),
-                    current.getCurrentObservation().getContext().getName());
+                    expectedContextName, actualContextName);
         }
         return (SELF) this;
     }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -240,9 +240,11 @@ public class TestObservationRegistryAssert
      */
     public TestObservationRegistryAssert hasNumberOfObservationsEqualTo(int expectedNumberOfObservations) {
         isNotNull();
-        if (this.actual.getContexts().size() != expectedNumberOfObservations) {
-            failWithMessage("There should be <%s> Observations but there were <%s>. Found following Observations:\n%s",
-                    expectedNumberOfObservations, this.actual.getContexts().size(),
+        int actualNumberOfObservations = this.actual.getContexts().size();
+        if (actualNumberOfObservations != expectedNumberOfObservations) {
+            failWithActualExpectedAndMessage(actualNumberOfObservations, expectedNumberOfObservations,
+                    "There should be <%s> Observations but there were <%s>. Found following Observations:\n%s",
+                    expectedNumberOfObservations, actualNumberOfObservations,
                     observationNames(this.actual.getContexts()));
         }
         return this;
@@ -268,14 +270,14 @@ public class TestObservationRegistryAssert
     public TestObservationRegistryAssert hasNumberOfObservationsWithNameEqualTo(String observationName,
             int expectedNumberOfObservations) {
         isNotNull();
-        long observationsWithNameSize = this.actual.getContexts()
+        long actualNumberOfObservations = this.actual.getContexts()
             .stream()
             .filter(f -> observationName.equals(f.getContext().getName()))
             .count();
-        if (observationsWithNameSize != expectedNumberOfObservations) {
-            failWithMessage(
+        if (actualNumberOfObservations != expectedNumberOfObservations) {
+            failWithActualExpectedAndMessage(actualNumberOfObservations, expectedNumberOfObservations,
                     "There should be <%s> Observations with name <%s> but there were <%s>. Found following Observations:\n%s",
-                    expectedNumberOfObservations, observationName, observationsWithNameSize,
+                    expectedNumberOfObservations, observationName, actualNumberOfObservations,
                     observationNames(this.actual.getContexts()));
         }
         return this;
@@ -302,14 +304,14 @@ public class TestObservationRegistryAssert
     public TestObservationRegistryAssert hasNumberOfObservationsWithNameEqualToIgnoreCase(String observationName,
             int expectedNumberOfObservations) {
         isNotNull();
-        long observationsWithNameSize = this.actual.getContexts()
+        long actualNumberOfObservations = this.actual.getContexts()
             .stream()
             .filter(f -> observationName.equalsIgnoreCase(f.getContext().getName()))
             .count();
-        if (observationsWithNameSize != expectedNumberOfObservations) {
-            failWithMessage(
+        if (actualNumberOfObservations != expectedNumberOfObservations) {
+            failWithActualExpectedAndMessage(actualNumberOfObservations, expectedNumberOfObservations,
                     "There should be <%s> Observations with name (ignoring case) <%s> but there were <%s>. Found following Observations:\n%s",
-                    expectedNumberOfObservations, observationName, observationsWithNameSize,
+                    expectedNumberOfObservations, observationName, actualNumberOfObservations,
                     observationNames(this.actual.getContexts()));
         }
         return this;

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationContextAssertTests.java
@@ -201,10 +201,18 @@ class ObservationContextAssertTests {
         observation.highCardinalityKeyValue("high", "bar");
 
         thenThrownBy(() -> assertThat(context).hasKeyValuesCount(1)).isInstanceOf(AssertionError.class)
-            .hasMessage("Observation expected to have <1> keys but has <2>.");
+            .hasMessage("Observation expected to have <1> keys but has <2>.")
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("2");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("1");
+            });
 
         thenThrownBy(() -> assertThat(context).hasKeyValuesCount(3)).isInstanceOf(AssertionError.class)
-            .hasMessage("Observation expected to have <3> keys but has <2>.");
+            .hasMessage("Observation expected to have <3> keys but has <2>.")
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("2");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("3");
+            });
     }
 
     @Test
@@ -414,7 +422,11 @@ class ObservationContextAssertTests {
     void should_throw_exception_when_map_entry_missing() {
         context.put("foo", "bar");
 
-        thenThrownBy(() -> assertThat(context).hasMapEntry("foo", "baz")).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(context).hasMapEntry("foo", "baz"))
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("bar");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("baz");
+            });
     }
 
     @Test

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -23,12 +23,13 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.BDDAssertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
 
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.thenNoException;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.assertj.core.api.BDDAssertions.then;
 
 class TestObservationRegistryAssertTests {
 
@@ -228,7 +229,12 @@ class TestObservationRegistryAssertTests {
     void should_fail_when_number_of_observations_does_not_match() {
         Observation.createNotStarted("FOO", registry).start().stop();
 
-        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsEqualTo(0)).isInstanceOf(AssertionError.class);
+        thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsEqualTo(0))
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("1");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("0");
+            });
+        ;
     }
 
     @Test
@@ -243,7 +249,10 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("foo", registry).start().stop();
 
         thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualTo("foo", 0))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("1");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("0");
+            });
     }
 
     @Test
@@ -251,7 +260,10 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("foo", registry).start().stop();
 
         thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualTo("bar", 1))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("0");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("1");
+            });
     }
 
     @Test
@@ -266,7 +278,10 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().stop();
 
         thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualToIgnoreCase("foo", 0))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("1");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("0");
+            });
     }
 
     @Test
@@ -274,7 +289,10 @@ class TestObservationRegistryAssertTests {
         Observation.createNotStarted("FOO", registry).start().stop();
 
         thenThrownBy(() -> assertThat(registry).hasNumberOfObservationsWithNameEqualToIgnoreCase("bar", 1))
-            .isInstanceOf(AssertionError.class);
+            .isInstanceOfSatisfying(AssertionFailedError.class, error -> {
+                then(error.getActual().getStringRepresentation()).isEqualTo("0");
+                then(error.getExpected().getStringRepresentation()).isEqualTo("1");
+            });
     }
 
     @Test


### PR DESCRIPTION
This PR changes to use `failWithActualExpectedAndMessage()` where possible.

See gh-5550