### PR TITLE
Log deprecation warning when creating SignalFxMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
+++ b/implementations/micrometer-registry-signalfx/src/main/java/io/micrometer/signalfx/SignalFxMeterRegistry.java
@@ -80,6 +80,7 @@ public class SignalFxMeterRegistry extends StepMeterRegistry {
 
     public SignalFxMeterRegistry(SignalFxConfig config, Clock clock, ThreadFactory threadFactory) {
         super(config, clock);
+        logger.warn("SignalFxMeterRegistry is deprecated in favor of micrometer-registry-otlp.");
         this.config = config;
 
         URI apiUri = URI.create(config.uri());


### PR DESCRIPTION
This follows up on #5813 and is part of #5807. It simply logs a warning to give users a bit more visibility into the deprecation of SignalFxMeterRegistry.