### PR TITLE
Use String.replace() where possible

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
@@ -48,7 +48,7 @@ public class InfluxNamingConvention implements NamingConvention {
 
     @Override
     public String name(String name, Meter.Type type, @Nullable String baseUnit) {
-        return escape(delegate.name(name, type, baseUnit).replace("=", "_"));
+        return escape(delegate.name(name, type, baseUnit).replace('=', '_'));
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -104,7 +104,7 @@ public class JvmThreadMetrics implements MeterBinder {
     }
 
     private static String getStateTagValue(Thread.State state) {
-        return state.name().toLowerCase(Locale.ROOT).replace("_", "-");
+        return state.name().toLowerCase(Locale.ROOT).replace('_', '-');
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -428,7 +428,7 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
     }
 
     private static String sanitize(String value) {
-        return value.replaceAll("-", ".");
+        return value.replace('-', '.');
     }
 
     @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -318,7 +318,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
 
     private List<Tag> meterTags(MetricName metricName, boolean includeCommonTags) {
         List<Tag> tags = new ArrayList<>();
-        metricName.tags().forEach((key, value) -> tags.add(Tag.of(key.replaceAll("-", "."), value)));
+        metricName.tags().forEach((key, value) -> tags.add(Tag.of(key.replace('-', '.'), value)));
         tags.add(Tag.of(KAFKA_VERSION_TAG_NAME, kafkaVersion));
         extraTags.forEach(tags::add);
         if (includeCommonTags) {
@@ -333,7 +333,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
 
     private String meterName(MetricName metricName) {
         String name = METRIC_NAME_PREFIX + metricName.group() + "." + metricName.name();
-        return name.replaceAll("-metrics", "").replaceAll("-", ".");
+        return name.replaceAll("-metrics", "").replace('-', '.');
     }
 
     private Meter.Id meterIdForComparison(MetricName metricName) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -386,7 +386,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     private Iterable<Tag> nameTag(ObjectName name) {
         String nameTagValue = name.getKeyProperty("name");
         if (nameTagValue != null) {
-            return Tags.of("name", nameTagValue.replaceAll("\"", ""));
+            return Tags.of("name", nameTagValue.replace("\"", ""));
         }
         return Collections.emptyList();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/util/HierarchicalNameMapper.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/util/HierarchicalNameMapper.java
@@ -36,7 +36,7 @@ public interface HierarchicalNameMapper {
             convention) -> id.getConventionName(convention) + id.getConventionTags(convention)
                 .stream()
                 .map(t -> "." + t.getKey() + "." + t.getValue())
-                .map(nameSegment -> nameSegment.replace(" ", "_"))
+                .map(nameSegment -> nameSegment.replace(' ', '_'))
                 .collect(Collectors.joining(""));
 
     String toHierarchicalName(Meter.Id id, NamingConvention convention);


### PR DESCRIPTION
This PR changes to use `String.replace(char, char)` and `String.replace(String, String)` where possible.

See https://github.com/spring-projects/spring-framework/pull/35025 and https://medium.com/javarevisited/micro-optimizations-in-java-string-replaceall-c6d0edf2ef6