### PR TITLE
Fix flakiness in JmsInstrumentationTests.shouldInstrumentMessageListener()

### DIFF
--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.jms;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for {@link JmsInstrumentation}.
@@ -134,10 +136,11 @@ class JmsInstrumentationTests {
             MessageProducer producer = session.createProducer(topic);
             producer.send(session.createTextMessage("test send"));
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-            TestObservationRegistryAssert.assertThat(registry)
-                .hasObservationWithNameEqualTo("jms.message.process")
-                .that()
-                .hasContextualNameEqualTo("test.send process");
+            await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> TestObservationRegistryAssert.assertThat(registry)
+                    .hasObservationWithNameEqualTo("jms.message.process")
+                    .that()
+                    .hasContextualNameEqualTo("test.send process"));
         }
     }
 


### PR DESCRIPTION
This PR attempts to mitigate flakiness in the `JmsInstrumentationTests.shouldInstrumentMessageListener()` by applying Awaitility as there seems to be a race condition.

See https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.core.instrument.binder.jms.JmsInstrumentationTests&tests.sortField=FLAKY&tests.test=shouldInstrumentMessageListener()