### PR TITLE
Remove redundant sorted check before Arrays.sort()

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
@@ -64,27 +64,6 @@ public final class KeyValues implements Iterable<KeyValue> {
     }
 
     /**
-     * Checks if the first {@code length} elements of the {@code keyValues} array form an
-     * ordered set of key-values.
-     * @param keyValues an array of key-values.
-     * @param length the number of elements to check.
-     * @return {@code true} if the first {@code length} elements of {@code keyValues} form
-     * an ordered set; otherwise {@code false}.
-     */
-    private static boolean isSortedSet(KeyValue[] keyValues, int length) {
-        if (length > keyValues.length) {
-            return false;
-        }
-        for (int i = 0; i < length - 1; i++) {
-            int cmp = keyValues[i].compareTo(keyValues[i + 1]);
-            if (cmp >= 0) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Constructs a {@code KeyValues} collection from the provided array of key-values.
      * @param keyValues an array of {@code KeyValue} objects, possibly unordered and/or
      * containing duplicates.
@@ -92,11 +71,8 @@ public final class KeyValues implements Iterable<KeyValue> {
      * key-values.
      */
     private static KeyValues toKeyValues(KeyValue[] keyValues) {
-        int len = keyValues.length;
-        if (!isSortedSet(keyValues, len)) {
-            Arrays.sort(keyValues);
-            len = dedup(keyValues);
-        }
+        Arrays.sort(keyValues);
+        int len = dedup(keyValues);
         return new KeyValues(keyValues, len);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -61,38 +61,14 @@ public final class Tags implements Iterable<Tag> {
     }
 
     /**
-     * Checks if the first {@code length} elements of the {@code tags} array form an
-     * ordered set of tags.
-     * @param tags an array of tags.
-     * @param length the number of elements to check.
-     * @return {@code true} if the first {@code length} elements of {@code tags} form an
-     * ordered set; otherwise {@code false}.
-     */
-    private static boolean isSortedSet(Tag[] tags, int length) {
-        if (length > tags.length) {
-            return false;
-        }
-        for (int i = 0; i < length - 1; i++) {
-            int cmp = tags[i].compareTo(tags[i + 1]);
-            if (cmp >= 0) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
      * Constructs a {@code Tags} collection from the provided array of tags.
      * @param tags an array of {@code Tag} objects, possibly unordered and/or containing
      * duplicates.
      * @return a {@code Tags} instance with a deduplicated and ordered set of tags.
      */
     private static Tags toTags(Tag[] tags) {
-        int len = tags.length;
-        if (!isSortedSet(tags, len)) {
-            Arrays.sort(tags);
-            len = dedup(tags);
-        }
+        Arrays.sort(tags);
+        int len = dedup(tags);
         return new Tags(tags, len);
     }
 


### PR DESCRIPTION
Removes the isSortedSet() pre-check before calling Arrays.sort() in both KeyValues and Tags classes. Modern JVM implementations make this optimization unnecessary and potentially counterproductive

Arrays.sort() uses TimSort which is already optimized for sorted arrays with O(n) best-case complexity. The pre-sort check adds unnecessary overhead for unsorted data (common case) without significant benefit.

* Simplified toKeyValues() and toTags() by removing isSortedSet() method and relying on TimSort's adaptive sorting behavior.
*  The isSortedSet(array, length) method was only ever called with `length = array.length`. The check if `(length > array.length)` could never be true, making this guard condition pointless.

