### PR TITLE
Add missing colons in "Environment" section in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,8 +13,8 @@ A clear and concise description of what the bug is.
 **Environment**
 <!-- In what environment did the bug happen? -->
 <!-- If you are not using the latest patch version of a supported Micrometer line, please upgrade to see if the issue happens on the latest patch version for that line (e.g. 1.6.x). See https://micrometer.io/support/ -->
- - Micrometer version [e.g. 1.7.1]
- - Micrometer registry [e.g. prometheus]
+ - Micrometer version: [e.g. 1.7.1]
+ - Micrometer registry: [e.g. prometheus]
  - OS: [e.g. macOS]
  - Java version: [e.g. output of `java -version`]
 


### PR DESCRIPTION
This PR adds missing colons in the "Environment" section in the `bug_report.md`.