### PR TITLE
Disable StringConcatToTextBlock warnings from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ subprojects {
                     "MissingOverride",
                     "StringCaseLocaleUsage"
             )
+            options.errorprone.disable(
+                    "StringConcatToTextBlock"
+            )
 
             if (!javaLanguageVersion.canCompileOrRun(17)) {
                 // Error Prone does not work with JDK <17


### PR DESCRIPTION
This PR changes to disable `StringConcatToTextBlock` warnings from Error Prone as there are 43 occurences that are not applicable.