### PR TITLE
Enable TimedAspectTest.pjpFunctionThrows()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/aop/TimedAspectTest.java
@@ -428,6 +428,7 @@ class TimedAspectTest {
     }
 
     @Issue("#5584")
+    @Test
     void pjpFunctionThrows() {
         MeterRegistry registry = new SimpleMeterRegistry();
 


### PR DESCRIPTION
This PR enables the `TimedAspectTest.pjpFunctionThrows()` as it seems to have been missed accidentally.