### PR TITLE
JettyConnectionMetrics: synchronize access to connectionSamples (#6578)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
@@ -121,7 +121,7 @@ public class JettyConnectionMetrics extends AbstractLifeCycle implements Connect
             .tags(tags)
             .register(registry);
 
-        Gauge.builder("jetty.connections.current", this, jcm -> jcm.connectionSamples.size())
+        Gauge.builder("jetty.connections.current", this, JettyConnectionMetrics::currentConnections)
             .strongReference(true)
             .baseUnit(BaseUnits.CONNECTIONS)
             .description("The current number of open Jetty connections")
@@ -258,6 +258,12 @@ public class JettyConnectionMetrics extends AbstractLifeCycle implements Connect
         catch (NoSuchMethodException ignore) {
         }
         return method;
+    }
+
+    private int currentConnections() {
+        synchronized (connectionSamplesLock) {
+            return connectionSamples.size();
+        }
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyConnectionMetrics.java
@@ -160,10 +160,12 @@ public class JettyConnectionMetrics extends AbstractLifeCycle implements Connect
     @Override
     public void onOpened(Connection connection) {
         Timer.Sample started = Timer.start(registry);
+        int connections;
         synchronized (connectionSamplesLock) {
             connectionSamples.put(connection, started);
-            maxConnections.record(connectionSamples.size());
+            connections = connectionSamples.size();
         }
+        maxConnections.record(connections);
     }
 
     @Override


### PR DESCRIPTION
Address [#6578](https://github.com/micrometer-metrics/micrometer/issues/6578) and shorten the duration the lock is held for, as a drive-by