### PR TITLE
Don't filter log events in LogbackMetricsBenchmark

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/resources/logback.xml
+++ b/benchmarks/benchmarks-core/src/jmh/resources/logback.xml
@@ -14,13 +14,20 @@
 	limitations under the License.
 -->
 <configuration>
-<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-	<encoder>
-		<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-	</encoder>
-</appender>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
 
-<root level="warn">
-	<appender-ref ref="STDOUT" />
-</root>
+	<appender name="NOP" class="ch.qos.logback.core.helpers.NOPAppender">
+	</appender>
+
+	<logger name="io.micrometer.benchmark.core.LogbackMetricsBenchmark" level="ALL" additivity="false">
+		<appender-ref ref="NOP" />
+	</logger>
+
+	<root level="WARN">
+		<appender-ref ref="STDOUT" />
+	</root>
 </configuration>


### PR DESCRIPTION
In `LogbackMetricsBenchmark` we test `LogbackMetrics` by emitting log events on `INFO` level. In #5688 a `logback.xml` was added that unfortunately set the lowest log level to `WARN` and broke `LogbackMetricsBenchmark` since the emitted `INFO` events never reached `MetricsTurboFilter` in `LogbackMetrics` and no metrics were recorded.

Another issue with `LogbackMetricsBenchmark` is log events going to `stdout` even when `logback.xml` in not present. To solve this we can use Logback's `NOPAppender` which will not output anything but lets log events reach `MetricsTurboFilter` in `LogbackMetrics` and record metrics.

See #5688