### PR TITLE
Suppress ArrayAsKeyOfSetOrMap, MixedMutabilityReturnType, and MutablePublicArray from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ subprojects {
                     "InlineFormatString",
                     "LongDoubleConversion",
                     "MissingOverride",
+                    "MixedMutabilityReturnType",
                     "ModifyCollectionInEnhancedForLoop",
                     "NarrowCalculation",
                     "OperatorPrecedence",

--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ subprojects {
             options.errorprone.disableWarningsInGeneratedCode = true
             options.errorprone.excludedPaths = ".*/build/generated/.*"
             options.errorprone.error(
+                    "ArrayAsKeyOfSetOrMap",
                     "AttemptedNegativeZero",
                     "BadImport",
                     "CatchAndPrintStackTrace",

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ subprojects {
                     "MissingOverride",
                     "MixedMutabilityReturnType",
                     "ModifyCollectionInEnhancedForLoop",
+                    "MutablePublicArray",
                     "NarrowCalculation",
                     "OperatorPrecedence",
                     "StringCaseLocaleUsage",

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/JvmServiceLevelObjectives.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/JvmServiceLevelObjectives.java
@@ -35,6 +35,7 @@ public class JvmServiceLevelObjectives {
      * <a href="https://www.jetbrains.com/help/teamcity/teamcity-memory-monitor.html">Team
      * City's memory monitor</a>.
      */
+    @SuppressWarnings("MutablePublicArray")
     public static final ServiceLevelObjective[] MEMORY = new ServiceLevelObjective[] {
             ServiceLevelObjective.build("jvm.pool.memory")
                 .failedMessage("Memory usage in a single memory pool exceeds 90% after garbage collection.")
@@ -72,6 +73,7 @@ public class JvmServiceLevelObjectives {
                                 + "Lasting memory lack may result in performance degradation and server instability.")
                 .and() };
 
+    @SuppressWarnings("MutablePublicArray")
     public static final ServiceLevelObjective[] ALLOCATIONS = new ServiceLevelObjective[] {
             ServiceLevelObjective.build("jvm.allocations.g1.humongous")
                 .failedMessage("A single object was allocated that exceeded 50% of the total size of the eden space.")

--- a/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/OperatingSystemServiceLevelObjectives.java
+++ b/implementations/micrometer-registry-health/src/main/java/io/micrometer/health/objectives/OperatingSystemServiceLevelObjectives.java
@@ -26,6 +26,7 @@ import io.micrometer.health.ServiceLevelObjective;
  */
 public class OperatingSystemServiceLevelObjectives {
 
+    @SuppressWarnings("MutablePublicArray")
     public static final ServiceLevelObjective[] DISK = new ServiceLevelObjective[] {
             ServiceLevelObjective.build("os.file.descriptors")
                 .failedMessage("Too many file descriptors are open. When the max is reached, "

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsAgentClientProvider.java
@@ -110,6 +110,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         return writeCounterValues(counter.getId(), counter.count());
     }
 
+    @SuppressWarnings("MixedMutabilityReturnType")
     private Map<String, Object> writeCounterValues(Meter.Id id, double count) {
         if (!Double.isFinite(count)) {
             return Collections.emptyMap();
@@ -121,6 +122,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         return attributes;
     }
 
+    @SuppressWarnings("MixedMutabilityReturnType")
     @Override
     public Map<String, Object> writeGauge(Gauge gauge) {
         double value = gauge.value();
@@ -134,6 +136,7 @@ public class NewRelicInsightsAgentClientProvider implements NewRelicClientProvid
         return attributes;
     }
 
+    @SuppressWarnings("MixedMutabilityReturnType")
     @Override
     public Map<String, Object> writeTimeGauge(TimeGauge gauge) {
         double value = gauge.value();

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -34,6 +34,7 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
 
     private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
 
+    @SuppressWarnings("ArrayAsKeyOfSetOrMap")
     private final ConcurrentMap<double[], ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
 
     private final SpanContext spanContext;

--- a/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/MessageFormatter.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/MessageFormatter.java
@@ -306,6 +306,7 @@ final class MessageFormatter {
         }
     }
 
+    @SuppressWarnings("ArrayAsKeyOfSetOrMap")
     private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Set<Object[]> seenSet) {
         if (a.length == 0) {
             return;

--- a/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/util/internal/logging/MessageFormatter.java
@@ -310,6 +310,7 @@ final class MessageFormatter {
         }
     }
 
+    @SuppressWarnings("ArrayAsKeyOfSetOrMap")
     private static void objectArrayAppend(StringBuilder sbuf, Object[] a, Set<Object[]> seenSet) {
         if (a.length == 0) {
             return;


### PR DESCRIPTION
This PR suppresses [ArrayAsKeyOfSetOrMap](https://errorprone.info/bugpattern/ArrayAsKeyOfSetOrMap), [MixedMutabilityReturnType](https://errorprone.info/bugpattern/MixedMutabilityReturnType), and [MutablePublicArray](https://errorprone.info/bugpattern/MutablePublicArray) from Error Prone.

This PR also changes to handle ArrayAsKeyOfSetOrMap, MixedMutabilityReturnType, and MutablePublicArray as errors.