### PR TITLE
Try to reduce flakiness in JvmGcMetricsTest.gcTimingIsCorrectForPauseCycleCollectors()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
@@ -104,6 +104,10 @@ class JvmGcMetricsTest {
     // in an LTS is 17
     @EnabledForJreRange(min = JRE.JAVA_17)
     void gcTimingIsCorrectForPauseCycleCollectors() {
+        // Try to reduce chances for GCs to happen between collecting initial values and
+        // binding metrics.
+        System.gc();
+
         // get initial GC timing metrics from JMX, if any
         // GC could have happened before this test due to testing infrastructure
         // If it did, it will not be captured in the metrics


### PR DESCRIPTION
This PR tries to reduce flakiness in the `JvmGcMetricsTest.gcTimingIsCorrectForPauseCycleCollectors()`.

See https://ge.micrometer.io/scans/tests?search.timeZoneId=Asia%2FSeoul&tests.container=io.micrometer.core.instrument.binder.jvm.JvmGcMetricsTest&tests.sortField=FLAKY&tests.test=gcTimingIsCorrectForPauseCycleCollectors()