### PR TITLE
Deprecate AggregationTemporality#toOtlpAggregationTemporality

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/AggregationTemporality.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/AggregationTemporality.java
@@ -36,6 +36,10 @@ public enum AggregationTemporality {
      */
     CUMULATIVE;
 
+    /**
+     * @deprecated This method was not intended to be public, users should not use it.
+     */
+    @Deprecated
     public static io.opentelemetry.proto.metrics.v1.AggregationTemporality toOtlpAggregationTemporality(
             AggregationTemporality aggregationTemporality) {
         switch (aggregationTemporality) {


### PR DESCRIPTION
It was not intended to be public, users should not use it.