### PR TITLE
Resolve CatchAndPrintStackTrace from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ subprojects {
             options.errorprone.error(
                     "AttemptedNegativeZero",
                     "BadImport",
+                    "CatchAndPrintStackTrace",
                     "ClassCanBeStatic",
                     "DefaultCharset",
                     "EqualsGetClass",

--- a/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
+++ b/samples/micrometer-samples-boot2/src/main/java/io/micrometer/boot2/samples/components/PersonController.java
@@ -45,7 +45,7 @@ public class PersonController {
             Thread.sleep(200);
         }
         catch (InterruptedException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
         return people;
     }


### PR DESCRIPTION
This PR resolves [`CatchAndPrintStackTrace`](https://errorprone.info/bugpattern/CatchAndPrintStackTrace) from Error Prone.

This PR also changes to handle `CatchAndPrintStackTrace` as errors.