### PR TITLE
Add a test verifying that a single character meter name is allowed for Prometheus

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -1016,6 +1016,12 @@ class PrometheusMeterRegistryTest {
         assertThat(convention.tagKeyCount.get()).isEqualTo(expectedTagKeyCount);
     }
 
+    @Test
+    void scrapeWhenMeterNameContainsSingleCharacter() {
+        registry.counter("c").increment();
+        assertThatNoException().isThrownBy(() -> registry.scrape());
+    }
+
     private static class CountingPrometheusNamingConvention extends PrometheusNamingConvention {
 
         AtomicInteger nameCount = new AtomicInteger();


### PR DESCRIPTION
This PR adds a test verifying that a single character meter name is allowed for Prometheus.

There seems to have been a regression that https://github.com/prometheus/client_java/pull/951 has fixed in 1.3.0 or later, and Micrometer 1.13.x uses Prometheus Java client 1.2.1 that doesn't contain the fix, so the test that this PR adds fails.

I'm not sure if it's worth upgrading to Prometheus Java client 1.3.0 or later to fix it as it's a minor upgrade that might cause other compatibility issues.

The migration guide for Micrometer 1.13 contains [an entry for it](https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide#single-character-names-are-no-longer-valid), and it sounds like a feature, so at least we might want to update the guide to rephrase it.