### PR TITLE
Handle programatically added log4j2 LoggerConfig

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -373,20 +373,6 @@ class Log4j2MetricsTest {
     void programmaticallyAddedLoggerConfigShouldBeCounted() {
         LoggerContext context = new LoggerContext("test");
 
-        AtomicInteger newLoggerUpdatedWithLoggerFilter = new AtomicInteger();
-
-        // checks that updateLoggers() is called after MetricsFilter is added to the
-        // programmatically added logger
-        context.addPropertyChangeListener(event -> {
-            if (event.getNewValue() instanceof Configuration) {
-                Configuration newConfiguration = (Configuration) event.getNewValue();
-                LoggerConfig loggerConfig = newConfiguration.getLoggerConfig("com.test");
-                if (!loggerConfig.isAdditive() && loggerConfig.getFilter() instanceof Log4j2Metrics.MetricsFilter) {
-                    newLoggerUpdatedWithLoggerFilter.incrementAndGet();
-                }
-            }
-        });
-
         Log4j2Metrics metrics = new Log4j2Metrics(emptyList(), context);
         metrics.bindTo(registry);
 
@@ -403,7 +389,6 @@ class Log4j2MetricsTest {
         context.updateLoggers(configuration);
 
         assertThat(addedLoggerConfig.getFilter()).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
-        assertThat(newLoggerUpdatedWithLoggerFilter).hasValue(1);
 
         logger.debug("test");
         assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(1);


### PR DESCRIPTION
The needed change for being able to bind to programmatically added loggers is simply to remove `listener.getOldValue() != listener.getNewValue()`.

However, when we do that it leads to three things:
- We need to always check if the `MetricsFilter` is already added to avoid adding it again on configuration reload
- We need some way to tell when to call `updateLoggers()` to avoid an endless loop (as the listener will be triggered again when calling `updateLoggers()`
- We need to move the check if its a new `Configuration` to the conditional before `removeMetricsFilter` to avoid removing all filters when we reload with the same `Configuration` instance

I did this by returning whether a `MetricsFilter` was added or not from `registerMetricsFilter()`. I tried out some different ways of doing this, but I ended up refactoring it a bit and I think it ended up quite readable.

I have also included a test that adds a logger programmatically (which would fail without these changes). It also verifies that `updateLoggers()` is called once with the new `MetricsFilter` configured, as expected.

Resolves https://github.com/micrometer-metrics/micrometer/issues/5901