### PR TITLE
Fix Stackdriver Distribution count and bucket count sum mismatch

### DIFF
--- a/implementations/micrometer-registry-stackdriver/build.gradle
+++ b/implementations/micrometer-registry-stackdriver/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     api libs.googleOauth2Http
     implementation 'org.slf4j:slf4j-api'
     compileOnly 'ch.qos.logback:logback-classic'
+    // needed for extending TimeWindowPercentileHistogram in StackdriverHistogramUtil
+    compileOnly libs.hdrhistogram
 
     testImplementation project(':micrometer-test')
 }

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverDistributionSummary.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverDistributionSummary.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.*;
+import io.micrometer.core.instrument.step.StepDistributionSummary;
+
+import static io.micrometer.stackdriver.StackdriverHistogramUtil.stackdriverHistogram;
+
+class StackdriverDistributionSummary extends StepDistributionSummary {
+
+    public StackdriverDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
+            double scale, long stepMillis) {
+        super(id, clock, distributionStatisticConfig, scale, stepMillis,
+                stackdriverHistogram(clock, distributionStatisticConfig));
+    }
+
+}

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.*;
+
+final class StackdriverHistogramUtil {
+
+    private StackdriverHistogramUtil() {
+    }
+
+    // copied and modified from AbstractDistributionSummary/AbstractTimer
+    static Histogram stackdriverHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig) {
+        if (distributionStatisticConfig.isPublishingPercentiles()) {
+            return new StackdriverClientSidePercentilesHistogram(clock, distributionStatisticConfig);
+        }
+        if (distributionStatisticConfig.isPublishingHistogram()) {
+            return new StackdriverFixedBoundaryHistogram(clock, distributionStatisticConfig);
+        }
+        return NoopHistogram.INSTANCE;
+    }
+
+    static class StackdriverClientSidePercentilesHistogram extends TimeWindowPercentileHistogram {
+
+        StackdriverClientSidePercentilesHistogram(Clock clock,
+                DistributionStatisticConfig distributionStatisticConfig) {
+            super(clock, distributionStatisticConfig, true, false, true);
+        }
+
+    }
+
+    static class StackdriverFixedBoundaryHistogram extends TimeWindowFixedBoundaryHistogram {
+
+        StackdriverFixedBoundaryHistogram(Clock clock, DistributionStatisticConfig config) {
+            super(clock, config, true, false, true);
+        }
+
+    }
+
+}

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverTimer.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverTimer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+import io.micrometer.core.instrument.step.StepTimer;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.micrometer.stackdriver.StackdriverHistogramUtil.stackdriverHistogram;
+
+class StackdriverTimer extends StepTimer {
+
+    public StackdriverTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
+            PauseDetector pauseDetector, TimeUnit baseTimeUnit, long stepDurationMillis) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, stepDurationMillis,
+                stackdriverHistogram(clock, distributionStatisticConfig));
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryHistogram.java
@@ -16,7 +16,6 @@
 package io.micrometer.core.instrument.distribution;
 
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 class FixedBoundaryHistogram {
@@ -93,32 +92,8 @@ class FixedBoundaryHistogram {
         return low < buckets.length ? low : -1;
     }
 
-    Iterator<CountAtBucket> countsAtValues(Iterator<Double> buckets) {
-        return new Iterator<CountAtBucket>() {
-            private double cumulativeCount = 0.0;
-
-            @Override
-            public boolean hasNext() {
-                return buckets.hasNext();
-            }
-
-            @Override
-            public CountAtBucket next() {
-                double bucket = buckets.next();
-                double count = countAtBucket(bucket);
-                if (isCumulativeBucketCounts) {
-                    cumulativeCount += count;
-                    return new CountAtBucket(bucket, cumulativeCount);
-                }
-                else {
-                    return new CountAtBucket(bucket, count);
-                }
-            }
-        };
-    }
-
     /**
-     * Returns the list of {@link CountAtBucket} for each of the buckets tracked by this
+     * Returns the array of {@link CountAtBucket} for each of the buckets tracked by this
      * histogram.
      */
     CountAtBucket[] getCountAtBuckets() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
@@ -20,7 +20,8 @@ import org.HdrHistogram.DoubleHistogram;
 import org.HdrHistogram.DoubleRecorder;
 
 import java.io.PrintStream;
-import java.util.Iterator;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * <b>NOTE: This class is intended for internal use as an implementation detail. You
@@ -37,10 +38,39 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
 
     private final DoubleHistogram intervalHistogram;
 
+    private final double[] histogramBuckets;
+
+    private final boolean isCumulativeBucketCounts;
+
     public TimeWindowPercentileHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig,
             boolean supportsAggregablePercentiles) {
-        super(clock, distributionStatisticConfig, DoubleRecorder.class, supportsAggregablePercentiles);
+        this(clock, distributionStatisticConfig, supportsAggregablePercentiles, true, false);
+    }
+
+    /**
+     * This constructor allows full customization of the histogram characteristics.
+     * @param clock clock used for time windowing
+     * @param distributionStatisticConfig distribution config to use with this histogram
+     * @param supportsAggregablePercentiles whether the backend receiving this histogram
+     * supports aggregating histograms to estimate percentiles
+     * @param isCumulativeBucketCounts whether histogram bucket counts are cumulative
+     * @param includeInfinityBucket whether to include the infinity histogram bucket
+     * @since 1.13.11
+     */
+    protected TimeWindowPercentileHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig,
+            boolean supportsAggregablePercentiles, boolean isCumulativeBucketCounts, boolean includeInfinityBucket) {
+        super(clock, distributionStatisticConfig, DoubleRecorder.class);
         intervalHistogram = new DoubleHistogram(percentilePrecision(distributionStatisticConfig));
+        this.isCumulativeBucketCounts = isCumulativeBucketCounts;
+
+        Set<Double> monitoredBuckets = distributionStatisticConfig.getHistogramBuckets(supportsAggregablePercentiles);
+        if (includeInfinityBucket) {
+            monitoredBuckets.add(Double.POSITIVE_INFINITY);
+        }
+        histogramBuckets = monitoredBuckets.stream()
+            .filter(Objects::nonNull)
+            .mapToDouble(Double::doubleValue)
+            .toArray();
         initRingBuffer();
     }
 
@@ -86,26 +116,18 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
     }
 
     @Override
-    Iterator<CountAtBucket> countsAtValues(Iterator<Double> values) {
-        return new Iterator<CountAtBucket>() {
-            private double cumulativeCount = 0.0;
-
-            private double lowerBoundValue = 0.0;
-
-            @Override
-            public boolean hasNext() {
-                return values.hasNext();
-            }
-
-            @Override
-            public CountAtBucket next() {
-                double higherBoundValue = values.next();
-                double count = accumulatedHistogram().getCountBetweenValues(lowerBoundValue, higherBoundValue);
-                lowerBoundValue = accumulatedHistogram().nextNonEquivalentValue(higherBoundValue);
-                cumulativeCount += count;
-                return new CountAtBucket(higherBoundValue, cumulativeCount);
-            }
-        };
+    CountAtBucket[] countsAtBuckets() {
+        double cumulativeCount = 0.0;
+        double lowerBoundValue = 0.0;
+        CountAtBucket[] counts = new CountAtBucket[histogramBuckets.length];
+        for (int i = 0; i < counts.length; i++) {
+            double higherBoundValue = histogramBuckets[i];
+            double count = accumulatedHistogram().getCountBetweenValues(lowerBoundValue, higherBoundValue);
+            lowerBoundValue = accumulatedHistogram().nextNonEquivalentValue(higherBoundValue);
+            counts[i] = new CountAtBucket(higherBoundValue,
+                    isCumulativeBucketCounts ? cumulativeCount += count : count);
+        }
+        return counts;
     }
 
     private int percentilePrecision(DistributionStatisticConfig config) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogramTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogramTest.java
@@ -27,9 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class TimeWindowPercentileHistogramTest {
 
+    MockClock clock = new MockClock();
+
     @Test
     void histogramsAreCumulative() {
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(),
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock,
                 DistributionStatisticConfig.builder()
                     .serviceLevelObjectives(3.0, 6, 7)
                     .build()
@@ -44,8 +46,7 @@ class TimeWindowPercentileHistogramTest {
             histogram.recordDouble(6);
 
             // Proves that the accumulated histogram is truly cumulative, and not just a
-            // representation
-            // of the last snapshot
+            // representation of the last snapshot
             assertThat(histogram.takeSnapshot(0, 0, 0).histogramCounts()).containsExactly(new CountAtBucket(3.0, 1),
                     new CountAtBucket(6.0, 2), new CountAtBucket(7.0, 2));
         }
@@ -53,7 +54,7 @@ class TimeWindowPercentileHistogramTest {
 
     @Test
     void sampleValueAboveMaximumExpectedValue() {
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(),
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock,
                 DistributionStatisticConfig.builder()
                     .serviceLevelObjectives(3.0)
                     .maximumExpectedValue(2.0)
@@ -68,7 +69,7 @@ class TimeWindowPercentileHistogramTest {
 
     @Test
     void recordValuesThatExceedTheDynamicRange() {
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(),
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock,
                 DistributionStatisticConfig.builder()
                     .serviceLevelObjectives(Double.POSITIVE_INFINITY)
                     .build()
@@ -87,7 +88,7 @@ class TimeWindowPercentileHistogramTest {
 
     @Test
     void percentiles() {
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(),
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock,
                 DistributionStatisticConfig.builder()
                     .percentiles(0.5, 0.9, 0.95)
                     .minimumExpectedValue(millisToUnit(1, TimeUnit.NANOSECONDS))
@@ -114,8 +115,7 @@ class TimeWindowPercentileHistogramTest {
             .build()
             .merge(DistributionStatisticConfig.DEFAULT);
 
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(), config,
-                false)) {
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock, config, false)) {
 
             ValueAtPercentile expectedPercentile = new ValueAtPercentile(0.5, 0);
             HistogramSnapshot snapshot = histogram.takeSnapshot(0, 0, 0);
@@ -130,8 +130,7 @@ class TimeWindowPercentileHistogramTest {
             .build()
             .merge(DistributionStatisticConfig.DEFAULT);
 
-        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(new MockClock(), config,
-                false)) {
+        try (TimeWindowPercentileHistogram histogram = new TimeWindowPercentileHistogram(clock, config, false)) {
 
             for (int i = 1; i <= 10; i++) {
                 histogram.recordLong((long) millisToUnit(i, TimeUnit.NANOSECONDS));
@@ -167,7 +166,6 @@ class TimeWindowPercentileHistogramTest {
             .build()
             .merge(DistributionStatisticConfig.DEFAULT);
 
-        MockClock clock = new MockClock();
         // Start from 0 for more comprehensive timing calculation.
         clock.add(-1, TimeUnit.NANOSECONDS);
         assertThat(clock.wallTime()).isZero();
@@ -235,6 +233,48 @@ class TimeWindowPercentileHistogramTest {
                 return valueAtPercentile.value();
         }
         return Double.NaN;
+    }
+
+    @Test
+    void nonCumulativeHistogram() {
+        DistributionStatisticConfig config = DistributionStatisticConfig.builder()
+            .serviceLevelObjectives(5, 10)
+            .build()
+            .merge(DistributionStatisticConfig.DEFAULT);
+        Histogram histogram = new TimeWindowPercentileHistogram(clock, config, false, false, false);
+        histogram.recordLong(3);
+        histogram.recordLong(4);
+        histogram.recordLong(10);
+
+        assertThat(histogram.takeSnapshot(0, 0, 0).histogramCounts()).containsExactly(new CountAtBucket(5d, 2),
+                new CountAtBucket(10d, 1));
+    }
+
+    @Test
+    void infinityBucketAddedWhenHistogramIsPresent() {
+        DistributionStatisticConfig config = DistributionStatisticConfig.builder()
+            .serviceLevelObjectives(5, 10)
+            .build()
+            .merge(DistributionStatisticConfig.DEFAULT);
+        Histogram histogram = new TimeWindowPercentileHistogram(clock, config, false, false, true);
+        histogram.recordLong(3);
+        histogram.recordLong(4);
+        histogram.recordLong(11);
+
+        assertThat(histogram.takeSnapshot(0, 0, 0).histogramCounts()).containsExactly(new CountAtBucket(5d, 2),
+                new CountAtBucket(10d, 0), new CountAtBucket(Double.POSITIVE_INFINITY, 1));
+    }
+
+    @Test
+    void infinityBucketAddedWhenNoHistogramBucketsAreConfigured() {
+        DistributionStatisticConfig config = DistributionStatisticConfig.DEFAULT;
+        Histogram histogram = new TimeWindowPercentileHistogram(clock, config, false, false, true);
+        histogram.recordLong(3);
+        histogram.recordLong(4);
+        histogram.recordLong(11);
+
+        assertThat(histogram.takeSnapshot(0, 0, 0).histogramCounts())
+            .containsExactly(new CountAtBucket(Double.POSITIVE_INFINITY, 3));
     }
 
 }


### PR DESCRIPTION
The count passed to the `HistogramSnapshot` is from the StepTimer and is step-based, while the histogram buckets have a separate time window. This mismatch in time windows caused the two to generally not match which causes a validation error when publishing Distribution metrics to Stackdriver.

This solves this by tracking an infinity bucket in the histogram so we can get a consistent count in the same time window as the rest of the histogram.

Closes gh-4868