### PR TITLE
Enhance logging of negative amount in AbstractTimer.record() by printing stack trace

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/WarnThenDebugLogger.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/WarnThenDebugLogger.java
@@ -46,6 +46,15 @@ public class WarnThenDebugLogger {
         this.logger = InternalLoggerFactory.getInstance(name);
     }
 
+    /**
+     * This may be useful to have different behavior before/after logging once.
+     * @return whether the warn-level log has been made or not
+     * @since 1.16.0
+     */
+    public boolean isWarnLogged() {
+        return warnLogged.get();
+    }
+
     public void log(String message, @Nullable Throwable ex) {
         if (this.warnLogged.compareAndSet(false, true)) {
             log(InternalLogLevel.WARN, getWarnMessage(message), ex);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.distribution.*;
 import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
@@ -37,7 +39,9 @@ import java.util.function.Supplier;
 
 public abstract class AbstractTimer extends AbstractMeter implements Timer {
 
-    private static final WarnThenDebugLogger log = new WarnThenDebugLogger(AbstractTimer.class);
+    private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(AbstractTimer.class);
+
+    private static final InternalLogger LOGGER = InternalLoggerFactory.getInstance(AbstractTimer.class);
 
     private static final Map<PauseDetector, Object> pauseDetectorCache = new ConcurrentHashMap<>();
 
@@ -264,7 +268,10 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
             }
         }
         else {
-            log.log(() -> "'amount' should not be negative but was: " + amount, new IllegalArgumentException());
+            if (!warnThenDebugLogger.isWarnLogged() || LOGGER.isDebugEnabled()) {
+                warnThenDebugLogger.log(() -> "'amount' should not be negative but was: " + amount,
+                        new IllegalArgumentException("Timer measurements cannot be negative"));
+            }
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -264,7 +264,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
             }
         }
         else {
-            log.log(() -> "'amount' should not be negative but was: " + amount);
+            log.log(() -> "'amount' should not be negative but was: " + amount, new IllegalArgumentException());
         }
     }
 


### PR DESCRIPTION
In PR #4573 , we added a warning log to `AbstractTimer.record()` when the amount is negative.

In production, we sometimes measure the elapsed time between two code points, and for various reasons the calculated value can occasionally be negative. When that happens, we need to trace the root cause and fix it.

Because this timing pattern is used in multiple places or projects, the current “negative amount” warning alone does not reveal where the problem originates.

Therefore, this PR appends a stack trace to the warning so we can quickly pinpoint the call site that triggered the invalid record() invocation.

See 
- #4573
- #2620


#### Verification with unit test:
<img width="1025" height="183" alt="image" src="https://github.com/user-attachments/assets/93ae88db-913b-4322-875c-6a9a55e9aabf" />

