### PR TITLE
Remove redundant Checkstyle checks in favor of StringCaseLocaleUsage check from Error Prone

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -46,22 +46,6 @@
             <property name="message" value="Please use AssertJ imports." />
             <property name="ignoreComments" value="true" />
         </module>
-        <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
-            <property name="id" value="toLowerCaseWithoutLocale"/>
-            <property name="format" value="\.toLowerCase\(\)"/>
-            <property name="maximum" value="0"/>
-            <property name="message"
-                      value="String.toLowerCase(Locale.ROOT) should be String.toLowerCase(Locale.ROOT)"/>
-            <property name="ignoreComments" value="true"/>
-        </module>
-        <module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
-            <property name="id" value="toUpperCaseWithoutLocale"/>
-            <property name="format" value="\.toUpperCase\(\)"/>
-            <property name="maximum" value="0"/>
-            <property name="message"
-                      value="String.toUpperCase(Locale.ROOT) should be String.toUpperCase(Locale.ROOT)"/>
-            <property name="ignoreComments" value="true"/>
-        </module>
 
         <!-- Whitespace -->
         <module name="SingleSpaceSeparator" />


### PR DESCRIPTION
This PR removes redundant Checkstyle checks in favor of the "StringCaseLocaleUsage" check from the Error Prone that provides the following warning:

```
/Users/izeye/IdeaProjects/micrometer/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java:75: warning: [StringCaseLocaleUsage] Specify a `Locale` when calling `String#to{Lower,Upper}Case`. (Note: there are multiple suggested fixes; the third may be most appropriate if you're dealing with ASCII Strings.)
                (timeUnit) -> timeUnit.toString().toLowerCase(),
                                                             ^
    (see https://errorprone.info/bugpattern/StringCaseLocaleUsage)
  Did you mean '(timeUnit) -> timeUnit.toString().toLowerCase(Locale.ROOT),' or '(timeUnit) -> timeUnit.toString().toLowerCase(Locale.getDefault()),' or '(timeUnit) -> Ascii.toLowerCase(timeUnit.toString()),'?
```

See gh-5711