### PR TITLE
KeyValues on Observation.Event

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationRegistryCompatibilityKit.java
@@ -88,9 +88,13 @@ public abstract class ObservationRegistryCompatibilityKit {
             Observation.Event event2 = Observation.Event.of("testEvent", "event for testing",
                     System.currentTimeMillis());
             observation.event(event2);
+            Observation.Event event3 = Observation.Event.of("retry", "retry", System.currentTimeMillis(),
+                    KeyValues.of("retryCount", "2"));
+            observation.event(event3);
 
             inOrder.verify(handler).onEvent(same(event), isA(Observation.Context.class));
             inOrder.verify(handler).onEvent(same(event2), isA(Observation.Context.class));
+            inOrder.verify(handler).onEvent(same(event3), isA(Observation.Context.class));
 
             Throwable exception = new IOException("simulated");
             observation.error(exception);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1373,7 +1373,22 @@ public interface Observation extends ObservationView {
          * @since 1.12.0
          */
         static Event of(String name, String contextualName, long wallTime) {
-            return new SimpleEvent(name, contextualName, wallTime);
+            return new SimpleEvent(name, contextualName, wallTime, KeyValues.empty());
+        }
+
+        /**
+         * Creates an {@link Event}.
+         * @param name The name of the event (should have low cardinality).
+         * @param contextualName The contextual name of the event (can have high
+         * cardinality).
+         * @param wallTime Wall time when the event happened in milliseconds since the
+         * epoch
+         * @param keyValues metadata specific to the event
+         * @return event
+         * @since 1.15.0
+         */
+        static Event of(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
+            return new SimpleEvent(name, contextualName, wallTime, keyValues);
         }
 
         /**
@@ -1410,6 +1425,16 @@ public interface Observation extends ObservationView {
          */
         default String getContextualName() {
             return getName();
+        }
+
+        /**
+         * Metadata about the event in the form of {@link KeyValue}. It may be empty if
+         * there is no metadata specific to the event.
+         * @return key values associated with this event
+         * @since 1.15.0
+         */
+        default Iterable<KeyValue> getKeyValues() {
+            return KeyValues.empty();
         }
 
         /**

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1377,18 +1377,36 @@ public interface Observation extends ObservationView {
         }
 
         /**
-         * Creates an {@link Event}.
+         * Creates an {@link Event} with high-cardinality key-values.
          * @param name The name of the event (should have low cardinality).
          * @param contextualName The contextual name of the event (can have high
          * cardinality).
          * @param wallTime Wall time when the event happened in milliseconds since the
          * epoch
-         * @param keyValues metadata specific to the event
+         * @param highCardinalityKeyValues high-cardinality metadata specific to the event
          * @return event
          * @since 1.18.0
          */
-        static Event of(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
-            return new SimpleEvent(name, contextualName, wallTime, keyValues);
+        static Event of(String name, String contextualName, long wallTime,
+                Iterable<KeyValue> highCardinalityKeyValues) {
+            return of(name, contextualName, wallTime, highCardinalityKeyValues, KeyValues.empty());
+        }
+
+        /**
+         * Creates an {@link Event} with high- and low-cardinality key-values.
+         * @param name The name of the event (should have low cardinality).
+         * @param contextualName The contextual name of the event (can have high
+         * cardinality).
+         * @param wallTime Wall time when the event happened in milliseconds since the
+         * epoch
+         * @param highCardinalityKeyValues high-cardinality metadata specific to the event
+         * @param lowCardinalityKeyValues low-cardinality metadata specific to the event
+         * @return event
+         * @since 1.18.0
+         */
+        static Event of(String name, String contextualName, long wallTime,
+                Iterable<KeyValue> highCardinalityKeyValues, Iterable<KeyValue> lowCardinalityKeyValues) {
+            return new SimpleEvent(name, contextualName, wallTime, highCardinalityKeyValues, lowCardinalityKeyValues);
         }
 
         /**
@@ -1428,13 +1446,33 @@ public interface Observation extends ObservationView {
         }
 
         /**
-         * Metadata about the event in the form of {@link KeyValues}. It may be empty if
+         * Low-cardinality metadata about the event in the form of {@link KeyValues}. It may
+         * be empty if there is no low-cardinality metadata specific to the event.
+         * @return low-cardinality key values associated with this event
+         * @since 1.18.0
+         */
+        default KeyValues getLowCardinalityKeyValues() {
+            return KeyValues.empty();
+        }
+
+        /**
+         * High-cardinality metadata about the event in the form of {@link KeyValues}. It
+         * may be empty if there is no high-cardinality metadata specific to the event.
+         * @return high-cardinality key values associated with this event
+         * @since 1.18.0
+         */
+        default KeyValues getHighCardinalityKeyValues() {
+            return KeyValues.empty();
+        }
+
+        /**
+         * All metadata about the event in the form of {@link KeyValues}. It may be empty if
          * there is no metadata specific to the event.
          * @return key values associated with this event
          * @since 1.18.0
          */
         default KeyValues getKeyValues() {
-            return KeyValues.empty();
+            return getLowCardinalityKeyValues().and(getHighCardinalityKeyValues());
         }
 
         /**
@@ -1445,7 +1483,7 @@ public interface Observation extends ObservationView {
          */
         default Event format(Object... dynamicEntriesForContextualName) {
             return Event.of(getName(), String.format(getContextualName(), dynamicEntriesForContextualName),
-                    getWallTime(), getKeyValues());
+                    getWallTime(), getHighCardinalityKeyValues(), getLowCardinalityKeyValues());
         }
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1404,8 +1404,8 @@ public interface Observation extends ObservationView {
          * @return event
          * @since 1.18.0
          */
-        static Event of(String name, String contextualName, long wallTime,
-                Iterable<KeyValue> highCardinalityKeyValues, Iterable<KeyValue> lowCardinalityKeyValues) {
+        static Event of(String name, String contextualName, long wallTime, Iterable<KeyValue> highCardinalityKeyValues,
+                Iterable<KeyValue> lowCardinalityKeyValues) {
             return new SimpleEvent(name, contextualName, wallTime, highCardinalityKeyValues, lowCardinalityKeyValues);
         }
 
@@ -1446,8 +1446,8 @@ public interface Observation extends ObservationView {
         }
 
         /**
-         * Low-cardinality metadata about the event in the form of {@link KeyValues}. It may
-         * be empty if there is no low-cardinality metadata specific to the event.
+         * Low-cardinality metadata about the event in the form of {@link KeyValues}. It
+         * may be empty if there is no low-cardinality metadata specific to the event.
          * @return low-cardinality key values associated with this event
          * @since 1.18.0
          */
@@ -1466,8 +1466,8 @@ public interface Observation extends ObservationView {
         }
 
         /**
-         * All metadata about the event in the form of {@link KeyValues}. It may be empty if
-         * there is no metadata specific to the event.
+         * All metadata about the event in the form of {@link KeyValues}. It may be empty
+         * if there is no metadata specific to the event.
          * @return key values associated with this event
          * @since 1.18.0
          */

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1373,7 +1373,7 @@ public interface Observation extends ObservationView {
          * @since 1.12.0
          */
         static Event of(String name, String contextualName, long wallTime) {
-            return new SimpleEvent(name, contextualName, wallTime, KeyValues.empty());
+            return of(name, contextualName, wallTime, KeyValues.empty());
         }
 
         /**
@@ -1385,7 +1385,7 @@ public interface Observation extends ObservationView {
          * epoch
          * @param keyValues metadata specific to the event
          * @return event
-         * @since 1.15.0
+         * @since 1.18.0
          */
         static Event of(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
             return new SimpleEvent(name, contextualName, wallTime, keyValues);
@@ -1428,12 +1428,12 @@ public interface Observation extends ObservationView {
         }
 
         /**
-         * Metadata about the event in the form of {@link KeyValue}. It may be empty if
+         * Metadata about the event in the form of {@link KeyValues}. It may be empty if
          * there is no metadata specific to the event.
          * @return key values associated with this event
-         * @since 1.15.0
+         * @since 1.18.0
          */
-        default Iterable<KeyValue> getKeyValues() {
+        default KeyValues getKeyValues() {
             return KeyValues.empty();
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1444,7 +1444,8 @@ public interface Observation extends ObservationView {
          * @return event
          */
         default Event format(Object... dynamicEntriesForContextualName) {
-            return Event.of(getName(), String.format(getContextualName(), dynamicEntriesForContextualName));
+            return Event.of(getName(), String.format(getContextualName(), dynamicEntriesForContextualName),
+                    getWallTime(), getKeyValues());
         }
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.observation;
 
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation.Event;
 
 /**
@@ -32,8 +34,10 @@ class SimpleEvent implements Event {
 
     private final long wallTime;
 
+    private final Iterable<KeyValue> keyValues;
+
     SimpleEvent(String name, String contextualName) {
-        this(name, contextualName, System.currentTimeMillis());
+        this(name, contextualName, System.currentTimeMillis(), KeyValues.empty());
     }
 
     /**
@@ -41,10 +45,11 @@ class SimpleEvent implements Event {
      * @param contextualName The contextual name of the event (can have high cardinality).
      * @param wallTime Wall time in milliseconds since the epoch
      */
-    SimpleEvent(String name, String contextualName, long wallTime) {
+    SimpleEvent(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
         this.name = name;
         this.contextualName = contextualName;
         this.wallTime = wallTime;
+        this.keyValues = keyValues;
     }
 
     @Override
@@ -60,6 +65,11 @@ class SimpleEvent implements Event {
     @Override
     public long getWallTime() {
         return this.wallTime;
+    }
+
+    @Override
+    public Iterable<KeyValue> getKeyValues() {
+        return this.keyValues;
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
@@ -34,23 +34,28 @@ final class SimpleEvent implements Event {
 
     private final long wallTime;
 
-    private final KeyValues keyValues;
+    private final KeyValues lowCardinalityKeyValues;
+
+    private final KeyValues highCardinalityKeyValues;
 
     SimpleEvent(String name, String contextualName) {
-        this(name, contextualName, System.currentTimeMillis(), KeyValues.empty());
+        this(name, contextualName, System.currentTimeMillis(), KeyValues.empty(), KeyValues.empty());
     }
 
     /**
      * @param name The name of the event (should have low cardinality).
      * @param contextualName The contextual name of the event (can have high cardinality).
      * @param wallTime Wall time in milliseconds since the epoch
-     * @param keyValues key-values associated with the event
+     * @param highCardinalityKeyValues high-cardinality key-values associated with the event
+     * @param lowCardinalityKeyValues low-cardinality key-values associated with the event
      */
-    SimpleEvent(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
+    SimpleEvent(String name, String contextualName, long wallTime, Iterable<KeyValue> highCardinalityKeyValues,
+            Iterable<KeyValue> lowCardinalityKeyValues) {
         this.name = name;
         this.contextualName = contextualName;
         this.wallTime = wallTime;
-        this.keyValues = KeyValues.of(keyValues);
+        this.highCardinalityKeyValues = KeyValues.of(highCardinalityKeyValues);
+        this.lowCardinalityKeyValues = KeyValues.of(lowCardinalityKeyValues);
     }
 
     @Override
@@ -69,8 +74,18 @@ final class SimpleEvent implements Event {
     }
 
     @Override
+    public KeyValues getLowCardinalityKeyValues() {
+        return this.lowCardinalityKeyValues;
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues() {
+        return this.highCardinalityKeyValues;
+    }
+
+    @Override
     public KeyValues getKeyValues() {
-        return this.keyValues;
+        return this.lowCardinalityKeyValues.and(this.highCardinalityKeyValues);
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
@@ -26,7 +26,7 @@ import io.micrometer.observation.Observation.Event;
  * @author Tommy Ludwig
  * @author Marcin Grzejszczak
  */
-class SimpleEvent implements Event {
+final class SimpleEvent implements Event {
 
     private final String name;
 
@@ -34,7 +34,7 @@ class SimpleEvent implements Event {
 
     private final long wallTime;
 
-    private final Iterable<KeyValue> keyValues;
+    private final KeyValues keyValues;
 
     SimpleEvent(String name, String contextualName) {
         this(name, contextualName, System.currentTimeMillis(), KeyValues.empty());
@@ -44,12 +44,13 @@ class SimpleEvent implements Event {
      * @param name The name of the event (should have low cardinality).
      * @param contextualName The contextual name of the event (can have high cardinality).
      * @param wallTime Wall time in milliseconds since the epoch
+     * @param keyValues key-values associated with the event
      */
     SimpleEvent(String name, String contextualName, long wallTime, Iterable<KeyValue> keyValues) {
         this.name = name;
         this.contextualName = contextualName;
         this.wallTime = wallTime;
-        this.keyValues = keyValues;
+        this.keyValues = KeyValues.of(keyValues);
     }
 
     @Override
@@ -68,7 +69,7 @@ class SimpleEvent implements Event {
     }
 
     @Override
-    public Iterable<KeyValue> getKeyValues() {
+    public KeyValues getKeyValues() {
         return this.keyValues;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleEvent.java
@@ -46,7 +46,8 @@ final class SimpleEvent implements Event {
      * @param name The name of the event (should have low cardinality).
      * @param contextualName The contextual name of the event (can have high cardinality).
      * @param wallTime Wall time in milliseconds since the epoch
-     * @param highCardinalityKeyValues high-cardinality key-values associated with the event
+     * @param highCardinalityKeyValues high-cardinality key-values associated with the
+     * event
      * @param lowCardinalityKeyValues low-cardinality key-values associated with the event
      */
     SimpleEvent(String name, String contextualName, long wallTime, Iterable<KeyValue> highCardinalityKeyValues,

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationEventTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationEventTests.java
@@ -32,6 +32,8 @@ class ObservationEventTests {
     @Test
     void defaultGetKeyValuesReturnsEmptyKeyValues() {
         Observation.Event customEvent = new CustomEvent("test");
+        assertThat(customEvent.getLowCardinalityKeyValues()).isSameAs(KeyValues.empty());
+        assertThat(customEvent.getHighCardinalityKeyValues()).isSameAs(KeyValues.empty());
         assertThat(customEvent.getKeyValues()).isSameAs(KeyValues.empty());
     }
 
@@ -44,6 +46,8 @@ class ObservationEventTests {
         assertThat(event.getName()).isEqualTo("myEvent");
         assertThat(event.getContextualName()).isEqualTo("myEvent");
         assertThat(event.getWallTime()).isBetween(before, after);
+        assertThat(event.getLowCardinalityKeyValues()).isEmpty();
+        assertThat(event.getHighCardinalityKeyValues()).isEmpty();
         assertThat(event.getKeyValues()).isEmpty();
     }
 
@@ -56,6 +60,8 @@ class ObservationEventTests {
         assertThat(event.getName()).isEqualTo("myEvent");
         assertThat(event.getContextualName()).isEqualTo("contextual %s");
         assertThat(event.getWallTime()).isBetween(before, after);
+        assertThat(event.getLowCardinalityKeyValues()).isEmpty();
+        assertThat(event.getHighCardinalityKeyValues()).isEmpty();
         assertThat(event.getKeyValues()).isEmpty();
     }
 
@@ -66,18 +72,36 @@ class ObservationEventTests {
         assertThat(event.getName()).isEqualTo("myEvent");
         assertThat(event.getContextualName()).isEqualTo("contextual");
         assertThat(event.getWallTime()).isEqualTo(123456L);
+        assertThat(event.getLowCardinalityKeyValues()).isEmpty();
+        assertThat(event.getHighCardinalityKeyValues()).isEmpty();
         assertThat(event.getKeyValues()).isEmpty();
     }
 
     @Test
-    void eventWithKeyValues() {
-        KeyValues keyValues = KeyValues.of("k1", "v1", "k2", "v2");
-        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, keyValues);
+    void eventWithHighCardinalityKeyValues() {
+        KeyValues highKeyValues = KeyValues.of("hk1", "hv1", "hk2", "hv2");
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, highKeyValues);
 
         assertThat(event.getName()).isEqualTo("myEvent");
         assertThat(event.getContextualName()).isEqualTo("contextual");
         assertThat(event.getWallTime()).isEqualTo(123456L);
-        assertThat(event.getKeyValues()).containsExactlyElementsOf(keyValues);
+        assertThat(event.getLowCardinalityKeyValues()).isEmpty();
+        assertThat(event.getHighCardinalityKeyValues()).containsExactlyElementsOf(highKeyValues);
+        assertThat(event.getKeyValues()).containsExactlyElementsOf(highKeyValues);
+    }
+
+    @Test
+    void eventWithHighAndLowCardinalityKeyValues() {
+        KeyValues highKeyValues = KeyValues.of("hk1", "hv1");
+        KeyValues lowKeyValues = KeyValues.of("lk1", "lv1");
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, highKeyValues, lowKeyValues);
+
+        assertThat(event.getName()).isEqualTo("myEvent");
+        assertThat(event.getContextualName()).isEqualTo("contextual");
+        assertThat(event.getWallTime()).isEqualTo(123456L);
+        assertThat(event.getHighCardinalityKeyValues()).containsExactlyElementsOf(highKeyValues);
+        assertThat(event.getLowCardinalityKeyValues()).containsExactlyElementsOf(lowKeyValues);
+        assertThat(event.getKeyValues()).containsExactly(KeyValue.of("hk1", "hv1"), KeyValue.of("lk1", "lv1"));
     }
 
     @Test
@@ -85,20 +109,25 @@ class ObservationEventTests {
         Iterable<KeyValue> keyValues = Collections.singletonList(KeyValue.of("k1", "v1"));
         Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, keyValues);
 
+        assertThat(event.getHighCardinalityKeyValues()).containsExactly(KeyValue.of("k1", "v1"));
         assertThat(event.getKeyValues()).containsExactly(KeyValue.of("k1", "v1"));
     }
 
     @Test
     void formatPreservesWallTimeAndKeyValues() {
-        KeyValues keyValues = KeyValues.of("retryCount", "3");
-        Observation.Event event = Observation.Event.of("retry", "attempt %s failed", 9999L, keyValues);
+        KeyValues highKeyValues = KeyValues.of("detail", "timeout");
+        KeyValues lowKeyValues = KeyValues.of("attempt", "2");
+        Observation.Event event = Observation.Event.of("retry", "attempt %s failed", 9999L, highKeyValues,
+                lowKeyValues);
 
         Observation.Event formatted = event.format(2);
 
         assertThat(formatted.getName()).isEqualTo("retry");
         assertThat(formatted.getContextualName()).isEqualTo("attempt 2 failed");
         assertThat(formatted.getWallTime()).isEqualTo(9999L);
-        assertThat(formatted.getKeyValues()).containsExactlyElementsOf(keyValues);
+        assertThat(formatted.getHighCardinalityKeyValues()).containsExactlyElementsOf(highKeyValues);
+        assertThat(formatted.getLowCardinalityKeyValues()).containsExactlyElementsOf(lowKeyValues);
+        assertThat(formatted.getKeyValues()).containsExactlyElementsOf(lowKeyValues.and(highKeyValues));
     }
 
     @Test

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationEventTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationEventTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link Observation.Event} and {@link SimpleEvent}.
+ */
+class ObservationEventTests {
+
+    @Test
+    void defaultGetKeyValuesReturnsEmptyKeyValues() {
+        Observation.Event customEvent = new CustomEvent("test");
+        assertThat(customEvent.getKeyValues()).isSameAs(KeyValues.empty());
+    }
+
+    @Test
+    void eventOfNameHasDefaultKeyValuesAndWallTime() {
+        long before = System.currentTimeMillis();
+        Observation.Event event = Observation.Event.of("myEvent");
+        long after = System.currentTimeMillis();
+
+        assertThat(event.getName()).isEqualTo("myEvent");
+        assertThat(event.getContextualName()).isEqualTo("myEvent");
+        assertThat(event.getWallTime()).isBetween(before, after);
+        assertThat(event.getKeyValues()).isEmpty();
+    }
+
+    @Test
+    void eventOfNameAndContextualNameHasDefaultKeyValues() {
+        long before = System.currentTimeMillis();
+        Observation.Event event = Observation.Event.of("myEvent", "contextual %s");
+        long after = System.currentTimeMillis();
+
+        assertThat(event.getName()).isEqualTo("myEvent");
+        assertThat(event.getContextualName()).isEqualTo("contextual %s");
+        assertThat(event.getWallTime()).isBetween(before, after);
+        assertThat(event.getKeyValues()).isEmpty();
+    }
+
+    @Test
+    void eventOfNameContextualNameAndWallTimeHasDefaultKeyValues() {
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L);
+
+        assertThat(event.getName()).isEqualTo("myEvent");
+        assertThat(event.getContextualName()).isEqualTo("contextual");
+        assertThat(event.getWallTime()).isEqualTo(123456L);
+        assertThat(event.getKeyValues()).isEmpty();
+    }
+
+    @Test
+    void eventWithKeyValues() {
+        KeyValues keyValues = KeyValues.of("k1", "v1", "k2", "v2");
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, keyValues);
+
+        assertThat(event.getName()).isEqualTo("myEvent");
+        assertThat(event.getContextualName()).isEqualTo("contextual");
+        assertThat(event.getWallTime()).isEqualTo(123456L);
+        assertThat(event.getKeyValues()).containsExactlyElementsOf(keyValues);
+    }
+
+    @Test
+    void eventWithIterableKeyValues() {
+        Iterable<KeyValue> keyValues = Collections.singletonList(KeyValue.of("k1", "v1"));
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, keyValues);
+
+        assertThat(event.getKeyValues()).containsExactly(KeyValue.of("k1", "v1"));
+    }
+
+    @Test
+    void formatPreservesWallTimeAndKeyValues() {
+        KeyValues keyValues = KeyValues.of("retryCount", "3");
+        Observation.Event event = Observation.Event.of("retry", "attempt %s failed", 9999L, keyValues);
+
+        Observation.Event formatted = event.format(2);
+
+        assertThat(formatted.getName()).isEqualTo("retry");
+        assertThat(formatted.getContextualName()).isEqualTo("attempt 2 failed");
+        assertThat(formatted.getWallTime()).isEqualTo(9999L);
+        assertThat(formatted.getKeyValues()).containsExactlyElementsOf(keyValues);
+    }
+
+    @Test
+    void toStringExcludesKeyValues() {
+        Observation.Event event = Observation.Event.of("myEvent", "contextual", 123456L, KeyValues.of("k1", "v1"));
+
+        assertThat(event.toString())
+            .isEqualTo("event.name='myEvent', event.contextualName='contextual', event.wallTime=123456");
+    }
+
+    @NullMarked
+    private static class CustomEvent implements Observation.Event {
+
+        private final String name;
+
+        CustomEvent(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return this.name;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Opening for discussion related to implementing #5238. It's been implemented in a way that nothing should break.

~I intentionally did not separate out high- vs low-cardinality keyvalues. I'd be interested to hear feedback on if it's needed and why.~

I think most of the real impact is in how this will be handled: by our DefaultMeterObservationHandler, our default tracing handler, and other handlers. This only provides the API and leaves behavior changes in handlesr as a follow-up if feedback warrants doing so.

Closes #5238