### PR TITLE
Skip DistributionStatisticsConfig creation when retrieving timers

### DIFF
--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -28,11 +28,11 @@ compileJava {
 
 dependencies {
     jmh project(':micrometer-core')
-//    jmh 'io.micrometer:micrometer-core:1.13.0-M2'
+//    jmh 'io.micrometer:micrometer-core:1.16.0-M2'
     jmh project(':micrometer-registry-prometheus')
-//    jmh 'io.micrometer:micrometer-registry-prometheus:1.13.0-M2'
+//    jmh 'io.micrometer:micrometer-registry-prometheus:1.16.0-M2'
     jmh project(':micrometer-registry-otlp')
-//    jmh 'io.micrometer:micrometer-registry-otlp:1.13.0-M2'
+//    jmh 'io.micrometer:micrometer-registry-otlp:1.16.0-M2'
 
     jmh libs.dropwizardMetricsCore5
     jmh libs.prometheusMetrics

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
@@ -15,12 +15,11 @@
  */
 package io.micrometer.benchmark.core;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Meter;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
@@ -50,6 +49,8 @@ public class MeterRegistrationBenchmark {
 
     Meter.MeterProvider<Counter> counterMeterProvider = Counter.builder("jmh.existing").withRegistry(registry);
 
+    Tags tags = Tags.of("key", "value");
+
     @Setup
     public void setup() {
         registry.config()
@@ -58,6 +59,17 @@ public class MeterRegistrationBenchmark {
         registry.counter("jmh.stale");
         registry.config().meterFilter(MeterFilter.acceptNameStartsWith("jmh"));
         registry.counter("jmh.existing", "k1", "v1");
+        registry.timer("jmh.existing.timer", tags);
+    }
+
+    @Benchmark
+    public Timer registerExistingTimer() {
+        return registry.timer("jmh.existing.timer", tags);
+    }
+
+    @Benchmark
+    public Timer registerExistingTimerBuilder() {
+        return Timer.builder("jmh.existing.timer").tags(tags).register(registry);
     }
 
     @Benchmark

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimerBuilder.java
@@ -32,6 +32,15 @@ import java.util.Arrays;
 @SuppressWarnings("unchecked")
 public abstract class AbstractTimerBuilder<B extends AbstractTimerBuilder<B>> {
 
+    /**
+     * Default {@link DistributionStatisticConfig} used with {@link Timer} if not
+     * overridden.
+     */
+    static final DistributionStatisticConfig DEFAULT_DISTRIBUTION_CONFIG = DistributionStatisticConfig.builder()
+        .minimumExpectedValue((double) Duration.ofMillis(1).toNanos())
+        .maximumExpectedValue((double) Duration.ofSeconds(30).toNanos())
+        .build();
+
     protected final String name;
 
     protected Tags tags = Tags.empty();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -287,6 +287,11 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      */
     class Builder {
 
+        static final DistributionStatisticConfig DEFAULT_DISTRIBUTION_CONFIG = DistributionStatisticConfig.builder()
+            .minimumExpectedValue((double) Duration.ofMinutes(2).toNanos())
+            .maximumExpectedValue((double) Duration.ofHours(2).toNanos())
+            .build();
+
         private final String name;
 
         private Tags tags = Tags.empty();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -486,7 +486,8 @@ public abstract class MeterRegistry {
      * @return A new or existing timer.
      */
     public Timer timer(String name, Iterable<Tag> tags) {
-        return Timer.builder(name).tags(tags).register(this);
+        return this.timer(new Meter.Id(name, Tags.of(tags), null, null, Meter.Type.TIMER),
+                AbstractTimerBuilder.DEFAULT_DISTRIBUTION_CONFIG, pauseDetector);
     }
 
     /**
@@ -1057,7 +1058,8 @@ public abstract class MeterRegistry {
          * @return A new or existing long task timer.
          */
         public LongTaskTimer longTaskTimer(String name, Iterable<Tag> tags) {
-            return LongTaskTimer.builder(name).tags(tags).register(MeterRegistry.this);
+            return longTaskTimer(new Meter.Id(name, Tags.of(tags), null, null, Meter.Type.LONG_TASK_TIMER),
+                    LongTaskTimer.Builder.DEFAULT_DISTRIBUTION_CONFIG);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
@@ -71,9 +71,8 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
     @Override
     public void onStart(Observation.Context context) {
         if (shouldCreateLongTaskTimer) {
-            LongTaskTimer.Sample longTaskSample = LongTaskTimer.builder(context.getName() + ".active")
-                .tags(createTags(context))
-                .register(meterRegistry)
+            LongTaskTimer.Sample longTaskSample = meterRegistry.more()
+                .longTaskTimer(context.getName() + ".active", createTags(context))
                 .start();
             context.put(LongTaskTimer.Sample.class, longTaskSample);
         }
@@ -89,7 +88,7 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
         List<Tag> tags = createTags(context);
         tags.add(Tag.of("error", getErrorValue(context)));
         Timer.Sample sample = context.getRequired(Timer.Sample.class);
-        sample.stop(Timer.builder(context.getName()).tags(tags).register(this.meterRegistry));
+        sample.stop(this.meterRegistry.timer(context.getName(), tags));
 
         if (shouldCreateLongTaskTimer) {
             LongTaskTimer.Sample longTaskSample = context.getRequired(LongTaskTimer.Sample.class);


### PR DESCRIPTION
In the case where the Timer/LongTaskTimer builder is not used, the DistributionStatisticsConfig is necessarily one with the default configuration being passed to registerMeterIfNecessary. We can avoid creating and configuring a DistributionStatisticsConfig that will always have the same config by keeping a static default one to use in these cases.

In performance critical areas the API to register Timer/LongTaskTimer that doesn't use the Builder should be preferred for this reason.

The usage in DefaultMeterObservationHandler has been updated accordingly, which should improve the performance and allocations for all applications using it.