### PR TITLE
Fix flakiness in JettyClientMetricsWithObservationTest.activeTimer()

### DIFF
--- a/micrometer-jetty12/build.gradle
+++ b/micrometer-jetty12/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation project(":micrometer-test")
 
     testImplementation libs.httpcomponents.client
+    testImplementation 'org.awaitility:awaitility'
 }
 
 java {


### PR DESCRIPTION
I saw the following failure locally:

```
JettyClientMetricsWithObservationTest > activeTimer(WireMockRuntimeInfo) FAILED
    org.opentest4j.AssertionFailedError:
    expected: 1
     but was: 0
        at java.base@17.0.14/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base@17.0.14/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base@17.0.14/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base@17.0.14/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at app//io.micrometer.jetty12.client.JettyClientMetricsWithObservationTest.activeTimer(JettyClientMetricsWithObservationTest.java:56)
```

It could be reproducible with `@RepeatedTest(100)` locally, and [the Develocity Build Scan](https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.core.instrument.binder.jetty.JettyClientMetricsWithObservationTest&tests.test=activeTimer()) also flags it as a flaky one.



Looking into its code, there seems to be a race condition, but I couldn't find a clean way to fix it.

This PR attempts to fix its flakiness even though it's still relying on timing.