### PR TITLE
Add convenience methods to match Meter.Ids

### DIFF
--- a/docs/modules/ROOT/pages/concepts/meter-filters.adoc
+++ b/docs/modules/ROOT/pages/concepts/meter-filters.adoc
@@ -160,10 +160,12 @@ See the following example:
 [source, java]
 ----
 registry.config()
-    .meterFilter(MeterFilter.forMeters(startsWith("prefix"), MeterFilter.ignoreTags("extra")));
-
-Predicate<Meter.Id> startsWith(String prefix) {
-    return id -> id.getName().startsWith(prefix);
-}
+    .meterFilter(MeterFilter.forMeters(Meter.Id.nameStartsWith("prefix"), MeterFilter.ignoreTags("extra")));
 ----
 ====
+
+`Meter.Id` provides the following convenience methods to match meters:
+
+* `nameStartsWith(String)`: Matches meters with names starting with the given prefix.
+* `hasName(String)`: Matches meters with names that are equal to the given name.
+* `hasType(Meter.Type)`: Matches meters with the given type

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -183,6 +184,18 @@ public interface Meter {
      * A meter is uniquely identified by its combination of name and tags.
      */
     class Id {
+
+        static Predicate<Meter.Id> hasName(String expectedName) {
+            return id -> id.getName().equals(expectedName);
+        }
+
+        static Predicate<Meter.Id> nameStartsWith(String expectedPrefix) {
+            return id -> id.getName().startsWith(expectedPrefix);
+        }
+
+        static Predicate<Meter.Id> hasType(Meter.Type expectedType) {
+            return id -> id.getType() == expectedType;
+        }
 
         private final String name;
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterIdTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterIdTest.java
@@ -56,4 +56,28 @@ class MeterIdTest {
         assertThat(newId.getTags()).containsExactlyElementsOf(Tags.of("k1", "n1", "k", "n"));
     }
 
+    @Test
+    void hasName() {
+        Meter.Id id = new Meter.Id("my.id", Tags.empty(), null, null, Meter.Type.COUNTER);
+
+        assertThat(Meter.Id.hasName("my.id")).accepts(id);
+        assertThat(Meter.Id.hasName("other.id")).rejects(id);
+    }
+
+    @Test
+    void nameStartsWith() {
+        Meter.Id id = new Meter.Id("my.id", Tags.empty(), null, null, Meter.Type.COUNTER);
+
+        assertThat(Meter.Id.nameStartsWith("my")).accepts(id);
+        assertThat(Meter.Id.nameStartsWith("other")).rejects(id);
+    }
+
+    @Test
+    void hasType() {
+        Meter.Id id = new Meter.Id("my.id", Tags.empty(), null, null, Meter.Type.COUNTER);
+
+        assertThat(Meter.Id.hasType(Meter.Type.COUNTER)).accepts(id);
+        assertThat(Meter.Id.hasType(Meter.Type.TIMER)).rejects(id);
+    }
+
 }


### PR DESCRIPTION
A follow-up to #6594, this adds the most likely predicates for usage with MeterFilter.forMeters