### PR TITLE
Resolve DefaultCharset from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,12 @@ subprojects {
         tasks.withType(JavaCompile).configureEach {
             options.errorprone.disableWarningsInGeneratedCode = true
             options.errorprone.excludedPaths = ".*/build/generated/.*"
-            options.errorprone.error("StringCaseLocaleUsage")
+            options.errorprone.error(
+                    "BadImport",
+                    "DefaultCharset",
+                    "MissingOverride",
+                    "StringCaseLocaleUsage"
+            )
 
             if (!javaLanguageVersion.canCompileOrRun(17)) {
                 // Error Prone does not work with JDK <17

--- a/docs/src/test/java/io/micrometer/docs/observation/messaging/ObservationMessagingIntegrationTest.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/messaging/ObservationMessagingIntegrationTest.java
@@ -179,7 +179,7 @@ class ObservationMessagingIntegrationTest {
                 // This is a very naive approach that takes the first ConsumerRecord
                 Header header = carrier.iterator().next().headers().lastHeader(key);
                 if (header != null) {
-                    return new String(header.value());
+                    return new String(header.value(), StandardCharsets.UTF_8);
                 }
                 return null;
             });

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceConfigTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -311,7 +312,7 @@ class DynatraceConfigTest {
 
         Files.write(tempFile, ("DT_METRICS_INGEST_URL = https://your-dynatrace-ingest-url/api/v2/metrics/ingest\n"
                 + "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN")
-            .getBytes());
+            .getBytes(StandardCharsets.UTF_8));
 
         DynatraceFileBasedConfigurationProvider.getInstance()
             .forceOverwriteConfig(tempFile.toString(), Duration.ofMillis(50));
@@ -333,7 +334,7 @@ class DynatraceConfigTest {
 
         Files.write(tempFile, ("DT_METRICS_INGEST_URL = https://a-different-url/api/v2/metrics/ingest\n"
                 + "DT_METRICS_INGEST_API_TOKEN = A.DIFFERENT.TOKEN")
-            .getBytes());
+            .getBytes(StandardCharsets.UTF_8));
 
         await().atMost(1_000, MILLISECONDS).until(() -> config.apiToken().equals("A.DIFFERENT.TOKEN"));
         assertThat(config.uri()).isEqualTo("https://a-different-url/api/v2/metrics/ingest");

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -760,9 +761,11 @@ class DynatraceExporterV2Test {
         final String firstUri = baseUri + "first";
         final String secondUri = baseUri + "second";
 
-        Files.write(tempFile, ("DT_METRICS_INGEST_URL = " + firstUri + "\n"
-                + "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.FIRST")
-            .getBytes());
+        Files
+            .write(tempFile,
+                    ("DT_METRICS_INGEST_URL = " + firstUri + "\n"
+                            + "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.FIRST")
+                        .getBytes(StandardCharsets.UTF_8));
 
         DynatraceFileBasedConfigurationProvider.getInstance()
             .forceOverwriteConfig(tempFile.toString(), Duration.ofMillis(50));
@@ -786,9 +789,10 @@ class DynatraceExporterV2Test {
         clock.add(config.step());
 
         // overwrite the file content to use the second uri
-        Files.write(tempFile, ("DT_METRICS_INGEST_URL = " + secondUri + "\n"
-                + "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.SECOND")
-            .getBytes());
+        Files.write(tempFile,
+                ("DT_METRICS_INGEST_URL = " + secondUri + "\n"
+                        + "DT_METRICS_INGEST_API_TOKEN = YOUR.DYNATRACE.TOKEN.SECOND")
+                    .getBytes(StandardCharsets.UTF_8));
 
         await().atMost(1_000, MILLISECONDS).until(() -> config.uri().equals(secondUri));
         exporter.export(Collections.singletonList(counter));

--- a/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
+++ b/implementations/micrometer-registry-new-relic/src/test/java/io/micrometer/newrelic/NewRelicMeterRegistryTest.java
@@ -24,6 +24,7 @@ import io.micrometer.core.ipc.http.HttpSender;
 import io.micrometer.newrelic.NewRelicMeterRegistryTest.MockNewRelicAgent.MockNewRelicInsights;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -612,7 +613,7 @@ class NewRelicMeterRegistryTest {
 
         apiProvider.sendEvents(apiProvider.writeGauge(gauge));
 
-        assertThat(new String(mockHttpClient.getRequest().getEntity())).contains(
+        assertThat(new String(mockHttpClient.getRequest().getEntity(), StandardCharsets.UTF_8)).contains(
                 "{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\"}");
 
         // test meterNameEventTypeEnabledConfig = true
@@ -624,7 +625,7 @@ class NewRelicMeterRegistryTest {
 
         apiProvider.sendEvents(apiProvider.writeGauge(gauge));
 
-        assertThat(new String(mockHttpClient.getRequest().getEntity()))
+        assertThat(new String(mockHttpClient.getRequest().getEntity(), StandardCharsets.UTF_8))
             .contains("{\"eventType\":\"myGauge2\",\"value\":1}");
     }
 
@@ -679,7 +680,7 @@ class NewRelicMeterRegistryTest {
         registry.publish();
 
         // should send a batch of multiple in one json payload
-        assertThat(new String(mockHttpClient.getRequest().getEntity())).contains(
+        assertThat(new String(mockHttpClient.getRequest().getEntity(), StandardCharsets.UTF_8)).contains(
                 "[{\"eventType\":\"MicrometerSample\",\"value\":2,\"metricName\":\"otherGauge\",\"metricType\":\"GAUGE\"},"
                         + "{\"eventType\":\"MicrometerSample\",\"value\":1,\"metricName\":\"myGauge\",\"metricType\":\"GAUGE\",\"theTag\":\"theValue\"}]");
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -41,6 +41,7 @@ import io.prometheus.metrics.tracer.common.SpanContext;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -133,7 +134,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
             scrape(outputStream, contentType);
-            return outputStream.toString();
+            return outputStream.toString(StandardCharsets.UTF_8.name());
         }
         catch (IOException e) {
             // This should not happen during writing a ByteArrayOutputStream
@@ -179,7 +180,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
             scrape(outputStream, contentType, includedNames);
-            return outputStream.toString();
+            return outputStream.toString(StandardCharsets.UTF_8.name());
         }
         catch (IOException e) {
             // This should not happen during writing a ByteArrayOutputStream

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryIntegrationTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryIntegrationTest.java
@@ -35,6 +35,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -277,9 +278,9 @@ class PrometheusMeterRegistryIntegrationTest {
             String response = registry.scrape(acceptHeader);
 
             httpExchange.getResponseHeaders().add("Content-Type", contentType);
-            httpExchange.sendResponseHeaders(200, response.getBytes().length);
+            httpExchange.sendResponseHeaders(200, response.getBytes(StandardCharsets.UTF_8).length);
             try (OutputStream outputStream = httpExchange.getResponseBody()) {
-                outputStream.write(response.getBytes());
+                outputStream.write(response.getBytes(StandardCharsets.UTF_8));
             }
         });
         new Thread(server::start).start();

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/BufferingFlux.java
@@ -18,6 +18,7 @@ package io.micrometer.statsd.internal;
 import reactor.core.publisher.DirectProcessor;
 import reactor.core.publisher.Flux;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -45,7 +46,7 @@ public class BufferingFlux {
     public static Flux<String> create(final Flux<String> source, final String delimiter, final int maxByteArraySize,
             final long maxMillisecondsBetweenEmits) {
         return Flux.defer(() -> {
-            final int delimiterSize = delimiter.getBytes().length;
+            final int delimiterSize = delimiter.getBytes(StandardCharsets.UTF_8).length;
             final AtomicInteger byteSize = new AtomicInteger();
             final AtomicLong lastTime = new AtomicLong();
 
@@ -62,7 +63,7 @@ public class BufferingFlux {
                 .mergeWith(heartbeat);
 
             return sourceWithEmptyStringKeepAlive.bufferUntil(line -> {
-                final int bytesLength = line.getBytes().length;
+                final int bytesLength = line.getBytes(StandardCharsets.UTF_8).length;
                 final long now = System.currentTimeMillis();
                 // Update last time to now if this is the first time
                 lastTime.compareAndSet(0, now);

--- a/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/ipc/http/HttpSender.java
@@ -120,7 +120,7 @@ public interface HttpSender {
                 printed.append("<no request body>");
             }
             else {
-                printed.append(new String(entity));
+                printed.append(new String(entity, StandardCharsets.UTF_8));
             }
             return printed.toString();
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -44,6 +44,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -150,7 +151,7 @@ class TomcatMetricsTest {
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("yes".getBytes());
+                resp.getOutputStream().write("yes".getBytes(StandardCharsets.UTF_8));
             }
         };
 
@@ -183,7 +184,7 @@ class TomcatMetricsTest {
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("yes".getBytes());
+                resp.getOutputStream().write("yes".getBytes(StandardCharsets.UTF_8));
             }
         };
 
@@ -217,7 +218,7 @@ class TomcatMetricsTest {
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("yes".getBytes());
+                resp.getOutputStream().write("yes".getBytes(StandardCharsets.UTF_8));
             }
         }, new HttpServlet() {
             @Override
@@ -225,7 +226,7 @@ class TomcatMetricsTest {
                     throws ServletException, IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("hi".getBytes());
+                resp.getOutputStream().write("hi".getBytes(StandardCharsets.UTF_8));
             }
         });
 
@@ -277,7 +278,7 @@ class TomcatMetricsTest {
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("yes".getBytes());
+                resp.getOutputStream().write("yes".getBytes(StandardCharsets.UTF_8));
             }
         }, new HttpServlet() {
             @Override
@@ -285,7 +286,7 @@ class TomcatMetricsTest {
                     throws ServletException, IOException {
                 IOUtils.toString(req.getInputStream());
                 sleep();
-                resp.getOutputStream().write("hi".getBytes());
+                resp.getOutputStream().write("hi".getBytes(StandardCharsets.UTF_8));
             }
         });
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/util/IOUtilsTest.java
@@ -33,7 +33,7 @@ class IOUtilsTest {
     void testToString() {
         String expected = "This is a sample.";
 
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes());
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(expected.getBytes(StandardCharsets.UTF_8));
 
         assertThat(IOUtils.toString(inputStream)).isEqualTo(expected);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/testsupport/system/OutputCapture.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/testsupport/system/OutputCapture.java
@@ -21,6 +21,7 @@ import org.springframework.util.Assert;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -260,7 +261,7 @@ class OutputCapture implements CapturedOutput {
 
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            this.copy.accept(new String(b, off, len));
+            this.copy.accept(new String(b, off, len, StandardCharsets.UTF_8));
             this.systemStream.write(b, off, len);
         }
 

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
@@ -64,6 +64,7 @@ import io.micrometer.wavefront.WavefrontMeterRegistry;
 
 import java.io.*;
 import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 public class SampleRegistries {
@@ -118,7 +119,7 @@ public class SampleRegistries {
                 String response = prometheusRegistry.scrape();
                 httpExchange.sendResponseHeaders(200, response.length());
                 OutputStream os = httpExchange.getResponseBody();
-                os.write(response.getBytes());
+                os.write(response.getBytes(StandardCharsets.UTF_8));
                 os.close();
             });
 


### PR DESCRIPTION
This PR tries to resolve the ["DefaultCharset"](https://errorprone.info/bugpattern/DefaultCharset) warnings from the Error Prone.

This PR also changes to handle "BadImport", "DefaultCharset", and "MissingOverride" as errors.

See gh-6143
See gh-6154