### PR TITLE
Fix flakiness in GuavaCacheMetricsTest.reportExpectedMetrics() and CaffeineCacheMetricsTest.reportExpectedGeneralMetrics()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -66,7 +67,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
         // specific to LoadingCache instance
         TimeGauge loadDuration = fetch(registry, "cache.load.duration").timeGauge();
-        assertThat(loadDuration.value(TimeUnit.NANOSECONDS)).isEqualTo(stats.totalLoadTime());
+        assertThat(loadDuration.value(TimeUnit.NANOSECONDS)).isCloseTo(stats.totalLoadTime(), Offset.offset(0.1));
 
         FunctionCounter successfulLoad = fetch(registry, "cache.load", Tags.of("result", "success")).functionCounter();
         assertThat(successfulLoad.count()).isEqualTo(stats.loadSuccessCount());

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/GuavaCacheMetricsTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.binder.cache;
 import com.google.common.cache.*;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -77,7 +78,7 @@ class GuavaCacheMetricsTest extends AbstractCacheMetricsTest {
 
         CacheStats stats = cache.stats();
         TimeGauge loadDuration = fetch(registry, "cache.load.duration").timeGauge();
-        assertThat(loadDuration.value(TimeUnit.NANOSECONDS)).isEqualTo(stats.totalLoadTime());
+        assertThat(loadDuration.value(TimeUnit.NANOSECONDS)).isCloseTo(stats.totalLoadTime(), Offset.offset(0.1));
 
         FunctionCounter successfulLoad = fetch(registry, "cache.load", Tags.of("result", "success")).functionCounter();
         assertThat(successfulLoad.count()).isEqualTo(stats.loadSuccessCount());


### PR DESCRIPTION
This PR tries to fix flakiness in the `GuavaCacheMetricsTest.reportExpectedMetrics()` and the `CaffeineCacheMetricsTest.reportExpectedGeneralMetrics()` by relaxing precision expectation as both seem to suffer from precision problems.

See https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.core.instrument.binder.cache.GuavaCacheMetricsTest&tests.sortField=FLAKY&tests.test=reportExpectedMetrics() and https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.core.instrument.binder.cache.CaffeineCacheMetricsTest&tests.sortField=FLAKY&tests.test=reportExpectedGeneralMetrics()