### PR TITLE
Document no support for meta-annotations with @Timed/@Counted

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -88,6 +88,8 @@ public class ExampleService {
 }
 ----
 
+NOTE: `CountedAspect` doesn't support meta-annotations with `@Counted`.
+
 == Function-tracking Counters
 
 Micrometer also provides a more infrequently used counter pattern that tracks a monotonically increasing function (a function that stays the same or increases over time but never decreases). Some monitoring systems, such as Prometheus, push cumulative values for counters to the backend, but others publish the rate at which a counter is incrementing over the push interval. By employing this pattern, you let the Micrometer implementation for your monitoring system choose whether to rate-normalize the counter, and your counter remains portable across different types of monitoring systems.

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -114,6 +114,8 @@ public class ExampleService {
 }
 ----
 
+NOTE: `TimedAspect` doesn't support meta-annotations with `@Timed`.
+
 === @MeterTag on Method Parameters
 
 To support using the `@MeterTag` annotation on method parameters, you need to configure the `@TimedAspect` to add the `MeterTagAnnotationHandler`.


### PR DESCRIPTION
This PR documents that meta-annotations with `@Timed` or `@Counted` are not supported in their respective aspect.

See gh-5657