### PR TITLE
Resolve AttemptedNegativeZero from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ subprojects {
             options.errorprone.disableWarningsInGeneratedCode = true
             options.errorprone.excludedPaths = ".*/build/generated/.*"
             options.errorprone.error(
+                    "AttemptedNegativeZero",
                     "BadImport",
                     "ClassCanBeStatic",
                     "DefaultCharset",

--- a/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchUtilsTest.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/test/java/io/micrometer/cloudwatch2/CloudWatchUtilsTest.java
@@ -46,7 +46,7 @@ class CloudWatchUtilsTest {
 
         assertThat(CloudWatchUtils.clampMetricValue(0)).as("Check 0").isEqualTo(0);
 
-        assertThat(CloudWatchUtils.clampMetricValue(-0)).as("Check -0").isEqualTo(0);
+        assertThat(CloudWatchUtils.clampMetricValue(-0.0)).as("Check -0").isEqualTo(0);
 
         assertThat(CloudWatchUtils.clampMetricValue(100.1)).as("Check positive value").isEqualTo(100.1);
 


### PR DESCRIPTION
This PR resolves [`AttemptedNegativeZero`](https://errorprone.info/bugpattern/AttemptedNegativeZero) from Error Prone.

This PR also changes to handle `AttemptedNegativeZero` as errors.