### PR TITLE
Apply gh-5553 to io.micrometer.core.instrument.binder.jdk

### DIFF
--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
@@ -266,12 +266,15 @@ public class MicrometerHttpClient extends HttpClient {
         HttpRequest request = httpRequestBuilder.build();
         return client.sendAsync(request, bodyHandler, pushPromiseHandler).handle((response, throwable) -> {
             instrumentation.setResponse(response);
-            stopObservationOrTimer(instrumentation, request, response);
             if (throwable != null) {
                 instrumentation.setThrowable(throwable);
+                stopObservationOrTimer(instrumentation, request, response);
                 throw new CompletionException(throwable);
             }
-            return response;
+            else {
+                stopObservationOrTimer(instrumentation, request, response);
+                return response;
+            }
         });
     }
 

--- a/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-core/src/main/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClient.java
@@ -17,9 +17,7 @@ package io.micrometer.core.instrument.binder.jdk;
 
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.observation.ObservationOrTimerCompatibleInstrumentation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -36,6 +34,7 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
@@ -234,19 +233,13 @@ public class MicrometerHttpClient extends HttpClient {
             ObservationOrTimerCompatibleInstrumentation<HttpClientContext> instrumentation, HttpRequest request,
             @Nullable HttpResponse<T> res) {
         instrumentation.stop(DefaultHttpClientObservationConvention.INSTANCE.getName(), "Timer for JDK's HttpClient",
-                () -> {
-                    Tags tags = Tags.of(HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.asString(),
-                            request.method(), HttpClientObservationDocumentation.LowCardinalityKeys.URI.asString(),
-                            DefaultHttpClientObservationConvention.INSTANCE.getUriTag(request, res, uriMapper));
-                    if (res != null) {
-                        tags = tags
-                            .and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
-                                    String.valueOf(res.statusCode())))
-                            .and(Tag.of(HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME.asString(),
-                                    Outcome.forStatus(res.statusCode()).name()));
-                    }
-                    return tags;
-                });
+                () -> Tags.of(HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.asString(), request.method(),
+                        HttpClientObservationDocumentation.LowCardinalityKeys.URI.asString(),
+                        DefaultHttpClientObservationConvention.INSTANCE.getUriTag(request, res, uriMapper),
+                        HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
+                        DefaultHttpClientObservationConvention.INSTANCE.getStatus(res),
+                        HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME.asString(),
+                        DefaultHttpClientObservationConvention.INSTANCE.getOutcome(res)));
     }
 
     private ObservationOrTimerCompatibleInstrumentation<HttpClientContext> observationOrTimer(
@@ -272,11 +265,12 @@ public class MicrometerHttpClient extends HttpClient {
                 httpRequestBuilder);
         HttpRequest request = httpRequestBuilder.build();
         return client.sendAsync(request, bodyHandler, pushPromiseHandler).handle((response, throwable) -> {
-            if (throwable != null) {
-                instrumentation.setThrowable(throwable);
-            }
             instrumentation.setResponse(response);
             stopObservationOrTimer(instrumentation, request, response);
+            if (throwable != null) {
+                instrumentation.setThrowable(throwable);
+                throw new CompletionException(throwable);
+            }
             return response;
         });
     }

--- a/micrometer-core/src/test/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClientTests.java
+++ b/micrometer-core/src/test/java11/io/micrometer/core/instrument/binder/jdk/MicrometerHttpClientTests.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.jdk;
 
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -33,8 +35,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.concurrent.CompletionException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
 
 @WireMockTest
@@ -47,6 +52,8 @@ class MicrometerHttpClientTests {
     @BeforeEach
     void setup() {
         stubFor(any(urlEqualTo("/metrics")).willReturn(ok().withBody("body")));
+        stubFor(any(urlEqualTo("/test-fault"))
+            .willReturn(new ResponseDefinitionBuilder().withFault(Fault.CONNECTION_RESET_BY_PEER)));
     }
 
     @Test
@@ -82,6 +89,21 @@ class MicrometerHttpClientTests {
         observedClient.send(request, HttpResponse.BodyHandlers.ofString());
 
         thenMeterRegistryContainsHttpClientTags();
+    }
+
+    @Test
+    void shouldThrowErrorFromSendAsync(WireMockRuntimeInfo wmInfo) {
+        var client = MicrometerHttpClient.instrumentationBuilder(httpClient, meterRegistry).build();
+        var request = HttpRequest.newBuilder(URI.create(wmInfo.getHttpBaseUrl() + "/test-fault")).GET().build();
+        var response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+        assertThatThrownBy(response::join).isInstanceOf(CompletionException.class);
+        assertThatNoException().isThrownBy(() -> meterRegistry.get("http.client.requests")
+            .tag("method", "GET")
+            // TODO fix status/uri in exceptional cases where response may be null
+            .tag("uri", "UNKNOWN")
+            .tag("status", "UNKNOWN")
+            .tag("outcome", "UNKNOWN")
+            .timer());
     }
 
     private void thenMeterRegistryContainsHttpClientTags() {


### PR DESCRIPTION
This PR applies the changes made in gh-5553 to the classes in the `io.micrometer.core.instrument.binder.jdk` package.