### PR TITLE
Suppress URLEqualsHashCode and resolve UnnecessaryAsync and UnnecessaryParentheses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ subprojects {
                     "StringCaseLocaleUsage",
                     "StringSplitter",
                     "UnnecessaryAsync",
+                    "UnnecessaryParentheses",
                     "URLEqualsHashCode"
             )
             options.errorprone.disable(

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,8 @@ subprojects {
                     "NarrowCalculation",
                     "OperatorPrecedence",
                     "StringCaseLocaleUsage",
-                    "StringSplitter"
+                    "StringSplitter",
+                    "URLEqualsHashCode"
             )
             options.errorprone.disable(
                     "StringConcatToTextBlock" // Requires JDK 15+

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ subprojects {
                     "OperatorPrecedence",
                     "StringCaseLocaleUsage",
                     "StringSplitter",
+                    "UnnecessaryAsync",
                     "URLEqualsHashCode"
             )
             options.errorprone.disable(

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -20,11 +20,7 @@ import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -108,7 +104,7 @@ class MultiGaugeTest {
         String testKey2 = "key2";
         AtomicInteger testValue2 = new AtomicInteger(2);
 
-        Map<String, AtomicInteger> map = new ConcurrentHashMap<>();
+        Map<String, AtomicInteger> map = new HashMap<>();
         map.put(testKey1, testValue1);
         map.put(testKey2, testValue2);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -564,10 +564,9 @@ class GrpcObservationTest {
             SimpleRequest request = SimpleRequest.newBuilder().setRequestMessage("Hello").build();
             stub.unaryRpc(request);
 
-            assertThat(scopeAwareServerInterceptor.lastObservation).isNotNull().satisfies((observation -> {
-                assertThat(observation.getContext().getContextualName())
-                    .isEqualTo("grpc.testing.SimpleService/UnaryRpc");
-            }));
+            assertThat(scopeAwareServerInterceptor.lastObservation).isNotNull()
+                .satisfies(observation -> assertThat(observation.getContext().getContextualName())
+                    .isEqualTo("grpc.testing.SimpleService/UnaryRpc"));
         }
 
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathClassLoader.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathClassLoader.java
@@ -219,6 +219,7 @@ final class ModifiedClassPathClassLoader extends URLClassLoader {
     }
 
     private static List<URL> getAdditionalUrls(List<MergedAnnotations> annotations) {
+        @SuppressWarnings("URLEqualsHashCode")
         Set<URL> urls = new LinkedHashSet<>();
         for (MergedAnnotations candidate : annotations) {
             MergedAnnotation<ClassPathOverrides> annotation = candidate.get(ClassPathOverrides.class);


### PR DESCRIPTION
This PR suppresses [URLEqualsHashCode](https://errorprone.info/bugpattern/URLEqualsHashCode) and resolves [UnnecessaryAsync](https://errorprone.info/bugpattern/UnnecessaryAsync) and [UnnecessaryParentheses](https://errorprone.info/bugpattern/UnnecessaryParentheses) from Error Prone.

This PR also changes to handle URLEqualsHashCode, UnnecessaryAsync, and UnnecessaryParentheses as errors.