### PR TITLE
Use String.toLowerCase()/toUpperCase() with Locale.ROOT consistently

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
@@ -58,7 +59,7 @@ public class DefaultLongTaskTimerBenchmark {
     public void setup() {
         clock = new MockClock();
         longTaskTimer = new DefaultLongTaskTimer(
-                new Meter.Id("ltt", Tags.empty(), TimeUnit.MILLISECONDS.toString().toLowerCase(), null,
+                new Meter.Id("ltt", Tags.empty(), TimeUnit.MILLISECONDS.toString().toLowerCase(Locale.ROOT), null,
                         Meter.Type.LONG_TASK_TIMER),
                 clock, TimeUnit.MILLISECONDS, DistributionStatisticConfig.DEFAULT, false);
         int randomIndex = random.nextInt(activeSampleCount);

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -46,6 +46,22 @@
             <property name="message" value="Please use AssertJ imports." />
             <property name="ignoreComments" value="true" />
         </module>
+        <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+            <property name="id" value="toLowerCaseWithoutLocale"/>
+            <property name="format" value="\.toLowerCase\(\)"/>
+            <property name="maximum" value="0"/>
+            <property name="message"
+                      value="String.toLowerCase(Locale.ROOT) should be String.toLowerCase(Locale.ROOT)"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+        <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+            <property name="id" value="toUpperCaseWithoutLocale"/>
+            <property name="format" value="\.toUpperCase\(\)"/>
+            <property name="maximum" value="0"/>
+            <property name="message"
+                      value="String.toUpperCase(Locale.ROOT) should be String.toUpperCase(Locale.ROOT)"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
 
         <!-- Whitespace -->
         <module name="SingleSpaceSeparator" />

--- a/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
+++ b/implementations/micrometer-registry-azure-monitor/src/main/java/io/micrometer/azuremonitor/AzureMonitorMeterRegistry.java
@@ -28,6 +28,7 @@ import io.micrometer.core.instrument.util.NamedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Locale;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -114,7 +115,7 @@ public class AzureMonitorMeterRegistry extends StepMeterRegistry {
 
     private Stream<MetricTelemetry> trackMeter(Meter meter) {
         return stream(meter.measure().spliterator(), false).map(ms -> {
-            MetricTelemetry mt = createMetricTelemetry(meter, ms.getStatistic().toString().toLowerCase());
+            MetricTelemetry mt = createMetricTelemetry(meter, ms.getStatistic().toString().toLowerCase(Locale.ROOT));
             mt.setValue(ms.getValue());
             return mt;
         });

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -62,7 +62,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         Map<String, StandardUnit> standardUnitByLowercaseValue = new HashMap<>();
         for (StandardUnit standardUnit : StandardUnit.values()) {
             if (standardUnit != StandardUnit.UNKNOWN_TO_SDK_VERSION) {
-                standardUnitByLowercaseValue.put(standardUnit.toString().toLowerCase(), standardUnit);
+                standardUnitByLowercaseValue.put(standardUnit.toString().toLowerCase(Locale.ROOT), standardUnit);
             }
         }
         STANDARD_UNIT_BY_LOWERCASE_VALUE = Collections.unmodifiableMap(standardUnitByLowercaseValue);
@@ -308,7 +308,7 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             if (unit == null) {
                 return StandardUnit.NONE;
             }
-            StandardUnit standardUnit = STANDARD_UNIT_BY_LOWERCASE_VALUE.get(unit.toLowerCase());
+            StandardUnit standardUnit = STANDARD_UNIT_BY_LOWERCASE_VALUE.get(unit.toLowerCase(Locale.ROOT));
             return standardUnit != null ? standardUnit : StandardUnit.NONE;
         }
 

--- a/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
+++ b/implementations/micrometer-registry-datadog/src/test/java/io/micrometer/datadog/DatadogMeterRegistryTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -71,7 +72,7 @@ class DatadogMeterRegistryTest {
         server.stubFor(any(anyUrl()));
 
         Counter.builder("my.counter#abc")
-            .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
+            .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase(Locale.ROOT))
             .description("metric description")
             .register(registry)
             .increment(Math.PI);
@@ -121,7 +122,7 @@ class DatadogMeterRegistryTest {
         server.stubFor(any(anyUrl()));
 
         Counter.builder("my.counter#abc")
-            .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase())
+            .baseUnit(TimeUnit.MICROSECONDS.toString().toLowerCase(Locale.ROOT))
             .description("metric description")
             .register(registry)
             .increment(Math.PI);

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceMetricDefinition.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v1/DynatraceMetricDefinition.java
@@ -20,6 +20,7 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
 
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -109,7 +110,7 @@ class DynatraceMetricDefinition {
 
         private static Map<String, DynatraceUnit> UNITS_MAPPING = Collections
             .unmodifiableMap(Stream.of(DynatraceUnit.values())
-                .collect(Collectors.toMap(k -> k.toString().toLowerCase() + "s", Function.identity())));
+                .collect(Collectors.toMap(k -> k.toString().toLowerCase(Locale.ROOT) + "s", Function.identity())));
 
         @Nullable
         static DynatraceUnit fromPlural(@Nullable String plural) {

--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -559,7 +559,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
      * @return The UCUM-compliant string if known, otherwise returns the original unit
      */
     private static String mapUnitIfNeeded(String unit) {
-        return unit != null ? UCUM_TIME_UNIT_MAP.getOrDefault(unit.toLowerCase(), unit) : null;
+        return unit != null ? UCUM_TIME_UNIT_MAP.getOrDefault(unit.toLowerCase(Locale.ROOT), unit) : null;
     }
 
     /**
@@ -570,22 +570,22 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private static Map<String, String> ucumTimeUnitMap() {
         Map<String, String> mapping = new HashMap<>();
         // There are redundant elements in case the toString method of TimeUnit changes
-        mapping.put(TimeUnit.NANOSECONDS.toString().toLowerCase(), "ns");
+        mapping.put(TimeUnit.NANOSECONDS.toString().toLowerCase(Locale.ROOT), "ns");
         mapping.put("nanoseconds", "ns");
         mapping.put("nanosecond", "ns");
-        mapping.put(TimeUnit.MICROSECONDS.toString().toLowerCase(), "us");
+        mapping.put(TimeUnit.MICROSECONDS.toString().toLowerCase(Locale.ROOT), "us");
         mapping.put("microseconds", "us");
         mapping.put("microsecond", "us");
-        mapping.put(TimeUnit.MILLISECONDS.toString().toLowerCase(), "ms");
+        mapping.put(TimeUnit.MILLISECONDS.toString().toLowerCase(Locale.ROOT), "ms");
         mapping.put("milliseconds", "ms");
         mapping.put("millisecond", "ms");
-        mapping.put(TimeUnit.SECONDS.toString().toLowerCase(), "s");
+        mapping.put(TimeUnit.SECONDS.toString().toLowerCase(Locale.ROOT), "s");
         mapping.put("seconds", "s");
         mapping.put("second", "s");
-        mapping.put(TimeUnit.MINUTES.toString().toLowerCase(), "min");
+        mapping.put(TimeUnit.MINUTES.toString().toLowerCase(Locale.ROOT), "min");
         mapping.put("minutes", "min");
         mapping.put("minute", "min");
-        mapping.put(TimeUnit.HOURS.toString().toLowerCase(), "h");
+        mapping.put(TimeUnit.HOURS.toString().toLowerCase(Locale.ROOT), "h");
         mapping.put("hours", "h");
         mapping.put("hour", "h");
 

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -18,6 +18,7 @@ package io.micrometer.elastic;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.step.StepMeterRegistry;
 import io.micrometer.core.instrument.util.MeterPartition;
@@ -31,10 +32,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -349,7 +347,7 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         StringBuilder sb = new StringBuilder(actionLine);
         String timestamp = generateTimestamp();
         String name = getConventionName(meter.getId());
-        String type = meter.getId().getType().toString().toLowerCase();
+        String type = meter.getId().getType().toString().toLowerCase(Locale.ROOT);
         sb.append("{\"")
             .append(config.timestampFieldName())
             .append("\":\"")

--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaMeterRegistry.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -134,7 +135,7 @@ public class GangliaMeterRegistry extends StepMeterRegistry {
 
     private void announceMeter(Meter meter) {
         for (Measurement measurement : meter.measure()) {
-            announce(meter, measurement.getValue(), measurement.getStatistic().toString().toLowerCase());
+            announce(meter, measurement.getValue(), measurement.getStatistic().toString().toLowerCase(Locale.ROOT));
         }
     }
 

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/ServiceLevelObjective.java
@@ -161,7 +161,7 @@ public abstract class ServiceLevelObjective {
         public String getValueAsString(MeterRegistry registry) {
             double value = getValue(registry);
             return Double.isNaN(value) ? "no value available"
-                    : getBaseUnit() != null && getBaseUnit().toLowerCase().contains("percent")
+                    : getBaseUnit() != null && getBaseUnit().toLowerCase(Locale.ROOT).contains("percent")
                             ? WHOLE_OR_SHORT_DECIMAL.get().format(value * 100) + "%"
                             : WHOLE_OR_SHORT_DECIMAL.get().format(value);
         }
@@ -366,7 +366,7 @@ public abstract class ServiceLevelObjective {
             abstract Double getValue(MeterRegistry registry);
 
             private String thresholdString(double threshold) {
-                return baseUnit != null && baseUnit.toLowerCase().contains("percent")
+                return baseUnit != null && baseUnit.toLowerCase(Locale.ROOT).contains("percent")
                         ? WHOLE_OR_SHORT_DECIMAL.get().format(threshold * 100) + "%"
                         : WHOLE_OR_SHORT_DECIMAL.get().format(threshold);
             }

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxApiVersion.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxApiVersion.java
@@ -20,6 +20,7 @@ import io.micrometer.core.ipc.http.HttpSender;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Locale;
 
 /**
  * Enum for the version of the InfluxDB API.
@@ -32,8 +33,8 @@ public enum InfluxApiVersion {
     V1 {
         @Override
         String writeEndpoint(final InfluxConfig config) {
-            String influxEndpoint = config.uri() + "/write?consistency=" + config.consistency().name().toLowerCase()
-                    + "&precision=ms&db=" + config.db();
+            String influxEndpoint = config.uri() + "/write?consistency="
+                    + config.consistency().name().toLowerCase(Locale.ROOT) + "&precision=ms&db=" + config.db();
             if (StringUtils.isNotBlank(config.retentionPolicy())) {
                 influxEndpoint += "&rp=" + config.retentionPolicy();
             }

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxMeterRegistry.java
@@ -30,6 +30,7 @@ import java.net.MalformedURLException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -175,14 +176,14 @@ public class InfluxMeterRegistry extends StepMeterRegistry {
             String fieldKey = measurement.getStatistic()
                 .getTagValueRepresentation()
                 .replaceAll("(.)(\\p{Upper})", "$1_$2")
-                .toLowerCase();
+                .toLowerCase(Locale.ROOT);
             fields.add(new Field(fieldKey, value));
         }
         if (fields.isEmpty()) {
             return Stream.empty();
         }
         Meter.Id id = m.getId();
-        return Stream.of(influxLineProtocol(id, id.getType().name().toLowerCase(), fields.stream()));
+        return Stream.of(influxLineProtocol(id, id.getType().name().toLowerCase(Locale.ROOT), fields.stream()));
     }
 
     private Stream<String> writeLongTaskTimer(LongTaskTimer timer) {

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryVersionsTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxMeterRegistryVersionsTest.java
@@ -29,6 +29,7 @@ import ru.lanwen.wiremock.ext.WiremockResolver.Wiremock;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -386,7 +387,7 @@ class InfluxMeterRegistryVersionsTest {
         InfluxMeterRegistry registry = new InfluxMeterRegistry(config, new MockClock());
 
         Counter.builder("my.counter")
-            .baseUnit(TimeUnit.MICROSECONDS.name().toLowerCase())
+            .baseUnit(TimeUnit.MICROSECONDS.name().toLowerCase(Locale.ROOT))
             .description("metric description")
             .register(registry)
             .increment(Math.PI);

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -93,7 +94,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         Map<String, Object> attributes = new HashMap<>();
         addAttribute(ACTIVE_TASKS, timer.activeTasks(), attributes);
         addAttribute(DURATION, timer.duration(timer.baseTimeUnit()), attributes);
-        addAttribute(TIME_UNIT, timer.baseTimeUnit().name().toLowerCase(), attributes);
+        addAttribute(TIME_UNIT, timer.baseTimeUnit().name().toLowerCase(Locale.ROOT), attributes);
         // process meter's name, type and tags
         addMeterAsAttributes(timer.getId(), attributes);
         return attributes;
@@ -141,7 +142,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         }
         Map<String, Object> attributes = new HashMap<>();
         addAttribute(VALUE, value, attributes);
-        addAttribute(TIME_UNIT, gauge.baseTimeUnit().name().toLowerCase(), attributes);
+        addAttribute(TIME_UNIT, gauge.baseTimeUnit().name().toLowerCase(Locale.ROOT), attributes);
         // process meter's name, type and tags
         addMeterAsAttributes(gauge.getId(), attributes);
         return attributes;
@@ -167,7 +168,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);
         addAttribute(MAX, timer.max(timeUnit), attributes);
-        addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(), attributes);
+        addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(Locale.ROOT), attributes);
         // process meter's name, type and tags
         addMeterAsAttributes(timer.getId(), attributes);
         return attributes;
@@ -180,7 +181,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         addAttribute(COUNT, timer.count(), attributes);
         addAttribute(AVG, timer.mean(timeUnit), attributes);
         addAttribute(TOTAL_TIME, timer.totalTime(timeUnit), attributes);
-        addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(), attributes);
+        addAttribute(TIME_UNIT, timeUnit.name().toLowerCase(Locale.ROOT), attributes);
         // process meter's name, type and tags
         addMeterAsAttributes(timer.getId(), attributes);
         return attributes;

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -16,6 +16,7 @@
 package io.micrometer.newrelic;
 
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.util.DoubleFormat;
 import io.micrometer.core.instrument.util.MeterPartition;
@@ -26,10 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -125,7 +123,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(event(timer.getId(), new Attribute(ACTIVE_TASKS, timer.activeTasks()),
                 new Attribute(DURATION, timer.duration(timeUnit)),
-                new Attribute(TIME_UNIT, timeUnit.name().toLowerCase())));
+                new Attribute(TIME_UNIT, timeUnit.name().toLowerCase(Locale.ROOT))));
     }
 
     @Override
@@ -156,7 +154,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         double value = gauge.value();
         if (Double.isFinite(value)) {
             return Stream.of(event(gauge.getId(), new Attribute(VALUE, value),
-                    new Attribute(TIME_UNIT, gauge.baseTimeUnit().name().toLowerCase())));
+                    new Attribute(TIME_UNIT, gauge.baseTimeUnit().name().toLowerCase(Locale.ROOT))));
         }
         return Stream.empty();
     }
@@ -171,9 +169,10 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
     @Override
     public Stream<String> writeTimer(Timer timer) {
         TimeUnit timeUnit = timer.baseTimeUnit();
-        return Stream.of(event(timer.getId(), new Attribute(COUNT, timer.count()),
-                new Attribute(AVG, timer.mean(timeUnit)), new Attribute(TOTAL_TIME, timer.totalTime(timeUnit)),
-                new Attribute(MAX, timer.max(timeUnit)), new Attribute(TIME_UNIT, timeUnit.name().toLowerCase())));
+        return Stream
+            .of(event(timer.getId(), new Attribute(COUNT, timer.count()), new Attribute(AVG, timer.mean(timeUnit)),
+                    new Attribute(TOTAL_TIME, timer.totalTime(timeUnit)), new Attribute(MAX, timer.max(timeUnit)),
+                    new Attribute(TIME_UNIT, timeUnit.name().toLowerCase(Locale.ROOT))));
     }
 
     @Override
@@ -181,7 +180,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         TimeUnit timeUnit = timer.baseTimeUnit();
         return Stream.of(event(timer.getId(), new Attribute(COUNT, timer.count()),
                 new Attribute(AVG, timer.mean(timeUnit)), new Attribute(TOTAL_TIME, timer.totalTime(timeUnit)),
-                new Attribute(TIME_UNIT, timeUnit.name().toLowerCase())));
+                new Attribute(TIME_UNIT, timeUnit.name().toLowerCase(Locale.ROOT))));
     }
 
     @Override

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.push.PushRegistryConfig;
 import java.time.Duration;
 import java.net.URLDecoder;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -151,7 +152,7 @@ public interface OtlpConfig extends PushRegistryConfig {
         return getEnum(this, AggregationTemporality.class, "aggregationTemporality").orElseGet(() -> {
             String preference = System.getenv().get("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE");
             if (preference != null) {
-                return AggregationTemporality.valueOf(preference.toUpperCase());
+                return AggregationTemporality.valueOf(preference.toUpperCase(Locale.ROOT));
             }
             return AggregationTemporality.CUMULATIVE;
         });

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -35,6 +35,7 @@ import reactor.util.concurrent.Queues;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -260,7 +261,7 @@ class StatsdMeterRegistryTest {
     void customNamingConvention() {
         final Processor<String, String> lines = lineProcessor();
         registry = StatsdMeterRegistry.builder(configWithFlavor(StatsdFlavor.ETSY))
-            .nameMapper((id, convention) -> id.getName().toUpperCase())
+            .nameMapper((id, convention) -> id.getName().toUpperCase(Locale.ROOT))
             .clock(clock)
             .lineSink(toLineSink(lines))
             .build();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -71,7 +71,7 @@ public abstract class MeterRegistry {
         .collect(
             Collectors.toMap(
                 Function.identity(),
-                (timeUnit) -> timeUnit.toString().toLowerCase(),
+                (timeUnit) -> timeUnit.toString().toLowerCase(Locale.ROOT),
                 (k, v) -> { throw new IllegalStateException("Duplicate keys should not exist."); },
                 () -> new EnumMap<>(TimeUnit.class)
             )

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/JooqExecuteListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/JooqExecuteListener.java
@@ -24,6 +24,7 @@ import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DefaultExecuteListener;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -91,8 +92,8 @@ class JooqExecuteListener extends DefaultExecuteListener {
         if (exception != null) {
             if (exception instanceof DataAccessException) {
                 DataAccessException dae = (DataAccessException) exception;
-                exceptionName = dae.sqlStateClass().name().toLowerCase().replace('_', ' ');
-                exceptionSubclass = dae.sqlStateSubclass().name().toLowerCase().replace('_', ' ');
+                exceptionName = dae.sqlStateClass().name().toLowerCase(Locale.ROOT).replace('_', ' ');
+                exceptionSubclass = dae.sqlStateSubclass().name().toLowerCase(Locale.ROOT).replace('_', ' ');
                 if (exceptionSubclass.contains("no subclass")) {
                     exceptionSubclass = "none";
                 }
@@ -107,7 +108,7 @@ class JooqExecuteListener extends DefaultExecuteListener {
         sample.stop(Timer.builder("jooq.query")
             .description("Execution time of a SQL query performed with JOOQ")
             .tags(queryTags)
-            .tag("type", ctx.type().name().toLowerCase())
+            .tag("type", ctx.type().name().toLowerCase(Locale.ROOT))
             .tag("exception", exceptionName)
             .tag("exception.subclass", exceptionSubclass)
             .tags(tags)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommand.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.*;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -162,7 +163,7 @@ public class MicrometerMetricsPublisherCommand implements HystrixMetricsPublishe
     private Counter getCounter(HystrixEventType hystrixEventType) {
         return Counter.builder(NAME_HYSTRIX_EXECUTION)
             .description(DESCRIPTION_HYSTRIX_EXECUTION)
-            .tags(Tags.concat(tags, "event", hystrixEventType.name().toLowerCase(), "terminal",
+            .tags(Tags.concat(tags, "event", hystrixEventType.name().toLowerCase(Locale.ROOT), "terminal",
                     Boolean.toString(hystrixEventType.isTerminal())))
             .register(meterRegistry);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -28,6 +28,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static java.util.Collections.emptyList;
 
@@ -103,7 +104,7 @@ public class JvmThreadMetrics implements MeterBinder {
     }
 
     private static String getStateTagValue(Thread.State state) {
-        return state.name().toLowerCase().replace("_", "-");
+        return state.name().toLowerCase(Locale.ROOT).replace("_", "-");
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/DurationValidator.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/validate/DurationValidator.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,7 +45,7 @@ public enum DurationValidator {
             "^\\s*([\\+]?\\d{0,3}([_,]?\\d{3})*(\\.\\d*)?)\\s*([a-zA-Z]{0,2})\\s*") {
         @Override
         protected Validated<Duration> doParse(String property, String value) {
-            Matcher matcher = patterns.get(0).matcher(value.toLowerCase().replaceAll("[,_\\s]", ""));
+            Matcher matcher = patterns.get(0).matcher(value.toLowerCase(Locale.ROOT).replaceAll("[,_\\s]", ""));
             if (!matcher.matches()) {
                 return Validated.invalid(property, value, "must be a valid duration", InvalidReason.MALFORMED);
             }
@@ -143,7 +144,7 @@ public enum DurationValidator {
             return Validated.valid(property, null);
         }
 
-        switch (unit.toLowerCase()) {
+        switch (unit.toLowerCase(Locale.ROOT)) {
             case "ns":
             case "nanoseconds":
             case "nanosecond":

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
@@ -28,6 +28,7 @@ import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.step.*;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 import java.util.function.ToLongFunction;
@@ -203,7 +204,7 @@ public class SimpleMeterRegistry extends MeterRegistry {
 
     private String toString(Measurement measurement, String meterUnitSuffix) {
         Statistic statistic = measurement.getStatistic();
-        return String.format("%s=%s%s", statistic.toString().toLowerCase(), measurement.getValue(),
+        return String.format("%s=%s%s", statistic.toString().toLowerCase(Locale.ROOT), measurement.getValue(),
                 getUnitSuffix(statistic, meterUnitSuffix));
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/TimeUtils.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.config.validate.DurationValidator;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -218,7 +219,7 @@ public final class TimeUtils {
      */
     @Deprecated
     public static Duration simpleParse(String time) {
-        String timeLower = PARSE_PATTERN.matcher(time.toLowerCase()).replaceAll("");
+        String timeLower = PARSE_PATTERN.matcher(time.toLowerCase(Locale.ROOT)).replaceAll("");
         if (timeLower.endsWith("ns")) {
             return Duration.ofNanos(Long.parseLong(timeLower.substring(0, timeLower.length() - 2)));
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommandTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherCommandTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MicrometerMetricsPublisherCommandTest {
@@ -86,7 +88,7 @@ class MicrometerMetricsPublisherCommandTest {
     }
 
     private void assertExecutionMetric(Iterable<Tag> tags, HystrixEventType eventType, double count) {
-        Iterable<Tag> myTags = Tags.concat(tags, "event", eventType.name().toLowerCase(), "terminal",
+        Iterable<Tag> myTags = Tags.concat(tags, "event", eventType.name().toLowerCase(Locale.ROOT), "terminal",
                 Boolean.toString(eventType.isTerminal()));
         assertThat(registry.get("hystrix.execution").tags(myTags).counter().count()).isEqualTo(count);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.lang.management.OperatingSystemMXBean;
+import java.util.Locale;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -47,7 +48,7 @@ class FileDescriptorMetricsTest {
 
     @Test
     void unixFileDescriptorMetrics() {
-        assumeFalse(System.getProperty("os.name").toLowerCase().contains("win"));
+        assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
 
         // tag::example[]
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
@@ -59,7 +60,7 @@ class FileDescriptorMetricsTest {
 
     @Test
     void windowsFileDescriptorMetrics() {
-        assumeTrue(System.getProperty("os.name").toLowerCase().contains("win"));
+        assumeTrue(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
 
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Locale;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -49,7 +50,7 @@ class ProcessorMetricsTest {
     @Test
     void cpuMetrics() {
         assertThat(registry.get("system.cpu.count").gauge().value()).isPositive();
-        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")) {
             assertThat(registry.find("system.load.average.1m").gauge()).describedAs("Not present on windows").isNull();
         }
         else {

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -159,7 +159,7 @@ public abstract class MeterRegistryCompatibilityKit {
         FunctionTimer ft = registry.get("function.timer").functionTimer();
         clock(registry).add(step());
         assertThat(ft.measure()).anySatisfy(ms -> {
-            TimeUnit baseUnit = TimeUnit.valueOf(requireNonNull(ft.getId().getBaseUnit()).toUpperCase());
+            TimeUnit baseUnit = TimeUnit.valueOf(requireNonNull(ft.getId().getBaseUnit()).toUpperCase(Locale.ROOT));
             assertThat(ms.getStatistic()).isEqualTo(Statistic.TOTAL_TIME);
             assertThat(TimeUtils.convert(ms.getValue(), baseUnit, TimeUnit.MILLISECONDS)).isEqualTo(1);
         });


### PR DESCRIPTION
This PR changes to use `String.toLowerCase()` and `String.toUpperCase()` with the `Locale.ROOT` consistently as it seems to be a good practice aside from security.

This PR also adds Checkstyle rules for it.

See https://github.com/spring-projects/spring-framework/issues/33708 and https://errorprone.info/bugpattern/StringCaseLocaleUsage