### PR TITLE
Support AutoShutdownDelegatedExecutorService in ExecutorServiceMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -310,7 +310,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
             if (className.equals("java.util.concurrent.Executors$DelegatedScheduledExecutorService")) {
                 monitor(registry, unwrapThreadPoolExecutor(executorService, executorService.getClass()));
             }
-            else if (className.equals("java.util.concurrent.Executors$FinalizableDelegatedExecutorService")) {
+            else if (className.equals("java.util.concurrent.Executors$FinalizableDelegatedExecutorService")
+                    || className.equals("java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService")) {
                 monitor(registry,
                         unwrapThreadPoolExecutor(executorService, executorService.getClass().getSuperclass()));
             }

--- a/micrometer-java21/build.gradle
+++ b/micrometer-java21/build.gradle
@@ -28,8 +28,13 @@ task reflectiveTests(type: Test) {
         includeTags 'reflective'
     }
 
-    // This hack is needed since VirtualThreadMetricsReflectiveTests utilizes reflection against java.lang, see its javadoc
-    jvmArgs += ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+    // This hack is needed for the following tests:
+    // - VirtualThreadMetricsReflectiveTests utilizes reflection against java.lang.
+    // - ExecutorServiceMetricsReflectiveTests utilizes reflection against java.util.concurrent.
+    jvmArgs += [
+            '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED'
+    ]
 }
 
 test {

--- a/micrometer-java21/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsReflectiveTests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsReflectiveTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ExecutorServiceMetrics} with reflection enabled.
+ *
+ * @author Tommy Ludwig
+ */
+@Tag("reflective")
+class ExecutorServiceMetricsReflectiveTests {
+
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    @Test
+    void threadPoolMetricsWith_AutoShutdownDelegatedExecutorService() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ExecutorService unmonitored = Executors.newSingleThreadExecutor();
+        assertThat(unmonitored.getClass().getName())
+            .isEqualTo("java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService");
+        ExecutorService monitored = ExecutorServiceMetrics.monitor(registry, unmonitored, "test");
+        monitored.execute(latch::countDown);
+        assertThat(latch.await(100, TimeUnit.MILLISECONDS)).isTrue();
+        assertThat(registry.get("executor.completed").tag("name", "test").functionCounter().count()).isEqualTo(1L);
+    }
+
+}


### PR DESCRIPTION
This PR simply includes https://github.com/micrometer-metrics/micrometer/pull/4315 and the test in its comment and adds a JVM option to make the test pass.