### PR TITLE
Always configure histogram for Stackdriver

### DIFF
--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
@@ -31,7 +31,7 @@ final class StackdriverHistogramUtil {
         if (distributionStatisticConfig.isPublishingHistogram()) {
             return new StackdriverFixedBoundaryHistogram(clock, distributionStatisticConfig);
         }
-        return NoopHistogram.INSTANCE;
+        return new StackdriverInfinityBucketHistogram(clock, distributionStatisticConfig);
     }
 
     static class StackdriverClientSidePercentilesHistogram extends TimeWindowPercentileHistogram {
@@ -47,6 +47,14 @@ final class StackdriverHistogramUtil {
 
         StackdriverFixedBoundaryHistogram(Clock clock, DistributionStatisticConfig config) {
             super(clock, config, true, false, true);
+        }
+
+    }
+
+    static class StackdriverInfinityBucketHistogram extends TimeWindowFixedBoundaryHistogram {
+
+        StackdriverInfinityBucketHistogram(Clock clock, DistributionStatisticConfig config) {
+            super(clock, config, false, false, true);
         }
 
     }

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverMeterRegistryTest.java
@@ -197,4 +197,18 @@ class StackdriverMeterRegistryTest {
         assertThat(distribution.getMean()).isZero();
     }
 
+    @Test
+    @Issue("#6401")
+    void distributionWithNoBucketsUsesStepCount() {
+        StackdriverMeterRegistry.Batch batch = meterRegistry.new Batch();
+        // halfway through first step
+        clock.add(config.step().dividedBy(2));
+        DistributionSummary ds = DistributionSummary.builder("ds").register(meterRegistry);
+        ds.record(3);
+        // 1/4 through the second step
+        clock.add(config.step().dividedBy(4).multipliedBy(3));
+        Distribution distribution = batch.distribution(ds.takeSnapshot(), false);
+        assertThat(distribution.getCount()).isEqualTo(1);
+    }
+
 }


### PR DESCRIPTION
A distribution is always published to Stackdriver for Timer and DistributionSummary meters. We want this Distribution to have an accurate count in the time window of the Distribution (histogram). A no-op Histogram was being used when no buckets and no percentiles were configured, and that always has a zero count. We can't use the step count because that would not be the count for the same period of time. This will add some overhead to Timer and DistributionSummary meters that did not have any buckets or percentiles configured.

Fixes gh-6401