### PR TITLE
ensure tags are preserved for fetchExists(Table, Condition)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -790,4 +790,9 @@ public class MetricsDSLContext extends DefaultDSLContext {
         return timeCoercable(super.update(table));
     }
 
+    @Override
+    public boolean fetchExists(Table<?> table, Condition condition) {
+        return super.fetchExists(super.selectOne().from(table).where(condition));
+    }
+
 }


### PR DESCRIPTION
Override MetricsDSLContext#fetchExists(Table, Condition) to delegate to
super.fetchExists(DSL.selectOne().from(table).where(condition)), forcing the
standard SELECT path so that JooqExecuteListener receives the tags and metrics
are reported with the provided tags.

Tests:
- fetchExistsIsTimedWithProvidedTags: verifies that calling
  dsl.tag("name","checkAuthorExists").fetchExists(...) records "jooq.query"
  with tags name=checkAuthorExists and type=read, and timer count = 1 on H2.

related #6583 