### PR TITLE
Suppress CollectionUndefinedEquality and DoNotCallSuggester from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ subprojects {
                     "ClassCanBeStatic",
                     "CollectionUndefinedEquality",
                     "DefaultCharset",
+                    "DoNotCallSuggester",
                     "EqualsGetClass",
                     "InlineFormatString",
                     "LongDoubleConversion",

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects {
                     "BadImport",
                     "CatchAndPrintStackTrace",
                     "ClassCanBeStatic",
+                    "CollectionUndefinedEquality",
                     "DefaultCharset",
                     "EqualsGetClass",
                     "InlineFormatString",

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcAsyncTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcAsyncTest.java
@@ -117,6 +117,7 @@ class GrpcAsyncTest {
         assertThat(futures).allSatisfy((future) -> {
             // Make sure the request-id in the response message matches with the one sent
             // to server.
+            @SuppressWarnings("CollectionUndefinedEquality")
             String expectedRequestId = requestIds.get(future);
             assertThat(future.get().getResponseMessage()).contains("request-id=" + expectedRequestId);
         });

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/utils/SampleRegistries.java
@@ -69,6 +69,7 @@ import java.time.Duration;
 
 public class SampleRegistries {
 
+    @SuppressWarnings("DoNotCallSuggester")
     public static MeterRegistry pickOne() {
         throw new RuntimeException(
                 "Pick some other method on SampleRegistries to ship sample metrics to the system of your choice");


### PR DESCRIPTION
This PR suppresses [CollectionUndefinedEquality](https://errorprone.info/bugpattern/CollectionUndefinedEquality) and [DoNotCallSuggester](https://errorprone.info/bugpattern/DoNotCallSuggester) from Error Prone.

This PR also changes to handle CollectionUndefinedEquality and DoNotCallSuggester as errors.