### PR TITLE
Increase wait duration in PushMeterRegistryTest.closeRespectsInterrupt()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -243,7 +243,7 @@ class PushMeterRegistryTest {
         Thread closeThread = new Thread(registry::close, "simulatedShutdownHookThread");
         closeThread.start();
         // close is blocked (waiting for publish to finish)
-        await().atMost(config.step())
+        await().atMost(Duration.ofMillis(100))
             .pollInterval(1, MILLISECONDS)
             .untilAsserted(() -> assertThat(closeThread.getState()).isEqualTo(Thread.State.WAITING));
 


### PR DESCRIPTION
This PR increases wait duration to 100 ms in the `PushMeterRegistryTest.closeRespectsInterrupt()` as it's flaky due to timeout and 10 ms seems to be short.

See https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/8379/workflows/ddfcbe08-388d-4b99-a0d0-abaacca96fb5/jobs/42323