### PR TITLE
Fix flakiness in TestObservationRegistryAssertTests.should_jump_to_and_back_from_context_assert()

### DIFF
--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -153,11 +153,15 @@ class ObservationValidatorTests {
     }
 
     @Test
-    @SuppressWarnings("resource")
     void scopeOpenAfterStopShouldBeValid() {
         Observation observation = Observation.start("test", registry);
         observation.stop();
-        observation.openScope();
+        Scope scope = observation.openScope();
+
+        // The scope should be closed to clear its entry in the static
+        // localObservationScope in the SimpleObservationRegistry. Otherwise, it will
+        // pollute it and could affect other tests.
+        scope.close();
     }
 
     @Test


### PR DESCRIPTION
The `TestObservationRegistryAssertTests.should_jump_to_and_back_from_context_assert()` is flaky, and it can be reproduced with the following command:

```
./gradlew clean :micrometer-observation-test:test --no-build-cache --tests ObservationValidatorTests --tests TestObservationRegistryAssertTests.should_jump_to_and_back_from_context_assert
```

The `Scope` wasn't closed in `ObservationValidatorTests.scopeOpenAfterStopShouldBeValid()`, so there was a static status leak that could affect other tests.

This PR fixes the flakiness in the `TestObservationRegistryAssertTests.should_jump_to_and_back_from_context_assert()` by closing the `Scope`.

See https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.observation.tck.TestObservationRegistryAssertTests&tests.sortField=FLAKY&tests.test=should_jump_to_and_back_from_context_assert()