### PR TITLE
Do not leak OTLP types on public-facing API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -392,6 +392,7 @@ subprojects {
                     packageExcludes = ['io.micrometer.shaded.*', 'io.micrometer.statsd.internal']
 
                     fieldExcludes = []
+                    methodExcludes = ['io.micrometer.registry.otlp.AggregationTemporality#toOtlpAggregationTemporality(io.micrometer.registry.otlp.AggregationTemporality)']
 
                     onlyIf { compatibleVersion != 'SKIP' }
                 }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/AggregationTemporality.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/AggregationTemporality.java
@@ -36,7 +36,7 @@ public enum AggregationTemporality {
      */
     CUMULATIVE;
 
-    public static io.opentelemetry.proto.metrics.v1.AggregationTemporality toOtlpAggregationTemporality(
+    static io.opentelemetry.proto.metrics.v1.AggregationTemporality toOtlpAggregationTemporality(
             AggregationTemporality aggregationTemporality) {
         switch (aggregationTemporality) {
             case DELTA:


### PR DESCRIPTION
`AggregationTemporality#toOtlpAggregationTemporality` was not intended to be public, users should not use it. This is a breaking change.

See https://github.com/micrometer-metrics/micrometer/pull/5733