### PR TITLE
Make benchmark module require at least Java 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ You can use a Git client to clone the source code to your local machine.
 
 Micrometer targets Java 8 but requires JDK 11 or later to build.
 If you are not running Gradle with JDK 11 or later and Gradle cannot detect an existing JDK 17 installation, it will download one.
-If you want to build the reference docs, you need to use JDK 17 or later.
+If you want to build the reference docs or benchmarks, you need to use JDK 17 or later.
 
 The Gradle wrapper is provided and should be used for building with a consistent version of Gradle.
 

--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -2,6 +2,22 @@ plugins {
     id "me.champeau.jmh" version "0.7.2"
 }
 
+// skip this module when building with jdk <17
+// Dropwizard 5 has a Java 17 baseline
+if (!javaLanguageVersion.canCompileOrRun(17)) {
+    project.tasks.configureEach { task -> task.enabled = false }
+}
+
+java {
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    options.release = 17
+}
+
 // Uncomment as needed for benchmarking against released versions of Micrometer
 //repositories {
 //    mavenCentral()


### PR DESCRIPTION
Dropwizard 5 requires Java 17, and we use this in the benchmark module.

See #6435