### PR TITLE
Remove redundant requireNonNull checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ subprojects {
                 )
 
                 option("NullAway:OnlyNullMarked", "true")
-                option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract")
+                option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract,org.assertj.core.internal.annotation.Contract")
                 option("NullAway:CheckContracts", "true")
                 option("NullAway:HandleTestAssertionLibraries", "true")
                 if (javaLanguageVersion.canCompileOrRun(22)) {

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v1/DynatraceExporterV1Test.java
@@ -198,8 +198,7 @@ class DynatraceExporterV1Test {
         DynatraceTimeSeries timeSeries = metric.getTimeSeries();
         try {
             Map<String, Object> map = mapper.readValue(timeSeries.asJson(), Map.class);
-            // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1224
-            List<List<Number>> dataPoints = Objects.requireNonNull((List<List<Number>>) map.get("dataPoints"));
+            List<List<Number>> dataPoints = (List<List<Number>>) map.get("dataPoints");
             assertThat(dataPoints).hasSize(1);
             assertThat(dataPoints.get(0).get(1).doubleValue()).isEqualTo(GAUGE_VALUE);
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -127,8 +127,7 @@ class PushMeterRegistryTest {
         onClosePublishThread.join();
 
         assertThat(overlappingStepMeterRegistry.publishes).as("only one publish happened").hasSize(1);
-        // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1219
-        Deque<Double> firstPublishValues = Objects.requireNonNull(overlappingStepMeterRegistry.publishes.get(0));
+        Deque<Double> firstPublishValues = overlappingStepMeterRegistry.publishes.get(0);
         assertThat(firstPublishValues).isNotNull();
         assertThat(firstPublishValues.pop()).isEqualTo(1);
         assertThat(firstPublishValues.pop()).isEqualTo(2.5);
@@ -191,8 +190,7 @@ class PushMeterRegistryTest {
         closeThread.join();
 
         assertThat(registry.publishes).as("only one publish happened").hasSize(1);
-        // TODO: remove requireNonNull: https://github.com/uber/NullAway/issues/1219
-        Deque<Double> firstPublishValues = Objects.requireNonNull(registry.publishes.get(0));
+        Deque<Double> firstPublishValues = registry.publishes.get(0);
         assertThat(firstPublishValues).isNotNull();
         assertThat(firstPublishValues.pop()).isEqualTo(1); // c1 counter count
         assertThat(firstPublishValues.pop()).isEqualTo(2.5); // c2 counter count

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationContextAssert.java
@@ -453,8 +453,7 @@ public class ObservationContextAssert<SELF extends ObservationContextAssert<SELF
         if (p == null) {
             failWithMessage("Observation should have a parent");
         }
-        // see: https://github.com/uber/NullAway/issues/1222
-        return Objects.requireNonNull(p);
+        return p;
     }
 
     /**


### PR DESCRIPTION
This commit also adds `org.assertj.core.internal.annotation.Contract` as a custom contract annotation.

Relates to:
* https://github.com/uber/NullAway/issues/1222
* https://github.com/assertj/assertj/pull/3882