### PR TITLE
Remove special handling of 404/301 from JDK HTTP client instrumentation

### DIFF
--- a/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -55,8 +55,7 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
 
     String getUri(HttpRequest request, @Nullable HttpResponse<?> httpResponse,
             Function<HttpRequest, String> uriMapper) {
-        return httpResponse != null && (httpResponse.statusCode() == 404 || httpResponse.statusCode() == 301)
-                ? "NOT_FOUND" : uriMapper.apply(request);
+        return uriMapper.apply(request);
     }
 
     String getStatus(@Nullable HttpResponse<?> response) {

--- a/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
+++ b/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/DefaultHttpClientObservationConvention.java
@@ -46,15 +46,14 @@ public class DefaultHttpClientObservationConvention implements HttpClientObserva
         return KeyValues.of(
                 HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.withValue(httpRequest.method()),
                 HttpClientObservationDocumentation.LowCardinalityKeys.URI
-                    .withValue(getUri(httpRequest, context.getResponse(), context.getUriMapper())),
+                    .withValue(getUri(httpRequest, context.getUriMapper())),
                 HttpClientObservationDocumentation.LowCardinalityKeys.STATUS
                     .withValue(getStatus(context.getResponse())),
                 HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME
                     .withValue(getOutcome(context.getResponse())));
     }
 
-    String getUri(HttpRequest request, @Nullable HttpResponse<?> httpResponse,
-            Function<HttpRequest, String> uriMapper) {
+    String getUri(HttpRequest request, Function<HttpRequest, String> uriMapper) {
         return uriMapper.apply(request);
     }
 

--- a/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
@@ -235,7 +235,7 @@ public class MicrometerHttpClient extends HttpClient {
         instrumentation.stop(DefaultHttpClientObservationConvention.INSTANCE.getName(), "Timer for JDK's HttpClient",
                 () -> Tags.of(HttpClientObservationDocumentation.LowCardinalityKeys.METHOD.asString(), request.method(),
                         HttpClientObservationDocumentation.LowCardinalityKeys.URI.asString(),
-                        DefaultHttpClientObservationConvention.INSTANCE.getUri(request, res, uriMapper),
+                        DefaultHttpClientObservationConvention.INSTANCE.getUri(request, uriMapper),
                         HttpClientObservationDocumentation.LowCardinalityKeys.STATUS.asString(),
                         DefaultHttpClientObservationConvention.INSTANCE.getStatus(res),
                         HttpClientObservationDocumentation.LowCardinalityKeys.OUTCOME.asString(),


### PR DESCRIPTION
This PR removes special handling of 404/301 from JDK HTTP client instrumentation.

See gh-5812