### PR TITLE
Document requirements for reflective access in ExecutorServiceMetrics

### DIFF
--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -50,6 +50,7 @@ To use the following `ExecutorService` instances, `--add-opens java.base/java.ut
 * `Executors.newSingleThreadScheduledExecutor()`
 * `Executors.newSingleThreadExecutor()`
 * `Executors.newThreadPerTaskExecutor()`
+* `Executors.newVirtualThreadPerTaskExecutor()`
 
 == Java 21 Metrics
 

--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -45,6 +45,12 @@ another. The reported value underestimates the actual total number of steals whe
 * `executor.parallelism` (`Gauge`): The targeted parallelism level of this pool.
 * `executor.pool.size` (`Gauge`): The current number of threads in the pool.
 
+To use the following `ExecutorService` instances, `--add-opens java.base/java.util.concurrent=ALL-UNNAMED` is required:
+
+* `Executors.newSingleThreadScheduledExecutor()`
+* `Executors.newSingleThreadExecutor()`
+* `Executors.newThreadPerTaskExecutor()`
+
 == Java 21 Metrics
 
 Micrometer provides support for https://openjdk.org/jeps/444[virtual threads] released in Java 21. In order to utilize it, you need to add the `io.micrometer:micrometer-java21` dependency to your classpath to use the binder:

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -57,6 +57,7 @@ import static java.util.stream.Collectors.toSet;
  * <li>Executors.newSingleThreadScheduledExecutor()</li>
  * <li>Executors.newSingleThreadExecutor()</li>
  * <li>Executors.newThreadPerTaskExecutor()</li>
+ * <li>Executors.newVirtualThreadPerTaskExecutor()</li>
  * </ul>
  *
  * @author Jon Schneider
@@ -333,7 +334,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
                 monitor(registry,
                         unwrapThreadPoolExecutor(executorService, executorService.getClass().getSuperclass()));
             }
-            // For Executors.newThreadPerTaskExecutor()
+            // For Executors.newThreadPerTaskExecutor() and
+            // Executors.newVirtualThreadPerTaskExecutor()
             else if (className.equals(CLASS_NAME_THREAD_PER_TASK_EXECUTOR)) {
                 monitorThreadPerTaskExecutor(registry, executorService);
             }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -50,6 +50,14 @@ import static java.util.stream.Collectors.toSet;
  * {@link ExecutorService}, like {@link TimedExecutorService}. Make sure to pass the
  * underlying, unwrapped ExecutorService to this MeterBinder, if it is wrapped in another
  * type.
+ * <p>
+ * To use the following {@link ExecutorService} instances,
+ * {@literal --add-opens java.base/java.util.concurrent=ALL-UNNAMED} is required:
+ * <ul>
+ * <li>Executors.newSingleThreadScheduledExecutor()</li>
+ * <li>Executors.newSingleThreadExecutor()</li>
+ * <li>Executors.newThreadPerTaskExecutor()</li>
+ * </ul>
  *
  * @author Jon Schneider
  * @author Clint Checketts
@@ -315,14 +323,17 @@ public class ExecutorServiceMetrics implements MeterBinder {
             monitor(registry, (ForkJoinPool) executorService);
         }
         else if (allowIllegalReflectiveAccess) {
+            // For Executors.newSingleThreadScheduledExecutor()
             if (className.equals("java.util.concurrent.Executors$DelegatedScheduledExecutorService")) {
                 monitor(registry, unwrapThreadPoolExecutor(executorService, executorService.getClass()));
             }
+            // For Executors.newSingleThreadExecutor()
             else if (className.equals("java.util.concurrent.Executors$FinalizableDelegatedExecutorService")
                     || className.equals("java.util.concurrent.Executors$AutoShutdownDelegatedExecutorService")) {
                 monitor(registry,
                         unwrapThreadPoolExecutor(executorService, executorService.getClass().getSuperclass()));
             }
+            // For Executors.newThreadPerTaskExecutor()
             else if (className.equals(CLASS_NAME_THREAD_PER_TASK_EXECUTOR)) {
                 monitorThreadPerTaskExecutor(registry, executorService);
             }


### PR DESCRIPTION
This PR documents requirements for reflective access in the `ExecutorServiceMetrics`.

See https://github.com/micrometer-metrics/micrometer/pull/6008#pullrequestreview-2689545471