### PR TITLE
MultiGauge doesn't work with MeterFilter.map()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -162,6 +162,25 @@ class MultiGaugeTest {
         testOverwrite("prefix.my.multi.gauge");
     }
 
+    @Test
+    void withMeterFilterIgnoreTags() {
+        registry.config().meterFilter(MeterFilter.ignoreTags("ignored"));
+
+        MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
+
+        multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "1"), 1d)));
+        assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(1d);
+
+        multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "2"), 2d)));
+        assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(1d);
+
+        multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "3"), 3d)), true);
+        assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(3d);
+    }
+
     private static class Color {
 
         final String name;


### PR DESCRIPTION
The `MultiGauge` doesn't seem to work with the `MeterFilter.ignoreTags()`.

See https://github.com/micrometer-metrics/micrometer/pull/6070/files#r2051508975