### PR TITLE
Handle StringCaseLocaleUsage as error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ subprojects {
         tasks.withType(JavaCompile).configureEach {
             options.errorprone.disableWarningsInGeneratedCode = true
             options.errorprone.excludedPaths = ".*/build/generated/.*"
+            options.errorprone.error("StringCaseLocaleUsage")
 
             if (!javaLanguageVersion.canCompileOrRun(17)) {
                 // Error Prone does not work with JDK <17


### PR DESCRIPTION
This PR changes to handle the "StringCaseLocaleUsage" as an error that causes a build to fail.

See https://github.com/micrometer-metrics/micrometer/pull/6163#issuecomment-2829280017