### PR TITLE
Improve nullability for gauges

### DIFF
--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/DynatraceMeterRegistryTest.java
@@ -24,7 +24,6 @@ import org.mockito.ArgumentCaptor;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -69,7 +68,7 @@ class DynatraceMeterRegistryTest {
         when(httpClient.send(isA(HttpSender.Request.class)))
             .thenReturn(new HttpSender.Response(202, "{ \"linesOk\": 3, \"linesInvalid\": 0, \"error\": null }"));
 
-        Double gauge = Objects.requireNonNull(meterRegistry.gauge("my.gauge", 42d));
+        Double gauge = meterRegistry.gauge("my.gauge", 42d);
         Counter counter = meterRegistry.counter("my.counter");
         counter.increment(12d);
         Timer timer = meterRegistry.timer("my.timer");

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.common.lang.internal.Contract;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
@@ -521,6 +522,7 @@ public abstract class MeterRegistry {
      * @return The state object that was passed in so the registration can be done as part
      * of an assignment statement.
      */
+    @Contract("_, _, null, _ -> null; _, _, !null, _ -> !null")
     public <T> @Nullable T gauge(String name, Iterable<Tag> tags, @Nullable T stateObject,
             ToDoubleFunction<T> valueFunction) {
         Gauge.builder(name, stateObject, valueFunction).tags(tags).register(this);
@@ -537,7 +539,7 @@ public abstract class MeterRegistry {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public <T extends Number> @Nullable T gauge(String name, Iterable<Tag> tags, T number) {
+    public <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
         return gauge(name, tags, number, Number::doubleValue);
     }
 
@@ -550,7 +552,7 @@ public abstract class MeterRegistry {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public <T extends Number> @Nullable T gauge(String name, T number) {
+    public <T extends Number> T gauge(String name, T number) {
         return gauge(name, emptyList(), number);
     }
 
@@ -564,7 +566,7 @@ public abstract class MeterRegistry {
      * @return The state object that was passed in so the registration can be done as part
      * of an assignment statement.
      */
-    public <T> @Nullable T gauge(String name, T stateObject, ToDoubleFunction<T> valueFunction) {
+    public <T> T gauge(String name, T stateObject, ToDoubleFunction<T> valueFunction) {
         return gauge(name, emptyList(), stateObject, valueFunction);
     }
 
@@ -582,7 +584,7 @@ public abstract class MeterRegistry {
      * @return The Collection that was passed in so the registration can be done as part
      * of an assignment statement.
      */
-    public <T extends Collection<?>> @Nullable T gaugeCollectionSize(String name, Iterable<Tag> tags, T collection) {
+    public <T extends Collection<?>> T gaugeCollectionSize(String name, Iterable<Tag> tags, T collection) {
         return gauge(name, tags, collection, Collection::size);
     }
 
@@ -599,7 +601,7 @@ public abstract class MeterRegistry {
      * @return The Map that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public <T extends Map<?, ?>> @Nullable T gaugeMapSize(String name, Iterable<Tag> tags, T map) {
+    public <T extends Map<?, ?>> T gaugeMapSize(String name, Iterable<Tag> tags, T map) {
         return gauge(name, tags, map, Map::size);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Metrics.java
@@ -16,7 +16,6 @@
 package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Map;
@@ -145,7 +144,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T> @Nullable T gauge(String name, Iterable<Tag> tags, T obj, ToDoubleFunction<T> valueFunction) {
+    public static <T> T gauge(String name, Iterable<Tag> tags, T obj, ToDoubleFunction<T> valueFunction) {
         return globalRegistry.gauge(name, tags, obj, valueFunction);
     }
 
@@ -159,7 +158,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T extends Number> @Nullable T gauge(String name, Iterable<Tag> tags, T number) {
+    public static <T extends Number> T gauge(String name, Iterable<Tag> tags, T number) {
         return globalRegistry.gauge(name, tags, number);
     }
 
@@ -172,7 +171,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T extends Number> @Nullable T gauge(String name, T number) {
+    public static <T extends Number> T gauge(String name, T number) {
         return globalRegistry.gauge(name, number);
     }
 
@@ -185,7 +184,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T> @Nullable T gauge(String name, T obj, ToDoubleFunction<T> valueFunction) {
+    public static <T> T gauge(String name, T obj, ToDoubleFunction<T> valueFunction) {
         return globalRegistry.gauge(name, obj, valueFunction);
     }
 
@@ -203,8 +202,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T extends Collection<?>> @Nullable T gaugeCollectionSize(String name, Iterable<Tag> tags,
-            T collection) {
+    public static <T extends Collection<?>> T gaugeCollectionSize(String name, Iterable<Tag> tags, T collection) {
         return globalRegistry.gaugeCollectionSize(name, tags, collection);
     }
 
@@ -221,7 +219,7 @@ public class Metrics {
      * @return The number that was passed in so the registration can be done as part of an
      * assignment statement.
      */
-    public static <T extends Map<?, ?>> @Nullable T gaugeMapSize(String name, Iterable<Tag> tags, T map) {
+    public static <T extends Map<?, ?>> T gaugeMapSize(String name, Iterable<Tag> tags, T map) {
         return globalRegistry.gaugeMapSize(name, tags, map);
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -388,7 +388,6 @@ public abstract class MeterRegistryCompatibilityKit {
         @DisplayName("gauges attached to a number are updated when their values are observed")
         void numericGauge() {
             AtomicInteger n = registry.gauge("my.gauge", new AtomicInteger());
-            assertThat(n).isNotNull();
             n.set(1);
 
             Gauge g = registry.get("my.gauge").gauge();
@@ -401,10 +400,7 @@ public abstract class MeterRegistryCompatibilityKit {
         @Test
         @DisplayName("gauges attached to an object are updated when their values are observed")
         void objectGauge() {
-            // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1219
-            List<String> list = Objects
-                .requireNonNull(registry.gauge("my.gauge", emptyList(), new ArrayList<>(), List::size));
-            assertThat(list).isNotNull();
+            List<String> list = registry.gauge("my.gauge", emptyList(), new ArrayList<>(), List::size);
             list.addAll(Arrays.asList("a", "b"));
 
             Gauge g = registry.get("my.gauge").gauge();
@@ -414,10 +410,7 @@ public abstract class MeterRegistryCompatibilityKit {
         @Test
         @DisplayName("gauges can be directly associated with collection size")
         void collectionSizeGauge() {
-            // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1219
-            List<String> list = Objects
-                .requireNonNull(registry.gaugeCollectionSize("my.gauge", emptyList(), new ArrayList<>()));
-            assertThat(list).isNotNull();
+            List<String> list = registry.gaugeCollectionSize("my.gauge", emptyList(), new ArrayList<>());
             list.addAll(Arrays.asList("a", "b"));
 
             Gauge g = registry.get("my.gauge").gauge();
@@ -427,9 +420,7 @@ public abstract class MeterRegistryCompatibilityKit {
         @Test
         @DisplayName("gauges can be directly associated with map entry size")
         void mapSizeGauge() {
-            // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1219
-            Map<String, Integer> map = requireNonNull(registry.gaugeMapSize("my.gauge", emptyList(), new HashMap<>()));
-            assertThat(map).isNotNull();
+            Map<String, Integer> map = registry.gaugeMapSize("my.gauge", emptyList(), new HashMap<>());
             map.put("a", 1);
 
             Gauge g = registry.get("my.gauge").gauge();
@@ -464,8 +455,8 @@ public abstract class MeterRegistryCompatibilityKit {
 
             assertThat(registry.get("my.gauge").gauges()).hasSize(1);
             assertThat(registry.get("my.gauge").gauge().value()).isEqualTo(1);
-            assertThat(n1).isNotNull().hasValue(1);
-            assertThat(n2).isNotNull().hasValue(2);
+            assertThat(n1).hasValue(1);
+            assertThat(n2).hasValue(2);
         }
 
         @Test
@@ -477,8 +468,8 @@ public abstract class MeterRegistryCompatibilityKit {
 
             assertThat(registry.get("my.gauge").gauges()).hasSize(1);
             assertThat(registry.get("my.gauge").gauge().value()).isEqualTo(1);
-            assertThat(n1).isNotNull().hasValue(1);
-            assertThat(n2).isNotNull().hasValue(2);
+            assertThat(n1).hasValue(1);
+            assertThat(n2).hasValue(2);
         }
 
     }


### PR DESCRIPTION
This PR changes to use `@Contract` to improve nullability for gauges.