### PR TITLE
Make jvm.classes.unloaded description generic

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
@@ -55,7 +55,7 @@ public class ClassLoaderMetrics implements MeterBinder {
 
         FunctionCounter.builder("jvm.classes.unloaded", classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
             .tags(tags)
-            .description("The total number of classes unloaded since the Java virtual machine has started execution")
+            .description("The number of classes unloaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
     }


### PR DESCRIPTION
The description before could have been confusing for step-based registries where the number would be the classes unloaded since the previous step rather than the cumulative count since the JVM started.

See gh-3561