### PR TITLE
Add JDK version requirement for building reference docs in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ You can use a Git client to clone the source code to your local machine.
 
 Micrometer targets Java 8 but requires JDK 11 or later to build.
 If you are not running Gradle with JDK 11 or later and Gradle cannot detect an existing JDK 17 installation, it will download one.
+If you want to build the reference docs, you need to use JDK 17 or later.
 
 The Gradle wrapper is provided and should be used for building with a consistent version of Gradle.
 


### PR DESCRIPTION
This PR adds JDK version requirement for building the reference docs in the `CONTRIBUTING.md`.

See https://github.com/micrometer-metrics/micrometer/pull/5582#discussion_r1795230115