### PR TITLE
Resolve UnusedMethod from Error Prone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ subprojects {
                     "StringSplitter",
                     "UnnecessaryAsync",
                     "UnnecessaryParentheses",
+                    "UnusedMethod",
                     "URLEqualsHashCode"
             )
             options.errorprone.disable(

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
@@ -252,6 +252,7 @@ class ObservationInstrumentingTests {
         mvc.stop();
     }
 
+    @SuppressWarnings("unused")
     private void enableContextPropagationForDocsSnippet() {
         // tag::reactor_hook[]
         Hooks.enableAutomaticContextPropagation();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryHistogram.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument.distribution;
 
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLongArray;
 
 class FixedBoundaryHistogram {
@@ -41,20 +40,6 @@ class FixedBoundaryHistogram {
 
     double[] getBuckets() {
         return this.buckets;
-    }
-
-    /**
-     * Returns the number of values that was recorded between previous bucket and the
-     * queried bucket (upper bound inclusive).
-     * @param bucket - the bucket to find values for
-     * @return 0 if bucket is not a valid bucket otherwise number of values recorded
-     * between (previous bucket, bucket]
-     */
-    private long countAtBucket(double bucket) {
-        int index = Arrays.binarySearch(buckets, bucket);
-        if (index < 0)
-            return 0;
-        return values.get(index);
     }
 
     void reset() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -69,6 +69,7 @@ class FileDescriptorMetricsTest {
     }
 
     /** Represents a JVM implementation we do not currently support. */
+    @SuppressWarnings("unused")
     private interface UnsupportedOperatingSystemMXBean extends OperatingSystemMXBean {
 
         long getOpenFileDescriptorCount();


### PR DESCRIPTION
This PR resolves [UnusedMethod](https://errorprone.info/bugpattern/UnusedMethod) from Error Prone by removing unused methods or suppressing warnings.

This PR also changes to handle UnusedMethod as errors.