### PR TITLE
Add AssertJ assertions for various Meters

### DIFF
--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryAssert.java
@@ -16,10 +16,10 @@
 package io.micrometer.core.tck;
 
 import io.micrometer.common.KeyValues;
-import io.micrometer.common.util.assertions.CounterAssert;
-import io.micrometer.common.util.assertions.GaugeAssert;
-import io.micrometer.common.util.assertions.MeterAssert;
-import io.micrometer.common.util.assertions.TimerAssert;
+import io.micrometer.test.assertions.CounterAssert;
+import io.micrometer.test.assertions.GaugeAssert;
+import io.micrometer.test.assertions.MeterAssert;
+import io.micrometer.test.assertions.TimerAssert;
 import io.micrometer.core.instrument.*;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
@@ -425,7 +425,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @see CounterAssert
      */
     public CounterAssert counter(String name, Tag... tags) {
-        MeterAssert<?> meter = meter(name, tags).hasType(Meter.Type.COUNTER);
+        MeterAssert<?> meter = meter(name, tags).hasType(Counter.class);
 
         return CounterAssert.assertThat((Counter) meter.actual())
             .as("Counter with name <%s> and tags <%s>", name, tags)
@@ -454,8 +454,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @see TimerAssert
      */
     public TimerAssert timer(String name, Tag... tags) {
-        MeterAssert<?> meter = meter(name, tags).hasType(Meter.Type.TIMER);
-
+        MeterAssert<?> meter = meter(name, tags).hasType(Timer.class);
         return TimerAssert.assertThat((Timer) meter.actual())
             .as("Timer with name <%s> and tags <%s>", name, tags)
             .isNotNull();
@@ -481,8 +480,7 @@ public class MeterRegistryAssert extends AbstractAssert<MeterRegistryAssert, Met
      * @see GaugeAssert
      */
     public GaugeAssert gauge(String name, Tag... tags) {
-        MeterAssert<?> meter = meter(name, tags).hasType(Meter.Type.GAUGE);
-
+        MeterAssert<?> meter = meter(name, tags).hasType(Gauge.class);
         return GaugeAssert.assertThat((Gauge) meter.actual())
             .as("Gauge with name <%s> and tags <%s>", name, tags)
             .isNotNull();

--- a/micrometer-test/src/main/java/io/micrometer/test/assertions/CounterAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/test/assertions/CounterAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
@@ -28,6 +28,7 @@ import org.assertj.core.api.IntegerAssert;
  * {@link io.micrometer.core.tck.MeterRegistryAssert#counter(String, Tag...)}.
  *
  * @author Emanuel Trandafir
+ * @since 1.17.0
  */
 public class CounterAssert extends AbstractAssert<CounterAssert, Counter> {
 
@@ -40,11 +41,7 @@ public class CounterAssert extends AbstractAssert<CounterAssert, Counter> {
         return new CounterAssert(actual);
     }
 
-    /**
-     * Creates a new instance of {@link CounterAssert}.
-     * @param actual the counter to assert on
-     */
-    public CounterAssert(Counter actual) {
+    private CounterAssert(Counter actual) {
         super(actual, CounterAssert.class);
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/test/assertions/GaugeAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/test/assertions/GaugeAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tag;
@@ -27,6 +27,7 @@ import org.assertj.core.api.DoubleAssert;
  * use {@link io.micrometer.core.tck.MeterRegistryAssert#gauge(String, Tag...)}.
  *
  * @author Emanuel Trandafir
+ * @since 1.17.0
  */
 public class GaugeAssert extends AbstractAssert<GaugeAssert, Gauge> {
 
@@ -39,11 +40,7 @@ public class GaugeAssert extends AbstractAssert<GaugeAssert, Gauge> {
         return new GaugeAssert(actual);
     }
 
-    /**
-     * Creates a new instance of {@link GaugeAssert}.
-     * @param actual the gauge to assert on
-     */
-    public GaugeAssert(Gauge actual) {
+    private GaugeAssert(Gauge actual) {
         super(actual, GaugeAssert.class);
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/test/assertions/MeterAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/test/assertions/MeterAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
@@ -36,21 +36,13 @@ import java.util.stream.StreamSupport;
  * To create a new instance of this class, invoke {@link MeterAssert#assertThat(Meter)} or
  * use {@link io.micrometer.core.tck.MeterRegistryAssert#meter(String, Tag...)}.
  *
- * @author Emanuel Trandafir
  * @see CounterAssert
  * @see TimerAssert
  * @see GaugeAssert
+ * @author Emanuel Trandafir
+ * @since 1.17.0
  */
 public class MeterAssert<METER extends Meter> extends AbstractAssert<MeterAssert<METER>, METER> {
-
-    /**
-     * Creates a new instance of {@link MeterAssert}.
-     * @param actual the meter to assert on
-     * @param type the class type for the assertion
-     */
-    protected MeterAssert(METER actual, Class<? extends MeterAssert> type) {
-        super(actual, type);
-    }
 
     /**
      * Creates a new instance of {@link MeterAssert}.
@@ -60,6 +52,10 @@ public class MeterAssert<METER extends Meter> extends AbstractAssert<MeterAssert
      */
     public static <M extends Meter> MeterAssert<M> assertThat(M actual) {
         return new MeterAssert<>(actual, MeterAssert.class);
+    }
+
+    private MeterAssert(METER actual, Class<? extends MeterAssert> type) {
+        super(actual, type);
     }
 
     /**
@@ -80,7 +76,6 @@ public class MeterAssert<METER extends Meter> extends AbstractAssert<MeterAssert
      * @param statistic the statistic type to check for
      * @param expectedValue the expected value for the statistic
      * @return this assertion object for chaining
-     * @see #hasType(Meter.Type)
      */
     public MeterAssert<METER> hasMeasurement(Statistic statistic, double expectedValue) {
         Optional<Double> measurement = StreamSupport.stream(actual.measure().spliterator(), false)
@@ -107,9 +102,8 @@ public class MeterAssert<METER extends Meter> extends AbstractAssert<MeterAssert
      * @param expectedType the expected meter type
      * @return this assertion object for chaining
      */
-    public MeterAssert<?> hasType(Meter.Type expectedType) {
-        Meter.Type actualType = actual().getId().getType();
-        Assertions.assertThat(actualType).isEqualTo(expectedType);
+    public <M extends Meter> MeterAssert<?> hasType(Class<M> expectedType) {
+        Assertions.assertThat(actual()).isInstanceOf(expectedType);
         return this;
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/test/assertions/TimerAssert.java
+++ b/micrometer-test/src/main/java/io/micrometer/test/assertions/TimerAssert.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.DoubleAssert;
 import org.assertj.core.api.DurationAssert;
 import org.assertj.core.api.IntegerAssert;
 
@@ -34,6 +33,7 @@ import io.micrometer.core.instrument.Timer;
  * use {@link io.micrometer.core.tck.MeterRegistryAssert#timer(String, Tag...)}.
  *
  * @author Emanuel Trandafir
+ * @since 1.17.0
  */
 public class TimerAssert extends AbstractAssert<TimerAssert, Timer> {
 

--- a/micrometer-test/src/main/java/io/micrometer/test/assertions/package-info.java
+++ b/micrometer-test/src/main/java/io/micrometer/test/assertions/package-info.java
@@ -16,9 +16,8 @@
 
 /**
  * AssertJ-style assertion classes for Micrometer
- * {@link io.micrometer.core.instrument.Meter}s.
  */
 @NullMarked
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import org.jspecify.annotations.NullMarked;

--- a/micrometer-test/src/test/java/io/micrometer/test/assertions/CounterAssertTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/test/assertions/CounterAssertTest.java
@@ -13,56 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
-import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.tck.MeterRegistryAssert;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class GaugeAssertTest {
+class CounterAssertTest {
 
     SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
 
     MeterRegistryAssert meterRegistryAssert = MeterRegistryAssert.assertThat(simpleMeterRegistry);
 
     @Test
-    void shouldFindGaugeByName() {
-        Gauge.builder("foo", () -> 10.0).register(simpleMeterRegistry);
+    void shouldFindCounterByName() {
+        Counter.builder("foo").register(simpleMeterRegistry).increment();
 
-        meterRegistryAssert.gauge("foo").hasValue(10.0);
+        meterRegistryAssert.counter("foo").hasCount(1);
     }
 
     @Test
-    void shouldThrowIfGaugeNotFound() {
-        Gauge.builder("foo", () -> 10.0).register(simpleMeterRegistry);
+    void shouldThrowIfCounterNotFound() {
+        Counter.builder("foo").register(simpleMeterRegistry).increment();
 
-        assertThatThrownBy(() -> meterRegistryAssert.gauge("foo", Tag.of("other-tag", "xxx")))
+        assertThatThrownBy(() -> meterRegistryAssert.counter("foo", Tag.of("other-tag", "xxx")))
             .isInstanceOf(AssertionError.class)
             .hasStackTraceContaining("Meter with name <foo> and tags <[tag(other-tag=xxx)]>")
             .hasMessageContaining("Expecting actual not to be null");
     }
 
     @Test
-    void shouldFindGaugeByNameAndTags() {
-        Gauge.builder("foo", 1.0, n -> n).tag("tag-1", "aa").register(simpleMeterRegistry);
+    void shouldFindCounterByNameAndTags() {
+        Counter.builder("foo").tag("tag-1", "aa").register(simpleMeterRegistry).increment(1.0);
 
-        Gauge.builder("foo", 99.0, n -> n).tag("tag-1", "bb").tag("tag-2", "cc").register(simpleMeterRegistry);
+        Counter.builder("foo").tag("tag-1", "bb").tag("tag-2", "cc").register(simpleMeterRegistry).increment(99.0);
 
-        meterRegistryAssert.gauge("foo", Tag.of("tag-1", "aa")).hasValue(1.0);
-        meterRegistryAssert.gauge("foo", Tag.of("tag-1", "bb"), Tag.of("tag-2", "cc")).hasValue(99.0);
+        meterRegistryAssert.counter("foo", Tag.of("tag-1", "aa")).hasCount(1);
+        meterRegistryAssert.counter("foo", Tag.of("tag-1", "bb"), Tag.of("tag-2", "cc")).hasCount(99);
     }
 
     @Test
-    void shouldLeverageDoubleAsserts() {
-        Gauge.builder("foo", () -> 50.0).register(simpleMeterRegistry);
+    void shouldLeverageIntegerAsserts() {
+        Counter.builder("foo").register(simpleMeterRegistry).increment(50.0);
 
-        meterRegistryAssert.gauge("foo").value().isBetween(40.0, 60.0);
+        meterRegistryAssert.counter("foo").count().isBetween(40, 60);
     }
 
 }

--- a/micrometer-test/src/test/java/io/micrometer/test/assertions/GaugeAssertTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/test/assertions/GaugeAssertTest.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
-import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.tck.MeterRegistryAssert;
@@ -23,44 +23,44 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class CounterAssertTest {
+class GaugeAssertTest {
 
     SimpleMeterRegistry simpleMeterRegistry = new SimpleMeterRegistry();
 
     MeterRegistryAssert meterRegistryAssert = MeterRegistryAssert.assertThat(simpleMeterRegistry);
 
     @Test
-    void shouldFindCounterByName() {
-        Counter.builder("foo").register(simpleMeterRegistry).increment();
+    void shouldFindGaugeByName() {
+        Gauge.builder("foo", () -> 10.0).register(simpleMeterRegistry);
 
-        meterRegistryAssert.counter("foo").hasCount(1);
+        meterRegistryAssert.gauge("foo").hasValue(10.0);
     }
 
     @Test
-    void shouldThrowIfCounterNotFound() {
-        Counter.builder("foo").register(simpleMeterRegistry).increment();
+    void shouldThrowIfGaugeNotFound() {
+        Gauge.builder("foo", () -> 10.0).register(simpleMeterRegistry);
 
-        assertThatThrownBy(() -> meterRegistryAssert.counter("foo", Tag.of("other-tag", "xxx")))
+        assertThatThrownBy(() -> meterRegistryAssert.gauge("foo", Tag.of("other-tag", "xxx")))
             .isInstanceOf(AssertionError.class)
             .hasStackTraceContaining("Meter with name <foo> and tags <[tag(other-tag=xxx)]>")
             .hasMessageContaining("Expecting actual not to be null");
     }
 
     @Test
-    void shouldFindCounterByNameAndTags() {
-        Counter.builder("foo").tag("tag-1", "aa").register(simpleMeterRegistry).increment(1.0);
+    void shouldFindGaugeByNameAndTags() {
+        Gauge.builder("foo", 1.0, n -> n).tag("tag-1", "aa").register(simpleMeterRegistry);
 
-        Counter.builder("foo").tag("tag-1", "bb").tag("tag-2", "cc").register(simpleMeterRegistry).increment(99.0);
+        Gauge.builder("foo", 99.0, n -> n).tag("tag-1", "bb").tag("tag-2", "cc").register(simpleMeterRegistry);
 
-        meterRegistryAssert.counter("foo", Tag.of("tag-1", "aa")).hasCount(1);
-        meterRegistryAssert.counter("foo", Tag.of("tag-1", "bb"), Tag.of("tag-2", "cc")).hasCount(99);
+        meterRegistryAssert.gauge("foo", Tag.of("tag-1", "aa")).hasValue(1.0);
+        meterRegistryAssert.gauge("foo", Tag.of("tag-1", "bb"), Tag.of("tag-2", "cc")).hasValue(99.0);
     }
 
     @Test
-    void shouldLeverageIntegerAsserts() {
-        Counter.builder("foo").register(simpleMeterRegistry).increment(50.0);
+    void shouldLeverageDoubleAsserts() {
+        Gauge.builder("foo", () -> 50.0).register(simpleMeterRegistry);
 
-        meterRegistryAssert.counter("foo").count().isBetween(40, 60);
+        meterRegistryAssert.gauge("foo").value().isBetween(40.0, 60.0);
     }
 
 }

--- a/micrometer-test/src/test/java/io/micrometer/test/assertions/MeterAssertTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/test/assertions/MeterAssertTest.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Statistic;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.tck.MeterRegistryAssert;
@@ -45,7 +44,7 @@ class MeterAssertTest {
     void shouldAssertOnType() {
         DistributionSummary.builder("foo").register(simpleMeterRegistry).record(100.0);
 
-        meterRegistryAssert.meter("foo").hasType(Meter.Type.DISTRIBUTION_SUMMARY);
+        meterRegistryAssert.meter("foo").hasType(DistributionSummary.class);
     }
 
 }

--- a/micrometer-test/src/test/java/io/micrometer/test/assertions/TimerAssertTest.java
+++ b/micrometer-test/src/test/java/io/micrometer/test/assertions/TimerAssertTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.common.util.assertions;
+package io.micrometer.test.assertions;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;


### PR DESCRIPTION
Dedicated assertion classes for the meter types: CounterAssert, TimerAssert, and GaugeAssert. 

For all the other meter types, we can use _MeterAssert_, which provides a generic assertion functionality (such as checking the type or a specific measurement). 

All classes integrate with _MeterRegistryAssert_ for convenient access and include practical examples via tests and javadoc.        


Closes gh-6763