### PR TITLE
Support newsgroups KeyValue for Jakarta Mail instrumentation

### DIFF
--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/mail/MailObservationDocumentation.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/mail/MailObservationDocumentation.java
@@ -121,6 +121,15 @@ public enum MailObservationDocumentation implements ObservationDocumentation {
             }
         },
         /**
+         * Newsgroup (Usenet news) recipient(s) of the mail.
+         */
+        SMTP_MESSAGE_NEWSGROUPS {
+            @Override
+            public String asString() {
+                return "smtp.message.newsgroups";
+            }
+        },
+        /**
          * Subject line of the mail.
          */
         SMTP_MESSAGE_SUBJECT {

--- a/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/mail/MailObservationDocumentationTest.java
+++ b/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/mail/MailObservationDocumentationTest.java
@@ -43,7 +43,7 @@ class MailObservationDocumentationTest {
         // Verify high cardinality key names
         KeyName[] highCardinalityKeyNames = mailSend.getHighCardinalityKeyNames();
         assertThat(highCardinalityKeyNames).containsExactly(SMTP_MESSAGE_FROM, SMTP_MESSAGE_TO, SMTP_MESSAGE_CC,
-                SMTP_MESSAGE_BCC, SMTP_MESSAGE_SUBJECT, SMTP_MESSAGE_ID);
+                SMTP_MESSAGE_BCC, SMTP_MESSAGE_NEWSGROUPS, SMTP_MESSAGE_SUBJECT, SMTP_MESSAGE_ID);
     }
 
 }


### PR DESCRIPTION
This PR changes to support newsgroups `KeyValue` for the Jakarta Mail instrumentation.

See https://github.com/micrometer-metrics/micrometer/pull/6554#discussion_r2220447314