### PR TITLE
Apache HC 5 OTel semantic convention

### DIFF
--- a/docs/modules/ROOT/pages/reference/httpcomponents.adoc
+++ b/docs/modules/ROOT/pages/reference/httpcomponents.adoc
@@ -31,6 +31,18 @@ include::{include-core-test-java}/io/micrometer/core/instrument/binder/httpcompo
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java[tags=example_async, indent=0]
 -----
 
+=== Configure a custom convention
+
+You can pass an instance of `ApacheHttpClientObservationConvention` to customize the convention used by the instrumentation to something other than the default convention.
+
+For example, you can pass the instance of `OpenTelemetryApacheHttpClientObservationConvention` to use the https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/http/http-metrics.md#http-client[OpenTelemetry Semantic Conventions for HTTP Clients based on version 1.36.0].
+
+[source,java,subs=+attributes]
+-----
+include::{include-core-test-java}/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java[tags=setup_classic_otel, indent=0]
+-----
+<1> Pass `OpenTelemetryApacheHttpClientObservationConvention.INSTANCE` to the `ObservationExecChainHandler` constructor
+
 == Retry Strategy Considerations
 
 HttpClient supports build-in request retry handling. Like micrometer observations, this functionality is implemented as an `ExecChainHandler` named `ChainElement.RETRY`. When instrumenting the client, you'll have to decide whether to observe individual retries or not. If the `ObservationExecChainHandler` is placed _before_ the retry handler, micrometer will see the initial request and the final outcome after the last retry. Elapsed time will account for any delays imposed by the retry handler. On the other hand, if micrometer is registered _after_ the retry handler, it will be invoked for each individual retry. Elapsed time will measure the individual http requests, but *_without_* the backoff delay imposed by the retry handler. The described behaviour and related configuration are the same for both the classic and the async client - with one exception described in the following note.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpMethods.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/http/HttpMethods.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.http;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Utility functions related to HTTP methods.
+ *
+ * @since 1.16.0
+ */
+public final class HttpMethods {
+
+    private static final Set<String> STANDARD_HTTP_METHODS = new HashSet<>(9);
+
+    static {
+        STANDARD_HTTP_METHODS.add("GET");
+        STANDARD_HTTP_METHODS.add("HEAD");
+        STANDARD_HTTP_METHODS.add("POST");
+        STANDARD_HTTP_METHODS.add("PUT");
+        STANDARD_HTTP_METHODS.add("DELETE");
+        STANDARD_HTTP_METHODS.add("CONNECT");
+        STANDARD_HTTP_METHODS.add("OPTIONS");
+        STANDARD_HTTP_METHODS.add("TRACE");
+        STANDARD_HTTP_METHODS.add("PATCH");
+
+    }
+
+    private HttpMethods() {
+    }
+
+    /**
+     * Checks if the given method is a well-known HTTP method defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC 9110</a> and
+     * <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC 5789</a>. This is
+     * case-sensitive and known methods are all uppercase.
+     * @param method HTTP method to check
+     * @return {@code true} if the given method is a standard HTTP method
+     */
+    public static boolean isStandard(String method) {
+        return STANDARD_HTTP_METHODS.contains(method);
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
@@ -53,7 +53,7 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
 
     private static final KeyValue STATUS_UNKNOWN = LowCardinalityKeyNames.STATUS.withValue("0");
 
-    private static final KeyValue EXCEPTION_NONE = LowCardinalityKeyNames.EXCEPTION.withNoneValue();
+    private static final KeyValue EXCEPTION_NONE = LowCardinalityKeyNames.ERROR_TYPE.withNoneValue();
 
     private static final KeyValue OUTCOME_UNKNOWN = LowCardinalityKeyNames.OUTCOME.withValue(Outcome.UNKNOWN.name());
 
@@ -173,7 +173,7 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
     protected KeyValue exception(ApacheHttpClientContext context) {
         Throwable error = context.getError();
         if (error != null) {
-            return LowCardinalityKeyNames.EXCEPTION.withValue(error.getClass().getSimpleName());
+            return LowCardinalityKeyNames.ERROR_TYPE.withValue(error.getClass().getSimpleName());
         }
         return EXCEPTION_NONE;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 VMware, Inc.
+ * Copyright 2025 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
@@ -51,9 +51,7 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
 
     private static final KeyValue URL_UNKNOWN = HighCardinalityKeyNames.URL.withValue("UNKNOWN");
 
-    private static final KeyValue STATUS_IO_ERROR = LowCardinalityKeyNames.STATUS.withValue("IO_ERROR");
-
-    private static final KeyValue STATUS_CLIENT_ERROR = LowCardinalityKeyNames.STATUS.withValue("CLIENT_ERROR");
+    private static final KeyValue STATUS_UNKNOWN = LowCardinalityKeyNames.STATUS.withValue("0");
 
     private static final KeyValue EXCEPTION_NONE = LowCardinalityKeyNames.EXCEPTION.withNoneValue();
 
@@ -61,7 +59,7 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
 
     private static final KeyValue SERVER_ADDRESS_UNKNOWN = LowCardinalityKeyNames.SERVER_ADDRESS.withValue("UNKNOWN");
 
-    private static final KeyValue SERVER_PORT_UNKNOWN = LowCardinalityKeyNames.SERVER_PORT.withValue("UNKNOWN");
+    private static final KeyValue SERVER_PORT_UNKNOWN = LowCardinalityKeyNames.SERVER_PORT.withValue("-1");
 
     // There is no need to instantiate this class multiple times, but it may be extended,
     // hence protected visibility.
@@ -188,13 +186,11 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
     protected KeyValue status(ApacheHttpClientContext context) {
         Throwable error = context.getError();
         if (error instanceof IOException || error instanceof HttpException || error instanceof RuntimeException) {
-            return STATUS_IO_ERROR;
+            return STATUS_UNKNOWN;
         }
         HttpResponse response = context.getResponse();
         if (response == null) {
-            // TODO should we return something like 0 or -1 to adhere to the definition of
-            // this as an int?
-            return STATUS_CLIENT_ERROR;
+            return STATUS_UNKNOWN;
         }
         return LowCardinalityKeyNames.STATUS.withValue(String.valueOf(response.getCode()));
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.httpcomponents.hc5;
 
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.binder.http.HttpMethods;
 import io.micrometer.core.instrument.binder.http.Outcome;
 import io.micrometer.core.instrument.binder.httpcomponents.hc5.OpenTelemetryApacheHttpClientObservationDocumentation.HighCardinalityKeyNames;
 import io.micrometer.core.instrument.binder.httpcomponents.hc5.OpenTelemetryApacheHttpClientObservationDocumentation.LowCardinalityKeyNames;
@@ -29,8 +30,6 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * Implementation of {@link ApacheHttpClientObservationConvention} based on the
@@ -63,26 +62,6 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
     private static final KeyValue SERVER_ADDRESS_UNKNOWN = LowCardinalityKeyNames.SERVER_ADDRESS.withValue("UNKNOWN");
 
     private static final KeyValue SERVER_PORT_UNKNOWN = LowCardinalityKeyNames.SERVER_PORT.withValue("UNKNOWN");
-
-    /**
-     * Known HTTP methods as defined in
-     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC 9110</a> and
-     * <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC 5789</a>.
-     */
-    private static final Set<String> KNOWN_HTTP_METHODS = new HashSet<>();
-
-    static {
-        KNOWN_HTTP_METHODS.add("GET");
-        KNOWN_HTTP_METHODS.add("HEAD");
-        KNOWN_HTTP_METHODS.add("POST");
-        KNOWN_HTTP_METHODS.add("PUT");
-        KNOWN_HTTP_METHODS.add("DELETE");
-        KNOWN_HTTP_METHODS.add("CONNECT");
-        KNOWN_HTTP_METHODS.add("OPTIONS");
-        KNOWN_HTTP_METHODS.add("TRACE");
-        KNOWN_HTTP_METHODS.add("PATCH");
-
-    }
 
     // There is no need to instantiate this class multiple times, but it may be extended,
     // hence protected visibility.
@@ -133,7 +112,7 @@ public class OpenTelemetryApacheHttpClientObservationConvention implements Apach
 
     protected @Nullable String maybeGetKnownMethod(HttpRequest request) {
         String httpMethod = request.getMethod();
-        if (KNOWN_HTTP_METHODS.contains(httpMethod)) {
+        if (HttpMethods.isStandard(httpMethod)) {
             return httpMethod;
         }
         return null;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationConvention.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.core.instrument.binder.http.Outcome;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.OpenTelemetryApacheHttpClientObservationDocumentation.HighCardinalityKeyNames;
+import io.micrometer.core.instrument.binder.httpcomponents.hc5.OpenTelemetryApacheHttpClientObservationDocumentation.LowCardinalityKeyNames;
+import org.apache.hc.client5.http.RouteInfo;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Implementation of {@link ApacheHttpClientObservationConvention} based on the
+ * OpenTelemetry Semantic Conventions v1.36.0 for HTTP clients.
+ *
+ * @since 1.16.0
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/http/README.md">OpenTelemetry
+ * Semantic Conventions v1.36.0 for HTTP</a>
+ */
+public class OpenTelemetryApacheHttpClientObservationConvention implements ApacheHttpClientObservationConvention {
+
+    /**
+     * Singleton instance of this convention.
+     */
+    public static final OpenTelemetryApacheHttpClientObservationConvention INSTANCE = new OpenTelemetryApacheHttpClientObservationConvention();
+
+    private static final KeyValue METHOD_OTHER = LowCardinalityKeyNames.METHOD.withValue("_OTHER");
+
+    private static final KeyValue URL_UNKNOWN = HighCardinalityKeyNames.URL.withValue("UNKNOWN");
+
+    private static final KeyValue STATUS_IO_ERROR = LowCardinalityKeyNames.STATUS.withValue("IO_ERROR");
+
+    private static final KeyValue STATUS_CLIENT_ERROR = LowCardinalityKeyNames.STATUS.withValue("CLIENT_ERROR");
+
+    private static final KeyValue EXCEPTION_NONE = LowCardinalityKeyNames.EXCEPTION.withNoneValue();
+
+    private static final KeyValue OUTCOME_UNKNOWN = LowCardinalityKeyNames.OUTCOME.withValue(Outcome.UNKNOWN.name());
+
+    private static final KeyValue SERVER_ADDRESS_UNKNOWN = LowCardinalityKeyNames.SERVER_ADDRESS.withValue("UNKNOWN");
+
+    private static final KeyValue SERVER_PORT_UNKNOWN = LowCardinalityKeyNames.SERVER_PORT.withValue("UNKNOWN");
+
+    /**
+     * Known HTTP methods as defined in
+     * <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-methods">RFC 9110</a> and
+     * <a href="https://www.rfc-editor.org/rfc/rfc5789.html">RFC 5789</a>.
+     */
+    private static final Set<String> KNOWN_HTTP_METHODS = new HashSet<>();
+
+    static {
+        KNOWN_HTTP_METHODS.add("GET");
+        KNOWN_HTTP_METHODS.add("HEAD");
+        KNOWN_HTTP_METHODS.add("POST");
+        KNOWN_HTTP_METHODS.add("PUT");
+        KNOWN_HTTP_METHODS.add("DELETE");
+        KNOWN_HTTP_METHODS.add("CONNECT");
+        KNOWN_HTTP_METHODS.add("OPTIONS");
+        KNOWN_HTTP_METHODS.add("TRACE");
+        KNOWN_HTTP_METHODS.add("PATCH");
+
+    }
+
+    // There is no need to instantiate this class multiple times, but it may be extended,
+    // hence protected visibility.
+    protected OpenTelemetryApacheHttpClientObservationConvention() {
+    }
+
+    @Override
+    public String getName() {
+        return "http.client.request.duration";
+    }
+
+    /**
+     * HTTP span names SHOULD be {@code {method} {target}} if there is a (low-cardinality)
+     * {@code target} available. If there is no (low-cardinality) {@code {target}}
+     * available, HTTP span names SHOULD be {@code {method}}.
+     * <p>
+     * The {@code {method}} MUST be {@code {http.request.method}} if the method represents
+     * the original method known to the instrumentation. In other cases (when Customize
+     * Toolbar… is set to {@code _OTHER}), {@code {method}} MUST be HTTP.
+     * <p>
+     * The {@code target} SHOULD be the {@code {url.template}} for HTTP Client spans if
+     * enabled and available.
+     * @param context context
+     * @return contextual name
+     * @see <a href=
+     * "https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/http/http-spans.md#name">OpenTelemetry
+     * Semantic Convention HTTP Span Name (v1.36.0)</a>
+     */
+    @Override
+    public String getContextualName(ApacheHttpClientContext context) {
+        if (context.getCarrier() == null) {
+            return "HTTP";
+        }
+        String maybeMethod = maybeGetKnownMethod(context.getCarrier());
+        return maybeMethod == null ? "HTTP" : maybeMethod;
+    }
+
+    @Override
+    public KeyValues getLowCardinalityKeyValues(ApacheHttpClientContext context) {
+        return KeyValues.of(exception(context), method(context), status(context), outcome(context),
+                serverAddress(context), serverPort(context));
+    }
+
+    @Override
+    public KeyValues getHighCardinalityKeyValues(ApacheHttpClientContext context) {
+        return KeyValues.of(urlFull(context));
+    }
+
+    protected @Nullable String maybeGetKnownMethod(HttpRequest request) {
+        String httpMethod = request.getMethod();
+        if (KNOWN_HTTP_METHODS.contains(httpMethod)) {
+            return httpMethod;
+        }
+        return null;
+    }
+
+    /**
+     * Extract {@code method} key value from context.
+     * @param context HTTP client context
+     * @return extracted {@code method} key value
+     */
+    protected KeyValue method(ApacheHttpClientContext context) {
+        HttpRequest request = context.getCarrier();
+        String method;
+        if (request != null && (method = maybeGetKnownMethod(request)) != null) {
+            return LowCardinalityKeyNames.METHOD.withValue(method);
+        }
+        return METHOD_OTHER;
+    }
+
+    /**
+     * Extract server address key value from context.
+     * @param context HTTP client context
+     * @return extracted server address key value
+     */
+    protected KeyValue serverAddress(ApacheHttpClientContext context) {
+        RouteInfo httpRoute = getHttpRoute(context);
+        if (httpRoute != null) {
+            return LowCardinalityKeyNames.SERVER_ADDRESS.withValue(httpRoute.getTargetHost().getHostName());
+        }
+        URI uri = getUri(context);
+        if (uri != null && uri.getHost() != null) {
+            return LowCardinalityKeyNames.SERVER_ADDRESS.withValue(uri.getHost());
+        }
+        return SERVER_ADDRESS_UNKNOWN;
+    }
+
+    /**
+     * Extract server port key value from context.
+     * @param context HTTP client context
+     * @return extracted server port key value
+     */
+    protected KeyValue serverPort(ApacheHttpClientContext context) {
+        RouteInfo httpRoute = getHttpRoute(context);
+        if (httpRoute != null) {
+            int port = httpRoute.getTargetHost().getPort();
+            return LowCardinalityKeyNames.SERVER_PORT.withValue(String.valueOf(port));
+        }
+        URI uri = getUri(context);
+        if (uri != null && uri.getPort() != -1) {
+            return LowCardinalityKeyNames.SERVER_PORT.withValue(String.valueOf(uri.getPort()));
+        }
+        return SERVER_PORT_UNKNOWN;
+    }
+
+    /**
+     * Extract {@code exception} key value from context.
+     * @param context HTTP client context
+     * @return extracted {@code exception} key value
+     */
+    protected KeyValue exception(ApacheHttpClientContext context) {
+        Throwable error = context.getError();
+        if (error != null) {
+            return LowCardinalityKeyNames.EXCEPTION.withValue(error.getClass().getSimpleName());
+        }
+        return EXCEPTION_NONE;
+    }
+
+    /**
+     * Extract status key value from context.
+     * @param context HTTP client context
+     * @return extracted Status key value
+     */
+    protected KeyValue status(ApacheHttpClientContext context) {
+        Throwable error = context.getError();
+        if (error instanceof IOException || error instanceof HttpException || error instanceof RuntimeException) {
+            return STATUS_IO_ERROR;
+        }
+        HttpResponse response = context.getResponse();
+        if (response == null) {
+            // TODO should we return something like 0 or -1 to adhere to the definition of
+            // this as an int?
+            return STATUS_CLIENT_ERROR;
+        }
+        return LowCardinalityKeyNames.STATUS.withValue(String.valueOf(response.getCode()));
+    }
+
+    /**
+     * Extract {@code outcome} key value from context.
+     * @param context HTTP client context
+     * @return extracted {@code outcome} key value
+     */
+    protected KeyValue outcome(ApacheHttpClientContext context) {
+        HttpResponse response = context.getResponse();
+        if (response == null) {
+            return OUTCOME_UNKNOWN;
+        }
+        return LowCardinalityKeyNames.OUTCOME.withValue(Outcome.forStatus(response.getCode()).name());
+    }
+
+    protected KeyValue urlFull(ApacheHttpClientContext context) {
+        HttpRequest request = context.getCarrier();
+        URI uri;
+        if (request != null && (uri = getUri(context)) != null) {
+            return HighCardinalityKeyNames.URL.withValue(uri.toString());
+        }
+        return URL_UNKNOWN;
+    }
+
+    private static @Nullable URI getUri(ApacheHttpClientContext context) {
+        HttpRequest request = context.getCarrier();
+        if (request != null) {
+            try {
+                return request.getUri();
+            }
+            catch (URISyntaxException ignored) {
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable RouteInfo getHttpRoute(ApacheHttpClientContext context) {
+        return context.getHttpClientContext().getHttpRoute();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 VMware, Inc.
+ * Copyright 2025 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.httpcomponents.hc5;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.docs.ObservationDocumentation;
+
+/**
+ * {@link ObservationDocumentation} for Apache HTTP Client 5 instrumentation based on
+ * OpenTelemetry Semantic Conventions v1.36.0 for HTTP.
+ *
+ * @since 1.16.0
+ * @see ObservationExecChainHandler
+ */
+public enum OpenTelemetryApacheHttpClientObservationDocumentation implements ObservationDocumentation {
+
+    DEFAULT {
+        @Override
+        public Class<? extends ObservationConvention<? extends Observation.Context>> getDefaultConvention() {
+            return OpenTelemetryApacheHttpClientObservationConvention.class;
+        }
+
+        @Override
+        public KeyName[] getLowCardinalityKeyNames() {
+            return LowCardinalityKeyNames.values();
+        }
+
+        @Override
+        public KeyName[] getHighCardinalityKeyNames() {
+            return HighCardinalityKeyNames.values();
+        }
+    };
+
+    enum LowCardinalityKeyNames implements KeyName {
+
+        METHOD {
+            @Override
+            public String asString() {
+                return "http.request.method";
+            }
+        },
+        SERVER_ADDRESS {
+            @Override
+            public String asString() {
+                return "server.address";
+            }
+        },
+        SERVER_PORT {
+            @Override
+            public String asString() {
+                return "server.port";
+            }
+        },
+        EXCEPTION {
+            @Override
+            public String asString() {
+                return "error.type";
+            }
+        },
+        STATUS {
+            @Override
+            public String asString() {
+                return "http.response.status_code";
+            }
+        },
+
+        /**
+         * Key name for outcome.
+         */
+        OUTCOME {
+            @Override
+            public String asString() {
+                return "outcome";
+            }
+        },
+
+    }
+
+    enum HighCardinalityKeyNames implements KeyName {
+
+        URL {
+            @Override
+            public String asString() {
+                return "url.full";
+            }
+        },
+        /**
+         * Original HTTP method sent by the client in the request line. This may differ
+         * from the {@code {http.request.method}} if an unknown method is used.
+         */
+        METHOD_ORIGINAL {
+            @Override
+            public String asString() {
+                return "http.request.method_original";
+            }
+        }
+
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/OpenTelemetryApacheHttpClientObservationDocumentation.java
@@ -66,7 +66,7 @@ public enum OpenTelemetryApacheHttpClientObservationDocumentation implements Obs
                 return "server.port";
             }
         },
-        EXCEPTION {
+        ERROR_TYPE {
             @Override
             public String asString() {
                 return "error.type";


### PR DESCRIPTION
Adds an ObservationConvention implementation for the Apache HC 5 instrumentation that follows the latest (at this time) OpenTelemetry semantic conventions for HTTP clients. Also adds an ObservationDocumentation for it as well.

Documentation has been updated to demonstrate how the convention can be configured with the instrumentation.