### PR TITLE
Remove special handling of 404 and redirection statuses from Jetty client instrumentation

### DIFF
--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/client/JettyClientKeyValues.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/client/JettyClientKeyValues.java
@@ -21,7 +21,6 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.binder.http.Outcome;
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.HttpStatus;
 
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
@@ -34,10 +33,6 @@ import java.util.regex.Pattern;
  * @since 1.13.0
  */
 public final class JettyClientKeyValues {
-
-    private static final KeyValue URI_NOT_FOUND = KeyValue.of("uri", "NOT_FOUND");
-
-    private static final KeyValue URI_REDIRECTION = KeyValue.of("uri", "REDIRECTION");
 
     private static final KeyValue URI_ROOT = KeyValue.of("uri", "root");
 
@@ -100,16 +95,6 @@ public final class JettyClientKeyValues {
      */
     public static KeyValue uri(Request request, @Nullable Result result,
             BiFunction<Request, Result, String> successfulUriPattern) {
-        if (result != null && result.getResponse() != null) {
-            int status = result.getResponse().getStatus();
-            if (HttpStatus.isRedirection(status)) {
-                return URI_REDIRECTION;
-            }
-            if (status == 404) {
-                return URI_NOT_FOUND;
-            }
-        }
-
         String matchingPattern = successfulUriPattern.apply(request, result);
         matchingPattern = MULTIPLE_SLASH_PATTERN.matcher(matchingPattern).replaceAll("/");
         if (matchingPattern.equals("/")) {
@@ -132,12 +117,6 @@ public final class JettyClientKeyValues {
         Throwable exception = result.getFailure();
         if (exception == null) {
             return EXCEPTION_NONE;
-        }
-        if (result.getResponse() != null) {
-            int status = result.getResponse().getStatus();
-            if (status == 404 || HttpStatus.isRedirection(status)) {
-                return EXCEPTION_NONE;
-            }
         }
         if (exception.getCause() != null) {
             exception = exception.getCause();

--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/client/JettyClientTags.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/client/JettyClientTags.java
@@ -19,9 +19,7 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.http.Outcome;
 import org.eclipse.jetty.client.Request;
-import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.client.Result;
-import org.eclipse.jetty.http.HttpStatus;
 
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -34,10 +32,6 @@ import java.util.regex.Pattern;
  * @since 1.13.0
  */
 public final class JettyClientTags {
-
-    private static final Tag URI_NOT_FOUND = Tag.of("uri", "NOT_FOUND");
-
-    private static final Tag URI_REDIRECTION = Tag.of("uri", "REDIRECTION");
 
     private static final Tag URI_ROOT = Tag.of("uri", "root");
 
@@ -91,17 +85,6 @@ public final class JettyClientTags {
      * @return the uri tag derived from the request result
      */
     public static Tag uri(Result result, Function<Result, String> successfulUriPattern) {
-        Response response = result.getResponse();
-        if (response != null) {
-            int status = response.getStatus();
-            if (HttpStatus.isRedirection(status)) {
-                return URI_REDIRECTION;
-            }
-            if (status == 404) {
-                return URI_NOT_FOUND;
-            }
-        }
-
         String matchingPattern = successfulUriPattern.apply(result);
         matchingPattern = MULTIPLE_SLASH_PATTERN.matcher(matchingPattern).replaceAll("/");
         if (matchingPattern.equals("/")) {
@@ -121,12 +104,6 @@ public final class JettyClientTags {
         Throwable exception = result.getFailure();
         if (exception == null) {
             return EXCEPTION_NONE;
-        }
-        if (result.getResponse() != null) {
-            int status = result.getResponse().getStatus();
-            if (status == 404 || HttpStatus.isRedirection(status)) {
-                return EXCEPTION_NONE;
-            }
         }
         if (exception.getCause() != null) {
             exception = exception.getCause();

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsTest.java
@@ -151,7 +151,7 @@ class JettyClientMetricsTest {
         assertThat(registry.get("jetty.client.requests")
             .tag("outcome", "CLIENT_ERROR")
             .tag("status", "404")
-            .tag("uri", "NOT_FOUND")
+            .tag("uri", "/doesNotExist")
             .tag("host", "localhost")
             .timer()
             .count()).isEqualTo(1);


### PR DESCRIPTION
Overview
---
1. Made corresponding changes in JettyClientTags and JettyClientKeyValues class
- Removed special handling for 404 status code in the uri method.
- Removed special handling for redirection status codes in the uri method.


Related
---
ISSUE: #5812 