### PR TITLE
Fix `gradle check` with JDK17+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,12 @@ buildscript {
         classpath libs.plugin.japicmp
         classpath libs.plugin.downloadTask
         classpath libs.plugin.spotless
-        classpath libs.plugin.bnd
+
+        if (javaLanguageVersion.asInt() < 17) {
+            classpath libs.plugin.bnd
+        } else {
+            classpath libs.plugin.bndForJava17
+        }
 
         constraints {
             classpath(libs.asmForPlugins) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -234,6 +234,7 @@ plugin-japicmp = { module = "me.champeau.gradle:japicmp-gradle-plugin", version 
 plugin-downloadTask = { module = "de.undercouch:gradle-download-task", version = "5.6.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }
 plugin-bnd = "biz.aQute.bnd:biz.aQute.bnd.gradle:6.4.0"
+plugin-bndForJava17 = "biz.aQute.bnd:biz.aQute.bnd.gradle:7.1.0"
 
 [plugins]
 kotlin19 = { id = "org.jetbrains.kotlin.jvm", version = "1.9.25" }

--- a/micrometer-osgi-test/build.gradle
+++ b/micrometer-osgi-test/build.gradle
@@ -26,8 +26,9 @@ dependencies {
 def testingBundle = tasks.register('testingBundle', Bundle) {
     archiveClassifier = 'tests'
     from sourceSets.test.output
-    sourceSet = sourceSets.test
-
+    if (javaLanguageVersion.asInt() < 17) {
+        sourceSet = sourceSets.test
+    }
     bundle {
         bnd """\
             Bundle-SymbolicName: \${task.archiveBaseName}-\${task.archiveClassifier}


### PR DESCRIPTION
Related gh-5599

I run `./gradlew :micrometer-osgi-test:check` and the result is success on my local machine with OS is Windows 11. 
I think we should check `./gradlew clean check` before merging (maybe the result will be different)