### PR TITLE
Use snapshot consistently in AppOpticsMeterRegistry.writeSummary()

### DIFF
--- a/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
+++ b/implementations/micrometer-registry-appoptics/src/main/java/io/micrometer/appoptics/AppOpticsMeterRegistry.java
@@ -238,10 +238,10 @@ public class AppOpticsMeterRegistry extends StepMeterRegistry {
 
     private Optional<String> writeSummary(DistributionSummary summary) {
         HistogramSnapshot snapshot = summary.takeSnapshot();
-        if (snapshot.count() > 0) {
-            return Optional
-                .of(write(summary.getId(), "distributionSummary", Fields.Count.tag(), decimal(summary.count()),
-                        Fields.Sum.tag(), decimal(summary.totalAmount()), Fields.Max.tag(), decimal(summary.max())));
+        long count = snapshot.count();
+        if (count > 0) {
+            return Optional.of(write(summary.getId(), "distributionSummary", Fields.Count.tag(), decimal(count),
+                    Fields.Sum.tag(), decimal(snapshot.total()), Fields.Max.tag(), decimal(snapshot.max())));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
This PR changes to use snapshot consistently in `AppOpticsMeterRegistry.writeSummary()`.