### PR TITLE
Log metrics recording failures in CountedAspect and TimedAspect

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -90,7 +90,7 @@ import java.util.function.Predicate;
 @Incubating(since = "1.0.0")
 public class TimedAspect {
 
-    private static final WarnThenDebugLogger joinPointTagsFunctionLogger = new WarnThenDebugLogger(TimedAspect.class);
+    private static final WarnThenDebugLogger WARN_THEN_DEBUG_LOGGER = new WarnThenDebugLogger(TimedAspect.class);
 
     private static final Predicate<ProceedingJoinPoint> DONT_SKIP_ANYTHING = pjp -> false;
 
@@ -176,7 +176,7 @@ public class TimedAspect {
                 return function.apply(pjp);
             }
             catch (Throwable t) {
-                joinPointTagsFunctionLogger
+                WARN_THEN_DEBUG_LOGGER
                     .log("Exception thrown from the tagsBasedOnJoinPoint function configured on TimedAspect.", t);
                 return Tags.empty();
             }
@@ -272,7 +272,7 @@ public class TimedAspect {
             sample.stop(recordBuilder(pjp, timed, metricName, exceptionClass).register(registry));
         }
         catch (Exception e) {
-            // ignoring on purpose
+            WARN_THEN_DEBUG_LOGGER.log("Failed to record.", e);
         }
     }
 

--- a/samples/micrometer-samples-spring-framework6/src/test/java/io/micrometer/samples/spring6/aop/CountedAspectTest.java
+++ b/samples/micrometer-samples-spring-framework6/src/test/java/io/micrometer/samples/spring6/aop/CountedAspectTest.java
@@ -279,6 +279,18 @@ class CountedAspectTest {
         assertThatThrownBy(() -> meterRegistry.get("metric.none").counter()).isInstanceOf(MeterNotFoundException.class);
     }
 
+    @Test
+    void brokenExtraTags() {
+        assertThatNoException().isThrownBy(() -> countedService.brokenExtraTags());
+        assertThat(meterRegistry.getMeters()).isEmpty();
+    }
+
+    @Test
+    void brokenExtraTagsWithCompletionStage() {
+        assertThatNoException().isThrownBy(() -> asyncCountedService.brokenExtraTags().get());
+        assertThat(meterRegistry.getMeters()).isEmpty();
+    }
+
     static class CountedService {
 
         @Counted(value = "metric.none", recordFailuresOnly = true)
@@ -304,6 +316,10 @@ class CountedAspectTest {
         @Counted
         void emptyMetricNameWithException() {
             throw new RuntimeException("This is it");
+        }
+
+        @Counted(value = "metric.broken", extraTags = { "key1" })
+        void brokenExtraTags() {
         }
 
     }
@@ -352,6 +368,11 @@ class CountedAspectTest {
         @Counted(value = "metric.none", recordFailuresOnly = true)
         CompletableFuture<?> successButNullWithoutMetrics() {
             return null;
+        }
+
+        @Counted(value = "metric.broken", extraTags = { "key1" })
+        CompletableFuture<String> brokenExtraTags() {
+            return CompletableFuture.completedFuture("test");
         }
 
     }


### PR DESCRIPTION
This PR changes to log metrics recording failures in the `CountedAspect` and the `TimedAspect`.

This PR also prevents metrics recording failures from interfering with application flow in the `CountedAspect`.

See gh-5820