### PR TITLE
Add eventexecutor workers metric for netty

### DIFF
--- a/docs/modules/ROOT/pages/reference/netty.adoc
+++ b/docs/modules/ROOT/pages/reference/netty.adoc
@@ -29,11 +29,11 @@ The `NettyEventExecutorMetrics` binder collects metrics from Netty's `EventExecu
 |===
 |Metric |Type |Description
 
-|`netty.eventexecutor.workers`
+|`eventexecutor.workers`
 |Gauge
 |The number of event executor workers
 
-|`netty.eventexecutor.tasks.pending`
+|`eventexecutor.tasks.pending`
 |Gauge
 |The number of pending tasks in individual event executors
 

--- a/docs/modules/ROOT/pages/reference/netty.adoc
+++ b/docs/modules/ROOT/pages/reference/netty.adoc
@@ -20,3 +20,21 @@ include::{include-java}/netty/NettyMetricsTests.java[tags=channelInstrumentation
 -----
 
 CAUTION: If you use lazy instrumentation, you must ensure that you do not bind metrics for the same resource multiple times, as this can have runtime drawbacks.
+
+== EventExecutor Metrics
+
+The `NettyEventExecutorMetrics` binder collects metrics from Netty's `EventExecutor` instances:
+
+.EventExecutor metrics
+|===
+|Metric |Type |Description
+
+|`netty.eventexecutor.workers`
+|Gauge
+|The number of event executor workers
+
+|`netty.eventexecutor.tasks.pending`
+|Gauge
+|The number of pending tasks in individual event executors
+
+|===

--- a/docs/src/test/java/io/micrometer/docs/netty/NettyMetricsTests.java
+++ b/docs/src/test/java/io/micrometer/docs/netty/NettyMetricsTests.java
@@ -121,7 +121,7 @@ class NettyMetricsTests {
             names.forEach(name -> assertThat(this.registry.get(NettyMeters.EVENT_EXECUTOR_TASKS_PENDING.getName())
                 .tags(Tags.of("name", name))
                 .gauge()
-                .value()).isNaN());
+                .value()).isEqualTo(0.0));
         });
 
         Tags tags = Tags.of("id", String.valueOf(unpooledByteBufAllocator.hashCode()), "allocator.type",

--- a/docs/src/test/java/io/micrometer/docs/netty/NettyMetricsTests.java
+++ b/docs/src/test/java/io/micrometer/docs/netty/NettyMetricsTests.java
@@ -121,7 +121,7 @@ class NettyMetricsTests {
             names.forEach(name -> assertThat(this.registry.get(NettyMeters.EVENT_EXECUTOR_TASKS_PENDING.getName())
                 .tags(Tags.of("name", name))
                 .gauge()
-                .value()).isEqualTo(0.0));
+                .value()).isNaN());
         });
 
         Tags tags = Tags.of("id", String.valueOf(unpooledByteBufAllocator.hashCode()), "allocator.type",

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyEventExecutorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyEventExecutorMetrics.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.netty.channel.EventLoop;
+import io.netty.channel.MultithreadEventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.concurrent.SingleThreadEventExecutor;
 
@@ -77,6 +78,16 @@ public class NettyEventExecutorMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
+        if (this.eventExecutors instanceof MultithreadEventLoopGroup) {
+            MultithreadEventLoopGroup eventLoopGroup = (MultithreadEventLoopGroup) this.eventExecutors;
+            Gauge
+                .builder(NettyMeters.EVENT_EXECUTOR_WORKERS.getName(), eventLoopGroup,
+                        MultithreadEventLoopGroup::executorCount)
+                .description("The total number of event loop workers.")
+                .tags(this.tags)
+                .register(registry);
+        }
+
         this.eventExecutors.forEach(eventExecutor -> {
             if (eventExecutor instanceof SingleThreadEventExecutor) {
                 SingleThreadEventExecutor singleThreadEventExecutor = (SingleThreadEventExecutor) eventExecutor;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyEventExecutorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyEventExecutorMetrics.java
@@ -81,7 +81,7 @@ public class NettyEventExecutorMetrics implements MeterBinder {
         Gauge
             .builder(NettyMeters.EVENT_EXECUTOR_WORKERS.getName(), this.eventExecutors,
                     NettyEventExecutorMetrics::getExecutorCount)
-            .description("The total number of event loop workers.")
+            .description("Number of event executor workers")
             .tags(tags)
             .register(registry);
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyMeters.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/netty4/NettyMeters.java
@@ -188,6 +188,26 @@ public enum NettyMeters implements MeterDocumentation {
         public KeyName[] getKeyNames() {
             return EventExecutorTasksPendingKeyNames.values();
         }
+    },
+
+    /**
+     * Number of event executor workers.
+     */
+    EVENT_EXECUTOR_WORKERS {
+        @Override
+        public String getName() {
+            return "netty.eventexecutor.workers";
+        }
+
+        @Override
+        public Meter.Type getType() {
+            return Meter.Type.GAUGE;
+        }
+
+        @Override
+        public KeyName[] getKeyNames() {
+            return new KeyName[0];
+        }
     };
 
     enum AllocatorKeyNames implements KeyName {


### PR DESCRIPTION
### Problem
It is difficult to monitor the state of Netty event loop workers in real-time during production, and having this visibility would be helpful for debugging and root cause analysis of network issues.
For example, in our Netty-based WebSocket + STOMP + RabbitMQ environment, we encountered ConnectTimeoutException errors under load. 
Being able to immediately check the status of workers would help us identify and resolve these problems more easily.


### Solution
Add the eventexecutor.workers metric to expose the number of Netty event loop workers in real-time.


### Rationale
This metric allows operators to quickly monitor the count and status of workers, enabling faster diagnosis and response to issues. 
Ultimately, it improves system stability and operational efficiency.


### Local Verification 
I've confirmed locally that the new metric is registered correctly after applying the changes. 
As you can see below, netty.eventexecutor.workers is successfully created with the expected value.

<img width="416" height="199" alt="image" src="https://github.com/user-attachments/assets/b70fb498-eab8-4131-87de-fd270a5e2574" />

<br/>

Resolves #6375  