### PR TITLE
Add more tests for TimedHandler

### DIFF
--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.jetty12.server;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.http.Outcome;
@@ -44,7 +45,7 @@ class TimedHandlerTest {
 
     private SimpleMeterRegistry registry;
 
-    private TimedHandler timedHandler;
+    private TestableTimedHandler timedHandler;
 
     private Server server;
 
@@ -55,7 +56,7 @@ class TimedHandlerTest {
     @BeforeEach
     void setup() {
         this.registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
-        this.timedHandler = new TimedHandler(registry, Tags.empty());
+        this.timedHandler = new TestableTimedHandler(registry, Tags.empty());
 
         this.server = new Server();
         this.connector = new LocalConnector(server);
@@ -240,6 +241,8 @@ class TimedHandlerTest {
             HttpTester.Response responseB = HttpTester.parseResponse(endpoint2.getResponse());
             assertThat(responseB.getStatus()).isEqualTo(200);
 
+            assertThat(timedHandler.awaitOnComplete(5, TimeUnit.SECONDS)).isTrue();
+
             assertThat(shutdownFuture.isDone()).isFalse();
 
             requestAFinish.countDown();
@@ -267,6 +270,30 @@ class TimedHandlerTest {
 
         private boolean await() throws InterruptedException {
             return latch.await(5, TimeUnit.SECONDS);
+        }
+
+    }
+
+    static class TestableTimedHandler extends TimedHandler {
+
+        private final CountDownLatch onCompleteLatch = new CountDownLatch(1);
+
+        TestableTimedHandler(MeterRegistry registry, Tags tags) {
+            super(registry, tags);
+        }
+
+        @Override
+        protected void onComplete(final Request request, final Throwable failure) {
+            try {
+                super.onComplete(request, failure);
+            }
+            finally {
+                onCompleteLatch.countDown();
+            }
+        }
+
+        public boolean awaitOnComplete(long timeout, TimeUnit unit) throws InterruptedException {
+            return onCompleteLatch.await(timeout, unit);
         }
 
     }

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
@@ -237,6 +237,9 @@ class TimedHandlerTest {
             assertThat(shutdownFuture.isDone()).isFalse();
 
             requestBFinish.countDown();
+            HttpTester.Response responseB = HttpTester.parseResponse(endpoint2.getResponse());
+            assertThat(responseB.getStatus()).isEqualTo(200);
+
             assertThat(shutdownFuture.isDone()).isFalse();
 
             requestAFinish.countDown();


### PR DESCRIPTION
This pull request addresses gh-6227.

This test verifies that TimedHandler.shutdown() does not complete while any in-flight requests are still processing.

Specifically, it covers the following scenario:

- Two requests (/a and /b) are initiated concurrently

- TimedHandler.shutdown() is called while both are still in progress

- One request (/b) completes

- shutdownFuture should remain incomplete until the other request (/a) also completes

This test verifies the shutdown behavior using only the internal request/response flow, without externally calling shutdown.check(), in line with the discussion in https://github.com/micrometer-metrics/micrometer/pull/6194#discussion_r2081159987