### PR TITLE
Migrate commons/observation modules to jSpecify

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ subprojects {
 
     if (project.name != 'micrometer-bom') {
         tasks.withType(JavaCompile).configureEach {
+            if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
+                options.errorprone.disable(
+                        "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
+                )
+            }
             options.errorprone {
                 disableWarningsInGeneratedCode = true
                 excludedPaths = ".*/build/generated/.*"
@@ -80,11 +85,6 @@ subprojects {
                 disable(
                         "StringConcatToTextBlock" // Requires JDK 15+
                 )
-                if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
-                    disable(
-                            "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
-                    )
-                }
 
                 error("BadImport",
                         "DefaultCharset",

--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ subprojects {
                 option("NullAway:OnlyNullMarked", "true")
                 option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract")
                 option("NullAway:CheckContracts", "true")
+                option("NullAway:HandleTestAssertionLibraries", "true")
                 if (!javaLanguageVersion.canCompileOrRun(17)) {
                     // Error Prone does not work with JDK <17
                     enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -73,31 +73,37 @@ subprojects {
 
     if (project.name != 'micrometer-bom') {
         tasks.withType(JavaCompile).configureEach {
-            options.errorprone.disableWarningsInGeneratedCode = true
-            options.errorprone.excludedPaths = ".*/build/generated/.*"
-            options.errorprone.error(
-                    "BadImport",
-                    "DefaultCharset",
-                    "LongDoubleConversion",
-                    "MissingOverride",
-                    "StringCaseLocaleUsage"
-            )
-            options.errorprone.disable(
-                    "StringConcatToTextBlock" // Requires JDK 15+
-            )
+            options.errorprone {
+                disableWarningsInGeneratedCode = true
+                excludedPaths = ".*/build/generated/.*"
 
-            if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
-                options.errorprone.disable(
-                        "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
+                disable(
+                        "StringConcatToTextBlock" // Requires JDK 15+
                 )
-            }
+                if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
+                    disable(
+                            "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
+                    )
+                }
 
-            if (!javaLanguageVersion.canCompileOrRun(17)) {
-                // Error Prone does not work with JDK <17
-                options.errorprone.enabled = false
-            }
-            if (System.env.CI != null) {
-                options.errorprone.disableAllWarnings = true
+                error("BadImport",
+                        "DefaultCharset",
+                        "LongDoubleConversion",
+                        "MissingOverride",
+                        "NullAway",
+                        "StringCaseLocaleUsage"
+                )
+
+                option("NullAway:OnlyNullMarked", "true")
+                option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract")
+                option("NullAway:CheckContracts", "true")
+                if (!javaLanguageVersion.canCompileOrRun(17)) {
+                    // Error Prone does not work with JDK <17
+                    enabled = false
+                }
+                if (System.env.CI != null) {
+                    disableAllWarnings = true
+                }
             }
         }
         if ((project.name.contains('samples') && !project.name.contains('kotlin')) || project.name.contains('benchmarks')) {
@@ -105,6 +111,8 @@ subprojects {
         } else {
             apply plugin: 'java-library'
             dependencies {
+                api(libs.jspecify)
+
                 testImplementation platform(libs.junitBom)
                 testImplementation libs.junitJupiter
                 testRuntimeOnly libs.junitPlatformLauncher
@@ -139,6 +147,7 @@ subprojects {
             optionalApi libs.jsr305
             checkstyle libs.spring.javaformatCheckstyle
             errorprone(libs.errorprone)
+            errorprone(libs.nullAway)
         }
 
         tasks {

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,11 @@ subprojects {
                 option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract")
                 option("NullAway:CheckContracts", "true")
                 option("NullAway:HandleTestAssertionLibraries", "true")
+                if (javaLanguageVersion.canCompileOrRun(22)) {
+                    // see https://bugs.openjdk.org/browse/JDK-8346471
+                    // see https://github.com/uber/NullAway/wiki/JSpecify-Support
+                    option("NullAway:JSpecifyMode", "true")
+                }
                 if (!javaLanguageVersion.canCompileOrRun(17)) {
                     // Error Prone does not work with JDK <17
                     enabled = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -156,6 +156,7 @@ jmhAnnotationProcessor = { module = "org.openjdk.jmh:jmh-generator-annprocess", 
 jooq = { module = "org.jooq:jooq", version = "3.14.16" }
 jooqLatest = { module = "org.jooq:jooq", version.ref = "jooqNew" }
 jsonPath = { module = "com.jayway.jsonpath:json-path", version = "2.9.0" }
+jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 jsr107 = { module = "org.jsr107.ri:cache-ri-impl", version.ref = "jsr107" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
 junitBom = { module = "org.junit:junit-bom", version.ref = "junit" }
@@ -179,6 +180,7 @@ mockitoCore5 = { module = "org.mockito:mockito-core", version.ref = "mockito5" }
 mongoSync = { module = "org.mongodb:mongodb-driver-sync", version.ref = "mongo" }
 nettyBom = { module = "io.netty:netty-bom", version.ref = "netty" }
 newrelicApi = { module = "com.newrelic.agent.java:newrelic-api", version.ref = "newrelic-api" }
+nullAway = { module = "com.uber.nullaway:nullaway", version = "0.12.6" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 # some proto are marked alpha, hence the alpha version. metrics proto is what we use and it is marked stable
 openTelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version = "1.5.0-alpha" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,7 +180,7 @@ mockitoCore5 = { module = "org.mockito:mockito-core", version.ref = "mockito5" }
 mongoSync = { module = "org.mongodb:mongodb-driver-sync", version.ref = "mongo" }
 nettyBom = { module = "io.netty:netty-bom", version.ref = "netty" }
 newrelicApi = { module = "com.newrelic.agent.java:newrelic-api", version.ref = "newrelic-api" }
-nullAway = { module = "com.uber.nullaway:nullaway", version = "0.12.6" }
+nullAway = { module = "com.uber.nullaway:nullaway", version = "0.12.7" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 # some proto are marked alpha, hence the alpha version. metrics proto is what we use and it is marked stable
 openTelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version = "1.5.0-alpha" }

--- a/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/ImmutableKeyValue.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.common;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
@@ -15,7 +15,8 @@
  */
 package io.micrometer.common;
 
-import io.micrometer.common.lang.Nullable;
+import io.micrometer.common.lang.internal.Contract;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
@@ -192,8 +193,8 @@ public final class KeyValues implements Iterable<KeyValue> {
      * @param keyValues the key/value pairs to add, elements mustn't be null
      * @return a new {@code KeyValues} instance
      */
-    public KeyValues and(@Nullable String... keyValues) {
-        if (blankVarargs(keyValues)) {
+    public KeyValues and(String @Nullable... keyValues) {
+        if (isEmptyVarargs(keyValues)) {
             return this;
         }
         return and(KeyValues.of(keyValues));
@@ -205,8 +206,8 @@ public final class KeyValues implements Iterable<KeyValue> {
      * @param keyValues the key values to add, elements mustn't be null
      * @return a new {@code KeyValues} instance
      */
-    public KeyValues and(@Nullable KeyValue... keyValues) {
-        if (blankVarargs(keyValues)) {
+    public KeyValues and(KeyValue @Nullable... keyValues) {
+        if (isEmptyVarargs(keyValues)) {
             return this;
         }
         return and(toKeyValues(keyValues));
@@ -339,7 +340,7 @@ public final class KeyValues implements Iterable<KeyValue> {
      * @return the merged key values
      */
     public static KeyValues concat(@Nullable Iterable<? extends KeyValue> keyValues,
-            @Nullable String... otherKeyValues) {
+            String @Nullable... otherKeyValues) {
         return KeyValues.of(keyValues).and(otherKeyValues);
     }
 
@@ -395,8 +396,8 @@ public final class KeyValues implements Iterable<KeyValue> {
      * @param keyValues the key/value pairs to add, elements mustn't be null
      * @return a new {@code KeyValues} instance
      */
-    public static KeyValues of(@Nullable String... keyValues) {
-        if (blankVarargs(keyValues)) {
+    public static KeyValues of(String @Nullable... keyValues) {
+        if (isEmptyVarargs(keyValues)) {
             return empty();
         }
         if (keyValues.length % 2 == 1) {
@@ -409,7 +410,8 @@ public final class KeyValues implements Iterable<KeyValue> {
         return toKeyValues(keyValueArray);
     }
 
-    private static boolean blankVarargs(@Nullable Object[] args) {
+    @Contract("null -> true")
+    private static boolean isEmptyVarargs(@Nullable Object @Nullable [] args) {
         return args == null || args.length == 0 || (args.length == 1 && args[0] == null);
     }
 
@@ -419,7 +421,7 @@ public final class KeyValues implements Iterable<KeyValue> {
      * @param keyValues the key values to add, elements mustn't be null
      * @return a new {@code KeyValues} instance
      */
-    public static KeyValues of(@Nullable KeyValue... keyValues) {
+    public static KeyValues of(KeyValue @Nullable... keyValues) {
         return empty().and(keyValues);
     }
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotatedObject.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotatedObject.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.common.annotation;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 
@@ -31,8 +31,7 @@ class AnnotatedObject {
 
     final Annotation annotation;
 
-    @Nullable
-    final Object object;
+    final @Nullable Object object;
 
     AnnotatedObject(Annotation annotation, @Nullable Object object) {
         this.annotation = annotation;

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
@@ -16,11 +16,11 @@
 package io.micrometer.common.annotation;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/ValueExpressionResolver.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/ValueExpressionResolver.java
@@ -16,7 +16,7 @@
 package io.micrometer.common.annotation;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Resolves the {@link KeyValue} value for the given parameter and the provided

--- a/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/Contract.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/Contract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2025 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NullMarked
-package io.micrometer.common;
+package io.micrometer.common.lang.internal;
 
-import org.jspecify.annotations.NullMarked;
+import java.lang.annotation.*;
+
+/**
+ * This is for internal use only.
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface Contract {
+
+    String value() default "";
+
+}

--- a/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/package-info.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 VMware, Inc.
+ * Copyright 2025 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NullMarked
-package io.micrometer.common;
-
-import org.jspecify.annotations.NullMarked;
+package io.micrometer.common.lang.internal;

--- a/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/package-info.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/lang/internal/package-info.java
@@ -13,4 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@NullMarked
 package io.micrometer.common.lang.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-commons/src/main/java/io/micrometer/common/lang/package-info.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/lang/package-info.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.common.lang;
+
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-commons/src/main/java/io/micrometer/common/util/StringUtils.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/StringUtils.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.common.util;
 
+import io.micrometer.common.lang.internal.Contract;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -48,6 +49,7 @@ public final class StringUtils {
      * @param string String to check
      * @return {@code true} if the String has any non-whitespace character
      */
+    @Contract("null -> false")
     public static boolean isNotBlank(@Nullable String string) {
         return !isBlank(string);
     }

--- a/micrometer-commons/src/main/java/io/micrometer/common/util/StringUtils.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/StringUtils.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.common.util;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Utilities for {@link String}.

--- a/micrometer-commons/src/test/java/io/micrometer/common/KeyValuesTest.java
+++ b/micrometer-commons/src/test/java/io/micrometer/common/KeyValuesTest.java
@@ -106,6 +106,9 @@ class KeyValuesTest {
 
     // @Issue("#3851")
     @Test
+    // While we specify elements should not be null, a single null element is a common
+    // enough mistake that we handle and test for it
+    @SuppressWarnings("NullAway")
     void nullKeyValuesShouldProduceEmptyKeyValues() {
         assertThat(KeyValues.of((String) null)).isSameAs(KeyValues.empty());
     }
@@ -117,6 +120,9 @@ class KeyValuesTest {
 
     // @Issue("#3851")
     @Test
+    // While we specify elements should not be null, a single null element is a common
+    // enough mistake that we handle and test for it
+    @SuppressWarnings("NullAway")
     void nullKeyValueShouldProduceEmptyKeyValues() {
         assertThat(KeyValues.of((KeyValue) null)).isSameAs(KeyValues.empty());
     }
@@ -146,6 +152,9 @@ class KeyValuesTest {
 
     // @Issue("#3851")
     @Test
+    // While we specify elements should not be null, a single null element is a common
+    // enough mistake that we handle and test for it
+    @SuppressWarnings("NullAway")
     void concatWhenKeyValuesAreNullShouldReturnCurrentInstance() {
         KeyValues source = KeyValues.of("k", "v1");
         KeyValues concatenated = KeyValues.concat(source, (String) null);
@@ -197,6 +206,9 @@ class KeyValuesTest {
 
     // @Issue("#3851")
     @Test
+    // While we specify elements should not be null, a single null element is a common
+    // enough mistake that we handle and test for it
+    @SuppressWarnings("NullAway")
     void andKeyValuesStringArrayWhenKeyValuesAreNullShouldReturnCurrentInstance() {
         KeyValues source = KeyValues.of("t1", "v1");
         KeyValues merged = source.and((String) null);
@@ -228,6 +240,9 @@ class KeyValuesTest {
 
     // @Issue("#3851")
     @Test
+    // While we specify elements should not be null, a single null element is a common
+    // enough mistake that we handle and test for it
+    @SuppressWarnings("NullAway")
     void andKeyValuesWhenKeyValueIsNullShouldReturnCurrentInstance() {
         KeyValues source = KeyValues.of("t1", "v1");
         KeyValues merged = source.and((KeyValue) null);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -16,7 +16,7 @@
 package io.micrometer.observation;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * No-op implementation of {@link Observation} so that we can disable the instrumentation

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationConfig.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.observation;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -48,7 +50,7 @@ final class NoopObservationConfig extends ObservationRegistry.ObservationConfig 
     }
 
     @Override
-    public boolean isObservationEnabled(String name, Observation.Context context) {
+    public boolean isObservationEnabled(@Nullable String name, Observation.@Nullable Context context) {
         return false;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservationRegistry.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.observation;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * No-op implementation of {@link ObservationRegistry} so that we can disable the
  * instrumentation logic.
@@ -34,17 +36,17 @@ final class NoopObservationRegistry implements ObservationRegistry {
     }
 
     @Override
-    public Observation getCurrentObservation() {
+    public @Nullable Observation getCurrentObservation() {
         return FOR_SCOPES.getCurrentObservation();
     }
 
     @Override
-    public Observation.Scope getCurrentObservationScope() {
+    public Observation.@Nullable Scope getCurrentObservationScope() {
         return FOR_SCOPES.getCurrentObservationScope();
     }
 
     @Override
-    public void setCurrentObservationScope(Observation.Scope current) {
+    public void setCurrentObservationScope(Observation.@Nullable Scope current) {
         FOR_SCOPES.setCurrentObservationScope(current);
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -18,8 +18,8 @@ package io.micrometer.observation;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -754,7 +754,7 @@ public interface Observation extends ObservationView {
      * @return the result from {@link CheckedCallable#call()}
      */
     @SuppressWarnings("unused")
-    default <T, E extends Throwable> T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
+    default <T, E extends Throwable> @Nullable T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
         try (Scope scope = openScope()) {
             return checkedCallable.call();
         }
@@ -819,7 +819,7 @@ public interface Observation extends ObservationView {
      * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    static <T, E extends Throwable> T tryScopedChecked(@Nullable Observation parent,
+    static <T, E extends Throwable> @Nullable T tryScopedChecked(@Nullable Observation parent,
             CheckedCallable<T, E> checkedCallable) throws E {
         if (parent != null) {
             return parent.scopedChecked(checkedCallable);
@@ -852,8 +852,7 @@ public interface Observation extends ObservationView {
          * @return previously opened scope when this one was created
          * @since 1.10.8
          */
-        @Nullable
-        default Observation.Scope getPreviousObservationScope() {
+        default Observation.@Nullable Scope getPreviousObservationScope() {
             return null;
         }
 
@@ -913,6 +912,7 @@ public interface Observation extends ObservationView {
 
         private final Map<Object, Object> map = new ConcurrentHashMap<>();
 
+        @Nullable
         private String name;
 
         @Nullable
@@ -933,7 +933,7 @@ public interface Observation extends ObservationView {
          * @return name
          */
         @Override
-        public String getName() {
+        public @Nullable String getName() {
             return this.name;
         }
 
@@ -941,7 +941,7 @@ public interface Observation extends ObservationView {
          * Sets the observation name.
          * @param name observation name
          */
-        public void setName(String name) {
+        public void setName(@Nullable String name) {
             this.name = name;
         }
 
@@ -951,7 +951,7 @@ public interface Observation extends ObservationView {
          * @return contextual name
          */
         @Override
-        public String getContextualName() {
+        public @Nullable String getContextualName() {
             return this.contextualName;
         }
 
@@ -1217,12 +1217,12 @@ public interface Observation extends ObservationView {
         }
 
         @Override
-        public KeyValue getLowCardinalityKeyValue(String key) {
+        public @Nullable KeyValue getLowCardinalityKeyValue(String key) {
             return this.lowCardinalityKeyValues.get(key);
         }
 
         @Override
-        public KeyValue getHighCardinalityKeyValue(String key) {
+        public @Nullable KeyValue getHighCardinalityKeyValue(String key) {
             return this.highCardinalityKeyValues.get(key);
         }
 
@@ -1344,6 +1344,7 @@ public interface Observation extends ObservationView {
          * The observation name.
          * @return name
          */
+        @Nullable
         String getName();
 
         /**
@@ -1470,6 +1471,7 @@ public interface Observation extends ObservationView {
     @FunctionalInterface
     interface CheckedCallable<T, E extends Throwable> {
 
+        @Nullable
         T call() throws E;
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -19,6 +19,7 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.lang.NonNull;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
@@ -557,8 +558,7 @@ public interface Observation extends ObservationView {
      * @param <T> the type parameter of the {@link Supplier}
      * @return the result from {@link Supplier#get()}
      */
-    @Nullable
-    default <T> T observe(Supplier<T> supplier) {
+    default <T> @NullUnmarked T observe(Supplier<T> supplier) {
         start();
         try (Scope scope = openScope()) {
             return supplier.get();
@@ -592,8 +592,7 @@ public interface Observation extends ObservationView {
      * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    @Nullable
-    default <T, E extends Throwable> T observeChecked(CheckedCallable<T, E> checkedCallable) throws E {
+    default <T, E extends Throwable> @NullUnmarked T observeChecked(CheckedCallable<T, E> checkedCallable) throws E {
         start();
         try (Scope scope = openScope()) {
             return checkedCallable.call();
@@ -635,9 +634,8 @@ public interface Observation extends ObservationView {
      * @deprecated scheduled for removal in 1.15.0, use {@code observe(...)} directly
      */
     @SuppressWarnings({ "unused", "unchecked" })
-    @Nullable
     @Deprecated
-    default <C extends Context, T> T observeWithContext(Function<C, T> function) {
+    default <C extends Context, T> @NullUnmarked T observeWithContext(Function<C, T> function) {
         InternalLoggerFactory.getInstance(Observation.class)
             .warn("This method is deprecated. Please migrate to observation.observe(...)");
         start();
@@ -679,10 +677,9 @@ public interface Observation extends ObservationView {
      * directly
      */
     @SuppressWarnings({ "unused", "unchecked" })
-    @Nullable
     @Deprecated
-    default <C extends Context, T, E extends Throwable> T observeCheckedWithContext(CheckedFunction<C, T, E> function)
-            throws E {
+    default <C extends Context, T, E extends Throwable> @NullUnmarked T observeCheckedWithContext(
+            CheckedFunction<C, T, E> function) throws E {
         InternalLoggerFactory.getInstance(Observation.class)
             .warn("This method is deprecated. Please migrate to observation.observeChecked(...)");
         start();
@@ -736,7 +733,7 @@ public interface Observation extends ObservationView {
      * @return the result from {@link Supplier#get()}
      */
     @SuppressWarnings("unused")
-    default <T> T scoped(Supplier<T> supplier) {
+    default <T> @NullUnmarked T scoped(Supplier<T> supplier) {
         try (Scope scope = openScope()) {
             return supplier.get();
         }
@@ -754,7 +751,7 @@ public interface Observation extends ObservationView {
      * @return the result from {@link CheckedCallable#call()}
      */
     @SuppressWarnings("unused")
-    default <T, E extends Throwable> @Nullable T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
+    default <T, E extends Throwable> @NullUnmarked T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
         try (Scope scope = openScope()) {
             return checkedCallable.call();
         }
@@ -803,7 +800,7 @@ public interface Observation extends ObservationView {
      * @param action action to run
      * @return result of the action
      */
-    static <T> T tryScoped(@Nullable Observation parent, Supplier<T> action) {
+    static <T> @NullUnmarked T tryScoped(@Nullable Observation parent, Supplier<T> action) {
         if (parent != null) {
             return parent.scoped(action);
         }
@@ -819,7 +816,7 @@ public interface Observation extends ObservationView {
      * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    static <T, E extends Throwable> @Nullable T tryScopedChecked(@Nullable Observation parent,
+    static <T, E extends Throwable> @NullUnmarked T tryScopedChecked(@Nullable Observation parent,
             CheckedCallable<T, E> checkedCallable) throws E {
         if (parent != null) {
             return parent.scopedChecked(checkedCallable);
@@ -941,7 +938,7 @@ public interface Observation extends ObservationView {
          * Sets the observation name.
          * @param name observation name
          */
-        public void setName(@Nullable String name) {
+        public void setName(String name) {
             this.name = name;
         }
 
@@ -1469,9 +1466,9 @@ public interface Observation extends ObservationView {
      * A functional interface like {@link Callable} but it can throw a {@link Throwable}.
      */
     @FunctionalInterface
+    @NullUnmarked
     interface CheckedCallable<T, E extends Throwable> {
 
-        @Nullable
         T call() throws E;
 
     }
@@ -1482,9 +1479,9 @@ public interface Observation extends ObservationView {
      * @since 1.11.0
      */
     @FunctionalInterface
+    @NullUnmarked
     interface CheckedFunction<T, R, E extends Throwable> {
 
-        @Nullable
         R apply(T t) throws E;
 
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationConvention.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationConvention.java
@@ -16,7 +16,7 @@
 package io.micrometer.observation;
 
 import io.micrometer.common.KeyValues;
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Contains conventions for naming and {@link KeyValues} providing.

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationHandler.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation.Context;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -66,14 +66,13 @@ public interface ObservationRegistry {
      * method will return the current present {@link Observation.Scope}.
      * @return current observation scope or {@code null} if it's not present
      */
-    @Nullable
-    Observation.Scope getCurrentObservationScope();
+    Observation.@Nullable Scope getCurrentObservationScope();
 
     /**
      * Sets the observation scope as current.
      * @param current observation scope
      */
-    void setCurrentObservationScope(@Nullable Observation.Scope current);
+    void setCurrentObservationScope(Observation.@Nullable Scope current);
 
     /**
      * Configuration options for this registry.
@@ -175,7 +174,7 @@ public interface ObservationRegistry {
          * @param context context
          * @return {@code true} when observation is enabled
          */
-        boolean isObservationEnabled(String name, @Nullable Observation.Context context) {
+        boolean isObservationEnabled(@Nullable String name, Observation.@Nullable Context context) {
             for (ObservationPredicate predicate : this.observationPredicates) {
                 if (!predicate.test(name, context)) {
                     return false;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
@@ -15,8 +15,8 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation.ContextView;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Read only view on the {@link Observation}.
@@ -45,8 +45,7 @@ public interface ObservationView {
      * @return scope for this {@link ObservationView}, {@code null} if there was no scope
      * @since 1.10.6
      */
-    @Nullable
-    default Observation.Scope getEnclosingScope() {
+    default Observation.@Nullable Scope getEnclosingScope() {
         return Observation.Scope.NOOP;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observations.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observations.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
@@ -61,6 +61,8 @@ public final class Observations {
         return globalRegistry;
     }
 
+    // We know delegate.get() cannot be null but NullAway does not.
+    @SuppressWarnings("NullAway")
     private static final class DelegatingObservationRegistry implements ObservationRegistry {
 
         private final AtomicReference<ObservationRegistry> delegate = new AtomicReference<>(ObservationRegistry.NOOP);
@@ -73,20 +75,18 @@ public final class Observations {
             this.delegate.set(Objects.requireNonNull(delegate, "Delegate must not be null"));
         }
 
-        @Nullable
         @Override
-        public Observation getCurrentObservation() {
+        public @Nullable Observation getCurrentObservation() {
             return delegate.get().getCurrentObservation();
         }
 
-        @Nullable
         @Override
-        public Observation.Scope getCurrentObservationScope() {
+        public Observation.@Nullable Scope getCurrentObservationScope() {
             return delegate.get().getCurrentObservationScope();
         }
 
         @Override
-        public void setCurrentObservationScope(@Nullable Observation.Scope current) {
+        public void setCurrentObservationScope(Observation.@Nullable Scope current) {
             delegate.get().setCurrentObservationScope(current);
         }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observations.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observations.java
@@ -62,6 +62,7 @@ public final class Observations {
     }
 
     // We know delegate.get() cannot be null but NullAway does not.
+    // see https://github.com/uber/NullAway/issues/681
     @SuppressWarnings("NullAway")
     private static final class DelegatingObservationRegistry implements ObservationRegistry {
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -16,11 +16,12 @@
 package io.micrometer.observation;
 
 import io.micrometer.common.KeyValue;
-import io.micrometer.common.lang.Nullable;
+
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
 import java.util.Collection;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -56,7 +56,7 @@ class SimpleObservation implements Observation {
 
     final Map<Thread, Scope> lastScope = new ConcurrentHashMap<>();
 
-    SimpleObservation(@Nullable String name, ObservationRegistry registry, Context context) {
+    SimpleObservation(String name, ObservationRegistry registry, Context context) {
         this.registry = registry;
         this.context = context;
         this.context.setName(name);

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservationRegistry.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default implementation of {@link ObservationRegistry}.
@@ -31,9 +31,8 @@ class SimpleObservationRegistry implements ObservationRegistry {
 
     private final ObservationConfig observationConfig = new ObservationConfig();
 
-    @Nullable
     @Override
-    public Observation getCurrentObservation() {
+    public @Nullable Observation getCurrentObservation() {
         Observation.Scope scope = localObservationScope.get();
         if (scope != null) {
             return scope.getCurrentObservation();
@@ -47,7 +46,7 @@ class SimpleObservationRegistry implements ObservationRegistry {
     }
 
     @Override
-    public void setCurrentObservationScope(Observation.Scope current) {
+    public void setCurrentObservationScope(Observation.@Nullable Scope current) {
         localObservationScope.set(current);
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/annotation/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/annotation/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation.annotation;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.observation.aop;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.Observations;
@@ -26,6 +24,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletionStage;
@@ -74,7 +73,6 @@ import java.util.function.Predicate;
  * @since 1.10.0
  */
 @Aspect
-@NonNullApi
 public class ObservedAspect {
 
     private static final Predicate<ProceedingJoinPoint> DONT_SKIP_ANYTHING = pjp -> false;
@@ -142,7 +140,7 @@ public class ObservedAspect {
         return observe(pjp, method, observed);
     }
 
-    private Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
+    private @Nullable Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
         Observation observation = ObservedAspectObservationDocumentation.of(pjp, observed, this.registry,
                 this.observationConvention);
         if (CompletionStage.class.isAssignableFrom(method.getReturnType())) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspect.java
@@ -24,6 +24,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
@@ -117,8 +118,7 @@ public class ObservedAspect {
     }
 
     @Around("@within(io.micrometer.observation.annotation.Observed) && !@annotation(io.micrometer.observation.annotation.Observed) && execution(* *.*(..))")
-    @Nullable
-    public Object observeClass(ProceedingJoinPoint pjp) throws Throwable {
+    public @NullUnmarked Object observeClass(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {
             return pjp.proceed();
         }
@@ -129,8 +129,7 @@ public class ObservedAspect {
     }
 
     @Around("execution (@io.micrometer.observation.annotation.Observed * *.*(..))")
-    @Nullable
-    public Object observeMethod(ProceedingJoinPoint pjp) throws Throwable {
+    public @NullUnmarked Object observeMethod(ProceedingJoinPoint pjp) throws Throwable {
         if (shouldSkip.test(pjp)) {
             return pjp.proceed();
         }
@@ -140,7 +139,7 @@ public class ObservedAspect {
         return observe(pjp, method, observed);
     }
 
-    private @Nullable Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
+    private @NullUnmarked Object observe(ProceedingJoinPoint pjp, Method method, Observed observed) throws Throwable {
         Observation observation = ObservedAspectObservationDocumentation.of(pjp, observed, this.registry,
                 this.observationConvention);
         if (CompletionStage.class.isAssignableFrom(method.getReturnType())) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
@@ -17,7 +17,7 @@ package io.micrometer.observation.aop;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.docs.KeyName;
-import io.micrometer.common.lang.Nullable;
+
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.annotation.Observed;
@@ -25,6 +25,7 @@ import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;
+import org.jspecify.annotations.Nullable;
 
 import static io.micrometer.observation.aop.ObservedAspectObservationDocumentation.ObservedAspectLowCardinalityKeyName.CLASS_NAME;
 import static io.micrometer.observation.aop.ObservedAspectObservationDocumentation.ObservedAspectLowCardinalityKeyName.METHOD_NAME;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservedAspectObservationDocumentation.java
@@ -17,11 +17,10 @@ package io.micrometer.observation.aop;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.docs.KeyName;
-
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.annotation.Observed;
-import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.Signature;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation.aop;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessor.java
@@ -23,6 +23,7 @@ import io.micrometer.observation.NullObservation;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A {@link ThreadLocalAccessor} to put and restore current {@link Observation}.
@@ -49,6 +50,7 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
      */
     private ObservationRegistry observationRegistry = ObservationRegistry.create();
 
+    @SuppressWarnings("NullAway.Init")
     private static ObservationThreadLocalAccessor instance;
 
     /**
@@ -106,7 +108,7 @@ public class ObservationThreadLocalAccessor implements ThreadLocalAccessor<Obser
     }
 
     @Override
-    public Observation getValue() {
+    public @Nullable Observation getValue() {
         return observationRegistry.getCurrentObservation();
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/contextpropagation/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation.contextpropagation;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/ObservationDocumentation.java
@@ -16,8 +16,8 @@
 package io.micrometer.observation.docs;
 
 import io.micrometer.common.docs.KeyName;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.*;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -145,6 +145,7 @@ public interface ObservationDocumentation {
      * @param contextSupplier observation context supplier
      * @return observation
      */
+    @SuppressWarnings("NullAway")
     default Observation observation(ObservationRegistry registry, Supplier<Observation.Context> contextSupplier) {
         Observation observation = Observation.createNotStarted(getName(), contextSupplier, registry);
         if (getContextualName() != null) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/docs/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/docs/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation.docs;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/Propagator.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/Propagator.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Inspired by OpenZipkin Brave and OpenTelemetry. Most of the documentation is taken

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/ReceiverContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/ReceiverContext.java
@@ -15,9 +15,8 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -35,20 +34,18 @@ public class ReceiverContext<C> extends Observation.Context {
 
     private final Kind kind;
 
-    private C carrier;
+    private @Nullable C carrier;
 
-    @Nullable
-    private String remoteServiceName;
+    private @Nullable String remoteServiceName;
 
-    @Nullable
-    private String remoteServiceAddress;
+    private @Nullable String remoteServiceAddress;
 
     /**
      * Creates a new instance of {@link ReceiverContext}.
      * @param getter propagator getter
      * @param kind kind
      */
-    public ReceiverContext(@NonNull Propagator.Getter<C> getter, @NonNull Kind kind) {
+    public ReceiverContext(Propagator.Getter<C> getter, Kind kind) {
         this.getter = Objects.requireNonNull(getter, "Getter must be set");
         this.kind = Objects.requireNonNull(kind, "Kind must be set");
     }
@@ -57,11 +54,11 @@ public class ReceiverContext<C> extends Observation.Context {
      * Creates a new instance of a {@link Kind#CONSUMER} {@link ReceiverContext}.
      * @param getter propagator getter
      */
-    public ReceiverContext(@NonNull Propagator.Getter<C> getter) {
+    public ReceiverContext(Propagator.Getter<C> getter) {
         this(getter, Kind.CONSUMER);
     }
 
-    public C getCarrier() {
+    public @Nullable C getCarrier() {
         return carrier;
     }
 
@@ -81,8 +78,7 @@ public class ReceiverContext<C> extends Observation.Context {
      * Return optional name for the service from which the message is polled.
      * @return optional name for the service from which the message is polled
      */
-    @Nullable
-    public String getRemoteServiceName() {
+    public @Nullable String getRemoteServiceName() {
         return remoteServiceName;
     }
 
@@ -98,8 +94,7 @@ public class ReceiverContext<C> extends Observation.Context {
      * Return optional address for the service that will be called.
      * @return optional address for the service that will be called
      */
-    @Nullable
-    public String getRemoteServiceAddress() {
+    public @Nullable String getRemoteServiceAddress() {
         return remoteServiceAddress;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
@@ -15,8 +15,7 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context used when receiving data over the wire with confirmation to be sent to sender
@@ -37,7 +36,7 @@ public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> impl
      * @param getter propagator getter
      * @param kind kind
      */
-    public RequestReplyReceiverContext(@NonNull Propagator.Getter<C> getter, @NonNull Kind kind) {
+    public RequestReplyReceiverContext(Propagator.Getter<C> getter, Kind kind) {
         super(getter, kind);
     }
 
@@ -45,7 +44,7 @@ public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> impl
      * Creates a new instance of {@link Kind#SERVER} {@link RequestReplyReceiverContext}.
      * @param getter propagator getter
      */
-    public RequestReplyReceiverContext(@NonNull Propagator.Getter<C> getter) {
+    public RequestReplyReceiverContext(Propagator.Getter<C> getter) {
         this(getter, Kind.SERVER);
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
@@ -15,8 +15,7 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Context used when sending data over the wire with the idea that you'll wait for some
@@ -37,7 +36,7 @@ public class RequestReplySenderContext<C, RES> extends SenderContext<C> implemen
      * @param setter propagator setter
      * @param kind kind
      */
-    public RequestReplySenderContext(@NonNull Propagator.Setter<C> setter, @NonNull Kind kind) {
+    public RequestReplySenderContext(Propagator.Setter<C> setter, Kind kind) {
         super(setter, kind);
     }
 
@@ -45,7 +44,7 @@ public class RequestReplySenderContext<C, RES> extends SenderContext<C> implemen
      * Creates a new instance of a {@link Kind#CLIENT} {@link RequestReplySenderContext}.
      * @param setter propagator setter
      */
-    public RequestReplySenderContext(@NonNull Propagator.Setter<C> setter) {
+    public RequestReplySenderContext(Propagator.Setter<C> setter) {
         this(setter, Kind.CLIENT);
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Common interface for getting/setting the response object on

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/SenderContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/SenderContext.java
@@ -15,9 +15,8 @@
  */
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.NonNull;
-import io.micrometer.common.lang.Nullable;
 import io.micrometer.observation.Observation;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -48,7 +47,7 @@ public class SenderContext<C> extends Observation.Context {
      * @param setter propagator setter
      * @param kind kind
      */
-    public SenderContext(@NonNull Propagator.Setter<C> setter, @NonNull Kind kind) {
+    public SenderContext(Propagator.Setter<C> setter, Kind kind) {
         this.setter = Objects.requireNonNull(setter, "Setter must be set");
         this.kind = Objects.requireNonNull(kind, "Kind must be set");
     }
@@ -57,7 +56,7 @@ public class SenderContext<C> extends Observation.Context {
      * Creates a new instance of a {@link Kind#PRODUCER} {@link SenderContext}.
      * @param setter propagator setter
      */
-    public SenderContext(@NonNull Propagator.Setter<C> setter) {
+    public SenderContext(Propagator.Setter<C> setter) {
         this(setter, Kind.PRODUCER);
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/package-info.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/package-info.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@NonNullApi
-@NonNullFields
+@NullMarked
 package io.micrometer.observation.transport;
 
-import io.micrometer.common.lang.NonNullApi;
-import io.micrometer.common.lang.NonNullFields;
+import org.jspecify.annotations.NullMarked;

--- a/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/AllMatchingCompositeObservationHandlerTests.java
@@ -29,12 +29,14 @@ class AllMatchingCompositeObservationHandlerTests {
 
     MatchingHandler matchingHandler2 = new MatchingHandler();
 
+    Observation.Context context = new Observation.Context();
+
     @Test
     void should_run_on_start_for_all_matching_handlers() {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onStart(null);
+        allMatchingHandler.onStart(context);
 
         assertThat(this.matchingHandler.started).isTrue();
         assertThat(this.matchingHandler2.started).isTrue();
@@ -45,7 +47,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onStop(null);
+        allMatchingHandler.onStop(context);
 
         assertThat(this.matchingHandler.stopped).isTrue();
         assertThat(this.matchingHandler2.stopped).isTrue();
@@ -56,7 +58,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onError(null);
+        allMatchingHandler.onError(context);
 
         assertThat(this.matchingHandler.errored).isTrue();
         assertThat(this.matchingHandler2.errored).isTrue();
@@ -67,7 +69,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onEvent(Observation.Event.of("testEvent"), null);
+        allMatchingHandler.onEvent(Observation.Event.of("testEvent"), context);
 
         assertThat(this.matchingHandler.eventDetected).isTrue();
         assertThat(this.matchingHandler2.eventDetected).isTrue();
@@ -78,7 +80,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onScopeOpened(null);
+        allMatchingHandler.onScopeOpened(context);
 
         assertThat(this.matchingHandler.scopeOpened).isTrue();
         assertThat(this.matchingHandler2.scopeOpened).isTrue();
@@ -89,7 +91,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler(), this.matchingHandler2);
 
-        allMatchingHandler.onScopeClosed(null);
+        allMatchingHandler.onScopeClosed(context);
 
         assertThat(this.matchingHandler.scopeClosed).isTrue();
         assertThat(this.matchingHandler2.scopeClosed).isTrue();
@@ -100,7 +102,7 @@ class AllMatchingCompositeObservationHandlerTests {
         AllMatchingCompositeObservationHandler allMatchingHandler = new AllMatchingCompositeObservationHandler(
                 this.matchingHandler, this.matchingHandler2);
 
-        allMatchingHandler.onScopeReset(null);
+        allMatchingHandler.onScopeReset(context);
 
         assertThat(this.matchingHandler.scopeReset).isTrue();
         assertThat(this.matchingHandler2.scopeReset).isTrue();

--- a/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
@@ -85,6 +85,7 @@ class CurrentObservationTest {
 
         executor2.submit(() -> {
             Observation myObservation = observationMap.get("myObservation");
+            assertThat(myObservation).isNotNull();
             try (Observation.Scope scope = myObservation.openScope()) {
                 assertThat(registry.getCurrentObservation()).isSameAs(myObservation);
             }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/FirstMatchingCompositeObservationHandlerTests.java
@@ -27,12 +27,14 @@ class FirstMatchingCompositeObservationHandlerTests {
 
     MatchingHandler matchingHandler = new MatchingHandler();
 
+    Observation.Context context = new Observation.Context();
+
     @Test
     void should_run_on_start_only_for_first_matching_handler() {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onStart(null);
+        firstMatchingHandler.onStart(context);
 
         assertThat(this.matchingHandler.started).isTrue();
     }
@@ -42,7 +44,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onStop(null);
+        firstMatchingHandler.onStop(context);
 
         assertThat(this.matchingHandler.stopped).isTrue();
     }
@@ -52,7 +54,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onError(null);
+        firstMatchingHandler.onError(context);
 
         assertThat(this.matchingHandler.errored).isTrue();
     }
@@ -62,7 +64,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onEvent(Observation.Event.of("testEvent"), null);
+        firstMatchingHandler.onEvent(Observation.Event.of("testEvent"), context);
 
         assertThat(this.matchingHandler.eventDetected).isTrue();
     }
@@ -72,7 +74,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onScopeOpened(null);
+        firstMatchingHandler.onScopeOpened(context);
 
         assertThat(this.matchingHandler.scopeOpened).isTrue();
     }
@@ -82,7 +84,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onScopeClosed(null);
+        firstMatchingHandler.onScopeClosed(context);
 
         assertThat(this.matchingHandler.scopeClosed).isTrue();
     }
@@ -92,7 +94,7 @@ class FirstMatchingCompositeObservationHandlerTests {
         FirstMatchingCompositeObservationHandler firstMatchingHandler = new FirstMatchingCompositeObservationHandler(
                 new NotMatchingHandler(), this.matchingHandler, new NotMatchingHandler());
 
-        firstMatchingHandler.onScopeReset(null);
+        firstMatchingHandler.onScopeReset(context);
 
         assertThat(this.matchingHandler.scopeReset).isTrue();
     }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/NoopObservationRegistryTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/NoopObservationRegistryTests.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 class NoopObservationRegistryTests {
 
     @Test
+    @SuppressWarnings("NullAway")
     void should_respect_scopes() {
         ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
         then(observationRegistry.getCurrentObservation()).isNull();

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -17,6 +17,7 @@ package io.micrometer.observation;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import static io.micrometer.observation.Observation.NOOP;
@@ -148,7 +149,7 @@ class ObservationRegistryTest {
 
     interface MessagingConvention extends KeyValuesConvention {
 
-        KeyValue queueName(String foo);
+        KeyValue queueName(@Nullable String foo);
 
     }
 
@@ -156,7 +157,7 @@ class ObservationRegistryTest {
 
         // In our standard the queue name should be registered under "baz" tag key
         @Override
-        public KeyValue queueName(String messagePayload) {
+        public KeyValue queueName(@Nullable String messagePayload) {
             return KeyValue.of("baz", messagePayload + " bar");
         }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -149,7 +149,9 @@ class ObservationTests {
         assertThat(child.getContextView()).isSameAs(childContext);
         assertThat(parent.getContextView()).isSameAs(parentContext);
 
-        assertThat(childContext.getParentObservation().getContextView()).isSameAs(parentContext);
+        ObservationView parentObservation = childContext.getParentObservation();
+        assertThat(parentObservation).isNotNull();
+        assertThat(parentObservation.getContextView()).isSameAs(parentContext);
     }
 
     @Test

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTextPublisherTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTextPublisherTests.java
@@ -67,6 +67,8 @@ class ObservationTextPublisherTests {
     }
 
     @Test
+    // null should not be passed, but we support it for now
+    @SuppressWarnings("NullAway")
     void shouldSupportAnyContextByDefault() {
         assertThat(publisher.supportsContext(null)).isTrue();
         assertThat(publisher.supportsContext(new Observation.Context())).isTrue();

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -25,6 +25,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -216,6 +217,7 @@ class ObservationThreadLocalAccessorTests {
     }
 
     @Test
+    @SuppressWarnings("NullAway")
     void acceptsANullCurrentScopeOnRestore() {
         observationRegistry.observationConfig().observationHandler(new TracingHandler());
 
@@ -227,13 +229,14 @@ class ObservationThreadLocalAccessorTests {
         }.restore(null));
     }
 
+    @SuppressWarnings("NullAway")
     private void thenCurrentObservationHasParent(Observation parent, Observation observation) {
         then(globalObservationRegistry.getCurrentObservation()).isSameAs(observation);
         then(globalObservationRegistry.getCurrentObservation().getContextView().getParentObservation())
             .isSameAs(parent);
     }
 
-    private Scope thenCurrentScopeHasParent(Scope first) {
+    private Scope thenCurrentScopeHasParent(@Nullable Scope first) {
         Scope inScope = TracingHandler.value.get();
         then(scopeParent(inScope)).isSameAs(first);
         return inScope;
@@ -264,6 +267,7 @@ class ObservationThreadLocalAccessorTests {
         }
 
         @Override
+        @SuppressWarnings("NullAway")
         public void onScopeOpened(Observation.Context context) {
             Scope currentScope = value.get();
             Scope newScope = new Scope(currentScope, context.getName());
@@ -274,7 +278,8 @@ class ObservationThreadLocalAccessorTests {
         @Override
         public void onScopeClosed(Observation.Context context) {
             Scope scope = context.get(Scope.class);
-            scope.close();
+            if (scope != null)
+                scope.close();
             System.out.println("\ton scope close [" + context + "]. Hashcode [" + scope + "]");
         }
 
@@ -361,7 +366,7 @@ class ObservationThreadLocalAccessorTests {
         }
 
         @Override
-        public <T> T readValue(Map sourceContext, Object key) {
+        public <T> @Nullable T readValue(Map sourceContext, Object key) {
             return (T) sourceContext.get(key);
         }
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
@@ -48,11 +48,12 @@ class ObservationDocumentationTests {
     }
 
     @Test
+    @SuppressWarnings("NullAway")
     void npeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionWasNotPassedToTheFactoryMethod() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(null, mockObservationConvention,
-                Observation.Context::new, registry))
+        thenThrownBy(
+                () -> TestConventionObservation.OVERRIDDEN.observation(null, null, Observation.Context::new, registry))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("You have not provided a default convention in the Observation factory method");
     }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
@@ -35,11 +35,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 class ObservationDocumentationTests {
 
+    ObservationConvention mockObservationConvention = mock(ObservationConvention.class);
+
     @Test
     void iseShouldBeThrownWhenDocumentedObservationHasNotOverriddenDefaultConvention() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(null, null,
+        thenThrownBy(() -> TestConventionObservation.NOT_OVERRIDDEN_METHODS.observation(null, mockObservationConvention,
                 Observation.Context::new, registry))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("You've decided to use convention based naming yet this observation");
@@ -49,8 +51,8 @@ class ObservationDocumentationTests {
     void npeShouldBeThrownWhenDocumentedObservationHasOverriddenDefaultConventionButDefaultConventionWasNotPassedToTheFactoryMethod() {
         ObservationRegistry registry = observationRegistry();
 
-        thenThrownBy(
-                () -> TestConventionObservation.OVERRIDDEN.observation(null, null, Observation.Context::new, registry))
+        thenThrownBy(() -> TestConventionObservation.OVERRIDDEN.observation(null, mockObservationConvention,
+                Observation.Context::new, registry))
             .isInstanceOf(NullPointerException.class)
             .hasMessageContaining("You have not provided a default convention in the Observation factory method");
     }
@@ -63,6 +65,17 @@ class ObservationDocumentationTests {
                 Observation.Context::new, registry))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("but you have provided an incompatible one of type");
+    }
+
+    @Test
+    void whenGetNameIsNotOverridden_thenNameShouldBeTakenFromDefaultConvention() {
+        ObservationRegistry registry = observationRegistry();
+        Observation.Context context = new Observation.Context();
+
+        TestConventionObservation.OVERRIDDEN.observation(registry, () -> context).start().stop();
+
+        then(context.getName()).isEqualTo("one");
+        then(context.getContextualName()).isEqualTo("contextual");
     }
 
     @Test

--- a/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/docs/ObservationDocumentationTests.java
@@ -68,17 +68,6 @@ class ObservationDocumentationTests {
     }
 
     @Test
-    void whenGetNameIsNotOverridden_thenNameShouldBeTakenFromDefaultConvention() {
-        ObservationRegistry registry = observationRegistry();
-        Observation.Context context = new Observation.Context();
-
-        TestConventionObservation.OVERRIDDEN.observation(registry, () -> context).start().stop();
-
-        then(context.getName()).isEqualTo("one");
-        then(context.getContextualName()).isEqualTo("contextual");
-    }
-
-    @Test
     void observationShouldBeCreatedWhenObservationConventionIsOfProperType() {
         ObservationRegistry registry = observationRegistry();
         Observation.Context context = new Observation.Context();


### PR DESCRIPTION
Replaces our JSR-305-based nullability annotations with the jSpecify annotations and adds NullAway compile-time analysis of nullability issues.

This PR migrates micrometer-commons and micrometer-observation. In order to keep review manageable, it may be best to merge this before proceeding with the migration of the other modules.

### Important!
- [x] branch for `1.15.x` before merging this to `main`.

See https://github.com/micrometer-metrics/micrometer/issues/5547