### PR TITLE
Use KeyValue.NONE_VALUE where possible

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.aop;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
@@ -83,7 +84,7 @@ public class CountedAspect {
 
     private static final Predicate<ProceedingJoinPoint> DONT_SKIP_ANYTHING = pjp -> false;
 
-    public final String DEFAULT_EXCEPTION_TAG_VALUE = "none";
+    public final String DEFAULT_EXCEPTION_TAG_VALUE = KeyValue.NONE_VALUE;
 
     public final String RESULT_TAG_FAILURE_VALUE = "failure";
 

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.aop;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
@@ -92,7 +93,7 @@ public class TimedAspect {
 
     public static final String DEFAULT_METRIC_NAME = "method.timed";
 
-    public static final String DEFAULT_EXCEPTION_TAG_VALUE = "none";
+    public static final String DEFAULT_EXCEPTION_TAG_VALUE = KeyValue.NONE_VALUE;
 
     /**
      * Tag key for an exception.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.commonspool2;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLogger;
@@ -129,17 +130,18 @@ public class CommonsObjectPool2Metrics implements MeterBinder, AutoCloseable {
 
     private Iterable<Tag> nameTag(ObjectName name, String type)
             throws AttributeNotFoundException, MBeanException, ReflectionException, InstanceNotFoundException {
-        return Tags.of("name", name.getKeyProperty("name"), "type", type, "factoryType", getFactoryType(name, type));
+        return Tags.of("name", name.getKeyProperty("name"), "type", type, "factoryType",
+                getFactoryTypeTagValue(name, type));
     }
 
-    private String getFactoryType(ObjectName name, String type)
+    private String getFactoryTypeTagValue(ObjectName name, String type)
             throws ReflectionException, AttributeNotFoundException, InstanceNotFoundException, MBeanException {
         if (Objects.equals(type, "GenericObjectPool")) {
             // for GenericObjectPool, we want to include the name and factoryType as tags
             return mBeanServer.getAttribute(name, "FactoryType").toString();
         }
         else {
-            return "none";
+            return KeyValue.NONE_VALUE;
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/JooqExecuteListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/JooqExecuteListener.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.db;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -84,8 +85,8 @@ class JooqExecuteListener extends DefaultExecuteListener {
         if (sample == null)
             return;
 
-        String exceptionName = "none";
-        String exceptionSubclass = "none";
+        String exceptionName = KeyValue.NONE_VALUE;
+        String exceptionSubclass = KeyValue.NONE_VALUE;
 
         Exception exception = ctx.exception();
         if (exception != null) {
@@ -94,7 +95,7 @@ class JooqExecuteListener extends DefaultExecuteListener {
                 exceptionName = dae.sqlStateClass().name().toLowerCase().replace('_', ' ');
                 exceptionSubclass = dae.sqlStateSubclass().name().toLowerCase().replace('_', ' ');
                 if (exceptionSubclass.contains("no subclass")) {
-                    exceptionSubclass = "none";
+                    exceptionSubclass = KeyValue.NONE_VALUE;
                 }
             }
             else {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.okhttp3;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.NonNullFields;
 import io.micrometer.common.lang.Nullable;
@@ -269,7 +270,7 @@ public class OkHttpMetricsEventListener extends EventListener {
         private final String name;
 
         private Function<Request, String> uriMapper = (request) -> Optional.ofNullable(request.header(URI_PATTERN))
-            .orElse("none");
+            .orElse(KeyValue.NONE_VALUE);
 
         private Tags tags = Tags.empty();
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
@@ -144,7 +144,7 @@ public class OkHttpObservationInterceptor implements Interceptor {
         private final ObservationRegistry registry;
 
         private Function<Request, String> uriMapper = (request) -> Optional.ofNullable(request.header(URI_PATTERN))
-            .orElse("none");
+            .orElse(KeyValue.NONE_VALUE);
 
         private KeyValues tags = KeyValues.empty();
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
@@ -105,7 +105,7 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
 
     private String getErrorValue(Observation.Context context) {
         Throwable error = context.getError();
-        return error != null ? error.getClass().getSimpleName() : "none";
+        return error != null ? error.getClass().getSimpleName() : KeyValue.NONE_VALUE;
     }
 
     private List<Tag> createTags(Observation.Context context) {

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.tck;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.core.Issue;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Timer;
@@ -929,7 +930,8 @@ public abstract class MeterRegistryCompatibilityKit {
 
             assertThat(longTaskTimer.activeTasks()).isEqualTo(0);
 
-            Timer timer = registry.timer("myObservation", "error", "none", "staticTag", "42", "dynamicTag", "24");
+            Timer timer = registry.timer("myObservation", "error", KeyValue.NONE_VALUE, "staticTag", "42", "dynamicTag",
+                    "24");
             assertSoftly(softly -> {
                 softly.assertThat(timer.count()).isEqualTo(1L);
                 softly.assertThat(timer.totalTime(TimeUnit.SECONDS)).isCloseTo(1, offset(1.0e-12));
@@ -951,7 +953,7 @@ public abstract class MeterRegistryCompatibilityKit {
             observation.stop();
             clock(registry).add(step());
 
-            Timer timer = registry.timer("myObservation", "error", "none");
+            Timer timer = registry.timer("myObservation", "error", KeyValue.NONE_VALUE);
             assertSoftly(softly -> {
                 softly.assertThat(timer.count()).isEqualTo(1L);
                 softly.assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isCloseTo(10, offset(1.0e-12));


### PR DESCRIPTION
This PR changes to use the `KeyValue.NONE_VALUE` where possible.