### PR TITLE
Suppress deprecations on AggregationTemporality.toOtlpAggregationTemporality()

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -56,6 +56,7 @@ class OtlpMetricConverter {
 
     private final long deltaTimeUnixNano;
 
+    @SuppressWarnings("deprecation")
     OtlpMetricConverter(Clock clock, Duration step, TimeUnit baseTimeUnit,
             AggregationTemporality aggregationTemporality, NamingConvention namingConvention) {
         this.clock = clock;

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -172,6 +172,7 @@ abstract class OtlpMeterRegistryTest {
         assertThat(writeToMetric(ds).getDataCase().getNumber()).isEqualTo(Metric.DataCase.SUMMARY.getNumber());
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void multipleMetricsWithSameMetaDataShouldBeSingleMetric() {
         Tags firstTag = Tags.of("key", "first");
@@ -333,6 +334,7 @@ abstract class OtlpMeterRegistryTest {
         clock.addSeconds(otlpConfig().step().getSeconds() * numStepsToSkip);
     }
 
+    @SuppressWarnings("deprecation")
     protected void assertHistogram(Metric metric, long startTime, long endTime, String unit, long count, double sum,
             double max) {
         assertThat(metric.getHistogram().getAggregationTemporality())
@@ -361,6 +363,7 @@ abstract class OtlpMeterRegistryTest {
         }
     }
 
+    @SuppressWarnings("deprecation")
     protected void assertSum(Metric metric, long startTime, long endTime, double expectedValue) {
         NumberDataPoint sumDataPoint = metric.getSum().getDataPoints(0);
         assertThat(metric.getName()).isEqualTo(METER_NAME);


### PR DESCRIPTION
This PR suppresses deprecations on the `AggregationTemporality.toOtlpAggregationTemporality()`.

See gh-5733