### PR TITLE
Improve OtlpMetricsSender API

### DIFF
--- a/docs/modules/ROOT/pages/implementations/otlp.adoc
+++ b/docs/modules/ROOT/pages/implementations/otlp.adoc
@@ -40,7 +40,7 @@ management:
           key1: value1
 ----
 
-1. `url` - The URL to which data is reported. Environment variables `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT` are also supported in the default implementation. If a value is not provided, it defaults to `http://localhost:4318/v1/metrics`
+1. `url` - The address to which metrics are published. Environment variables `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT` are also supported in the default implementation. If a value is not provided, it defaults to `http://localhost:4318/v1/metrics`
 2. `batchSize` - number of ``Meter``s to include in a single payload sent to the backend. The default is 10,000.
 3. `aggregationTemporality` - https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality[Aggregation temporality, window=_blank] determines how the additive quantities are expressed, in relation to time. The environment variable `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` is supported by the default implementation. The supported values are `cumulative` or `delta`. Defaults to `cumulative`.
 4. `headers` - Additional headers to send with exported metrics. This can be used for authorization headers. By default, headers are loaded from the config. If that is not set, they can be taken from the environment variables `OTEL_EXPORTER_OTLP_HEADERS` and `OTEL_EXPORTER_OTLP_METRICS_HEADERS`. If a header is set in both the environmental variables, the header in the latter overrides the former.
@@ -78,7 +78,7 @@ You may use a different `HttpSender` implementation by creating and configuring 
 include::{include-java}/metrics/OtlpMeterRegistryCustomizationTest.java[tags=customizeHttpSender, indent=0]
 -----
 
-You can also provide a custom implementation of `OtlpMetricsSender` that does not use HTTP at all.
+You can also provide a custom implementation of `OtlpMetricsSender` that does not use `HttpSender` at all. `OtlpConfig#url` will be used as the address when the sender is called in the `OtlpMeterRegistry` `publish` method.
 For instance, if you made a gRPC implementation, you could configure it in the following way.
 Micrometer does not currently provide a gRPC implementation of `OtlpMetricsSender`.
 

--- a/docs/src/test/java/io/micrometer/docs/metrics/OtlpMeterRegistryCustomizationTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/OtlpMeterRegistryCustomizationTest.java
@@ -31,7 +31,7 @@ class OtlpMeterRegistryCustomizationTest {
     void customizeHttpSender() {
         // tag::customizeHttpSender[]
         OtlpConfig config = OtlpConfig.DEFAULT;
-        OtlpHttpMetricsSender httpMetricsSender = new OtlpHttpMetricsSender(new OkHttpSender(), config);
+        OtlpHttpMetricsSender httpMetricsSender = new OtlpHttpMetricsSender(new OkHttpSender());
         OtlpMeterRegistry meterRegistry = OtlpMeterRegistry.builder(config).metricsSender(httpMetricsSender).build();
         // end::customizeHttpSender[]
     }
@@ -49,7 +49,7 @@ class OtlpMeterRegistryCustomizationTest {
     private static class OtlpGrpcMetricsSender implements OtlpMetricsSender {
 
         @Override
-        public void send(byte[] metricsData, Map<String, String> headers) {
+        public void send(String address, byte[] metricsData, Map<String, String> headers) {
         }
 
     }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/MetricsSender.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/MetricsSender.java
@@ -24,9 +24,12 @@ interface MetricsSender {
     /**
      * Send encoded metrics data from a {@link io.micrometer.core.instrument.MeterRegistry
      * MeterRegistry}.
+     * @param address where to send the metrics
      * @param metricsData encoded batch of metrics
      * @param headers metadata to send as headers with the metrics data
+     * @throws Throwable when there is an exception in sending the metrics; the caller
+     * should handle this in some way such as logging the exception
      */
-    void send(byte[] metricsData, Map<String, String> headers);
+    void send(String address, byte[] metricsData, Map<String, String> headers) throws Throwable;
 
 }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -111,7 +111,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
      * @since 1.14.0
      */
     public OtlpMeterRegistry(OtlpConfig config, Clock clock, ThreadFactory threadFactory) {
-        this(config, clock, threadFactory, new OtlpHttpMetricsSender(new HttpUrlConnectionSender(), config));
+        this(config, clock, threadFactory, new OtlpHttpMetricsSender(new HttpUrlConnectionSender()));
     }
 
     private OtlpMeterRegistry(OtlpConfig config, Clock clock, ThreadFactory threadFactory,
@@ -181,12 +181,23 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                         .build())
                     .build();
 
-                metricsSender.send(request.toByteArray(), this.config.headers());
+                metricsSender.send(config.url(), request.toByteArray(), config.headers());
             }
             catch (Throwable e) {
-                logger.warn("Failed to publish metrics to OTLP receiver", e);
+                logger.warn(String.format("Failed to publish metrics to OTLP receiver (context: %s)",
+                        getConfigurationContext()), e);
             }
         }
+    }
+
+    /**
+     * Get the configuration context.
+     * @return A message containing enough information for the log reader to figure out
+     * what configuration details may have contributed to the failure.
+     */
+    private String getConfigurationContext() {
+        // While other values may contribute to failures, these two are most common
+        return "url=" + config.url() + ", resource-attributes=" + config.resourceAttributes();
     }
 
     @Override
@@ -492,7 +503,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
 
         private Builder(OtlpConfig otlpConfig) {
             this.otlpConfig = otlpConfig;
-            this.metricsSender = new OtlpHttpMetricsSender(new HttpUrlConnectionSender(), otlpConfig);
+            this.metricsSender = new OtlpHttpMetricsSender(new HttpUrlConnectionSender());
         }
 
         /** Override the default clock. */

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricsSender.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricsSender.java
@@ -26,11 +26,14 @@ import java.util.Map;
 public interface OtlpMetricsSender extends MetricsSender {
 
     /**
-     * Send a batch of OTLP Protobuf format metrics to a receiver.
+     * Send a batch of OTLP Protobuf format metrics to an OTLP receiver.
+     * @param address address of the OTLP receiver to which metrics will be sent
      * @param metricsData OTLP protobuf encoded batch of metrics
      * @param headers metadata to send as headers with the metrics data
+     * @throws Throwable when there is an exception in sending the metrics; the caller
+     * should handle this in some way such as logging the exception
      */
     @Override
-    void send(byte[] metricsData, Map<String, String> headers);
+    void send(String address, byte[] metricsData, Map<String, String> headers) throws Throwable;
 
 }

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -68,7 +68,7 @@ abstract class OtlpMeterRegistryTest {
         this.clock = new MockClock();
         OtlpConfig config = otlpConfig();
         this.mockHttpSender = mock(HttpSender.class);
-        OtlpMetricsSender metricsSender = new OtlpHttpMetricsSender(mockHttpSender, config);
+        OtlpMetricsSender metricsSender = new OtlpHttpMetricsSender(mockHttpSender);
         this.registry = OtlpMeterRegistry.builder(config).clock(clock).metricsSender(metricsSender).build();
         this.registryWithExponentialHistogram = new OtlpMeterRegistry(exponentialHistogramOtlpConfig(), clock);
     }


### PR DESCRIPTION
Remove the possible inconsistency where the sender could be given an instance of OtlpConfig that differs from the one passed to OtlpMeterRegistry. It is not clear which would be used or why. Now it is clear that the config on the registry will be used and the same sender can be used with different registry instances, potentially configured with different addresses (OtlpConfig#url).

See #5691 and specifically https://github.com/micrometer-metrics/micrometer/pull/5691#discussion_r1948505743. Breaks the API introduced in the previous milestone for #5690.