### PR TITLE
Fix return type nullability on wrapper methods

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSupport;
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
@@ -68,7 +67,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * @return The return value of {@code f}.
      * @throws Exception Any exception bubbling up from the callable.
      */
-    default <T> @NullUnmarked T recordCallable(Callable<T> f) throws Exception {
+    default <T extends @Nullable Object> T recordCallable(Callable<T> f) throws Exception {
         Sample sample = start();
         try {
             return f.call();
@@ -84,7 +83,7 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
      * @param <T> The return type of the {@link Supplier}.
      * @return The return value of {@code f}.
      */
-    default <T> @NullUnmarked T record(Supplier<T> f) {
+    default <T extends @Nullable Object> T record(Supplier<T> f) {
         Sample sample = start();
         try {
             return f.get();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Timer.java
@@ -22,7 +22,6 @@ import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.util.TimeUtils;
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
@@ -132,7 +131,7 @@ public interface Timer extends Meter, HistogramSupport {
      * @param <T> The return type of the {@link Supplier}.
      * @return The return value of {@code f}.
      */
-    <T> @NullUnmarked T record(Supplier<T> f);
+    <T extends @Nullable Object> T record(Supplier<T> f);
 
     /**
      * Executes the Supplier {@code f} and records the time taken.
@@ -189,7 +188,7 @@ public interface Timer extends Meter, HistogramSupport {
      * @return The return value of {@code f}.
      * @throws Exception Any exception bubbling up from the callable.
      */
-    <T> @NullUnmarked T recordCallable(Callable<T> f) throws Exception;
+    <T extends @Nullable Object> T recordCallable(Callable<T> f) throws Exception;
 
     /**
      * Executes the runnable {@code f} and records the time taken.

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -18,7 +18,6 @@ package io.micrometer.observation;
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
@@ -558,7 +557,7 @@ public interface Observation extends ObservationView {
      * @param <T> the type parameter of the {@link Supplier}
      * @return the result from {@link Supplier#get()}
      */
-    default <T> @NullUnmarked T observe(Supplier<T> supplier) {
+    default <T extends @Nullable Object> T observe(Supplier<T> supplier) {
         start();
         try (Scope scope = openScope()) {
             return supplier.get();
@@ -592,7 +591,8 @@ public interface Observation extends ObservationView {
      * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    default <T, E extends Throwable> @NullUnmarked T observeChecked(CheckedCallable<T, E> checkedCallable) throws E {
+    default <T extends @Nullable Object, E extends Throwable> T observeChecked(CheckedCallable<T, E> checkedCallable)
+            throws E {
         start();
         try (Scope scope = openScope()) {
             return checkedCallable.call();
@@ -635,7 +635,7 @@ public interface Observation extends ObservationView {
      */
     @SuppressWarnings({ "unused", "unchecked" })
     @Deprecated
-    default <C extends Context, T> @NullUnmarked T observeWithContext(Function<C, T> function) {
+    default <C extends Context, T extends @Nullable Object> T observeWithContext(Function<C, T> function) {
         InternalLoggerFactory.getInstance(Observation.class)
             .warn("This method is deprecated. Please migrate to observation.observe(...)");
         start();
@@ -678,7 +678,7 @@ public interface Observation extends ObservationView {
      */
     @SuppressWarnings({ "unused", "unchecked" })
     @Deprecated
-    default <C extends Context, T, E extends Throwable> @NullUnmarked T observeCheckedWithContext(
+    default <C extends Context, T extends @Nullable Object, E extends Throwable> T observeCheckedWithContext(
             CheckedFunction<C, T, E> function) throws E {
         InternalLoggerFactory.getInstance(Observation.class)
             .warn("This method is deprecated. Please migrate to observation.observeChecked(...)");
@@ -733,7 +733,7 @@ public interface Observation extends ObservationView {
      * @return the result from {@link Supplier#get()}
      */
     @SuppressWarnings("unused")
-    default <T> @NullUnmarked T scoped(Supplier<T> supplier) {
+    default <T extends @Nullable Object> T scoped(Supplier<T> supplier) {
         try (Scope scope = openScope()) {
             return supplier.get();
         }
@@ -751,7 +751,8 @@ public interface Observation extends ObservationView {
      * @return the result from {@link CheckedCallable#call()}
      */
     @SuppressWarnings("unused")
-    default <T, E extends Throwable> @NullUnmarked T scopedChecked(CheckedCallable<T, E> checkedCallable) throws E {
+    default <T extends @Nullable Object, E extends Throwable> T scopedChecked(CheckedCallable<T, E> checkedCallable)
+            throws E {
         try (Scope scope = openScope()) {
             return checkedCallable.call();
         }
@@ -800,7 +801,7 @@ public interface Observation extends ObservationView {
      * @param action action to run
      * @return result of the action
      */
-    static <T> @NullUnmarked T tryScoped(@Nullable Observation parent, Supplier<T> action) {
+    static <T extends @Nullable Object> T tryScoped(@Nullable Observation parent, Supplier<T> action) {
         if (parent != null) {
             return parent.scoped(action);
         }
@@ -816,7 +817,7 @@ public interface Observation extends ObservationView {
      * @param <E> type of exception checkedCallable throws
      * @return the result from {@link CheckedCallable#call()}
      */
-    static <T, E extends Throwable> @NullUnmarked T tryScopedChecked(@Nullable Observation parent,
+    static <T extends @Nullable Object, E extends Throwable> T tryScopedChecked(@Nullable Observation parent,
             CheckedCallable<T, E> checkedCallable) throws E {
         if (parent != null) {
             return parent.scopedChecked(checkedCallable);
@@ -1445,8 +1446,7 @@ public interface Observation extends ObservationView {
      * A functional interface like {@link Callable} but it can throw a {@link Throwable}.
      */
     @FunctionalInterface
-    @NullUnmarked
-    interface CheckedCallable<T, E extends Throwable> {
+    interface CheckedCallable<T extends @Nullable Object, E extends Throwable> {
 
         T call() throws E;
 
@@ -1458,8 +1458,7 @@ public interface Observation extends ObservationView {
      * @since 1.11.0
      */
     @FunctionalInterface
-    @NullUnmarked
-    interface CheckedFunction<T, R, E extends Throwable> {
+    interface CheckedFunction<T extends @Nullable Object, R, E extends Throwable> {
 
         R apply(T t) throws E;
 


### PR DESCRIPTION
We were using `@NullUnmarked` which we expected to work to mean the nullability is unknown for the return value. However, without changing the type parameter nullability, it was being considered non-null.

This updates all wrapping methods to use `T extends @Nullable Object` for the type parameter of the return value.

Resolves gh-6869