### PR TITLE
Omit EnumSource.value where possible

### DIFF
--- a/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
@@ -42,7 +42,7 @@ class TimedAspectTest {
         // end::resolvers[]
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithText(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);
@@ -65,7 +65,7 @@ class TimedAspectTest {
         }
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithResolver(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);
@@ -88,7 +88,7 @@ class TimedAspectTest {
         }
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithExpression(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -80,7 +80,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void receiveAllBufferedMetricsAfterCloseSuccessfully(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
         serverLatch = new CountDownLatch(3);
@@ -98,7 +98,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void receiveMetricsSuccessfully(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
         serverLatch = new CountDownLatch(3);
@@ -116,7 +116,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void resumeSendingMetrics_whenServerIntermittentlyFails(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
         serverLatch = new CountDownLatch(1);
@@ -163,7 +163,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     @Issue("#1676")
     void stopAndStartMeterRegistrySendsMetrics(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
@@ -206,7 +206,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void whenBackendInitiallyDown_metricsSentAfterBackendStarts(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
         AtomicInteger writeCount = new AtomicInteger();
@@ -245,7 +245,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void whenRegistryStopped_doNotConnectToBackend(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
         serverLatch = new CountDownLatch(3);
@@ -264,7 +264,7 @@ class StatsdMeterRegistryPublishTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     @Issue("#2177")
     void whenSendError_reconnectsAndWritesNewMetrics(StatsdProtocol protocol) throws InterruptedException {
         skipUdsTestOnWindows(protocol);
@@ -296,7 +296,7 @@ class StatsdMeterRegistryPublishTest {
 
     @Issue("#2880")
     @ParameterizedTest
-    @EnumSource(StatsdProtocol.class)
+    @EnumSource
     void receiveParallelMetricsSuccessfully(StatsdProtocol protocol) throws InterruptedException {
         final int n = 10;
 

--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryTest.java
@@ -79,7 +79,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     void counterLineProtocol(StatsdFlavor flavor) {
         String line = null;
         switch (flavor) {
@@ -112,7 +112,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     void gaugeLineProtocol(StatsdFlavor flavor) {
         final AtomicInteger n = new AtomicInteger(2);
         final StatsdConfig config = configWithFlavor(flavor);
@@ -145,7 +145,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     void timerLineProtocol(StatsdFlavor flavor) {
         String line = null;
         switch (flavor) {
@@ -178,7 +178,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     void summaryLineProtocol(StatsdFlavor flavor) {
         String line = null;
         switch (flavor) {
@@ -211,7 +211,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     void longTaskTimerLineProtocol(StatsdFlavor flavor) {
         final StatsdConfig config = configWithFlavor(flavor);
         long stepMillis = config.step().toMillis();
@@ -286,7 +286,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     @Issue("#370")
     void serviceLevelObjectivesOnlyNoPercentileHistogram(StatsdFlavor flavor) {
         StatsdConfig config = configWithFlavor(flavor);
@@ -390,7 +390,7 @@ class StatsdMeterRegistryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(StatsdFlavor.class)
+    @EnumSource
     @Issue("#600")
     void memoryPerformanceOfNamingConventionInHotLoops(StatsdFlavor flavor) {
         AtomicInteger namingConventionUses = new AtomicInteger();

--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -425,7 +425,7 @@ class TimedAspectTest {
                 aClass -> valueExpressionResolver);
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithText(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);
@@ -442,7 +442,7 @@ class TimedAspectTest {
         }
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithResolver(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);
@@ -462,7 +462,7 @@ class TimedAspectTest {
         }
 
         @ParameterizedTest
-        @EnumSource(AnnotatedTestClass.class)
+        @EnumSource
         void meterTagsWithExpression(AnnotatedTestClass annotatedClass) {
             MeterRegistry registry = new SimpleMeterRegistry();
             TimedAspect timedAspect = new TimedAspect(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineStatsCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineStatsCounterTest.java
@@ -94,7 +94,7 @@ class CaffeineStatsCounterTest {
     }
 
     @ParameterizedTest
-    @EnumSource(RemovalCause.class)
+    @EnumSource
     void evictionWithCause(RemovalCause cause) {
         stats.recordEviction(3, cause);
         DistributionSummary summary = fetch("cache.evictions", "cause", cause.name()).summary();

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpClientTimingInstrumentationVerificationTests.java
@@ -144,7 +144,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void getTemplatedPathForUri(TestType testType, WireMockRuntimeInfo wmRuntimeInfo) {
         checkAndSetupTestForTestType(testType);
 
@@ -162,7 +162,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     @Disabled("apache/jetty http client instrumentation currently fails this test")
     void timedWhenServerIsMissing(TestType testType) throws IOException {
         checkAndSetupTestForTestType(testType);
@@ -186,7 +186,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void serverException(TestType testType, WireMockRuntimeInfo wmRuntimeInfo) {
         checkAndSetupTestForTestType(testType);
 
@@ -203,7 +203,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void clientException(TestType testType, WireMockRuntimeInfo wmRuntimeInfo) {
         checkAndSetupTestForTestType(testType);
 
@@ -223,7 +223,7 @@ public abstract class HttpClientTimingInstrumentationVerificationTests<CLIENT>
     // TODO this test doesn't need to be parameterized but the custom resolver for
     // Before/After methods doesn't like when it isn't.
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void headerIsPropagatedFromContext(TestType testType, WireMockRuntimeInfo wmRuntimeInfo) {
         checkAndSetupTestForTestType(testType);
 

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/HttpServerTimingInstrumentationVerificationTests.java
@@ -120,14 +120,14 @@ public abstract class HttpServerTimingInstrumentationVerificationTests extends I
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void uriIsNotFound_whenRouteIsUnmapped(TestType testType) throws Throwable {
         sender.get(baseUri + "notFound").send();
         checkTimer(rs -> rs.tags("uri", "NOT_FOUND", "status", "404", "method", "GET").timer().count() == 1);
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void uriTemplateIsTagged(TestType testType) throws Throwable {
         sender.get(baseUri + "hello/world").send();
         checkTimer(rs -> rs.tags("uri", InstrumentedRoutes.TEMPLATED_ROUTE, "status", "200", "method", "GET")
@@ -136,7 +136,7 @@ public abstract class HttpServerTimingInstrumentationVerificationTests extends I
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void redirect(TestType testType) throws Throwable {
         sender.get(baseUri + "foundRedirect").send();
         checkTimer(rs -> rs.tags("uri", InstrumentedRoutes.REDIRECT, "status", "302", "method", "GET")
@@ -145,7 +145,7 @@ public abstract class HttpServerTimingInstrumentationVerificationTests extends I
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void errorResponse(TestType testType) throws Throwable {
         sender.post(baseUri + "error").send();
         checkTimer(
@@ -153,7 +153,7 @@ public abstract class HttpServerTimingInstrumentationVerificationTests extends I
     }
 
     @ParameterizedTest
-    @EnumSource(TestType.class)
+    @EnumSource
     void canExtractContextFromHeaders(TestType testType) throws Throwable {
         sender.get(baseUri + "hello/micrometer").withHeader("Test-Propagation", "someValue").send();
 

--- a/micrometer-test/src/main/java/io/micrometer/core/ipc/http/HttpSenderCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/ipc/http/HttpSenderCompatibilityKit.java
@@ -56,7 +56,7 @@ public abstract class HttpSenderCompatibilityKit {
 
     @ParameterizedTest
     @DisplayName("successfully send a request with NO body and receive a response with NO body")
-    @EnumSource(HttpSender.Method.class)
+    @EnumSource
     void successfulRequestSentWithNoBody(HttpSender.Method method, @WiremockResolver.Wiremock WireMockServer server)
             throws Throwable {
         server.stubFor(any(urlEqualTo("/metrics")));
@@ -104,7 +104,7 @@ public abstract class HttpSenderCompatibilityKit {
 
     @ParameterizedTest
     @DisplayName("receive an error response")
-    @EnumSource(HttpSender.Method.class)
+    @EnumSource
     void errorResponseReceived(HttpSender.Method method, @WiremockResolver.Wiremock WireMockServer server)
             throws Throwable {
         server.stubFor(any(urlEqualTo("/metrics")).willReturn(badRequest().withBody("Error processing metrics")));
@@ -121,7 +121,7 @@ public abstract class HttpSenderCompatibilityKit {
     }
 
     @ParameterizedTest
-    @EnumSource(HttpSender.Method.class)
+    @EnumSource
     void basicAuth(HttpSender.Method method, @WiremockResolver.Wiremock WireMockServer server) throws Throwable {
         server.stubFor(any(urlEqualTo("/metrics")).willReturn(unauthorized()));
 
@@ -140,7 +140,7 @@ public abstract class HttpSenderCompatibilityKit {
     }
 
     @ParameterizedTest
-    @EnumSource(HttpSender.Method.class)
+    @EnumSource
     void customHeader(HttpSender.Method method, @WiremockResolver.Wiremock WireMockServer server) throws Throwable {
         server.stubFor(any(urlEqualTo("/metrics")).willReturn(unauthorized()));
 


### PR DESCRIPTION
This PR changes to omit `value` attribute in `@EnumSource` where possible.

See https://github.com/spring-projects/spring-boot/pull/43214