### PR TITLE
JUnit should not be an `api` scope dependency

### DIFF
--- a/micrometer-observation-test/build.gradle
+++ b/micrometer-observation-test/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':micrometer-observation')
 
     api 'org.assertj:assertj-core'
-    api libs.junitJupiter
+    implementation libs.junitJupiter
 
     implementation libs.mockitoCore4
 

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -43,8 +43,8 @@ dependencies {
 
     api 'org.assertj:assertj-core'
 
-    api libs.junitJupiter
-    api 'org.junit.jupiter:junit-jupiter-engine'
+    implementation(libs.junitJupiter)
+    implementation('org.junit.jupiter:junit-jupiter-engine')
 
     api 'ru.lanwen.wiremock:wiremock-junit5'
     api 'com.github.tomakehurst:wiremock-jre8-standalone'


### PR DESCRIPTION
API scope can cause issues for consumers due to runtime version mismatches.

Resolves gh-6012