### PR TITLE
Add benchmarks for basic prebuilt MeterFilter implementations

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/BenchmarkSupport.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/BenchmarkSupport.java
@@ -15,7 +15,7 @@
  */
 package io.micrometer.benchmark;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
@@ -204,7 +204,7 @@ public class BenchmarkSupport {
             .warmupTime(new TimeValue(5L, TimeUnit.SECONDS))
             // 9.5m benchmarks
             .measurementIterations(57)
-            .measurementTime(new TimeValue(5L, TimeUnit.SECONDS))
+            .measurementTime(new TimeValue(10L, TimeUnit.SECONDS))
             .mode(Mode.AverageTime)
             .timeUnit(TimeUnit.NANOSECONDS)
             .shouldDoGC(true)

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/BenchmarkSupport.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/BenchmarkSupport.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark;
+
+import io.micrometer.common.lang.Nullable;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.profile.LinuxPerfAsmProfiler;
+import org.openjdk.jmh.profile.LinuxPerfNormProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Locale;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+public class BenchmarkSupport {
+
+    // Making things deterministic
+    private static final Random RANDOM = new Random(0x5EAL);
+
+    // A generic number of test instances to use. Making sure it's small
+    // enough for L2 even for moderately sized objects, yet big enough
+    // to confuse JIT.
+    public static final int DEFAULT_POOL_SIZE = 1 << 12;
+
+    // A bitmask that would prevent an incremented number escaping
+    // DEFAULT_POOL_SIZE by a simple AND operation.
+    public static final int DEFAULT_MASK = DEFAULT_POOL_SIZE - 1;
+
+    // To prevent any kind of JIT assumption that a specific instance
+    // corresponds to a specific sample (shouldn't happen, but anyway),
+    // we need to walk them at a different rate. 2 is a bad choice,
+    // because it will discard half of the samples, but for every
+    // n = 2^k the value of 3 will be a divisor of either n + 1 or
+    // 2n + 1.
+    public static final int SAMPLE_STEP = 3;
+
+    private BenchmarkSupport() {
+    }
+
+    /**
+     * When you need to break existing patterns in an array.
+     */
+    public static <T> T[] shuffle(T[] values) {
+        for (int i = 0; i < values.length; i++) {
+            int target = RANDOM.nextInt(values.length);
+            T buffer = values[target];
+            values[target] = values[i];
+            values[i] = buffer;
+        }
+
+        return values;
+    }
+
+    /**
+     * Create a bit mask with [count] of [options] bits set. A simple method to select a
+     * combination of unique items using each bit as the presence mark for every item.
+     * @param count Number of bits to be set.
+     * @param options Number of all possible options.
+     */
+    public static BitSet selection(int count, int options) {
+        if (count > options) {
+            throw new IllegalArgumentException(
+                    "Requested count " + count + " is bigger than list of available options (" + options + ")");
+        }
+
+        if (count < 0) {
+            throw new IllegalArgumentException(
+                    "Number of selected options must be non-negative, " + count + " provided");
+        }
+
+        BitSet reply = new BitSet(options);
+
+        if (count == options) {
+            for (int i = 0; i < count; i++) {
+                reply.set(i);
+            }
+            return reply;
+        }
+
+        for (int flag = 0; flag < count; flag++) {
+            // with [remaining] positions left, we select a _disabled_
+            // bit N to install, meaning we have to pretend that all
+            // _enabled_ bits don't exist at all.
+
+            int remaining = options - flag;
+            int next = RANDOM.nextInt(remaining);
+            int skipped = 0;
+
+            for (int bit = 0; bit < options; bit++) {
+                if (reply.get(bit)) {
+                    skipped++;
+                    continue;
+                }
+
+                if (bit == skipped + next) {
+                    reply.set(bit);
+                    break;
+                }
+            }
+
+            // bit can be as much as options - 1 in the previous loop, thus >=
+            if (skipped + next >= options) {
+                String message = String.format(
+                        "Failed to set the bit: while looking to set option #%d out of total %d, disabled bit #%d should have been enabled, however, %d bits were skipped in %s",
+                        flag, options, next, skipped, reply);
+                throw new IllegalStateException(message);
+            }
+        }
+
+        return reply;
+    }
+
+    public static BitSet selection(int minimum, int maximum, int options) {
+        int count = minimum + RANDOM.nextInt(maximum - minimum + 1);
+        return selection(count, options);
+    }
+
+    public static BitSet selection(int options) {
+        return selection(RANDOM.nextInt(options + 1), options);
+    }
+
+    public static class ModeUniformDistribution {
+
+        private ModeUniformDistribution() {
+        }
+
+        /**
+         * <p>
+         * A silly mock distribution to test the reaction of the code to different input
+         * sizes. With the specified probability, the [mode] value will be returned,
+         * otherwise a value between [minimum] and [maximum] (inclusively, but without the
+         * mode) will be selected uniformly.
+         * </p>
+         *
+         * <p>
+         * The reason for not taking any nonsilly distribution is the generic case modeled
+         * here, a case with a distinct mode, but without the probability of other values
+         * falling off sharply with the distance from the mode. This allows both to see
+         * how code reacts to the position of that mode and to confuse the JIT regarding
+         * any assumptions (beyond mode value) and machinery like predictors. Using just a
+         * bell-like distribution here would either shrink the mode or reduce output to
+         * 3-5 values that would totally dominate everything else, so it requires a tight
+         * bell mixed with a uniform distribution to blend in all possibilities. This is
+         * exactly what this method does, with replacing the distribution by explicit
+         * boost for a specific value to keep things less error-prone (no one ever will
+         * plot these values or look at them in the debugger again).
+         * </p>
+         * @param minimum The minimum amount that can be selected, inclusive.
+         * @param maximum The maximum amount that can be selected, inclusive.
+         * @param mode The value that appears with increased probability.
+         * @param probability The probability of selecting the value instead of using
+         * uniform distribution.
+         * @return Value that differs from uniform distribution by a more often selected
+         * mode, according to passed probability.
+         */
+        public static int sample(int minimum, int maximum, int mode, double probability) {
+            if (mode < minimum || mode > maximum) {
+                throw new IllegalArgumentException(
+                        "Provided mode " + mode + " isn't in the min/max interval [" + minimum + ", " + maximum + "]");
+            }
+
+            if (RANDOM.nextDouble() < probability) {
+                return mode;
+            }
+
+            // excluding mode here, so upper bound is maximum, not maximum + 1
+            int selection = minimum + RANDOM.nextInt(maximum - minimum);
+
+            // compensating for absent mode
+            if (selection >= mode) {
+                return selection + 1;
+            }
+
+            return selection;
+        }
+
+    }
+
+    public static ChainedOptionsBuilder defaults() {
+        ChainedOptionsBuilder options = new OptionsBuilder().forks(1)
+            // 0.5m warmups
+            .warmupIterations(6)
+            .warmupTime(new TimeValue(5L, TimeUnit.SECONDS))
+            // 9.5m benchmarks
+            .measurementIterations(57)
+            .measurementTime(new TimeValue(5L, TimeUnit.SECONDS))
+            .mode(Mode.AverageTime)
+            .timeUnit(TimeUnit.NANOSECONDS)
+            .shouldDoGC(true)
+            .addProfiler(GCProfiler.class);
+
+        // Please forgive me
+        if (System.getProperty("os.name", "_fallback_").toLowerCase(Locale.ROOT).contains("linux")) {
+            options.addProfiler(LinuxPerfAsmProfiler.class).addProfiler(LinuxPerfNormProfiler.class);
+        }
+
+        return options;
+    }
+
+    /**
+     * Runs benchmarks in specified classes with defaults (10s iterations, 0.5m warmup,
+     * 9.5m benchmark, GC & perf profilers). As usual, be aware that defaults might not
+     * suit your case, use overrides when necessary.
+     */
+    public static void run(String[] patterns, @Nullable ChainedOptionsBuilder override) throws RunnerException {
+        ChainedOptionsBuilder options = defaults();
+
+        for (String pattern : patterns) {
+            options.include(pattern);
+        }
+
+        Options defaults = options.build();
+
+        new Runner(override == null ? defaults : override.parent(defaults).build()).run();
+    }
+
+    /**
+     * @see #run(String[], ChainedOptionsBuilder)
+     */
+    public static void run(String[] patterns) throws RunnerException {
+        run(patterns, null);
+    }
+
+    /**
+     * @see #run(String[], ChainedOptionsBuilder)
+     */
+    public static void run(Class<?>[] sources, @Nullable ChainedOptionsBuilder override) throws RunnerException {
+        String[] patterns = Arrays.stream(sources).map(Class::getCanonicalName).toArray(String[]::new);
+
+        run(patterns, override);
+    }
+
+    /**
+     * @see #run(String[], ChainedOptionsBuilder)
+     */
+    public static void run(Class<?> source, @Nullable ChainedOptionsBuilder override) throws RunnerException {
+        run(new Class<?>[] { source }, override);
+    }
+
+    /**
+     * @see #run(String[], ChainedOptionsBuilder)
+     */
+    public static void run(Class<?>... sources) throws RunnerException {
+        run(sources, null);
+    }
+
+    /**
+     * @see #run(String[], ChainedOptionsBuilder)
+     */
+    public static void run(Class<?> source) throws RunnerException {
+        run(source, null);
+    }
+
+    public static void main(String[] includes) throws RunnerException {
+        ChainedOptionsBuilder builder = defaults()
+            // Only 2m benchmarks, we're launching everything at once here
+            .measurementIterations(24)
+            .measurementTime(new TimeValue(5L, TimeUnit.SECONDS));
+
+        for (String pattern : includes) {
+            builder.include(pattern);
+        }
+
+        Options options = builder.build();
+
+        Runner runner = new Runner(options);
+
+        if (includes.length == 0) {
+            System.out.println("Specify benchmark patterns as CLI arguments");
+            runner.list();
+        }
+        else {
+            runner.run();
+        }
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/MeterBenchmarks.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/MeterBenchmarks.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.benchmark.core.instrument.config.filter.FilterBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class MeterBenchmarks {
+
+    private MeterBenchmarks() {
+    }
+
+    @Fork(value = 1)
+    @Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @State(Scope.Benchmark)
+    public static class GetTags {
+
+        private static final int COUNT = BenchmarkSupport.DEFAULT_POOL_SIZE;
+
+        private static final int MASK = BenchmarkSupport.DEFAULT_MASK;
+
+        @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+        public int mode;
+
+        private Meter.Id[] identifiers;
+
+        private int iteration;
+
+        @Setup
+        public void setUp() {
+            identifiers = FilterBenchmarkSupport.distributed(mode).limit(COUNT).toArray(Meter.Id[]::new);
+        }
+
+        @Benchmark
+        public List<Tag> baseline() {
+            return identifiers[iteration++ & MASK].getTags();
+        }
+
+        public static void main(String[] args) throws RunnerException {
+            BenchmarkSupport.run(GetTags.class);
+        }
+
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchmarkSupport.run(MeterBenchmarks.class);
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/TagsBenchmarkSupport.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/TagsBenchmarkSupport.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+public class TagsBenchmarkSupport {
+
+    public static final Random RANDOM = new Random(0x5EAL);
+
+    public static final int DEFAULT_MAXIMUM_TAG_COUNT = 64;
+
+    // 68 tags makes us able to select many different 64-element combinations
+    // Given that there are only 68 elements these tags should never leave L2
+    // It doesn't make much sense to create randomized Keys \times Values
+    // variants, as we're interested in tag combinations rather than individual
+    // tags, and also reusing the same keys would only result in them
+    // overwriting each other.
+    private static final Tag[] SAMPLES = {
+            // 1 - 8
+            Tag.of("challenge", "trivial"), Tag.of("status", "4xx"), Tag.of("error", "severe"),
+            Tag.of("exception", "recoverable"),
+
+            Tag.of("failure", "vm"), Tag.of("latency", "intolerable"), Tag.of("duration", "long"),
+            Tag.of("role", "admin"),
+
+            // 9 - 16
+            Tag.of("song", "astonishing"), Tag.of("datacenter", "moon-east-1"), Tag.of("traffic", "moderate"),
+            Tag.of("prices", "rising"),
+
+            Tag.of("cores", "32"), Tag.of("ram", "64g"), Tag.of("disk", "nvme"), Tag.of("benchmark", "boring"),
+
+            // 17 - 24
+            Tag.of("kitchen", "clean"), Tag.of("cutlery", "new"), Tag.of("salmon", "fresh"),
+            Tag.of("burger", "cheapskate"),
+
+            Tag.of("access", "restricted"), Tag.of("entrance", "cellar"), Tag.of("shoes", "slippers"),
+            Tag.of("ninja", "perfect"),
+
+            // 25 - 32
+            Tag.of("fallacy", "logical"), Tag.of("philosopher", "aristotel"), Tag.of("dining", "true"),
+            Tag.of("demonstrates", "contention"),
+
+            Tag.of("brand", "brandmann"), Tag.of("delivers", "groceries"), Tag.of("recognition", "nationwide"),
+            Tag.of("balance", "positive"),
+
+            // 33 - 40
+            Tag.of("figure", "circle"), Tag.of("corners", "zero"), Tag.of("dimensions", "two"),
+            Tag.of("domain", "geometry"),
+
+            Tag.of("quality", "720p"), Tag.of("streams", "three"), Tag.of("captions", "english"),
+            Tag.of("kbps", "1411"),
+
+            // 41 - 48
+            Tag.of("genre", "comedy"), Tag.of("format", "play"), Tag.of("location", "garden"),
+            Tag.of("characters", "mixed"),
+
+            Tag.of("delay", "hour"), Tag.of("transport", "railway"), Tag.of("compensation", "25%"),
+            Tag.of("repetition", "daily"),
+
+            // 49 - 56
+            Tag.of("magnification", "binoculars"), Tag.of("signal", "analog"), Tag.of("gamma", "wowRGB"),
+            Tag.of("light", "sun"),
+
+            Tag.of("furniture", "table"), Tag.of("standing", "true"), Tag.of("sitting", "true"), Tag.of("engines", "2"),
+
+            // 57 - 64
+            Tag.of("computer", "desktop"), Tag.of("cables", "173"), Tag.of("cpu", "2024"), Tag.of("gpu", "2021"),
+
+            Tag.of("warehouse", "narnia"), Tag.of("customer", "lion"), Tag.of("subscription", "platinum"),
+            Tag.of("interest", "magic"),
+
+            // 65 - 68
+            Tag.of("form", "2477"), Tag.of("periodicity", "yearly"), Tag.of("submission", "initial"),
+            Tag.of("history", "positive") };
+
+    public static final int COUNT = SAMPLES.length;
+
+    /**
+     * @return A random tag from the prepared set.
+     */
+    public static Tag sample() {
+        return SAMPLES[RANDOM.nextInt(SAMPLES.length)];
+    }
+
+    /**
+     * @return The preconfigured set of tags. This is a finite stream (emitting every
+     * preconfigured tag once) with a deterministic order.
+     */
+    public static Stream<Tag> samples() {
+        return Arrays.stream(SAMPLES);
+    }
+
+    /**
+     * @param mask Selection mask where every bit corresponds to a preconfigured tag.
+     * @return A container with tags selected by the bitmask.
+     */
+    public static Tags selection(BitSet mask) {
+        List<Tag> tags = new ArrayList<>();
+
+        for (int i = 0; i < SAMPLES.length; i++) {
+            if (mask.get(i)) {
+                tags.add(SAMPLES[i]);
+            }
+        }
+
+        return Tags.of(tags);
+    }
+
+    /**
+     * @return A Tags object with arbitrary number of randomly selected tags.
+     */
+    public static Tags container() {
+        return selection(BenchmarkSupport.selection(SAMPLES.length));
+    }
+
+    /**
+     * @return A Tags object with exactly [count] number of randomly selected tags.
+     */
+    public static Tags container(int count) {
+        return selection(BenchmarkSupport.selection(count, SAMPLES.length));
+    }
+
+    /**
+     * @return A Tags object with a number of randomly selected tags between [minimum] and
+     * [maximum].
+     */
+    public static Tags container(int minimum, int maximum) {
+        return selection(BenchmarkSupport.selection(minimum, maximum, SAMPLES.length));
+    }
+
+    /**
+     * @return A Tags object with a number of randomly selected tags between [minimum] and
+     * [maximum]. Probability of this number being [mode] is equal to [probability], all
+     * other variants are selected uniformly.
+     */
+    public static Tags biased(int minimum, int maximum, int mode, double probability) {
+        return container(BenchmarkSupport.ModeUniformDistribution.sample(minimum, maximum, mode, probability));
+    }
+
+    /**
+     * @return An infinite stream of Tags objects with arbitrary number of randomly
+     * selected tags.
+     */
+    public static Stream<Tags> containers() {
+        return Stream.generate(TagsBenchmarkSupport::container);
+    }
+
+    /**
+     * @return An infinite stream of Tags objects with exactly [count] number of randomly
+     * selected tags.
+     */
+    public static Stream<Tags> containers(int count) {
+        return Stream.generate(() -> container(count));
+    }
+
+    /**
+     * @return An infinite stream of Tags objects with a number of randomly selected tags
+     * between [minimum] and [maximum].
+     */
+    public static Stream<Tags> containers(int minimum, int maximum) {
+        return Stream.generate(() -> container(minimum, maximum));
+    }
+
+    /**
+     * @return An infinite stream of Tags objects with a number of randomly selected tags
+     * between [minimum] and [maximum]. Probability of this number being [mode] is equal
+     * to [probability], all other variants are selected uniformly.
+     */
+    public static Stream<Tags> distribution(int minimum, int maximum, int mode, double probability) {
+        return Stream.generate(() -> biased(minimum, maximum, mode, probability));
+    }
+
+    private TagsBenchmarkSupport() {
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/TagsBenchmarks.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/TagsBenchmarks.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TagsBenchmarks {
+
+    private static final String NULL_GENERATOR_NAME = "null";
+
+    private static final String TAGS_GENERATOR_NAME = "tags";
+
+    private static final String LIST_GENERATOR_NAME = "list";
+
+    private static final String SET_GENERATOR_NAME = "set";
+
+    private static final String ITERABLE_GENERATOR_NAME = "iterable";
+
+    private static final String[] GENERATOR_NAMES = { NULL_GENERATOR_NAME, TAGS_GENERATOR_NAME, LIST_GENERATOR_NAME,
+            SET_GENERATOR_NAME, ITERABLE_GENERATOR_NAME };
+
+    private static final String ABSENT_DOMINANT = "absent";
+
+    private static final Random RANDOM = new Random(0x5EAL);
+
+    private static final int COUNT = 1 << 10;
+
+    private static final int MASK = COUNT - 1;
+
+    private static final Supplier<Iterable<Tag>> NULL_GENERATOR = () -> null;
+
+    private static final Supplier<Iterable<Tag>> TAGS_GENERATOR = TagsBenchmarkSupport::container;
+
+    private static final Supplier<Iterable<Tag>> LIST_GENERATOR = () -> TagsBenchmarkSupport.container()
+        .stream()
+        .collect(Collectors.toList());
+
+    private static final Supplier<Iterable<Tag>> SET_GENERATOR = () -> TagsBenchmarkSupport.container()
+        .stream()
+        .collect(Collectors.toSet());
+
+    private static final Supplier<Iterable<Tag>> ITERABLE_GENERATOR = () -> TagsBenchmarkSupport.container()::iterator;
+
+    private static final Map<String, Supplier<Iterable<Tag>>> GENERATORS = new HashMap<>();
+
+    static {
+        GENERATORS.put(NULL_GENERATOR_NAME, NULL_GENERATOR);
+        GENERATORS.put(TAGS_GENERATOR_NAME, TAGS_GENERATOR);
+        GENERATORS.put(LIST_GENERATOR_NAME, LIST_GENERATOR);
+        GENERATORS.put(SET_GENERATOR_NAME, SET_GENERATOR);
+        GENERATORS.put(ITERABLE_GENERATOR_NAME, ITERABLE_GENERATOR);
+    }
+
+    private static String category(String dominant) {
+        if (Arrays.binarySearch(GENERATOR_NAMES, dominant) != -1 && RANDOM.nextDouble() < 0.9) {
+            return dominant;
+        }
+
+        return GENERATOR_NAMES[RANDOM.nextInt(GENERATOR_NAMES.length)];
+    }
+
+    private TagsBenchmarks() {
+    }
+
+    /**
+     * Evaluates performance of Tags.of() calls against different kinds of sources. Except
+     * for the actual underlying type, all inputs contain a uniformly distributed number
+     * of tags in [0..64] range. The [dominant] parameter defines the category that would
+     * occupy 90% of the samples, other will be evenly distributed in the remaining 10%.
+     */
+    @Fork(value = 1)
+    @Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @State(Scope.Benchmark)
+    public static class Of {
+
+        @Param({ ABSENT_DOMINANT, NULL_GENERATOR_NAME, TAGS_GENERATOR_NAME, LIST_GENERATOR_NAME, SET_GENERATOR_NAME,
+                ITERABLE_GENERATOR_NAME })
+        public String dominant;
+
+        private Iterable<Tag>[] samples;
+
+        private int iteration;
+
+        @SuppressWarnings("unchecked")
+        @Setup
+        public void setUp() {
+            samples = Stream.generate(() -> category(dominant))
+                .map(category -> GENERATORS.get(category).get())
+                .limit(COUNT)
+                .toArray(Iterable[]::new);
+        }
+
+        @Benchmark
+        public Tags baseline() {
+            return Tags.of(samples[iteration++ & MASK]);
+        }
+
+        public static void main(String[] args) throws RunnerException {
+            BenchmarkSupport.run(Of.class);
+        }
+
+    }
+
+    /**
+     * Evaluates performance of Tags.concat() calls against different kinds of sources.
+     * Except for the actual underlying type, all inputs contain a uniformly distributed
+     * number of tags in [0..64] range. The [dominant] parameter defines the category that
+     * would occupy 90% of the samples, other will be evenly distributed in the remaining
+     * 10%.
+     */
+    @Fork(value = 1)
+    @Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 12, time = 10, timeUnit = TimeUnit.SECONDS)
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    @State(Scope.Benchmark)
+    public static class Concat {
+
+        @Param({ ABSENT_DOMINANT, NULL_GENERATOR_NAME, TAGS_GENERATOR_NAME, LIST_GENERATOR_NAME, SET_GENERATOR_NAME,
+                ITERABLE_GENERATOR_NAME })
+        public String dominantSource;
+
+        @Param({ ABSENT_DOMINANT, NULL_GENERATOR_NAME, TAGS_GENERATOR_NAME, LIST_GENERATOR_NAME, SET_GENERATOR_NAME,
+                ITERABLE_GENERATOR_NAME })
+        public String dominantAddition;
+
+        private Iterable<Tag>[] sources;
+
+        private Iterable<Tag>[] additions;
+
+        private int source;
+
+        private int addition;
+
+        @SuppressWarnings("unchecked")
+        @Setup
+        public void setUp() {
+            sources = Stream.generate(() -> category(dominantSource))
+                .map(category -> GENERATORS.get(category).get())
+                .limit(COUNT)
+                .toArray(Iterable[]::new);
+
+            additions = Stream.generate(() -> category(dominantAddition))
+                .map(category -> GENERATORS.get(category).get())
+                .limit(COUNT)
+                .toArray(Iterable[]::new);
+        }
+
+        @Benchmark
+        public Tags baseline() {
+            int index = addition += BenchmarkSupport.SAMPLE_STEP;
+
+            return Tags.concat(sources[source++ & MASK], additions[index & MASK]);
+        }
+
+        public static void main(String[] args) throws RunnerException {
+            BenchmarkSupport.run(Concat.class,
+                    // Not the coolest thing to do, but we're dealing with 6x6 matrix
+                    new OptionsBuilder().measurementIterations(12));
+        }
+
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/FilterBenchmarkSupport.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/FilterBenchmarkSupport.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument.config.filter;
+
+import io.micrometer.benchmark.core.instrument.TagsBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tags;
+
+import java.util.stream.Stream;
+
+public class FilterBenchmarkSupport {
+
+    // A generic upper bound on the number of tags in an identifier
+    public static final double DEFAULT_MODE_PROBABILITY = 0.9;
+
+    private FilterBenchmarkSupport() {
+    }
+
+    public static Meter.Id toMeter(Tags tags) {
+        return new Meter.Id("_irrelevant_", tags, null, null, Meter.Type.COUNTER);
+    }
+
+    /**
+     * @return An identifier having between [minimum] and [maximum] tags. With
+     * [probability] it will have exactly [mode] number of tags, other options are
+     * selected evenly.
+     */
+    public static Meter.Id identifier(int minimum, int maximum, int mode, double probability) {
+        return toMeter(TagsBenchmarkSupport.biased(minimum, maximum, mode, probability));
+    }
+
+    /**
+     * @return An infinite stream of identifiers having between [minimum] and [maximum]
+     * tags. With [probability] they will have exactly [mode] number of tags, other
+     * options are selected evenly.
+     */
+    public static Stream<Meter.Id> distributed(int minimum, int maximum, int mode, double probability) {
+        return Stream.generate(() -> identifier(minimum, maximum, mode, probability));
+    }
+
+    /**
+     * @return An infinite stream of identifiers having between arbitrary number of tags.
+     * With [probability] they will have exactly [mode] number of tags, other options are
+     * selected evenly.
+     */
+    public static Stream<Meter.Id> distributed(int mode, double probability) {
+        return distributed(0, TagsBenchmarkSupport.DEFAULT_MAXIMUM_TAG_COUNT, mode, probability);
+    }
+
+    /**
+     * @return An infinite stream of identifiers having between arbitrary number of tags.
+     * With {@link #DEFAULT_MODE_PROBABILITY} they will have exactly [mode] number of
+     * tags, other options are selected evenly.
+     */
+    public static Stream<Meter.Id> distributed(int mode) {
+        return distributed(mode, DEFAULT_MODE_PROBABILITY);
+    }
+
+    /**
+     * @return Infinite stream of identifiers that have between [minimum] and [maximum]
+     * (inclusive) tags, with equal probability for every possible number.
+     */
+    public static Stream<Meter.Id> identifiers(int minimum, int maximum) {
+        return TagsBenchmarkSupport.containers(minimum, maximum).map(FilterBenchmarkSupport::toMeter);
+    }
+
+    /**
+     * @return Infinite stream of identifiers that have exactly [count] tags.
+     */
+    public static Stream<Meter.Id> identifiers(int count) {
+        return identifiers(count, count);
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterCommonTagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterCommonTagsBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument.config.filter;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.benchmark.core.instrument.TagsBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Evaluates performance of {@link MeterFilter#commonTags(Iterable)}. To simulate at least
+ * a somewhat realistic scenario and prevent false JIT assumptions, the input identifiers
+ * have an arbitrary number of tags (0 to 64), having a prominent mode of [supplied].
+ */
+// Use jvmArgsAppend = "-XX:CompileCommand=dontinline,*.Tags.*" and
+// similar wildcards if you need to check clean assembly output
+// separately from other code.
+@Fork(value = 1)
+@Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class MeterFilterCommonTagsBenchmark {
+
+    private static final int COUNT = BenchmarkSupport.DEFAULT_POOL_SIZE;
+
+    private static final int MASK = BenchmarkSupport.DEFAULT_MASK;
+
+    private static final int SAMPLE_STEP = BenchmarkSupport.SAMPLE_STEP;
+
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int supplied;
+
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int ignored;
+
+    private Meter.Id[] samples;
+
+    private MeterFilter[] instances;
+
+    private int instance;
+
+    private int sample;
+
+    @Setup
+    public void setUp() {
+        samples = FilterBenchmarkSupport.distributed(supplied).limit(COUNT).toArray(Meter.Id[]::new);
+
+        instances = TagsBenchmarkSupport.containers(ignored)
+            // Using List and not Tags to simulate the worst case
+            // scenario. We're most interested in saving the performance
+            // where it suffers most.
+            .map(tags -> tags.stream().collect(Collectors.toList()))
+            .map(MeterFilter::commonTags)
+            .limit(COUNT)
+            .toArray(MeterFilter[]::new);
+
+        // Generally unnecessary, but just to be able to simulate the
+        // benchmark in debugger if needed
+        instance = 0;
+        sample = 0;
+    }
+
+    @Benchmark
+    public Meter.Id baseline() {
+        int index = sample += SAMPLE_STEP;
+
+        return instances[instance++ & MASK].map(samples[index & MASK]);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchmarkSupport.run(MeterFilterCommonTagsBenchmark.class);
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterCommonTagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterCommonTagsBenchmark.java
@@ -51,7 +51,7 @@ public class MeterFilterCommonTagsBenchmark {
     public int supplied;
 
     @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
-    public int ignored;
+    public int commonTagCount;
 
     private Meter.Id[] samples;
 
@@ -65,7 +65,7 @@ public class MeterFilterCommonTagsBenchmark {
     public void setUp() {
         samples = FilterBenchmarkSupport.distributed(supplied).limit(COUNT).toArray(Meter.Id[]::new);
 
-        instances = TagsBenchmarkSupport.containers(ignored)
+        instances = TagsBenchmarkSupport.containers(commonTagCount)
             // Using List and not Tags to simulate the worst case
             // scenario. We're most interested in saving the performance
             // where it suffers most.

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterIgnoreTagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterIgnoreTagsBenchmark.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument.config.filter;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.benchmark.core.instrument.TagsBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Evaluates performance of {@link MeterFilter#commonTags(Iterable)}. To simulate at least
+ * a somewhat realistic scenario and prevent false JIT assumptions, the input identifiers
+ * have an arbitrary number of tags (0 to 64), having a prominent mode of [supplied].
+ */
+// Use jvmArgsAppend = "-XX:CompileCommand=dontinline,*.Tags.*" and
+// similar wildcards if you need to check clean assembly output
+// separately from other code.
+@Fork(value = 1)
+@Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class MeterFilterIgnoreTagsBenchmark {
+
+    private static final int COUNT = BenchmarkSupport.DEFAULT_POOL_SIZE;
+
+    private static final int MASK = BenchmarkSupport.DEFAULT_MASK;
+
+    private static final int SAMPLE_STEP = BenchmarkSupport.SAMPLE_STEP;
+
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int supplied;
+
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int ignored;
+
+    private Meter.Id[] samples;
+
+    private MeterFilter[] instances;
+
+    private int instance;
+
+    private int sample;
+
+    @Setup
+    public void setUp() {
+        samples = FilterBenchmarkSupport.distributed(supplied).limit(COUNT).toArray(Meter.Id[]::new);
+
+        instances = TagsBenchmarkSupport.containers(ignored)
+            .map(tags -> tags.stream().map(Tag::getKey).toArray(String[]::new))
+            .map(MeterFilter::ignoreTags)
+            .limit(COUNT)
+            .toArray(MeterFilter[]::new);
+
+        // Generally unnecessary, but just to be able to simulate the
+        // benchmark in debugger if needed
+        instance = 0;
+        sample = 0;
+    }
+
+    @Benchmark
+    public Meter.Id baseline() {
+        int index = sample += SAMPLE_STEP;
+
+        return instances[instance++ & MASK].map(samples[index & MASK]);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchmarkSupport.run(MeterFilterIgnoreTagsBenchmark.class);
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterIgnoreTagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterIgnoreTagsBenchmark.java
@@ -26,9 +26,10 @@ import org.openjdk.jmh.runner.RunnerException;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Evaluates performance of {@link MeterFilter#commonTags(Iterable)}. To simulate at least
- * a somewhat realistic scenario and prevent false JIT assumptions, the input identifiers
- * have an arbitrary number of tags (0 to 64), having a prominent mode of [supplied].
+ * Evaluates performance of {@link MeterFilter#ignoreTags(String...)}. To simulate at
+ * least a somewhat realistic scenario and prevent false JIT assumptions, the input
+ * identifiers have an arbitrary number of tags (0 to 64), having a prominent mode of
+ * [supplied].
  */
 // Use jvmArgsAppend = "-XX:CompileCommand=dontinline,*.Tags.*" and
 // similar wildcards if you need to check clean assembly output

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterRenameTagBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterRenameTagBenchmark.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument.config.filter;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.benchmark.core.instrument.TagsBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+// Use jvmArgsAppend = "-XX:CompileCommand=dontinline,*.Tags.*" and
+// similar wildcards if you need to check clean assembly output
+// separately from other code.
+@Fork(value = 1)
+@Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class MeterFilterRenameTagBenchmark {
+
+    private static final int SAMPLE_STEP = BenchmarkSupport.SAMPLE_STEP;
+
+    /**
+     * Mode of the number of supplied tags.
+     */
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int supplied;
+
+    private MeterFilter[] instances;
+
+    private Meter.Id[] samples;
+
+    private int instance;
+
+    private int sample;
+
+    private int instanceMask;
+
+    private int sampleMask;
+
+    // Having four variations will result in 1/4 probability of hitting
+    // the prefix. It is likely to be smaller in real life, but smaller
+    // values would render the difference less distinguishable.
+    // While this says "average latency will be low", the prefix
+    // matching would be positive in very specific paths that would
+    // suffer every time.
+    private static Stream<String> alphabet() {
+        return Stream.of("alfa", "bravo", "charlie", "delta");
+    }
+
+    private static Stream<String> names() {
+        // Making as many variations as possible, 4^4 = 256
+        return alphabet().flatMap(prefix -> alphabet().map(suffix -> prefix + '.' + suffix))
+            .flatMap(prefix -> alphabet().map(suffix -> prefix + '.' + suffix))
+            .flatMap(prefix -> alphabet().map(suffix -> prefix + '.' + suffix));
+    }
+
+    @Setup
+    public void setUp() {
+        instances = alphabet()
+            .flatMap(prefix -> names()
+                .map(replacement -> MeterFilter.renameTag(prefix, TagsBenchmarkSupport.sample().getKey(), replacement)))
+            .toArray(MeterFilter[]::new);
+
+        samples = names()
+            // This will blow L1, but we really need to make sure JIT doesn't
+            // see the same string going in, and we're interested mostly in the
+            // trend
+            .flatMap(name -> FilterBenchmarkSupport.distributed(supplied).limit(256).map(id -> id.withName(name)))
+            .toArray(Meter.Id[]::new);
+
+        if (Integer.bitCount(samples.length) != 1) {
+            throw new IllegalStateException("Number of samples isn't a power of 2: " + samples.length);
+        }
+
+        if (Integer.bitCount(instances.length) != 1) {
+            throw new IllegalStateException("Number of instances isn't a power of 2: " + instances.length);
+        }
+
+        // Fuzzing to prevent any kind of patterns and repeated names/tags
+        BenchmarkSupport.shuffle(samples);
+        BenchmarkSupport.shuffle(instances);
+
+        // Generally unnecessary, but just to be able to simulate the
+        // benchmark in debugger if needed
+        instance = 0;
+        sample = 0;
+
+        // this could have been a constant, but it's too easy to fail here
+        sampleMask = samples.length - 1;
+        instanceMask = instances.length - 1;
+    }
+
+    @SuppressWarnings("java:S1117")
+    @Benchmark
+    public Meter.Id baseline() {
+        int index = sample += SAMPLE_STEP;
+
+        return instances[instance++ & instanceMask].map(samples[index & sampleMask]);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchmarkSupport.run(MeterFilterRenameTagBenchmark.class);
+    }
+
+}

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterReplaceTagValuesBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/instrument/config/filter/MeterFilterReplaceTagValuesBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core.instrument.config.filter;
+
+import io.micrometer.benchmark.BenchmarkSupport;
+import io.micrometer.benchmark.core.instrument.TagsBenchmarkSupport;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.config.MeterFilter;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+// Use jvmArgsAppend = "-XX:CompileCommand=dontinline,*.Tags.*" if you
+// need to check clean filter output separately from other code.
+@Fork(value = 1)
+@Warmup(iterations = 6, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 54, time = 10, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class MeterFilterReplaceTagValuesBenchmark {
+
+    private static final int POOL_SIZE = BenchmarkSupport.DEFAULT_POOL_SIZE;
+
+    private static final int MASK = BenchmarkSupport.DEFAULT_MASK;
+
+    private static final int SAMPLE_STEP = BenchmarkSupport.SAMPLE_STEP;
+
+    @Param({ "0", "1", "2", "4", "8", "16", "32", "64" })
+    public int supplied;
+
+    private Meter.Id[] samples;
+
+    private MeterFilter[] instances;
+
+    private int instance;
+
+    private int sample;
+
+    @Setup
+    public void setUp() {
+        samples = FilterBenchmarkSupport.distributed(supplied).limit(POOL_SIZE).toArray(Meter.Id[]::new);
+
+        instances = Stream.generate(() -> {
+            String matcher = TagsBenchmarkSupport.sample().getKey();
+            String[] values = TagsBenchmarkSupport.samples().map(Tag::getValue).toArray(String[]::new);
+            BenchmarkSupport.shuffle(values);
+
+            String[] exceptions = Arrays.stream(values)
+                // 1/4 chance to hit an exception
+                .limit(TagsBenchmarkSupport.COUNT / 4)
+                .toArray(String[]::new);
+
+            BenchmarkSupport.shuffle(exceptions);
+            return MeterFilter.replaceTagValues(matcher, any -> TagsBenchmarkSupport.sample().getValue(), exceptions);
+        }).limit(POOL_SIZE).toArray(MeterFilter[]::new);
+
+        // Generally unnecessary, but just to be able to simulate the
+        // benchmark in debugger if needed
+        instance = 0;
+        sample = 0;
+    }
+
+    @Benchmark
+    public Meter.Id baseline() {
+        int index = sample += SAMPLE_STEP;
+
+        return instances[instance++ & MASK].map(samples[index & MASK]);
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        BenchmarkSupport.run(MeterFilterReplaceTagValuesBenchmark.class);
+    }
+
+}


### PR DESCRIPTION
# What is this?

This PR contains only benchmarks for some basic API, MeterFilter implementations and a couple of Tags methods - no new symbols visible for users, no changes in production code. It goes a bit extra by exploiting different inputs so that different usage patterns would be evaluated and "better at this count, yet worse at that count" situations had less chance of getting unnoticed (assuming that whoever works on improving performance of specific code part runs these benchmarks prior to and after the changes).

# Is it really needed?

I'm prepping other PRs for some non-dramatic updates in filters and tags code (also no new symbols or new functionality, but changing the existing one preserving the present functionality), so these benchmarks just had to emerge. It's not up to me to decide if they are needed in the project, but they came up naturally and they shouldn't take any resources from anyone except for the time from people explicitly running them, so i don't see an obstacle here.

But at the same time i'm just having fun, so i don't have a problem with any requested changes or removals.

# There are already benchmarks for tags!

Yes, but: 1) i've noticed them just when i was preparing this PR, 2) they use static input (which also comes with a fixed size). I don't have any energy to check the assembly, but JIT theoretically might infer wrong assumptions from that; i also think that dynamic input size is a must here, as the whole sort-the-array story is non-linear from the very beginning. Not sure what do with these, but you can guide me.

# Aren't these benchmarks too sophisticated?

They are sophisticated, but not "too" for me; they aren't entirely necessary, but since they are coming for free and doing the more thorough matrix evaluation, i see this as a benefit. But i'm farming my XP here, so if there's a concern against checking these in, i'm OK with it.

# Any interesting results?

These are just the baseline measurements, i.e. they exist to compare two different revisions. There are some hints on the situations that can be improved. Selecting the biggest offender (using Intel N100 @ 2GHz) for a dramatic effect:

| name | ignored tags | tags in identifier | result | unit|
|:--|:--|:--|:--|:---|
| config.filter.MeterFilterIgnoreTagsBenchmark.baseline | 64 | 64 | 8439.085 ±  7.119 | ns/op |
| config.filter.MeterFilterIgnoreTagsBenchmark.baseline:instructions:u | 64 | 64 | 38896.080 | #/op |

Thing's happening here is just taking ~64 elements (there are many samples, _most_ of which have 64 tags) and filter out the ones that match a set of 64 keys. While here it comes at 8.4usec, this could be just an O(n) task executing in a matter of a couple of hundreds of nanoseconds. My forthcoming PRs would somewhat address things like that (being honest: this is the biggest offender, other places are not so impressive), but getting to the best position would require #6113.