### PR TITLE
TimedHandler shutdown hanging indefinitely

### DIFF
--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
@@ -135,6 +135,8 @@ public class TimedHandler extends EventsHandler implements Graceful {
         request.removeAttribute(SAMPLE_REQUEST_LONG_TASK_TIMER_ATTRIBUTE);
 
         requestSample.stop();
+
+        shutdown.check();
     }
 
     private void beginHandlerTiming(Request request) {

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
@@ -25,7 +25,6 @@ import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -166,13 +165,11 @@ class TimedHandlerTest {
 
             // initiate a shutdown
             Future<Void> shutdownFuture = timedHandler.shutdown();
-            Graceful.Shutdown shutdown = timedHandler.getShutdown();
             assertThat(shutdownFuture.isDone()).isFalse();
 
             // delay half what the handler is sleeping
             Thread.sleep(delay / 2);
             // response is still active, so don't shutdown.
-            shutdown.check();
             assertThat(shutdownFuture.isDone()).isFalse();
 
             // Read response to ensure it is done
@@ -181,7 +178,6 @@ class TimedHandlerTest {
             assertThat(response1.getContent()).isEmpty();
 
             Thread.sleep(delay);
-            shutdown.check();
             assertThat(shutdownFuture.isDone()).isTrue();
         }
     }


### PR DESCRIPTION
the future returned by `io.micrometer.jetty12.server.TimedHandler.shutdown()` would never complete if `shutdown()` is called while requests are still active, even after all active requests are completed.

this change fixes the issue by calling `shutdown.check()` after completing each request.

an `if (shutdown.isShutdown())` could be introduced before `shutdown.check()` for clarity, but since the current implementation of `check()` effectively does this already, i felt it wasn't worth it.
