### PR TITLE
Fix JavaDurationGetSecondsToToSeconds warnings for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,14 @@ subprojects {
                     "StringCaseLocaleUsage"
             )
             options.errorprone.disable(
-                    "StringConcatToTextBlock"
+                    "StringConcatToTextBlock" // Requires JDK 15+
             )
+
+            if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
+                options.errorprone.disable(
+                        "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
+                )
+            }
 
             if (!javaLanguageVersion.canCompileOrRun(17)) {
                 // Error Prone does not work with JDK <17

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -292,7 +292,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
 
         stepOverNStep(1);
         ds.record(4);
-        clock.addSeconds(otlpConfig().step().getSeconds() - 5);
+        clock.addSeconds(otlpConfig().step().toSeconds() - 5);
 
         metric = writeToMetric(ds);
         assertHistogram(writeToMetric(ds), TimeUnit.MINUTES.toNanos(2), TimeUnit.MINUTES.toNanos(3), BaseUnits.BYTES, 1,
@@ -365,7 +365,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         Function<Meter, NumberDataPoint> getDataPoint = (meter) -> writeToMetric(meter).getSum().getDataPoints(0);
         assertThat(getDataPoint.apply(counter).getStartTimeUnixNano()).isEqualTo(0);
         assertThat(getDataPoint.apply(counter).getTimeUnixNano()).isEqualTo(60000000000L);
-        clock.addSeconds(otlpConfig().step().getSeconds() - 1);
+        clock.addSeconds(otlpConfig().step().toSeconds() - 1);
         assertThat(getDataPoint.apply(counter).getStartTimeUnixNano()).isEqualTo(0);
         assertThat(getDataPoint.apply(counter).getTimeUnixNano()).isEqualTo(60000000000L);
         clock.addSeconds(1);
@@ -407,7 +407,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         assertThat(writeToMetric(functionTimer).getHistogram().getDataPoints(0).getSum()).isEqualTo(16);
         assertThat(writeToMetric(functionTimer).getHistogram().getDataPoints(0).getCount()).isEqualTo(16);
 
-        clock.addSeconds(otlpConfig().step().getSeconds() / 2);
+        clock.addSeconds(otlpConfig().step().toSeconds() / 2);
         // pollMeters should be idempotent within a time window
         registry.pollMetersToRollover();
         assertSum(writeToMetric(counter), TimeUnit.MINUTES.toNanos(1), TimeUnit.MINUTES.toNanos(2), 1);
@@ -415,7 +415,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         assertThat(writeToMetric(functionTimer).getHistogram().getDataPoints(0).getSum()).isEqualTo(16);
         assertThat(writeToMetric(functionTimer).getHistogram().getDataPoints(0).getCount()).isEqualTo(16);
 
-        clock.addSeconds(otlpConfig().step().getSeconds() / 2);
+        clock.addSeconds(otlpConfig().step().toSeconds() / 2);
         registry.pollMetersToRollover();
         assertSum(writeToMetric(counter), TimeUnit.MINUTES.toNanos(2), TimeUnit.MINUTES.toNanos(3), 10);
         assertThat(writeToMetric(functionCounter).getSum().getDataPoints(0).getAsDouble()).isEqualTo(10);

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -331,7 +331,7 @@ abstract class OtlpMeterRegistryTest {
     }
 
     protected void stepOverNStep(int numStepsToSkip) {
-        clock.addSeconds(otlpConfig().step().getSeconds() * numStepsToSkip);
+        clock.addSeconds(otlpConfig().step().toSeconds() * numStepsToSkip);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
This PR fixes "JavaDurationGetSecondsToToSeconds" warnings for tests.

This PR also disables "JavaDurationGetSecondsToToSeconds" warnings for tasks that are not applicable.