### PR TITLE
Suppress Error Prone warnings from generated code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,9 @@ subprojects {
 
     if (project.name != 'micrometer-bom') {
         tasks.withType(JavaCompile).configureEach {
+            options.errorprone.disableWarningsInGeneratedCode = true
+            options.errorprone.excludedPaths = ".*/build/generated/.*"
+
             if (!javaLanguageVersion.canCompileOrRun(17)) {
                 // Error Prone does not work with JDK <17
                 options.errorprone.enabled = false


### PR DESCRIPTION
There are 191 warnings from generated code, for example as follows:

```
/Users/izeye/IdeaProjects/micrometer/concurrency-tests/build/generated/sources/annotationProcessor/java/jcstress/io/micrometer/concurrencytests/PrometheusMeterRegistryConcurrencyTest_ConsistentTimerHistogram_jcstress.java:175: warning: [UnusedMethod] Method 'jcstress_sink' is never used.
    private void jcstress_sink(Object v) {};
                 ^
    (see https://errorprone.info/bugpattern/UnusedMethod)
  Did you mean ';'?
```

`disableWarningsInGeneratedCode` doesn't work as they are not annotated with `@Generated`. 

This PR suppresses Error Prone warnings from generated code by excluding generated source paths.