### PR TITLE
Catch IllegalArgumentException in VirtualThreadMetrics

### DIFF
--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -121,7 +121,8 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
                 .description(LIVE_THREADS_DESCRIPTION)
                 .register(registry);
         }
-        catch (ClassNotFoundException | ClassCastException | NoSuchMethodException | IllegalAccessException ignored) {
+        catch (ClassNotFoundException | ClassCastException | NoSuchMethodException | IllegalAccessException
+                | IllegalArgumentException ignored) {
             // cannot instrument VirtualThreadSchedulerMXBean
         }
     }


### PR DESCRIPTION
According to javadoc `getPlatformMXBean` may throw `IllegalArgumentException` in case if `mxbeanInterface` is not a platform management interface or not a singleton platform MXBean. This is currently the case for graalvm native image (at least for 24.0.2).

I hesitated to add a test, but it looks a bit excessive. I also thought, maybe it's better to catch all `j.l.Exception`s for simplicity?