### PR TITLE
Log requests as trace level for OtlpMeterRegistry

### DIFF
--- a/implementations/micrometer-registry-otlp/build.gradle
+++ b/implementations/micrometer-registry-otlp/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.awaitility:awaitility'
     testImplementation libs.mockitoCore5
+    testImplementation libs.logbackLatest
 }
 
 dockerTest {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -165,6 +165,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
                             .build())
                         .build())
                     .build();
+                logger.trace("Request: {}", request);
                 HttpSender.Request.Builder httpRequest = this.httpSender.post(this.config.url())
                     .withHeader("User-Agent", this.userAgentHeader)
                     .withContent("application/x-protobuf", request.toByteArray());

--- a/implementations/micrometer-registry-otlp/src/test/resources/logback.xml
+++ b/implementations/micrometer-registry-otlp/src/test/resources/logback.xml
@@ -1,0 +1,30 @@
+<!--
+
+    Copyright 2025 VMware, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="io.micrometer.registry.otlp.OtlpMeterRegistry" level="trace"/>
+</configuration>


### PR DESCRIPTION
This PR changes to log requests as trace level for the `OtlpMeterRegistry`.

See https://github.com/micrometer-metrics/micrometer/issues/6308#issuecomment-2913438840