### PR TITLE
Remove ThreadLocal usage from LogbackMetrics

### DIFF
--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -148,13 +148,6 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
         if (config.enabled()) {
             this.sink = processor.sink();
-
-            try {
-                Class.forName("ch.qos.logback.classic.turbo.TurboFilter", false, getClass().getClassLoader());
-                this.sink = new LogbackMetricsSuppressingFluxSink(this.sink);
-            }
-            catch (ClassNotFoundException ignore) {
-            }
             start();
         }
     }

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/LogbackMetricsSuppressingFluxSink.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/internal/LogbackMetricsSuppressingFluxSink.java
@@ -26,7 +26,11 @@ import java.util.function.LongConsumer;
 /**
  * This is an internal class only for use within Micrometer. This suppresses logback event
  * metrics during Sink operations to avoid infinite loops.
+ *
+ * @deprecated Should not be needed anymore since {@link LogbackMetrics} records logback
+ * events asynchronously and should not get into an infinite loop.
  */
+@Deprecated
 public class LogbackMetricsSuppressingFluxSink implements FluxSink<String> {
 
     private final FluxSink<String> delegate;

--- a/samples/micrometer-samples-jersey3/src/test/java/io/micrometer/samples/jersey3/Jersey3Test.java
+++ b/samples/micrometer-samples-jersey3/src/test/java/io/micrometer/samples/jersey3/Jersey3Test.java
@@ -70,7 +70,7 @@ class Jersey3Test extends JerseyTest {
             logbackMetrics.bindTo(registry);
             InternalLogger logger = InternalLoggerFactory.getInstance(Jersey3Test.class);
             logger.info("test");
-            assertThat(registry.get("logback.events").tags("level", "info").counter().count()).isPositive();
+            assertThat(registry.get("logback.events").tags("level", "info").functionCounter().count()).isPositive();
         }
     }
 


### PR DESCRIPTION
Before this change, LogbackMetrics used Counter to keep track of the number of emitted log events by level. This caused issues since there are cases where incrementing a Counter can result in emitting log events. Because of this, the MetricsTurboFilter in LogbackMetrics had a chance to get into an infinite loop since it was triggered by emitting log events and it incremented a Counter that also emitted a log event which triggered MetricsTurboFilter again...

The scenario was the following:
1. Somebody emits a log event (e.g.: LOGGER.info("test");)
2. MetricsTurboFilter gets notified about it and increments a Counter
3. Incrementing the Counter triggers emitting another log event
4. MetricsTurboFilter gets notified about it and increments a Counter ...

To fix this issue, a ThreadLocal was used to ignore some of the log events (the ones that were emitted by incrementing a Counter).

This change removes the ThreadLocal usage and instead of using Counter, it keeps track of the number of emitted log events using a LongAdder. Then it uses this LongAdder in a FunctionCounter. It assumes that LongAdder does not emit any log events that will end up triggering MetricsTurboFilter again.