### PR TITLE
Replace Meter.Id.getTags() with cheaper alternatives

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
+++ b/implementations/micrometer-registry-dynatrace/src/main/java/io/micrometer/dynatrace/v2/DynatraceExporterV2.java
@@ -403,7 +403,7 @@ public final class DynatraceExporterV2 extends AbstractDynatraceExporter {
     private MetricLineBuilder.TypeStep createTypeStep(Meter meter) throws MetricException {
         MetricLineBuilder.TypeStep typeStep = MetricLineBuilder.create(preConfiguration)
             .metricKey(meter.getId().getName());
-        for (Tag tag : meter.getId().getTags()) {
+        for (Tag tag : meter.getId().getTagsAsIterable()) {
             typeStep.dimension(tag.getKey(), tag.getValue());
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -239,7 +239,7 @@ public interface Meter {
          * @since 1.1.0
          */
         public Id withTags(Iterable<Tag> tags) {
-            return new Id(name, Tags.concat(getTags(), tags), baseUnit, description, type);
+            return new Id(name, Tags.concat(this.tags, tags), baseUnit, description, type);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/Search.java
@@ -241,7 +241,7 @@ public final class Search {
     private boolean isRequiredTagKeysPresent(Meter.Id id) {
         if (!requiredTagKeys.isEmpty()) {
             final Set<String> tagKeys = new HashSet<>();
-            id.getTags().forEach(t -> tagKeys.add(t.getKey()));
+            id.getTagsAsIterable().forEach(t -> tagKeys.add(t.getKey()));
             return tagKeys.containsAll(requiredTagKeys);
         }
         return true;
@@ -250,7 +250,7 @@ public final class Search {
     private boolean isTagPredicatesMatched(Meter.Id id) {
         if (!tagMatches.isEmpty()) {
             final Set<String> matchingTagKeys = new HashSet<>();
-            id.getTags().forEach(t -> {
+            id.getTagsAsIterable().forEach(t -> {
                 Collection<Predicate<String>> tagValueMatchers = tagMatches.get(t.getKey());
                 if (tagValueMatchers != null) {
                     if (tagValueMatchers.stream().allMatch(matcher -> matcher.test(t.getValue()))) {


### PR DESCRIPTION
This PR replaces `Meter.Id.getTags()` with cheaper alternatives.