### PR TITLE
Remove Dropwizard 5 usage

### DIFF
--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     jmh project(':micrometer-registry-prometheus')
 //    jmh 'io.micrometer:micrometer-registry-prometheus:1.13.0-M2'
 
-    jmh libs.dropwizardMetricsCore5
     jmh libs.prometheusMetrics
 
     jmh libs.dropwizardMetricsCore

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareCountersWithOtherLibraries.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareCountersWithOtherLibraries.java
@@ -23,8 +23,6 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -86,34 +84,6 @@ public class CompareCountersWithOtherLibraries {
     }
 
     @State(Scope.Benchmark)
-    public static class Dropwizard5State {
-
-        io.dropwizard.metrics5.MetricRegistry registry;
-
-        io.dropwizard.metrics5.Counter counter;
-
-        io.dropwizard.metrics5.Counter counterWithTags;
-
-        @Setup(Level.Trial)
-        public void setup() {
-            registry = new io.dropwizard.metrics5.MetricRegistry();
-            counter = registry.counter("untagged");
-            Map<String, String> tags = new HashMap<>();
-            tags.put("key1", "value1");
-            tags.put("key2", "value2");
-            counterWithTags = registry.counter(new io.dropwizard.metrics5.MetricName("tagged", tags));
-        }
-
-        @TearDown(Level.Trial)
-        public void tearDown(Blackhole hole) {
-            for (io.dropwizard.metrics5.Counter c : registry.getCounters().values()) {
-                hole.consume(c.getCount());
-            }
-        }
-
-    }
-
-    @State(Scope.Benchmark)
     public static class PrometheusState {
 
         io.prometheus.metrics.core.metrics.Counter counter;
@@ -130,24 +100,6 @@ public class CompareCountersWithOtherLibraries {
                 .register();
         }
 
-    }
-
-    // @Benchmark
-    public void dropwizard5Counter(Dropwizard5State state) {
-        state.counter.inc();
-    }
-
-    // @Benchmark
-    public void dropwizard5CounterFixedTags(Dropwizard5State state) {
-        state.counterWithTags.inc();
-    }
-
-    // @Benchmark
-    public void dropwizard5CounterTags(Dropwizard5State state) {
-        Map<String, String> tags = new HashMap<>();
-        tags.put("key1", "value1");
-        tags.put("key2", "value2");
-        state.registry.counter(new io.dropwizard.metrics5.MetricName("tagged", tags)).inc();
     }
 
     // @Benchmark

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ cloudwatch2 = "2.25.70"
 colt = "1.2.0"
 dagger = "2.51.1"
 dropwizard-metrics = "4.2.33"
-dropwizard-metrics5 = "5.0.0"
 dynatrace-utils = "2.2.1"
 ehcache2 = "2.10.9.2"
 ehcache3 = "3.10.8"
@@ -98,7 +97,6 @@ daggerCompiler = { module = "com.google.dagger:dagger-compiler", version.ref = "
 dropwizardMetricsCore = { module = "io.dropwizard.metrics:metrics-core", version.ref = "dropwizard-metrics" }
 dropwizardMetricsGraphite = { module = "io.dropwizard.metrics:metrics-graphite", version.ref = "dropwizard-metrics" }
 dropwizardMetricsJmx = { module = "io.dropwizard.metrics:metrics-jmx", version.ref = "dropwizard-metrics" }
-dropwizardMetricsCore5 = { module = "io.dropwizard.metrics5:metrics-core", version.ref = "dropwizard-metrics5" }
 dynatraceUtils = { module = "com.dynatrace.metric.util:dynatrace-metric-utils-java", version.ref = "dynatrace-utils" }
 ehcache2 = { module = "net.sf.ehcache:ehcache", version.ref = "ehcache2" }
 ehcache3 = { module = "org.ehcache:ehcache", version.ref = "ehcache3" }


### PR DESCRIPTION
It seems the 5.0.0 release was a mistake and we should not have been using it all this time. The 5.0.1 is the first intended Dropwizard 5 release, and it bumps the Java baseline. We can consider how to deal with that on `main`, but it's best to remove it from maintenance branches in the meantime.

See #6447 