### PR TITLE
Support instrumentation for Executors.newVirtualThreadPerTaskExecutor()

### DIFF
--- a/micrometer-java11/build.gradle
+++ b/micrometer-java11/build.gradle
@@ -7,7 +7,6 @@ dependencies {
     testImplementation 'ru.lanwen.wiremock:wiremock-junit5'
     testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
     testImplementation project(":micrometer-observation-test")
-    testImplementation libs.awaitility
 }
 
 java {

--- a/micrometer-java11/build.gradle
+++ b/micrometer-java11/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     testImplementation 'ru.lanwen.wiremock:wiremock-junit5'
     testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
     testImplementation project(":micrometer-observation-test")
+    testImplementation libs.awaitility
 }
 
 java {


### PR DESCRIPTION
This PR tries to support instrumentation for the `Executors.newVirtualThreadPerTaskExecutor()`.

Closes gh-5488