### PR TITLE
Resolve StringSplitter from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,8 @@ subprojects {
                     "InlineFormatString",
                     "LongDoubleConversion",
                     "MissingOverride",
-                    "StringCaseLocaleUsage"
+                    "StringCaseLocaleUsage",
+                    "StringSplitter"
             )
             options.errorprone.disable(
                     "StringConcatToTextBlock" // Requires JDK 15+

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -1258,14 +1258,14 @@ class DynatraceExporterV2Test {
     private String extractBase(String line) {
         if (line.startsWith("#"))
             return String.join(" ", Arrays.copyOfRange(line.split(" ", 3), 0, 2));
-        return line.split(",", 2)[0] + " " + line.split(" ")[1]
-                + (line.split(" ").length == 3 ? " " + line.split(" ")[2] : "");
+        String[] parts = line.split(" ", -1);
+        return line.split(",", 2)[0] + " " + parts[1] + (parts.length == 3 ? " " + parts[2] : "");
     }
 
     private List<String> extractDims(String line) {
         if (line.startsWith("#"))
             return Arrays.asList(line.split(" ", 3)[2].split(","));
-        return Arrays.asList(line.split(",", 2)[1].split(" ")[0].split(","));
+        return Arrays.asList(line.split(",", 2)[1].split(" ", -1)[0].split(",", -1));
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
@@ -73,7 +73,7 @@ public interface NamingConvention {
         }
 
         private String toCamelCase(String value) {
-            String[] parts = value.split("\\.", -1);
+            String[] parts = value.split("\\.", 0);
             StringBuilder conventionName = new StringBuilder(value.length());
             for (int i = 0; i < parts.length; i++) {
                 String str = parts[i];

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/NamingConvention.java
@@ -73,7 +73,7 @@ public interface NamingConvention {
         }
 
         private String toCamelCase(String value) {
-            String[] parts = value.split("\\.");
+            String[] parts = value.split("\\.", -1);
             StringBuilder conventionName = new StringBuilder(value.length());
             for (int i = 0; i < parts.length; i++) {
                 String str = parts[i];


### PR DESCRIPTION
This PR resolves [StringSplitter](https://errorprone.info/bugpattern/StringSplitter) from Error Prone.

This PR also changes to handle StringSplitter as errors.