### PR TITLE
Handle RuntimeException when getting/setting JMS headers

### DIFF
--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsProcessObservationContext.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsProcessObservationContext.java
@@ -16,8 +16,8 @@
 
 package io.micrometer.jakarta9.instrument.jms;
 
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.observation.transport.ReceiverContext;
-import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 
 /**
@@ -33,12 +33,15 @@ import jakarta.jms.Message;
  */
 public class JmsProcessObservationContext extends ReceiverContext<Message> {
 
+    private static final WarnThenDebugLogger logger = new WarnThenDebugLogger(JmsProcessObservationContext.class);
+
     public JmsProcessObservationContext(Message receivedMessage) {
         super((message, key) -> {
             try {
                 return message.getStringProperty(key);
             }
-            catch (JMSException exc) {
+            catch (Exception exc) {
+                logger.log("Failed to get message property.", exc);
                 return null;
             }
         });

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContext.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsPublishObservationContext.java
@@ -17,8 +17,8 @@
 package io.micrometer.jakarta9.instrument.jms;
 
 import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.observation.transport.SenderContext;
-import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 
 /**
@@ -33,15 +33,17 @@ import jakarta.jms.Message;
  */
 public class JmsPublishObservationContext extends SenderContext<Message> {
 
+    private static final WarnThenDebugLogger logger = new WarnThenDebugLogger(JmsPublishObservationContext.class);
+
     public JmsPublishObservationContext(@Nullable Message sendMessage) {
         super((message, key, value) -> {
-            try {
-                if (message != null) {
+            if (message != null) {
+                try {
                     message.setStringProperty(key, value);
                 }
-            }
-            catch (JMSException exc) {
-                // ignore
+                catch (Exception exc) {
+                    logger.log("Failed to set message property.", exc);
+                }
             }
         });
         setCarrier(sendMessage);


### PR DESCRIPTION
Currently JMSException is handled when getting/setting JMS headers. Some JMS providers will throw RuntimeException instead of JMSException when failing to get/set JMS headers. This change adds so that RuntimeException is also handled.

For example, [Qpid JMS throws IllegalArgumentException](https://github.com/apache/qpid-jms/blob/main/qpid-jms-client/src/main/java/org/apache/qpid/jms/message/JmsMessagePropertySupport.java#L101) which leads to similar issue as #4202.