### PR TITLE
Avoid capturing lambda allocation when retrieving existing meters

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 2)
 @Measurement(iterations = 5)
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(2)
 public class MeterRegistrationBenchmark {
 
@@ -49,7 +49,7 @@ public class MeterRegistrationBenchmark {
 
     Meter.MeterProvider<Counter> counterMeterProvider = Counter.builder("jmh.existing").withRegistry(registry);
 
-    Tags tags = Tags.of("key", "value");
+    Tags tags = Tags.of("k1", "v1");
 
     @Setup
     public void setup() {
@@ -89,8 +89,8 @@ public class MeterRegistrationBenchmark {
     }
 
     @Benchmark
-    public Meter registerExisting() {
-        return registry.counter("jmh.existing", "k1", "v1");
+    public Meter registerExistingCounter() {
+        return registry.counter("jmh.existing", tags);
     }
 
     @Benchmark

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
@@ -80,11 +80,11 @@ public class ObservationBenchmark {
         };
     }
 
-    @TearDown
-    public void tearDown() {
-        System.out.println("Meters:");
-        System.out.println(meterRegistry.getMetersAsString());
-    }
+    // @TearDown
+    // public void tearDown() {
+    // System.out.println("Meters:");
+    // System.out.println(meterRegistry.getMetersAsString());
+    // }
 
     @Benchmark
     public void baseline() {

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
@@ -80,11 +80,11 @@ public class ObservationBenchmark {
         };
     }
 
-    // @TearDown
-    // public void tearDown() {
-    // System.out.println("Meters:");
-    // System.out.println(meterRegistry.getMetersAsString());
-    // }
+    @TearDown
+    public void tearDown() {
+        System.out.println("Meters:");
+        System.out.println(meterRegistry.getMetersAsString());
+    }
 
     @Benchmark
     public void baseline() {

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/types/DynatraceTimerTest.java
@@ -47,7 +47,7 @@ class DynatraceTimerTest {
 
     private static final DistributionStatisticConfig DISTRIBUTION_STATISTIC_CONFIG = DistributionStatisticConfig.NONE;
 
-    private static final PauseDetector PAUSE_DETECTOR = new NoPauseDetector();
+    private static final PauseDetector PAUSE_DETECTOR = NoPauseDetector.INSTANCE;
 
     @Test
     void testTimerCount() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -456,7 +456,7 @@ public abstract class MeterRegistry {
      * @return A new or existing counter.
      */
     public Counter counter(String name, Iterable<Tag> tags) {
-        return Counter.builder(name).tags(tags).register(this);
+        return counter(name, Tags.of(tags));
     }
 
     /**
@@ -468,6 +468,17 @@ public abstract class MeterRegistry {
      */
     public Counter counter(String name, String... tags) {
         return counter(name, Tags.of(tags));
+    }
+
+    /**
+     * Tracks a monotonically increasing value.
+     * @param name The base metric name
+     * @param tags Sequence of dimensions for breaking down the name.
+     * @return A new or existing counter.
+     * @since 1.16.0
+     */
+    public Counter counter(String name, Tags tags) {
+        return counter(new Meter.Id(name, tags, null, null, Meter.Type.COUNTER));
     }
 
     /**
@@ -498,8 +509,7 @@ public abstract class MeterRegistry {
      * @return A new or existing timer.
      */
     public Timer timer(String name, Iterable<Tag> tags) {
-        return this.timer(new Meter.Id(name, Tags.of(tags), null, null, Meter.Type.TIMER),
-                AbstractTimerBuilder.DEFAULT_DISTRIBUTION_CONFIG, pauseDetector);
+        return this.timer(name, Tags.of(tags));
     }
 
     /**
@@ -511,6 +521,18 @@ public abstract class MeterRegistry {
      */
     public Timer timer(String name, String... tags) {
         return timer(name, Tags.of(tags));
+    }
+
+    /**
+     * Measures the time taken for short tasks and the count of these tasks.
+     * @param name The base metric name
+     * @param tags Sequence of dimensions for breaking down the name.
+     * @return A new or existing timer.
+     * @since 1.16.0
+     */
+    public Timer timer(String name, Tags tags) {
+        return this.timer(new Meter.Id(name, tags, null, null, Meter.Type.TIMER),
+                AbstractTimerBuilder.DEFAULT_DISTRIBUTION_CONFIG, pauseDetector);
     }
 
     /**
@@ -1093,7 +1115,18 @@ public abstract class MeterRegistry {
          * @return A new or existing long task timer.
          */
         public LongTaskTimer longTaskTimer(String name, Iterable<Tag> tags) {
-            return longTaskTimer(new Meter.Id(name, Tags.of(tags), null, null, Meter.Type.LONG_TASK_TIMER),
+            return longTaskTimer(name, Tags.of(tags));
+        }
+
+        /**
+         * Measures the time taken for long tasks.
+         * @param name Name of the long task timer being registered.
+         * @param tags Sequence of dimensions for breaking down the name.
+         * @return A new or existing long task timer.
+         * @since 1.16.0
+         */
+        public LongTaskTimer longTaskTimer(String name, Tags tags) {
+            return longTaskTimer(new Meter.Id(name, tags, null, null, Meter.Type.LONG_TASK_TIMER),
                     LongTaskTimer.Builder.DEFAULT_DISTRIBUTION_CONFIG);
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -337,7 +337,7 @@ public abstract class MeterRegistry {
     }
 
     /**
-     * Only used by {@link Counter#builder(String)}.
+     * Only used internally.
      * @param id The identifier for this counter.
      * @return A new or existing counter.
      * @implNote Avoids allocation in the case the meter is already registered,
@@ -676,27 +676,6 @@ public abstract class MeterRegistry {
             mappedId = filter.map(mappedId);
         }
         return mappedId;
-    }
-
-    @FunctionalInterface
-    // Brittle, but this is internal. We pass nulls for some meter types as explained in
-    // JavaDoc.
-    @NullUnmarked
-    private interface NewMeterSupplier<M extends Meter> {
-
-        /**
-         * Create a new meter with the given parameters. The DistributionStatisticConfig
-         * and PauseDetector will be null for meter types that do not take them.
-         * @param registry the registry from which to make the new meter
-         * @param id the ID of the meter to create
-         * @param distributionStatisticConfig optional distribution config for types that
-         * take it
-         * @param pauseDetector optional pause detector for types that take it
-         * @return a new meter
-         */
-        @NonNull M create(MeterRegistry registry, Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
-                PauseDetector pauseDetector);
-
     }
 
     private Meter getOrCreateMeter(@Nullable DistributionStatisticConfig config,
@@ -1131,7 +1110,7 @@ public abstract class MeterRegistry {
         }
 
         /**
-         * Only used by {@link LongTaskTimer#builder(String)}.
+         * Only used internally.
          * @param id The identifier for this long task timer.
          * @return A new or existing long task timer.
          * @implNote Avoids allocation in the case the meter is already registered,
@@ -1311,6 +1290,27 @@ public abstract class MeterRegistry {
         for (BiConsumer<Meter.Id, String> listener : meterRegistrationFailedListeners) {
             listener.accept(id, reason);
         }
+    }
+
+    @FunctionalInterface
+    // Brittle, but this is internal. We pass nulls for some meter types as explained in
+    // JavaDoc.
+    @NullUnmarked
+    private interface NewMeterSupplier<M extends Meter> {
+
+        /**
+         * Create a new meter with the given parameters. The DistributionStatisticConfig
+         * and PauseDetector will be null for meter types that do not take them.
+         * @param registry the registry from which to make the new meter
+         * @param id the ID of the meter to create
+         * @param distributionStatisticConfig optional distribution config for types that
+         * take it
+         * @param pauseDetector optional pause detector for types that take it
+         * @return a new meter
+         */
+        @NonNull M create(MeterRegistry registry, Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
+                PauseDetector pauseDetector);
+
     }
 
     // VisibleForTesting

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/pause/NoPauseDetector.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/pause/NoPauseDetector.java
@@ -15,6 +15,22 @@
  */
 package io.micrometer.core.instrument.distribution.pause;
 
+/**
+ * No-op implementation of a {@link PauseDetector}.
+ */
 public class NoPauseDetector implements PauseDetector {
+
+    /**
+     * Singleton instance of {@link NoPauseDetector}.
+     * @since 1.16.0
+     */
+    public static final NoPauseDetector INSTANCE = new NoPauseDetector();
+
+    /**
+     * @deprecated use {@link #INSTANCE} instead.
+     */
+    @Deprecated
+    public NoPauseDetector() {
+    }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
@@ -75,7 +75,7 @@ class AbstractTimerTests {
 
         MyTimer() {
             super(new Meter.Id("name", Tags.empty(), null, null, Meter.Type.TIMER), Clock.SYSTEM,
-                    DistributionStatisticConfig.DEFAULT, new NoPauseDetector(), TimeUnit.SECONDS, false);
+                    DistributionStatisticConfig.DEFAULT, NoPauseDetector.INSTANCE, TimeUnit.SECONDS, false);
         }
 
         @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryAllocationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryAllocationTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import com.sun.management.ThreadMXBean;
+import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import java.lang.management.ManagementFactory;
+
+import static io.micrometer.core.instrument.MeterRegistryAllocationTest.JAVA_VM_NAME_J9_REGEX;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test expected allocation (or lack thereof) for methods expected to be used on hot paths
+ * from {@link MeterRegistry}.
+ */
+@DisabledIfSystemProperty(named = "java.vm.name", matches = JAVA_VM_NAME_J9_REGEX,
+        disabledReason = "Sun ThreadMXBean with allocation counter not available on J9 JVM")
+class MeterRegistryAllocationTest {
+
+    // Should match "Eclipse OpenJ9 VM" and "IBM J9 VM"
+    static final String JAVA_VM_NAME_J9_REGEX = ".*J9 VM$";
+
+    MeterRegistry registry = new SimpleMeterRegistry();
+
+    Tags tags = Tags.of("a", "b", "c", "d");
+
+    static ThreadMXBean threadMXBean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    /**
+     * Number of bytes allocated when constructing a Meter.Id. This can vary by JVM and
+     * configuration, which is why we measure it programmatically. For most common cases,
+     * it should be 40 bytes.
+     */
+    static long newIdBytes;
+
+    @BeforeAll
+    static void setup() {
+        // Construct once here so any static initialization doesn't get measured.
+        new Meter.Id("name", Tags.empty(), null, null, Meter.Type.OTHER);
+        newIdBytes = measureAllocatedBytes(() -> new Meter.Id("name", Tags.empty(), null, null, Meter.Type.OTHER));
+    }
+
+    private static long measureAllocatedBytes(Runnable runnable) {
+        long currentThreadId = Thread.currentThread().getId();
+        long allocatedBytesBefore = threadMXBean.getThreadAllocatedBytes(currentThreadId);
+
+        runnable.run();
+
+        return threadMXBean.getThreadAllocatedBytes(currentThreadId) - allocatedBytesBefore;
+    }
+
+    @BeforeEach
+    void setUp() {
+        registry.timer("timer", tags);
+        LongTaskTimer.builder("ltt").tags(tags).register(registry);
+        Counter.builder("counter").tags(tags).register(registry);
+    }
+
+    @Nested
+    @DisplayName("Internal implementation details")
+    class Internal {
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingTimer_noAllocation() {
+            Meter.Id id = new Meter.Id("timer", tags, null, null, Meter.Type.TIMER);
+            assertNoAllocation(() -> registry.timer(id, AbstractTimerBuilder.DEFAULT_DISTRIBUTION_CONFIG,
+                    NoPauseDetector.INSTANCE));
+        }
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingLongTaskTimer_noAllocation() {
+            Meter.Id id = new Meter.Id("ltt", tags, null, null, Meter.Type.LONG_TASK_TIMER);
+            assertNoAllocation(
+                    () -> registry.more().longTaskTimer(id, LongTaskTimer.Builder.DEFAULT_DISTRIBUTION_CONFIG));
+        }
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingCounter_noAllocation() {
+            Meter.Id id = new Meter.Id("counter", tags, null, null, Meter.Type.COUNTER);
+            assertNoAllocation(() -> registry.counter(id));
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Public API available to users")
+    class PublicApi {
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingTimer_onlyIdAllocation() {
+            assertBytesAllocated(newIdBytes, () -> registry.timer("timer", tags));
+        }
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingLongTaskTimer_onlyIdAllocation() {
+            assertBytesAllocated(newIdBytes, () -> registry.more().longTaskTimer("ltt", tags));
+        }
+
+        @Issue("#6670")
+        @Test
+        void retrieveExistingCounter_onlyIdAllocation() {
+            assertBytesAllocated(newIdBytes, () -> registry.counter("counter", tags));
+        }
+
+    }
+
+    private void assertBytesAllocated(long bytes, Runnable runnable) {
+        assertThat(measureAllocatedBytes(runnable)).isEqualTo(bytes);
+    }
+
+    private void assertNoAllocation(Runnable runnable) {
+        assertBytesAllocated(0, runnable);
+    }
+
+}


### PR DESCRIPTION
In particular focuses on Timer, LongTaskTimer, and Counter as these are the types expected to be retrieved (non-functional) the most on hot code paths. Avoiding this allocation makes the retrieval faster and generates less garbage, causing less GC pressure.

Similar to #6661, this helps with Observation-based instrumentation that's using the `DefaultMeterObservationHandler`, which will retrieve a LongTaskTimer and Timer on start and stop respectively.

Adds new public overloads of timer, longTaskTimer, and counter methods that take `Tags` because the existing methods take `Iterable<Tag>` which means `Tags.of` needs to be called on it, which can result in allocation (to check the size of the Iterable) before JIT optimization.