### PR TITLE
Use direct equals call instead of Objects.equals wrapper

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.distribution.HistogramGauges;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -356,7 +356,7 @@ public interface Meter {
             if (o == null || getClass() != o.getClass())
                 return false;
             Meter.Id meterId = (Meter.Id) o;
-            return Objects.equals(name, meterId.name) && Objects.equals(tags, meterId.tags);
+            return name.equals(meterId.name) && tags.equals(meterId.tags);
         }
 
         @Override


### PR DESCRIPTION
We known that `name` and `tags` are non-null values. (E.g. hashCode doesn't have `null` checks). When we know that value is non-null - we can call `equals` directly - it will be a bit faster