### PR TITLE
Add StackdriverConfig autoCreateMetricDescriptors option

### DIFF
--- a/implementations/micrometer-registry-stackdriver/build.gradle
+++ b/implementations/micrometer-registry-stackdriver/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation libs.slf4jApi
     compileOnly libs.logback12
     testRuntimeOnly libs.logback12
+    testImplementation libs.mockitoCore5
     // needed for extending TimeWindowPercentileHistogram in StackdriverHistogramUtil
     compileOnly libs.hdrhistogram
 

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/MetricServiceClientFactory.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/MetricServiceClientFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceSettings;
+
+import java.io.IOException;
+
+interface MetricServiceClientFactory {
+
+    MetricServiceClient create(MetricServiceSettings settings) throws IOException;
+
+}

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverConfig.java
@@ -121,6 +121,16 @@ public interface StackdriverConfig extends StepRegistryConfig {
         }).get();
     }
 
+    /**
+     * Whether it should be attempted to create a metric descriptor before writing a time
+     * series. If you set up your metric descriptors using IaC tools like Terraform, you
+     * will likely want to disable this.
+     * @return true, if metric descriptors should be auto-created
+     */
+    default boolean autoCreateMetricDescriptors() {
+        return getBoolean(this, "autoCreateMetricDescriptors").orElse(true);
+    }
+
     @Override
     default Validated<?> validate() {
         return checkAll(this, c -> StepRegistryConfig.validate(c),

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMetricServiceClientFactory.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverMetricServiceClientFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceSettings;
+
+import java.io.IOException;
+
+class StackdriverMetricServiceClientFactory implements MetricServiceClientFactory {
+
+    @Override
+    public MetricServiceClient create(MetricServiceSettings settings) throws IOException {
+        return MetricServiceClient.create(settings);
+    }
+
+}

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryDescriptorAutoCreationTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryDescriptorAutoCreationTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.stackdriver;
+
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.MetricServiceSettings;
+import com.google.monitoring.v3.ListMetricDescriptorsRequest;
+import io.micrometer.core.instrument.Tags;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class StackdriverMeterRegistryDescriptorAutoCreationTest {
+
+    @Test
+    void disabledAutoCreationShouldNotCreateMetricDescriptor() {
+        var mockClient = mock(MetricServiceClient.class);
+        when(mockClient.listMetricDescriptors((ListMetricDescriptorsRequest) any())).thenReturn(emptyResponse());
+
+        var meterRegistry = mockMeterRegistry(mockClient, false);
+
+        meterRegistry.start(Executors.defaultThreadFactory());
+
+        meterRegistry.counter("testCounter", Tags.empty());
+
+        meterRegistry.publish();
+
+        verify(mockClient, never()).createMetricDescriptor(any());
+        verify(mockClient, times(1)).createTimeSeries(any());
+    }
+
+    @Test
+    void enabledAutoCreationShouldCreateMetricDescriptor() {
+        var mockClient = mock(MetricServiceClient.class);
+        var meterRegistry = mockMeterRegistry(mockClient, true);
+
+        meterRegistry.start(Executors.defaultThreadFactory());
+
+        meterRegistry.counter("testCounter", Tags.empty());
+
+        meterRegistry.publish();
+
+        verify(mockClient, times(1)).createMetricDescriptor(any());
+        verify(mockClient, times(1)).createTimeSeries(any());
+    }
+
+    private StackdriverMeterRegistry mockMeterRegistry(MetricServiceClient mockClient,
+            boolean autoCreateMetricDescriptors) {
+        var factory = new MetricServiceClientFactory() {
+            @Override
+            public MetricServiceClient create(MetricServiceSettings settings) {
+                return mockClient;
+            }
+        };
+
+        return StackdriverMeterRegistry.builder(stackdriverConfig(autoCreateMetricDescriptors))
+            .clientFactory(factory)
+            .build();
+    }
+
+    private StackdriverConfig stackdriverConfig(boolean autoCreateMetricDescriptors) {
+        return new StackdriverConfig() {
+            @Override
+            public boolean enabled() {
+                return true;
+            }
+
+            @Override
+            public String projectId() {
+                return "doesnotmatter";
+            }
+
+            @Override
+            public @Nullable String get(String key) {
+                return null;
+            }
+
+            @Override
+            public boolean autoCreateMetricDescriptors() {
+                return autoCreateMetricDescriptors;
+            }
+        };
+    }
+
+    private MetricServiceClient.ListMetricDescriptorsPagedResponse emptyResponse() {
+        return mock(MetricServiceClient.ListMetricDescriptorsPagedResponse.class);
+    }
+
+}


### PR DESCRIPTION
This resolves #6281 by making the automatic creation of Stackdriver metric descriptors configurable via a configuration property.

To be able to unit-test the behaviour, I have introduced a new `MetricServiceClientFactory` class, that can be replaced in tests.

Looking forward to your feedback :)