### PR TITLE
Flag to register JCache cache.removals as FunctionCounter

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -18,10 +18,7 @@ package io.micrometer.core.instrument.binder.cache;
 import io.micrometer.common.lang.NonNullApi;
 import io.micrometer.common.lang.NonNullFields;
 import io.micrometer.common.lang.Nullable;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
 
 import javax.cache.Cache;
@@ -46,6 +43,8 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
     // VisibleForTesting
     @Nullable
     ObjectName objectName;
+
+    private final boolean registerCacheRemovalsAsFunctionCounter;
 
     /**
      * Record metrics on a JCache cache.
@@ -75,21 +74,49 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
      * proxied in any way.
      */
     public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, Iterable<Tag> tags) {
-        new JCacheMetrics<>(cache, tags).bindTo(registry);
+        return monitor(registry, cache, Tags.of(tags), false);
+    }
+
+    /**
+     * Record metrics on a JCache cache.
+     * @param registry The registry to bind metrics to.
+     * @param cache The cache to instrument.
+     * @param tags Tags to apply to all recorded metrics.
+     * @param registerCacheRemovalsAsFunctionCounter whether to register the
+     * {@code cache.removals} metric as a FunctionCounter
+     * @param <C> The cache type.
+     * @param <K> The cache key type.
+     * @param <V> The cache value type.
+     * @return The instrumented cache, unchanged. The original cache is not wrapped or
+     * proxied in any way.
+     * @since 1.14.9
+     */
+    public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, Iterable<Tag> tags,
+            boolean registerCacheRemovalsAsFunctionCounter) {
+        new JCacheMetrics<>(cache, tags, registerCacheRemovalsAsFunctionCounter).bindTo(registry);
         return cache;
     }
 
     public JCacheMetrics(C cache, Iterable<Tag> tags) {
+        this(cache, tags, false);
+    }
+
+    /**
+     * Create a {@link CacheMeterBinder} for a JCache instance.
+     * @param cache the JCache instance to instrument
+     * @param tags additional tags to add to JCache meters
+     * @param registerCacheRemovalsAsFunctionCounter whether to register the
+     * {@code cache.removals} metric as a FunctionCounter
+     * @since 1.14.9
+     */
+    public JCacheMetrics(C cache, Iterable<Tag> tags, boolean registerCacheRemovalsAsFunctionCounter) {
         super(cache, cache.getName(), tags);
+        this.registerCacheRemovalsAsFunctionCounter = registerCacheRemovalsAsFunctionCounter;
         try {
             CacheManager cacheManager = cache.getCacheManager();
             if (cacheManager != null) {
-                String cacheManagerUri = cacheManager.getURI().toString().replace(':', '.'); // ehcache's
-                                                                                             // uri
-                                                                                             // is
-                                                                                             // prefixed
-                                                                                             // with
-                                                                                             // 'urn:'
+                // ehcache's uri is prefixed with 'urn:'
+                String cacheManagerUri = cacheManager.getURI().toString().replace(':', '.');
 
                 this.objectName = new ObjectName("javax.cache:type=CacheStatistics" + ",CacheManager=" + cacheManagerUri
                         + ",Cache=" + cache.getName());
@@ -130,10 +157,18 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
     @Override
     protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
         if (objectName != null) {
-            Gauge.builder("cache.removals", objectName, objectName -> lookupStatistic("CacheRemovals"))
-                .tags(getTagsWithCacheName())
-                .description("Cache removals")
-                .register(registry);
+            if (registerCacheRemovalsAsFunctionCounter) {
+                FunctionCounter.builder("cache.removals", objectName, objectName -> lookupStatistic("CacheRemovals"))
+                    .tags(getTagsWithCacheName())
+                    .description("Cache removals")
+                    .register(registry);
+            }
+            else {
+                Gauge.builder("cache.removals", objectName, objectName -> lookupStatistic("CacheRemovals"))
+                    .tags(getTagsWithCacheName())
+                    .description("Cache removals")
+                    .register(registry);
+            }
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -161,7 +162,17 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry();
         metrics.bindImplementationSpecificMetrics(registry);
 
-        assertThat(registry.find("cache.removals").tags(expectedTag).functionCounter()).isNull();
+        assertThat(registry.find("cache.removals").tags(expectedTag).meter()).isNull();
+    }
+
+    @Test
+    void cacheRemovalsIsFunctionCounterWhenConfigured() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        metrics = new JCacheMetrics<>(cache, expectedTag, true);
+        metrics.bindTo(meterRegistry);
+
+        assertThat(meterRegistry.get("cache.removals").tags(expectedTag).meter()).isNotNull()
+            .isInstanceOf(FunctionCounter.class);
     }
 
     private static class CacheMBeanStub implements DynamicMBean {


### PR DESCRIPTION
Some other CacheMeterBinder implementations are known to register the `cache.removals` meter as a FunctionCounter, which is more semantically accurate. For backward compatibility, we do not want to unconditionally change the meter type for everyone, especially in a maintenance release. However, we want to make it possible to register the `cache.removals` as a `FunctionCounter` to align it. In the future, we can flip the default for this flag.

See gh-6434