### PR TITLE
Resolve NarrowCalculation and OperatorPrecedence from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
                     "LongDoubleConversion",
                     "MissingOverride",
                     "ModifyCollectionInEnhancedForLoop",
+                    "NarrowCalculation",
                     "StringCaseLocaleUsage",
                     "StringSplitter"
             )

--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ subprojects {
                     "MissingOverride",
                     "ModifyCollectionInEnhancedForLoop",
                     "NarrowCalculation",
+                    "OperatorPrecedence",
                     "StringCaseLocaleUsage",
                     "StringSplitter"
             )

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -174,7 +174,7 @@ public final class Tags implements Iterable<Tag> {
 
     @Override
     public boolean equals(@Nullable Object obj) {
-        return this == obj || obj != null && getClass() == obj.getClass() && tagsEqual((Tags) obj);
+        return this == obj || (obj != null && getClass() == obj.getClass() && tagsEqual((Tags) obj));
     }
 
     private boolean tagsEqual(Tags obj) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -476,7 +476,7 @@ class CompositeMeterRegistryTest {
         assertThat(executor.awaitTermination(1L, TimeUnit.SECONDS)).isTrue();
         for (int i = 0; i < tagCount; i++) {
             assertThat(this.composite.find(meterName).tag(tagName, String.valueOf(i)).counter().count())
-                .isEqualTo(count / tagCount);
+                .isEqualTo((double) count / tagCount);
         }
     }
 


### PR DESCRIPTION
This PR resolves [NarrowCalculation](https://errorprone.info/bugpattern/NarrowCalculation) and [OperatorPrecedence](https://errorprone.info/bugpattern/OperatorPrecedence) from Error Prone.

This PR also changes to handle NarrowCalculation and OperatorPrecedence as errors.