### PR TITLE
Remove redundant get() methods from "Config" classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,7 +399,11 @@ subprojects {
                     ignoreMissingClasses = true
                     includeSynthetic = true
 
-                    classExcludes = []
+                    classExcludes = [
+                            'io.micrometer.elastic.ElasticConfig',
+                            'io.micrometer.ganglia.GangliaConfig',
+                            'io.micrometer.graphite.GraphiteConfig'
+                    ]
                     compatibilityChangeExcludes = [ "METHOD_NEW_DEFAULT" ]
 
                     packageExcludes = ['io.micrometer.shaded.*', 'io.micrometer.statsd.internal']

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticConfig.java
@@ -40,14 +40,6 @@ public interface ElasticConfig extends StepRegistryConfig {
     ElasticConfig DEFAULT = k -> null;
 
     /**
-     * Get the value associated with a key.
-     * @param key Key to look up in the config.
-     * @return Value for the key or null if no key is present.
-     */
-    @Nullable
-    String get(String key);
-
-    /**
      * Property prefix to prepend to configuration names.
      * @return property prefix
      */

--- a/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaConfig.java
+++ b/implementations/micrometer-registry-ganglia/src/main/java/io/micrometer/ganglia/GangliaConfig.java
@@ -38,14 +38,6 @@ public interface GangliaConfig extends StepRegistryConfig {
     GangliaConfig DEFAULT = k -> null;
 
     /**
-     * Get the value associated with a key.
-     * @param key Key to lookup in the config.
-     * @return Value for the key or null if no key is present.
-     */
-    @Nullable
-    String get(String key);
-
-    /**
      * @return Property prefix to prepend to configuration names.
      */
     default String prefix() {

--- a/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
+++ b/implementations/micrometer-registry-graphite/src/main/java/io/micrometer/graphite/GraphiteConfig.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.graphite;
 
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.dropwizard.DropwizardConfig;
 
@@ -35,14 +34,6 @@ public interface GraphiteConfig extends DropwizardConfig {
      * Accept configuration defaults
      */
     GraphiteConfig DEFAULT = k -> null;
-
-    /**
-     * Get the value associated with a key.
-     * @param key Key to lookup in the config.
-     * @return Value for the key or null if no key is present.
-     */
-    @Nullable
-    String get(String key);
 
     /**
      * @return Property prefix to prepend to configuration names.


### PR DESCRIPTION
This PR removes redundant `get()` methods from "Config" classes.