### PR TITLE
Validate low cardinality keys

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
@@ -19,6 +19,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Context;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,10 @@ public class InvalidObservationException extends RuntimeException {
 
     private final List<HistoryElement> history;
 
+    InvalidObservationException(String message, Context context) {
+        this(message, context, Collections.emptyList());
+    }
+
     InvalidObservationException(String message, Context context, List<HistoryElement> history) {
         super(message);
         this.context = context;
@@ -53,8 +58,13 @@ public class InvalidObservationException extends RuntimeException {
 
     @Override
     public String toString() {
-        return super.toString() + "\n"
-                + history.stream().map(HistoryElement::toString).collect(Collectors.joining("\n"));
+        if (history.isEmpty()) {
+            return super.toString();
+        }
+        else {
+            return super.toString() + "\n"
+                    + history.stream().map(HistoryElement::toString).collect(Collectors.joining("\n"));
+        }
     }
 
     public static class HistoryElement {

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -234,4 +234,73 @@ class ObservationValidatorTests {
         new NullObservation(registry).openScope();
     }
 
+    @Test
+    void capabilitiesCanBeDisabledUsingTheBuilder() {
+        TestObservationRegistry registry = TestObservationRegistry.builder()
+            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(false)
+            .build();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
+        Observation.createNotStarted("test", registry).start().stop();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
+    }
+
+    @Test
+    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysByDefaultUsingCreate() {
+        TestObservationRegistry registry = TestObservationRegistry.create();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value2").start().stop();
+    }
+
+    @Test
+    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysByDefaultUsingTheBuilder() {
+        TestObservationRegistry registry = TestObservationRegistry.builder().build();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value2").start().stop();
+    }
+
+    @Test
+    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysWhenEnabledUsingTheBuilder() {
+        TestObservationRegistry registry = TestObservationRegistry.builder()
+            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(true)
+            .build();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        assertThatThrownBy(() -> {
+            Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
+        }).isExactlyInstanceOf(InvalidObservationException.class)
+            .hasMessageContaining(
+                    "Metrics backends may require that all observations with the same name have the same set of low cardinality keys.");
+
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value2").start().stop();
+    }
+
 }


### PR DESCRIPTION
Observations with the same name should have the same set of low cardinality keys.
Example 1:
```
observation{name=test, lowCardinalityKeyValues=[color=red]}
observation{name=test, lowCardinalityKeyValues=[color=green]}
observation{name=test, lowCardinalityKeyValues=[color=blue]}
```
Example 1 is valid since all the observations with the same name ("test") has the same set of low cardinality keys ("color").

Example 2:
```
observation{name=test, lowCardinalityKeyValues=[color=red]}
observation{name=test, lowCardinalityKeyValues=[]}
observation{name=test, lowCardinalityKeyValues=[status=ok]}
```
Example 2 is invalid since the second observation is missing a key the first one has ("color") and the third observation is not only missing a key the first one has ("color") but it also has an extra key the first one does not have ("status").

If the validator detects this, it will give you an error like this:
```
Metrics backends may require that all observations with the same name have the same set of low cardinality keys.
There is already an existing observation named 'test' containing keys [color].
The observation you are attempting to register has keys [status].
```

In order to fix it, you should always add the same set of keys to the Observation. If some data is missing, you can signal it with a `"none"`/`"unknown"`/etc. value:
```
observation{name=test, lowCardinalityKeyValues=[color=red, status=unknown]}
observation{name=test, lowCardinalityKeyValues=[color=unknown, status=unknown]}
observation{name=test, lowCardinalityKeyValues=[color=unknown, status=ok]}
```

In your codebase, this means if you attach keyvalues conditionally:
```java
if (color !=null) {
    observation.lowCardinalityKeyValue("color", color);
}
```
you should only apply the condition to the value only:
```java
observation.lowCardinalityKeyValue("color", color !=null ? color : "unknown");
```

If you want to turn this validation off (not recommended), you can do it this way:
```java
TestObservationRegistry registry = TestObservationRegistry.builder()
        .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(false)
        .build();
```

