### PR TITLE
Add Javadoc since for OtlpMeterRegistry.Builder

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -475,6 +475,11 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         return sloWithPositiveInf;
     }
 
+    /**
+     * Builder for {@link OtlpMeterRegistry}.
+     *
+     * @since 1.15.0
+     */
     public static class Builder {
 
         private final OtlpConfig otlpConfig;


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `OtlpMeterRegistry.Builder`.

See gh-5690