### PR TITLE
Log warning about "function" meter re-registration

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -117,3 +117,11 @@ FunctionCounter counter = FunctionCounter
     .tags("region", "test") // optional
     .register(registry);
 ----
+
+WARNING: Attempting to construct a function-tracking counter with a primitive number or one of its `java.lang` object forms is always incorrect. These numbers are immutable. Thus, the function-tracking counter cannot ever be changed. Attempting to "re-register" the function-tracking counter with a different number does not work, as the registry maintains only one meter for each unique combination of name and tags. "Re-registering" a function-tracking counter can happen indirectly for example as the result of a `MeterFilter` modifying the name and/or the tags of two different function-tracking counter so that they will be the same after the filter is applied.
+
+Attempting to "re-register" a function-tracking counter will result in a warning like this:
+[source]
+----
+WARNING: This FunctionCounter has been already registered (MeterId{name='my.fc', tags=[]}), the registration will be ignored. Note that subsequent logs will be logged at debug level.
+----

--- a/docs/modules/ROOT/pages/concepts/gauges.adoc
+++ b/docs/modules/ROOT/pages/concepts/gauges.adoc
@@ -44,6 +44,12 @@ This pattern should be less common than the `DoubleFunction` form. Remember that
 
 WARNING: Attempting to construct a gauge with a primitive number or one of its `java.lang` object forms is always incorrect. These numbers are immutable. Thus, the gauge cannot ever be changed. Attempting to "re-register" the gauge with a different number does not work, as the registry maintains only one meter for each unique combination of name and tags. "Re-registering" a gauge can happen indirectly for example as the result of a `MeterFilter` modifying the name and/or the tags of two different gauges so that they will be the same after the filter is applied.
 
+Attempting to "re-register" a gauge will result in a warning like this:
+[source]
+----
+WARNING: This Gauge has been already registered (MeterId{name='my.gauge', tags=[]}), the registration will be ignored. Note that subsequent logs will be logged at debug level.
+----
+
 == Gauge Fluent Builder
 
 The interface contains a fluent builder for gauges:

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -182,6 +182,14 @@ FunctionTimer.builder("cache.gets.latency", cache,
     .register(registry);
 ----
 
+WARNING: Attempting to construct a function-tracking timer with a primitive number or one of its `java.lang` object forms is always incorrect. These numbers are immutable. Thus, the function-tracking timer cannot ever be changed. Attempting to "re-register" the function-tracking timer with a different number does not work, as the registry maintains only one meter for each unique combination of name and tags. "Re-registering" a function-tracking timer can happen indirectly for example as the result of a `MeterFilter` modifying the name and/or the tags of two different function-tracking timer so that they will be the same after the filter is applied.
+
+Attempting to "re-register" a function-tracking timer will result in a warning like this:
+[source]
+----
+WARNING: This FunctionTimer has been already registered (MeterId{name='my.ft', tags=[]}), the registration will be ignored. Note that subsequent logs will be logged at debug level.
+----
+
 == Pause Detection
 
 Micrometer uses the `LatencyUtils` package to compensate for https://highscalability.com/blog/2015/10/5/your-load-generator-is-probably-lying-to-you-take-the-red-pi.html[coordinated omission] -- extra latency arising from system and VM pauses that skew your latency statistics downward. Distribution statistics, such as percentiles and SLO counts, are influenced by a pause detector implementation that adds additional latency here and there to compensate for pauses.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -712,10 +712,20 @@ public abstract class MeterRegistry {
     }
 
     private void checkAndWarnAboutDoubleRegistration(Meter meter) {
-        if (meter instanceof Gauge || meter instanceof FunctionCounter || meter instanceof FunctionTimer) {
-            doubleRegistrationLogger.log(() -> String.format(
-                    "This Meter has been already registered (%s), the registration will be ignored.", meter.getId()));
+        if (meter instanceof Gauge) { // also TimeGauge
+            warnAboutDoubleRegistration("Gauge", meter.getId());
         }
+        else if (meter instanceof FunctionCounter) {
+            warnAboutDoubleRegistration("FunctionCounter", meter.getId());
+        }
+        else if (meter instanceof FunctionTimer) {
+            warnAboutDoubleRegistration("FunctionTimer", meter.getId());
+        }
+    }
+
+    private void warnAboutDoubleRegistration(String type, Meter.Id id) {
+        doubleRegistrationLogger.log(() -> String
+            .format("This %s has been already registered (%s), the registration will be ignored.", type, id));
     }
 
     private boolean accept(Meter.Id id) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -67,8 +67,7 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class MeterRegistry {
 
-    private static final WarnThenDebugLogger gaugeDoubleRegistrationLogger = new WarnThenDebugLogger(
-            MeterRegistry.class);
+    private static final WarnThenDebugLogger doubleRegistrationLogger = new WarnThenDebugLogger(MeterRegistry.class);
 
     // @formatter:off
     private static final EnumMap<TimeUnit, String> BASE_TIME_UNIT_STRING_CACHE = Arrays.stream(TimeUnit.values())
@@ -640,7 +639,7 @@ public abstract class MeterRegistry {
 
         Meter m = preFilterIdToMeterMap.get(originalId);
         if (m != null && !isStaleId(originalId)) {
-            checkAndWarnAboutGaugeDoubleRegistration(m);
+            checkAndWarnAboutDoubleRegistration(m);
             return m;
         }
 
@@ -653,7 +652,7 @@ public abstract class MeterRegistry {
             if (isStaleId(originalId)) {
                 unmarkStaleId(originalId);
             }
-            checkAndWarnAboutGaugeDoubleRegistration(m);
+            checkAndWarnAboutDoubleRegistration(m);
         }
         else {
             if (isClosed()) {
@@ -712,11 +711,10 @@ public abstract class MeterRegistry {
         return !stalePreFilterIds.isEmpty() && stalePreFilterIds.remove(originalId);
     }
 
-    private void checkAndWarnAboutGaugeDoubleRegistration(Meter meter) {
-        if (meter instanceof Gauge) {
-            gaugeDoubleRegistrationLogger.log(() -> String.format(
-                    "This Gauge has been already registered (%s), the Gauge registration will be ignored.",
-                    meter.getId()));
+    private void checkAndWarnAboutDoubleRegistration(Meter meter) {
+        if (meter instanceof Gauge || meter instanceof FunctionCounter || meter instanceof FunctionTimer) {
+            doubleRegistrationLogger.log(() -> String.format(
+                    "This Meter has been already registered (%s), the registration will be ignored.", meter.getId()));
         }
     }
 


### PR DESCRIPTION
>I also realized that while we added logging for gauge double registration, any of the "functional" meters are affected - FunctionCounter, FunctionTimer. That's relevant to KafkaMetrics because it only registers Gauges and FunctionCounters. /cc @jonatan-ivanov

found by @shakuzen, see: https://github.com/micrometer-metrics/micrometer/issues/5757#issuecomment-2760837057

See gh-5616
See gh-5688
See gh-5617