### PR TITLE
Fix a possible typo in metric name.

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -101,7 +101,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
             .tag("state", "available")
             .register(registry);
         Gauge
-            .builder("httpcomponents.httpclient.pool.total.connections", connPoolControl,
+            .builder("httpcomponents.httpclient.pool.total.leased", connPoolControl,
                     (connPoolControl) -> connPoolControl.getTotalStats().getLeased())
             .description("The number of persistent and leased connections for all routes.")
             .tags(tags)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinder.java
@@ -94,7 +94,7 @@ public class PoolingHttpClientConnectionManagerMetricsBinder implements MeterBin
             .tag("state", "available")
             .register(registry);
         Gauge
-            .builder("httpcomponents.httpclient.pool.total.connections", connPoolControl,
+            .builder("httpcomponents.httpclient.pool.total.leased", connPoolControl,
                     (connPoolControl) -> connPoolControl.getTotalStats().getLeased())
             .description("The number of persistent and leased connections for all routes.")
             .tags(tags)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -75,7 +75,7 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getLeased()).thenReturn(23);
         when(connPoolControl.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.leased")
             .tags("httpclient", "test", "state", "leased")
             .gauge()
             .value()).isEqualTo(23.0);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/PoolingHttpClientConnectionManagerMetricsBinderTest.java
@@ -75,7 +75,7 @@ class PoolingHttpClientConnectionManagerMetricsBinderTest {
         PoolStats poolStats = mock(PoolStats.class);
         when(poolStats.getLeased()).thenReturn(23);
         when(connPoolControl.getTotalStats()).thenReturn(poolStats);
-        assertThat(registry.get("httpcomponents.httpclient.pool.total.connections")
+        assertThat(registry.get("httpcomponents.httpclient.pool.total.leased")
             .tags("httpclient", "test", "state", "leased")
             .gauge()
             .value()).isEqualTo(23.0);


### PR DESCRIPTION
'httpcomponents.httpclient.pool.total.connections' was set by two different functions before. This PR creates different metrics for 'leased' connections.