### PR TITLE
Fix HdrHistogram range issues by computing ratio from min/max expected values

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
@@ -65,7 +65,7 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
             boolean supportsAggregablePercentiles, boolean isCumulativeBucketCounts, boolean includeInfinityBucket) {
         super(clock, distributionStatisticConfig, DoubleRecorder.class);
         intervalHistogram = new DoubleHistogram(computeHighestToLowestValueRatio(distributionStatisticConfig),
-            percentilePrecision(distributionStatisticConfig));
+                percentilePrecision(distributionStatisticConfig));
         intervalHistogram.setAutoResize(true);
 
         this.isCumulativeBucketCounts = isCumulativeBucketCounts;
@@ -84,7 +84,7 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
     @Override
     DoubleRecorder newBucket() {
         return new DoubleRecorder(computeHighestToLowestValueRatio(distributionStatisticConfig),
-            percentilePrecision(distributionStatisticConfig));
+                percentilePrecision(distributionStatisticConfig));
     }
 
     @Override
@@ -105,7 +105,7 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
     @Override
     DoubleHistogram newAccumulatedHistogram(DoubleRecorder[] ringBuffer) {
         return new DoubleHistogram(computeHighestToLowestValueRatio(distributionStatisticConfig),
-            percentilePrecision(distributionStatisticConfig));
+                percentilePrecision(distributionStatisticConfig));
     }
 
     @Override
@@ -149,9 +149,9 @@ public class TimeWindowPercentileHistogram extends AbstractTimeWindowHistogram<D
     }
 
     /**
-     * Compute the highestToLowestValueRatio based on the configured min/max expected values.
-     * This allows HdrHistogram to cover the expected range without frequent resizing.
-     *
+     * Compute the highestToLowestValueRatio based on the configured min/max expected
+     * values. This allows HdrHistogram to cover the expected range without frequent
+     * resizing.
      * @param config The distribution statistic configuration
      * @return The computed ratio, or 2 if not enough information is available
      */


### PR DESCRIPTION
The fix computes an appropriate `highestToLowestValueRatio` from the configured `minimumExpectedValue` and `maximumExpectedValue` in `DistributionStatisticConfig`, allowing HdrHistogram to cover the expected range without constant resizing.

## Problem

The current implementation hardcodes a ratio of 2:
```java
new DoubleHistogram(percentilePrecision(distributionStatisticConfig));
// This constructor internally calls: this(2, numberOfSignificantValueDigits, ...)
```

This means the histogram can only handle values that differ by a factor of 2 (e.g., 1ms to 2ms). When recording typical operation times that span microseconds to seconds, HdrHistogram constantly attempts to resize, frequently throwing `ArrayIndexOutOfBoundsException` during the resize operations.

In production environments, this can result in hundreds of thousands of exceptions being thrown, causing significant performance overhead.

## Solution

This PR modifies `TimeWindowPercentileHistogram` to:

1. **Compute the ratio from configuration**: When `minimumExpectedValue` and `maximumExpectedValue` are provided, calculate an appropriate ratio
2. **Use the computed ratio**: Pass this ratio to HdrHistogram constructors instead of relying on the default
3. **Maintain backward compatibility**: When min/max values are not configured, fall back to the original behavior (ratio=2)

## Performance Impact

### Before
- Frequent `ArrayIndexOutOfBoundsException` as values exceed the narrow range
- Initial `HdrHistogram#counts` has length of 127

### After
- No exceptions when values are within the configured min/max range
- Initial `HdrHistogram#counts` has length of 272 when using defaults (1ms - 30s)

This last bullet could be a problem and require a different solution.

## Issues

- Fixes #4327
