### PR TITLE
Make Timer and LongTaskTimer output similar in LoggingMeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -150,8 +150,11 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
                     int activeTasks = longTaskTimer.activeTasks();
                     if (!config.logInactive() && activeTasks == 0)
                         return;
+                    HistogramSnapshot snapshot = longTaskTimer.takeSnapshot();
                     loggingSink.accept(print.id() + " active=" + wholeOrDecimal(activeTasks) + " duration="
-                            + print.time(longTaskTimer.duration(getBaseTimeUnit())));
+                            + print.time(longTaskTimer.duration(getBaseTimeUnit())) + " throughput="
+                            + print.unitlessRate(activeTasks) + " mean=" + print.time(snapshot.mean(getBaseTimeUnit()))
+                            + " max=" + print.time(snapshot.max(getBaseTimeUnit())));
                 }, timeGauge -> {
                     double value = timeGauge.value(getBaseTimeUnit());
                     if (!config.logInactive() && value == 0)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/logging/LoggingMeterRegistry.java
@@ -152,9 +152,9 @@ public class LoggingMeterRegistry extends StepMeterRegistry {
                         return;
                     HistogramSnapshot snapshot = longTaskTimer.takeSnapshot();
                     loggingSink.accept(print.id() + " active=" + wholeOrDecimal(activeTasks) + " duration="
-                            + print.time(longTaskTimer.duration(getBaseTimeUnit())) + " throughput="
-                            + print.unitlessRate(activeTasks) + " mean=" + print.time(snapshot.mean(getBaseTimeUnit()))
-                            + " max=" + print.time(snapshot.max(getBaseTimeUnit())));
+                            + print.time(longTaskTimer.duration(getBaseTimeUnit())) + " mean="
+                            + print.time(snapshot.mean(getBaseTimeUnit())) + " max="
+                            + print.time(snapshot.max(getBaseTimeUnit())));
                 }, timeGauge -> {
                     double value = timeGauge.value(getBaseTimeUnit());
                     if (!config.logInactive() && value == 0)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
@@ -231,8 +231,7 @@ class LoggingMeterRegistryTest {
         IntStream.rangeClosed(1, 30).forEach(t -> timer.start());
         clock.add(config.step());
         recordingRegistry.publish();
-        assertThat(recordingRegistry.getLogs())
-            .containsExactly("my.ltt{} active=30 duration=30m throughput=0.5/s mean=1m max=1m");
+        assertThat(recordingRegistry.getLogs()).containsExactly("my.ltt{} active=30 duration=30m mean=1m max=1m");
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/logging/LoggingMeterRegistryTest.java
@@ -231,7 +231,8 @@ class LoggingMeterRegistryTest {
         IntStream.rangeClosed(1, 30).forEach(t -> timer.start());
         clock.add(config.step());
         recordingRegistry.publish();
-        assertThat(recordingRegistry.getLogs()).containsExactly("my.ltt{} active=30 duration=30m");
+        assertThat(recordingRegistry.getLogs())
+            .containsExactly("my.ltt{} active=30 duration=30m throughput=0.5/s mean=1m max=1m");
     }
 
     @Test


### PR DESCRIPTION
In case of the LoggingMeterRegistry, the output of a LongTaskTimer looks like this:
```
"my.ltt{} active=30 duration=30m"
```
while the output of a Timer is something like this:
```
"my.timer{} delta_count=30 throughput=0.5/s mean=1s max=1s"
```

We can add the missing fields to the LongTaskTimer output:
```
"my.ltt{} active=30 duration=30m mean=1m max=1m"
```