### PR TITLE
Fix missing error on context in MicrometerHttpClient.sendAsync()

### DIFF
--- a/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
@@ -266,12 +266,15 @@ public class MicrometerHttpClient extends HttpClient {
         HttpRequest request = httpRequestBuilder.build();
         return client.sendAsync(request, bodyHandler, pushPromiseHandler).handle((response, throwable) -> {
             instrumentation.setResponse(response);
-            stopObservationOrTimer(instrumentation, request, response);
             if (throwable != null) {
                 instrumentation.setThrowable(throwable);
+                stopObservationOrTimer(instrumentation, request, response);
                 throw new CompletionException(throwable);
             }
-            return response;
+            else {
+                stopObservationOrTimer(instrumentation, request, response);
+                return response;
+            }
         });
     }
 


### PR DESCRIPTION
This PR fixes missing error on context in the `MicrometerHttpClient.sendAsync()` that was introducted in https://github.com/micrometer-metrics/micrometer/pull/5708.

See https://github.com/micrometer-metrics/micrometer/pull/5704#discussion_r1857537259