### PR TITLE
Remove redundant Error Prone disabling for JDK 11 in micrometer-core

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -283,11 +283,6 @@ java11Test {
 }
 
 compileJava11TestJava {
-    options.errorprone.enabled = false
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
-}
-
-compileJava11Java {
-    options.errorprone.enabled = false
 }


### PR DESCRIPTION
This PR removes redundant Error Prone disabling for JDK 11 in the `micrometer-core`.