### PR TITLE
Replace deprecated Project.task()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ subprojects {
             }
         }
 
-        task dockerTest(type: Test) {
+        tasks.register("dockerTest", Test) {
             // set heap size for the test JVM(s)
             maxHeapSize = "1500m"
 
@@ -343,7 +343,7 @@ subprojects {
                 }
             }
 
-            task testModules(type: Exec) {
+            tasks.register("testModules", Exec) {
                 dependsOn jar
                 String executablePath = javaToolchains.launcherFor { languageVersion = javaLanguageVersion }.get().executablePath
                 commandLine "$executablePath", '-p', "$jar.archivePath", '--list-modules'
@@ -363,7 +363,7 @@ subprojects {
                 apply plugin: 'me.champeau.gradle.japicmp'
                 apply plugin: 'de.undercouch.download'
 
-                task downloadBaseline(type: Download) {
+                tasks.register("downloadBaseline", Download) {
                     onlyIf {
                         if (project.gradle.startParameter.isOffline()) {
                             println 'Offline: skipping downloading of baseline and JAPICMP'
@@ -392,7 +392,7 @@ subprojects {
                     dest layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar")
                 }
 
-                task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
+                tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
                     oldClasspath.from(layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar"))
                     newClasspath.from(files(jar.archiveFile, project(":${project.name}").jar))
                     onlyBinaryIncompatibleModified = true

--- a/docs/src/test/resources/docs-generator-build.gradle
+++ b/docs/src/test/resources/docs-generator-build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	adoc "io.micrometer:micrometer-docs-generator:$micrometerDocsVersion"
 }
 
-task generateObservabilityDocs(type: JavaExec) {
+tasks.register("generateObservabilityDocs", JavaExec) {
 	mainClass = "io.micrometer.docs.DocsGeneratorCommand"
 	classpath configurations.adoc
 	// input folder, inclusion pattern, output folder

--- a/implementations/micrometer-registry-stackdriver/build.gradle
+++ b/implementations/micrometer-registry-stackdriver/build.gradle
@@ -23,7 +23,7 @@ test {
     }
 }
 
-task stackdriverTest(type: Test) {
+tasks.register("stackdriverTest", Test) {
     useJUnitPlatform {
         includeTags 'gcp-it'
     }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     testImplementation 'com.squareup.retrofit2:retrofit'
 }
 
-task shenandoahTest(type: Test) {
+tasks.register("shenandoahTest", Test) {
     // set heap size for the test JVM(s)
     maxHeapSize = "1500m"
 
@@ -220,7 +220,7 @@ task shenandoahTest(type: Test) {
     jvmArgs '-XX:+UseShenandoahGC'
 }
 
-task zgcTest(type: Test) {
+tasks.register("zgcTest", Test) {
     // set heap size for the test JVM(s)
     maxHeapSize = "1500m"
 
@@ -231,7 +231,7 @@ task zgcTest(type: Test) {
     jvmArgs '-XX:+UseZGC'
 }
 
-task zgcGenerationalTest(type: Test) {
+tasks.register("zgcGenerationalTest", Test) {
     // set heap size for the test JVM(s)
     maxHeapSize = "1500m"
 
@@ -242,7 +242,7 @@ task zgcGenerationalTest(type: Test) {
     jvmArgs '-XX:+UseZGC', '-XX:+ZGenerational'
 }
 
-task openj9BalancedTest(type: Test) {
+tasks.register("openj9BalancedTest", Test) {
     // set heap size for the test JVM(s)
     maxHeapSize = "1500m"
 
@@ -253,7 +253,7 @@ task openj9BalancedTest(type: Test) {
     jvmArgs '-Xgcpolicy:balanced'
 }
 
-task openj9ConcurrentScavengeTest(type: Test) {
+tasks.register("openj9ConcurrentScavengeTest", Test) {
     // set heap size for the test JVM(s)
     maxHeapSize = "1500m"
 


### PR DESCRIPTION
This PR replaces deprecated `Project.task()` with `tasks.register()`.

See https://docs.gradle.org/current/userguide/upgrading_version_8.html#source_level_deprecation_of_project_task_methods