### PR TITLE
Rebind log4j2 metrics if configuration is changed

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -89,7 +89,9 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         PropertyChangeListener changeListener = listener -> {
             if (listener.getNewValue() instanceof Configuration && listener.getOldValue() != listener.getNewValue()) {
-                registerMetricsFilter((Configuration) listener.getNewValue(), registry);
+                Configuration newConfiguration = (Configuration) listener.getNewValue();
+                registerMetricsFilter(newConfiguration, registry);
+                loggerContext.updateLoggers(newConfiguration);
                 if (listener.getOldValue() instanceof Configuration) {
                     removeMetricsFilter((Configuration) listener.getOldValue());
                 }
@@ -139,6 +141,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
     @Override
     public void close() {
         changeListeners.forEach(loggerContext::removePropertyChangeListener);
+        changeListeners.clear();
 
         if (!metricsFilters.isEmpty()) {
             Configuration configuration = loggerContext.getConfiguration();
@@ -146,6 +149,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
             loggerContext.updateLoggers(configuration);
 
             metricsFilters.values().forEach(MetricsFilter::stop);
+            metricsFilters.clear();
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -17,6 +17,8 @@ package io.micrometer.core.instrument.binder.logging;
 
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.NonNullFields;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -60,6 +62,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private static final String METER_DESCRIPTION = "Number of log events";
 
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Log4j2Metrics.class);
+
     private final Iterable<Tag> tags;
 
     private final LoggerContext loggerContext;
@@ -83,6 +87,10 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     @Override
     public void bindTo(MeterRegistry registry) {
+        if (metricsFilters.containsKey(registry)) {
+            logger.warn("This Log4j2Metrics instance has already been bound to the registry {}", registry);
+            return;
+        }
         Configuration configuration = loggerContext.getConfiguration();
         registerMetricsFilter(configuration, registry);
         loggerContext.updateLoggers(configuration);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -163,7 +163,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
             .filter(loggerConfig -> !loggerConfig.isAdditive())
             .forEach(loggerConfig -> {
                 if (loggerConfig != rootLoggerConfig) {
-                    metricsFilters.values().forEach(rootLoggerConfig::removeFilter);
+                    metricsFilters.values().forEach(loggerConfig::removeFilter);
                 }
             });
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -329,6 +329,7 @@ class Log4j2MetricsTest {
         try (Log4j2Metrics metrics = new Log4j2Metrics(emptyList(), context)) {
             metrics.bindTo(registry);
             logger.error("first");
+            assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1);
         }
 
         // This will reload the configuration to default

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -288,4 +288,56 @@ class Log4j2MetricsTest {
         assertThat(registry2.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(2);
     }
 
+    @Issue("#5756")
+    @Test
+    void rebindsMetricsWhenConfigurationIsReloaded() {
+        LoggerContext context = new LoggerContext("test");
+        Logger logger = context.getLogger("com.test");
+        Configuration oldConfiguration = context.getConfiguration();
+
+        try (Log4j2Metrics metrics = new Log4j2Metrics(emptyList(), context)) {
+            metrics.bindTo(registry);
+
+            logger.error("first");
+            assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1);
+
+            // Should have added filter to configuration
+            Filter oldFilter = oldConfiguration.getRootLogger().getFilter();
+            assertThat(oldFilter).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
+
+            // This will reload the configuration to default
+            context.reconfigure();
+
+            Configuration newConfiguration = context.getConfiguration();
+
+            // For this event to be counted, the metrics must be rebound
+            logger.error("second");
+            assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(2);
+
+            // Should have removed filter from old configuration, adding it to the new
+            assertThat(oldConfiguration.getRootLogger().getFilter()).isNull();
+            Filter newFilter = newConfiguration.getRootLogger().getFilter();
+            assertThat(newFilter).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
+        }
+    }
+
+    @Test
+    void shouldNotRebindMetricsIfBinderIsClosed() {
+        LoggerContext context = new LoggerContext("test");
+        Logger logger = context.getLogger("com.test");
+
+        try (Log4j2Metrics metrics = new Log4j2Metrics(emptyList(), context)) {
+            metrics.bindTo(registry);
+            logger.error("first");
+        }
+
+        // This will reload the configuration to default
+        context.reconfigure();
+
+        // This event should not be counted as the metrics binder is already closed
+        logger.error("second");
+
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1);
+    }
+
 }


### PR DESCRIPTION
*Describe the issue*

This PR is intended to fix https://github.com/micrometer-metrics/micrometer/issues/5756

When log4j2 metrics are reconfigured, metrics will no longer be recorded. For example, if `monitorInterval` ([docs](https://logging.apache.org/log4j/2.x/manual/configuration.html#configuration-attribute-monitorInterval)) is configured to 30 is used and configuration is reloaded after application start, metrics would only be recorded for the first 30 seconds.

---

By using a `PropertyChangeListener`, it looks like we can register the `MetricsFilter` in much the same way, but it will be rebound after reloading the configuration. All the previous tests seem to pass too when using this method of configuration.