### PR TITLE
Add link to the latest Micrometer Team talk

### DIFF
--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -8,7 +8,7 @@ Micrometer is a metrics instrumentation library for JVM-based applications. It p
 
 Starting from Micrometer 1.10, Micrometer provides the xref:observation.adoc[Observation API] and a plugin mechanism that lets you add capabilities, including the tracing features. You can read more about tracing in the https://docs.micrometer.io/tracing/reference/[Micrometer Tracing documentation].
 
-For better understanding of the differences among these different types of systems (Metrics, Distributed Tracing, and Logging) we recommend Adrian Cole's talk, titled https://www.youtube.com/watch?v=juP9VApKy_I[Observability 3 Ways]. To learn more about Micrometer Observation API, we recommend Tommy Ludwig's and Marcin Grzejszczak's talk, titled https://www.youtube.com/watch?v=fh3VbrPvAjg[Observability of Your Application].
+For better understanding of the differences among these different types of systems (Metrics, Distributed Tracing, and Logging) we recommend Adrian Cole's talk, titled https://www.youtube.com/watch?v=juP9VApKy_I[Observability 3 Ways]. To learn more about Micrometer Observation API, we recommend Tommy Ludwig's and Marcin Grzejszczak's talk, titled https://www.youtube.com/watch?v=fh3VbrPvAjg[Observability of Your Application] and Tommy Ludwig's and Jonatan Ivanov's talk, titled https://www.youtube.com/watch?v=Qyku6cR6ADY[Micrometer Mastery].
 
 [[concepts-dependencies]]
 == Dependencies


### PR DESCRIPTION
Hello,

I decided it would be beneficial to extend the existing documentation with a link to the Micrometer talk from Spring I/O 2024 (30–31 May, Barcelona).

- The talk builds on top of the first one, "Observability of Your Application".
- I tried to add minimal overhead, including only the speakers, link, and title.
- The talk contains a lot of interesting things about Micrometer, so it would be valuable to include it here.

