### PR TITLE
Make KafkaMetrics class public

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetrics.java
@@ -23,8 +23,11 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
 
 /**
  * Kafka Client metrics binder. This should be closed on application shutdown to clean up
@@ -139,6 +142,40 @@ public class KafkaClientMetrics extends KafkaMetrics {
      */
     public KafkaClientMetrics(AdminClient adminClient) {
         super(adminClient::metrics);
+    }
+
+    /**
+     * Kafka client metrics binder
+     * @param metricsSupplier supplier of metrics, make sure this comes from the Java
+     * Kafka Client because {@link KafkaClientMetrics} heavily depends on the behavior of
+     * the Java Kafka Client
+     */
+    public KafkaClientMetrics(Supplier<Map<MetricName, ? extends Metric>> metricsSupplier) {
+        super(metricsSupplier);
+    }
+
+    /**
+     * Kafka client metrics binder
+     * @param metricsSupplier supplier of metrics, make sure this comes from the Java
+     * Kafka Client because {@link KafkaClientMetrics} heavily depends on the behavior of
+     * the Java Kafka Client
+     * @param tags additional tags
+     */
+    public KafkaClientMetrics(Supplier<Map<MetricName, ? extends Metric>> metricsSupplier, Iterable<Tag> tags) {
+        super(metricsSupplier, tags);
+    }
+
+    /**
+     * Kafka client metrics binder
+     * @param metricsSupplier supplier of metrics, make sure this comes from the Java
+     * Kafka Client because {@link KafkaClientMetrics} heavily depends on the behavior of
+     * the Java Kafka Client
+     * @param tags additional tags
+     * @param scheduler custom scheduler to check and bind metrics
+     */
+    public KafkaClientMetrics(Supplier<Map<MetricName, ? extends Metric>> metricsSupplier, Iterable<Tag> tags,
+            ScheduledExecutorService scheduler) {
+        super(metricsSupplier, tags, scheduler);
     }
 
 }


### PR DESCRIPTION
`KafkaMetrics` class is currently _package private_. Making this public will enable using it in cases where constructing `KafkaClientMetrics` nor `KafkaConsumerMetrics` is a viable option.

Specifically, when using fs2-kafka (a Scala library), where the access to the underlying Java Producer/Consumer isn't viable.

But the constructor of `KafkaMetrics` can be satisfied even with fs2-kafka.