### PR TITLE
Do not register error on gRPC client cancel

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientCallListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/grpc/ObservationGrpcClientCallListener.java
@@ -51,7 +51,8 @@ class ObservationGrpcClientCallListener<RespT> extends SimpleForwardingClientCal
         GrpcClientObservationContext context = (GrpcClientObservationContext) this.observation.getContext();
         context.setStatusCode(status.getCode());
         context.setTrailers(trailers);
-        if (status.getCause() != null) {
+        if (!Status.Code.OK.equals(status.getCode()) && !Status.Code.CANCELLED.equals(status.getCode())
+                && status.getCause() != null) {
             observation.error(status.getCause());
         }
         this.observation.stop();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -339,6 +339,28 @@ class GrpcObservationTest {
             verifyHeaders();
         }
 
+        @Test
+        void cancelledRpc() {
+            SimpleServiceBlockingStub stub = SimpleServiceGrpc.newBlockingStub(channel);
+
+            SimpleRequest request = SimpleRequest.newBuilder().setRequestMessage("Hello").build();
+            io.grpc.Context.CancellableContext context = io.grpc.Context.current().withCancellation();
+            context.cancel(new RuntimeException("Cancelled!"));
+            assertThatExceptionOfType(StatusRuntimeException.class)
+                .isThrownBy(() -> context.run(() -> stub.unaryRpc(request)));
+
+            verifyClientContext("grpc.testing.SimpleService", "UnaryRpc", "grpc.testing.SimpleService/UnaryRpc",
+                    MethodType.UNARY);
+            assertThat(clientHandler.getContext().getStatusCode()).isEqualTo(Code.CANCELLED);
+            assertThat(clientHandler.getEvents()).containsExactly(GrpcClientEvents.MESSAGE_SENT);
+
+            TestObservationRegistryAssert.assertThat(observationRegistry).hasAnObservation(observationContextAssert -> {
+                observationContextAssert.doesNotHaveError();
+                observationContextAssert.hasNameEqualTo("grpc.client");
+                assertCommonKeyValueNames(observationContextAssert);
+            });
+        }
+
         private StreamObserver<SimpleResponse> createResponseObserver(List<String> messages, AtomicBoolean completed) {
             return new StreamObserver<>() {
 


### PR DESCRIPTION
Currently a gRPC client cancellation will be registered as an error but a cancellation is not an error.
This change makes it so that OK and CANCELLED statuses are not registered as errors.
Closes #6261