### PR TITLE
Configure histogram flavor/max buckets per meter

### DIFF
--- a/docs/modules/ROOT/pages/implementations/otlp.adoc
+++ b/docs/modules/ROOT/pages/implementations/otlp.adoc
@@ -146,14 +146,17 @@ Micrometer `Timer` and `DistributionSummary` support configuring xref:/concepts/
 | publishPercentiles and serviceLevelObjectives
 | Histogram
 |===
-__* The configuration `histogramFlavor` determines whether the OTLP DataPoint is a Histogram/Exponential Histogram.__
+__* The configuration `histogramFlavorPerMeter` and `histogramFlavor` determine whether the OTLP DataPoint is a Histogram/Exponential Histogram.__
 
-`OtlpMeterRegistry` supports 2 types of Histogram implementations (1.Explicit Bucket Histogram (or simply called Histogram), 2. Exponential Histogram) when `publishPercentileHistogram` is configured. The choice is chosen by setting `histogramFlavor` in `OtlpConfig` used by registry. When the implementation is exponential histogram, it also supports 2 additional properties
+`OtlpMeterRegistry` supports 2 types of Histogram implementations (1.Explicit Bucket Histogram (or simply called Histogram), 2. Exponential Histogram) when `publishPercentileHistogram` is configured.
+The type is determined by `histogramFlavorPerMeter` and `histogramFlavor` in `OtlpConfig` used by the registry.
+When the implementation is the exponential histogram, additional configuration applies:
 
-1. maxScale used to cap the maximum https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-scale[scale, window=_blank] used by the Exponential Histogram (defaults to 20).
-2. maxBuckets determines the maximum number of https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-buckets[buckets, window=_blank] to be used for exponential histograms (defaults to 160).
+1. `maxScale` used to cap the maximum https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-scale[scale, window=_blank] used by the Exponential Histogram (defaults to 20).
+2. `maxBuckets` determines the maximum number of https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponential-buckets[buckets, window=_blank] to be used for exponential histograms (defaults to 160).
+3. `maxBucketsPerMeter` overrides `maxBuckets` for specific meter names, giving more fine-grained configurability.
 
-Since Exponential Histogram cannot have custom SLO's specified, explicit bucket histogram is used whenever `serviceLevelObjectives` are added.
+Since Exponential Histogram cannot have custom SLO's specified, an explicit bucket histogram is used whenever `serviceLevelObjectives` are configured.
 
 ===  Configuration with Spring Boot
 If you use Spring Boot, you can use the https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#actuator.metrics.customizing.per-meter-properties[per-meter properties, window=_blank] to configure this behavior.

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.registry.otlp;
 
-import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.push.PushRegistryConfig;
@@ -24,7 +23,6 @@ import java.time.Duration;
 import java.net.URLDecoder;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;
@@ -238,8 +236,8 @@ public interface OtlpConfig extends PushRegistryConfig {
      * @see #histogramFlavor()
      */
     default Map<String, HistogramFlavor> histogramFlavorPerMeter() {
-        String flavorPerMeterString = getString(this, "histogramFlavorPerMeter").orElse(null);
-        return propertiesStringToMap(flavorPerMeterString, HistogramFlavor::fromString);
+        return getStringMap(this, "histogramFlavorPerMeter", HistogramFlavor::fromString)
+            .orElse(Collections.emptyMap());
     }
 
     /**
@@ -277,7 +275,7 @@ public interface OtlpConfig extends PushRegistryConfig {
      * @see #maxBucketCount()
      */
     default Map<String, Integer> maxBucketsPerMeter() {
-        return propertiesStringToMap(getString(this, "maxBucketsPerMeter").orElse(null), Integer::parseInt);
+        return getStringMap(this, "maxBucketsPerMeter", Integer::parseInt).orElse(Collections.emptyMap());
     }
 
     @Override
@@ -290,16 +288,6 @@ public interface OtlpConfig extends PushRegistryConfig {
 
     default TimeUnit baseTimeUnit() {
         return getTimeUnit(this, "baseTimeUnit").orElse(TimeUnit.MILLISECONDS);
-    }
-
-    static <V> Map<String, V> propertiesStringToMap(String propertiesString,
-            Function<String, ? extends V> valueMapper) {
-        String[] keyvals = StringUtils.isBlank(propertiesString) ? new String[] {} : propertiesString.trim().split(",");
-        return Arrays.stream(keyvals)
-            .map(String::trim)
-            .filter(keyValue -> keyValue.length() > 2 && keyValue.indexOf('=') > 0)
-            .collect(Collectors.toMap(keyvalue -> keyvalue.substring(0, keyvalue.indexOf('=')).trim(),
-                    keyvalue -> valueMapper.apply(keyvalue.substring(keyvalue.indexOf('=') + 1).trim())));
     }
 
 }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -15,17 +15,16 @@
  */
 package io.micrometer.registry.otlp;
 
+import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.push.PushRegistryConfig;
 
 import java.time.Duration;
 import java.net.URLDecoder;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.config.MeterRegistryConfigValidator.*;
@@ -215,6 +214,7 @@ public interface OtlpConfig extends PushRegistryConfig {
      * {@link HistogramFlavor#EXPLICIT_BUCKET_HISTOGRAM} is used for those meters.
      * </p>
      * @return - histogram flavor to be used
+     * @see #histogramFlavorPerMeter()
      *
      * @since 1.14.0
      */
@@ -230,6 +230,19 @@ public interface OtlpConfig extends PushRegistryConfig {
     }
 
     /**
+     * Configures the histogram flavor to use on a per-meter level. This will override the
+     * {@link #histogramFlavor()} configuration for matching Meters. The key is used to do
+     * an exact match on the Meter's name.
+     * @return mapping of meter name to histogram flavor
+     * @since 1.15.0
+     * @see #histogramFlavor()
+     */
+    default Map<String, HistogramFlavor> histogramFlavorPerMeter() {
+        String flavorPerMeterString = getString(this, "histogramFlavorPerMeter").orElse(null);
+        return propertiesStringToMap(flavorPerMeterString, HistogramFlavor::fromString);
+    }
+
+    /**
      * Max scale to use for exponential histograms, if configured.
      * @return maxScale
      * @see #histogramFlavor()
@@ -242,14 +255,29 @@ public interface OtlpConfig extends PushRegistryConfig {
 
     /**
      * Maximum number of buckets to be used for exponential histograms, if configured.
-     * This has no effect on explicit bucket histograms.
+     * This has no effect on explicit bucket histograms. This can be overridden per meter
+     * with {@link #maxBucketsPerMeter()}.
      * @return - maxBuckets
      * @see #histogramFlavor()
+     * @see #maxBucketsPerMeter()
      *
      * @since 1.14.0
      */
     default int maxBucketCount() {
         return getInteger(this, "maxBucketCount").orElse(160);
+    }
+
+    /**
+     * Configures the max bucket count to use on a per-meter level. This will override the
+     * {@link #maxBucketCount()} configuration for matching Meters. The key is used to do
+     * an exact match on the Meter's name. This has no effect on a meter if it does not
+     * have an exponential bucket histogram configured.
+     * @return mapping of meter name to max bucket count
+     * @since 1.15.0
+     * @see #maxBucketCount()
+     */
+    default Map<String, Integer> maxBucketsPerMeter() {
+        return propertiesStringToMap(getString(this, "maxBucketsPerMeter").orElse(null), Integer::parseInt);
     }
 
     @Override
@@ -262,6 +290,16 @@ public interface OtlpConfig extends PushRegistryConfig {
 
     default TimeUnit baseTimeUnit() {
         return getTimeUnit(this, "baseTimeUnit").orElse(TimeUnit.MILLISECONDS);
+    }
+
+    static <V> Map<String, V> propertiesStringToMap(String propertiesString,
+            Function<String, ? extends V> valueMapper) {
+        String[] keyvals = StringUtils.isBlank(propertiesString) ? new String[] {} : propertiesString.trim().split(",");
+        return Arrays.stream(keyvals)
+            .map(String::trim)
+            .filter(keyValue -> keyValue.length() > 2 && keyValue.indexOf('=') > 0)
+            .collect(Collectors.toMap(keyvalue -> keyvalue.substring(0, keyvalue.indexOf('=')).trim(),
+                    keyvalue -> valueMapper.apply(keyvalue.substring(keyvalue.indexOf('=') + 1).trim())));
     }
 
 }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -283,7 +283,9 @@ public interface OtlpConfig extends PushRegistryConfig {
         return checkAll(this, c -> PushRegistryConfig.validate(c), checkRequired("url", OtlpConfig::url),
                 check("resourceAttributes", OtlpConfig::resourceAttributes),
                 check("baseTimeUnit", OtlpConfig::baseTimeUnit),
-                check("aggregationTemporality", OtlpConfig::aggregationTemporality));
+                check("aggregationTemporality", OtlpConfig::aggregationTemporality),
+                check("histogramFlavorPerMeter", OtlpConfig::histogramFlavorPerMeter),
+                check("maxBucketsPerMeter", OtlpConfig::maxBucketsPerMeter));
     }
 
     default TimeUnit baseTimeUnit() {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeDistributionSummary.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeDistributionSummary.java
@@ -27,17 +27,12 @@ import java.util.concurrent.TimeUnit;
 class OtlpCumulativeDistributionSummary extends CumulativeDistributionSummary
         implements StartTimeAwareMeter, OtlpHistogramSupport {
 
-    private final HistogramFlavor histogramFlavor;
-
     private final long startTimeNanos;
 
     OtlpCumulativeDistributionSummary(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            double scale, OtlpConfig otlpConfig) {
-        super(id, clock, distributionStatisticConfig, scale,
-                OtlpMeterRegistry.getHistogram(clock, distributionStatisticConfig, otlpConfig));
+            double scale, Histogram histogram) {
+        super(id, clock, distributionStatisticConfig, scale, histogram);
         this.startTimeNanos = TimeUnit.MILLISECONDS.toNanos(clock.wallTime());
-        this.histogramFlavor = OtlpMeterRegistry.histogramFlavor(otlpConfig.histogramFlavor(),
-                distributionStatisticConfig);
     }
 
     @Override
@@ -48,7 +43,7 @@ class OtlpCumulativeDistributionSummary extends CumulativeDistributionSummary
     @Override
     @Nullable
     public ExponentialHistogramSnapShot getExponentialHistogramSnapShot() {
-        if (histogramFlavor == HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM) {
+        if (histogram instanceof Base2ExponentialHistogram) {
             return ((Base2ExponentialHistogram) histogram).getLatestExponentialHistogramSnapshot();
         }
         return null;

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeTimer.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeTimer.java
@@ -27,16 +27,11 @@ import java.util.concurrent.TimeUnit;
 
 class OtlpCumulativeTimer extends CumulativeTimer implements StartTimeAwareMeter, OtlpHistogramSupport {
 
-    private final HistogramFlavor histogramFlavor;
-
     private final long startTimeNanos;
 
     OtlpCumulativeTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            PauseDetector pauseDetector, TimeUnit baseTimeUnit, OtlpConfig otlpConfig) {
-        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit,
-                OtlpMeterRegistry.getHistogram(clock, distributionStatisticConfig, otlpConfig, baseTimeUnit));
-        this.histogramFlavor = OtlpMeterRegistry.histogramFlavor(otlpConfig.histogramFlavor(),
-                distributionStatisticConfig);
+            PauseDetector pauseDetector, TimeUnit baseTimeUnit, Histogram histogram) {
+        super(id, clock, distributionStatisticConfig, pauseDetector, baseTimeUnit, histogram);
         this.startTimeNanos = TimeUnit.MILLISECONDS.toNanos(clock.wallTime());
     }
 
@@ -48,7 +43,7 @@ class OtlpCumulativeTimer extends CumulativeTimer implements StartTimeAwareMeter
     @Override
     @Nullable
     public ExponentialHistogramSnapShot getExponentialHistogramSnapShot() {
-        if (histogramFlavor == HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM) {
+        if (histogram instanceof Base2ExponentialHistogram) {
             return ((Base2ExponentialHistogram) histogram).getLatestExponentialHistogramSnapshot();
         }
         return null;

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepTimer.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepTimer.java
@@ -15,9 +15,10 @@
  */
 package io.micrometer.registry.otlp;
 
+import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.AbstractTimer;
 import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.Histogram;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
 import io.micrometer.registry.otlp.internal.Base2ExponentialHistogram;
@@ -27,8 +28,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 class OtlpStepTimer extends AbstractTimer implements OtlpHistogramSupport {
-
-    private final HistogramFlavor histogramFlavor;
 
     private final LongAdder count = new LongAdder();
 
@@ -42,20 +41,14 @@ class OtlpStepTimer extends AbstractTimer implements OtlpHistogramSupport {
      * Create a new {@code OtlpStepTimer}.
      * @param id ID
      * @param clock clock
-     * @param distributionStatisticConfig distribution statistic configuration
      * @param pauseDetector pause detector
-     * @param baseTimeUnit base time unit
      * @param otlpConfig config of the registry
      */
-    OtlpStepTimer(Id id, Clock clock, DistributionStatisticConfig distributionStatisticConfig,
-            PauseDetector pauseDetector, TimeUnit baseTimeUnit, OtlpConfig otlpConfig) {
-        super(id, clock, pauseDetector, otlpConfig.baseTimeUnit(),
-                OtlpMeterRegistry.getHistogram(clock, distributionStatisticConfig, otlpConfig, baseTimeUnit));
+    OtlpStepTimer(Id id, Clock clock, PauseDetector pauseDetector, Histogram histogram, OtlpConfig otlpConfig) {
+        super(id, clock, pauseDetector, otlpConfig.baseTimeUnit(), histogram);
         countTotal = new OtlpStepTuple2<>(clock, otlpConfig.step().toMillis(), 0L, 0L, count::sumThenReset,
                 total::sumThenReset);
         max = new StepMax(clock, otlpConfig.step().toMillis());
-        this.histogramFlavor = OtlpMeterRegistry.histogramFlavor(otlpConfig.histogramFlavor(),
-                distributionStatisticConfig);
     }
 
     @Override
@@ -99,8 +92,9 @@ class OtlpStepTimer extends AbstractTimer implements OtlpHistogramSupport {
     }
 
     @Override
+    @Nullable
     public ExponentialHistogramSnapShot getExponentialHistogramSnapShot() {
-        if (histogramFlavor == HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM) {
+        if (histogram instanceof Base2ExponentialHistogram) {
             return ((Base2ExponentialHistogram) histogram).getLatestExponentialHistogramSnapshot();
         }
         return null;

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
@@ -274,6 +275,27 @@ class OtlpConfigTest {
                 "base2_exponential_bucket_histogram")
             .execute(() -> assertThat(config.histogramFlavor())
                 .isEqualTo(HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM));
+    }
+
+    @Test
+    void histogramFlavorPerMeter() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otlp.histogramFlavorPerMeter",
+                "a.b.c=explicit_bucket_histogram ,expo =base2_exponential_bucket_histogram");
+        OtlpConfig otlpConfig = properties::get;
+        assertThat(otlpConfig.validate().isValid()).isTrue();
+        assertThat(otlpConfig.histogramFlavorPerMeter()).containsExactly(
+                entry("a.b.c", HistogramFlavor.EXPLICIT_BUCKET_HISTOGRAM),
+                entry("expo", HistogramFlavor.BASE2_EXPONENTIAL_BUCKET_HISTOGRAM));
+    }
+
+    @Test
+    void maxBucketsPerMeter() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otlp.maxBucketsPerMeter", "a.b.c = 10");
+        OtlpConfig otlpConfig = properties::get;
+        assertThat(otlpConfig.validate().isValid()).isTrue();
+        assertThat(otlpConfig.maxBucketsPerMeter()).containsExactly(entry("a.b.c", 10));
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/config/validate/PropertyValidatorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/config/validate/PropertyValidatorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.config.validate;
+
+import io.micrometer.core.instrument.config.MeterRegistryConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PropertyValidatorTest {
+
+    Properties props = new Properties();
+
+    MeterRegistryConfig config = new MeterRegistryConfig() {
+        @Override
+        public String prefix() {
+            return "test";
+        }
+
+        @Override
+        public String get(String key) {
+            return props.getProperty(key);
+        }
+    };
+
+    @Test
+    void stringMapValid() {
+        props.put("test.map", "a=1,b=2");
+        Validated<Map<String, Integer>> validated = PropertyValidator.getStringMap(config, "map", Integer::parseInt);
+        assertThat(validated.isValid()).isTrue();
+    }
+
+    @Test
+    void stringMapBlank() {
+        props.put("test.map", " ");
+        Validated<Map<String, Integer>> validated = PropertyValidator.getStringMap(config, "map", Integer::parseInt);
+        assertThat(validated.isValid()).isTrue();
+        assertThat(validated.get()).isNull();
+        assertThat(validated.orElse(Collections.emptyMap())).isEmpty();
+    }
+
+    @Test
+    void stringMapInvalid() {
+        props.setProperty("test.map", "a=1,b=c");
+        Validated<Map<String, Integer>> validated = PropertyValidator.getStringMap(config, "map", Integer::parseInt);
+        assertThat(validated.isInvalid()).isTrue();
+    }
+
+}


### PR DESCRIPTION
Adds new configuration methods to override the registry-wide configuration at a per Meter (name) level. This gives more fine-grain control of the configuration.

The registry-wide HistogramFlavor configuration can be overridden at the meter level with the new `histogramFlavorPerMeter` configuration method, which returns a `Map<String, HistogramFlavor>` where the key is the exact Meter name to match.

Likewise, the registry-wide max bucket count can be overridden at the meter level with the new `maxBucketsPerMeter` configuration method, which returns a `Map<String, Integer>` where the key is the exact Meter name to match.

- [x] TODO: Update documentation

Closes #5459