### PR TITLE
Remove replace call that does nothing in TelegrafStatsdLineBuilder.telegrafEscape()

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/TelegrafStatsdLineBuilder.java
@@ -109,7 +109,7 @@ public class TelegrafStatsdLineBuilder extends FlavorStatsdLineBuilder {
     // backslash escape =
     // trying to escape spaces and comma drops everything after that
     private String telegrafEscape(String value) {
-        return value.replaceAll("=", "\\=").replaceAll("[\\s,:]", "_");
+        return value.replaceAll("[\\s,:]", "_");
     }
 
 }


### PR DESCRIPTION
While looking into https://github.com/micrometer-metrics/micrometer/pull/6449, I noticed that the `TelegrafStatsdLineBuilder.telegrafEscape()` doesn't escape '=' properly.