### PR TITLE
Check Tags instanceof check before iterator empty check in Tags.of()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -221,11 +221,14 @@ public final class Tags implements Iterable<Tag> {
      * @return a new {@code Tags} instance
      */
     public static Tags of(@Nullable Iterable<? extends Tag> tags) {
-        if (tags == null || tags == EMPTY || !tags.iterator().hasNext()) {
+        if (tags == null || tags == EMPTY) {
             return Tags.empty();
         }
         else if (tags instanceof Tags) {
             return (Tags) tags;
+        }
+        else if (!tags.iterator().hasNext()) {
+            return Tags.empty();
         }
         else if (tags instanceof Collection) {
             Collection<? extends Tag> tagsCollection = (Collection<? extends Tag>) tags;


### PR DESCRIPTION
This PR changes to check `Tags` `instanceof` check before iterator empty check in `Tags.of()` to save `ArrayIterator` creation.