### PR TITLE
Remove outdated warnings in docs for @Counted/@Timed

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -50,8 +50,6 @@ Counter counter = Counter
 
 The `micrometer-core` module contains a `@Counted` annotation that frameworks can use to add counting support to either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
 
-WARNING: Micrometer's Spring Boot configuration does _not_ recognize `@Counted` on arbitrary methods.
-
 Also, an incubating AspectJ aspect is included in `micrometer-core`. You can use it in your application either through compile/load time AspectJ weaving or through framework facilities that interpret AspectJ aspects and proxy targeted methods in some other way, such as Spring AOP. Here is a sample Spring AOP configuration:
 
 [source,java]

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -73,8 +73,6 @@ Note how we do not decide the timer to which to accumulate the sample until it i
 
 The `micrometer-core` module contains a `@Timed` annotation that frameworks can use to add timing support to either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
 
-WARNING: Micrometer's Spring Boot configuration does _not_ recognize `@Timed` on arbitrary methods.
-
 Also, an incubating AspectJ aspect is included in `micrometer-core`. You can use it in your application either through compile/load time AspectJ weaving or through framework facilities that interpret AspectJ aspects and proxy targeted methods in some other way, such as Spring AOP. Here is a sample Spring AOP configuration:
 
 [source,java]


### PR DESCRIPTION
This PR removes outdated warnings in docs for `@Counted` and `@Timed` as they seem to be for the removed Spring Boot legacy module.

I can see some more related to Spring Boot application properties for meter registries (ex. [AppOptics](https://docs.micrometer.io/micrometer/reference/implementations/appOptics.html#_configuring)). I think we can replace them with links to Spring Boot reference docs for them (ex. [AppOptics](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.appoptics)). I can try this with another PR if you agree with this direction.