### PR TITLE
Avoid needless re-registering Kafka metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -218,11 +218,10 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                             registeredMeterIds.remove(otherId);
                         }
                         // Check if already exists
-                        else if (tags.size() == meterTagsWithCommonTags.size())
+                        else if (tags.size() == meterTagsWithCommonTags.size()) {
                             if (tags.containsAll(meterTagsWithCommonTags))
                                 return;
-                            else
-                                break;
+                        }
                         else
                             hasLessTags = true;
                     }


### PR DESCRIPTION
Functionally this does not cause any issue because calls to register after the first will not do anything, but it results in a warning in the log for Gauge re-registration, which can mask other issues.

Resolves #5757 