### PR TITLE
Restore cache.size in CaffeineCacheMetrics without enabling recordStats()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -150,7 +150,7 @@ public class CaffeineCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMete
 
     @Override
     protected Long size() {
-        return getOrDefault(Cache::estimatedSize, null);
+        return getOrDefault(Cache::estimatedSize, null, false);
     }
 
     @Override
@@ -208,9 +208,14 @@ public class CaffeineCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMete
 
     @Nullable
     private Long getOrDefault(Function<C, Long> function, @Nullable Long defaultValue) {
+        return getOrDefault(function, defaultValue, true);
+    }
+
+    @Nullable
+    private Long getOrDefault(Function<C, Long> function, @Nullable Long defaultValue, boolean recordingStatsRequired) {
         C cache = getCache();
         if (cache != null) {
-            if (!cache.policy().isRecordingStats()) {
+            if (recordingStatsRequired && !cache.policy().isRecordingStats()) {
                 return null;
             }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -25,8 +25,11 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.testsupport.system.CapturedOutput;
+import io.micrometer.core.testsupport.system.OutputCaptureExtension;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +41,7 @@ import static org.assertj.core.api.Assertions.*;
  * @author Oleksii Bondar
  * @author Johnny Lim
  */
+@ExtendWith(OutputCaptureExtension.class)
 class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
     // tag::setup[]
@@ -101,6 +105,22 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
     @Test
     void returnCacheSize() {
         assertThat(metrics.size()).isEqualTo(cache.estimatedSize());
+    }
+
+    @Test
+    void returnCacheSizeWithoutRecordStats(CapturedOutput output) {
+        LoadingCache<String, String> cache = Caffeine.newBuilder().build(key -> "");
+        CaffeineCacheMetrics<String, String, Cache<String, String>> metrics = new CaffeineCacheMetrics<>(cache,
+                "testCache", Tags.empty());
+
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        metrics.bindTo(meterRegistry);
+
+        cache.put("a", "1");
+        assertThat(metrics.size()).isOne();
+        assertThat(meterRegistry.get("cache.size").gauge().value()).isOne();
+        assertThat(output).contains(
+                "The cache 'testCache' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
     }
 
     @Test


### PR DESCRIPTION
This PR restores the `cache.size` in the `CaffeineCacheMetrics` without enabling the `recordStats()`.

Closes gh-6128