### PR TITLE
Add test for unsuccessful OtlpHttpMetricsSender.send()

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpHttpMetricsSenderTests.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpHttpMetricsSenderTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.registry.otlp;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.micrometer.core.ipc.http.HttpSender;
+import io.micrometer.core.ipc.http.HttpUrlConnectionSender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+/**
+ * Tests for {@link OtlpHttpMetricsSender}.
+ *
+ * @author Johnny Lim
+ */
+@ExtendWith(WiremockResolver.class)
+class OtlpHttpMetricsSenderTests {
+
+    @Test
+    void sendWhenResponseIsUnsuccessful(@WiremockResolver.Wiremock WireMockServer server) {
+        String path = "/metrics";
+        server.stubFor(any(urlEqualTo(path)).willReturn(badRequest()));
+
+        HttpSender httpSender = new HttpUrlConnectionSender();
+        OtlpHttpMetricsSender otlpHttpMetricsSender = new OtlpHttpMetricsSender(httpSender);
+        OtlpMetricsSender.Request request = OtlpMetricsSender.Request.builder(new byte[0])
+            .address(server.url(path))
+            .build();
+        assertThatException().isThrownBy(() -> otlpHttpMetricsSender.send(request))
+            .satisfies((ex) -> assertThat(ex.getClass().getSimpleName())
+                .isEqualTo("OtlpHttpMetricsSendUnsuccessfulException"));
+    }
+
+}


### PR DESCRIPTION
This PR adds a test for an unsuccessful `OtlpHttpMetricsSender.send()`.

See https://github.com/micrometer-metrics/micrometer/pull/6071#discussion_r2020036544