### PR TITLE
Fix flakiness in JmsInstrumentationTests.shouldInstrumentMessageListener()

### DIFF
--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.jms;
 
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Tests for {@link JmsInstrumentation}.
@@ -131,9 +133,10 @@ class JmsInstrumentationTests {
             MessageProducer producer = session.createProducer(topic);
             producer.send(session.createTextMessage("test send"));
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-            assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
-                .that()
-                .hasContextualNameEqualTo("test.send process");
+            await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
+                    .that()
+                    .hasContextualNameEqualTo("test.send process"));
         }
     }
 


### PR DESCRIPTION
https://github.com/micrometer-metrics/micrometer/pull/5899 seems to have been lost while merging it into the 1.14.x branch.