### PR TITLE
Improve JMH and gradle integration

### DIFF
--- a/benchmarks/benchmarks-core/build.gradle
+++ b/benchmarks/benchmarks-core/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "me.champeau.jmh" version "0.7.2"
+    id "me.champeau.jmh" version "0.7.3"
 }
 
 // Uncomment as needed for benchmarking against released versions of Micrometer
@@ -33,9 +33,19 @@ dependencies {
 }
 
 jmh {
-    fork = 1
-    warmupIterations = 1
-    iterations = 1
     duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
     zip64 = true
+    // So we can do these:
+    // ./gradlew :micrometer-benchmarks-core:jmh -PjmhIncludes=io.micrometer.benchmark.core.CounterBenchmark
+    // ./gradlew :micrometer-benchmarks-core:jmh -PjmhIncludes=io.micrometer.benchmark.core.CounterBenchmark -PjmhProfilers=gc
+    if (project.hasProperty('jmhIncludes')) {
+        includes = [project.property('jmhIncludes')]
+    }
+    if (project.hasProperty('jmhProfilers')) {
+        profilers = [project.property('jmhProfilers')]
+    }
+}
+
+tasks.named('jmh') {
+    outputs.upToDateWhen { false }
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareCountersWithOtherLibraries.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareCountersWithOtherLibraries.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
@@ -29,8 +28,8 @@ import java.util.concurrent.TimeUnit;
  * @author John Karp
  */
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(16)
@@ -128,10 +127,9 @@ public class CompareCountersWithOtherLibraries {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(CompareCountersWithOtherLibraries.class.getSimpleName())
+        new Runner(new OptionsBuilder().include(CompareCountersWithOtherLibraries.class.getSimpleName())
             .addProfiler(GCProfiler.class)
-            .build();
-        new Runner(opt).run();
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareHistogramsWithOtherLibraries.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareHistogramsWithOtherLibraries.java
@@ -35,7 +35,6 @@ import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Iterator;
@@ -48,8 +47,8 @@ import java.util.stream.Stream;
  * @author John Karp
  */
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(16)
@@ -198,8 +197,9 @@ public class CompareHistogramsWithOtherLibraries {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(CompareHistogramsWithOtherLibraries.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(CompareHistogramsWithOtherLibraries.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareOTLPHistograms.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/compare/CompareOTLPHistograms.java
@@ -25,7 +25,6 @@ import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 //CHECKSTYLE:OFF
 import com.google.common.collect.Iterators;
@@ -44,8 +43,8 @@ import io.micrometer.registry.otlp.OtlpMeterRegistry;
  * @author Lenin Jaganathan
  */
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 3)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(2)
@@ -365,8 +364,9 @@ public class CompareOTLPHistograms {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(CompareOTLPHistograms.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(CompareOTLPHistograms.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/CounterBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/CounterBenchmark.java
@@ -22,25 +22,17 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
 public class CounterBenchmark {
-
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(CounterBenchmark.class.getSimpleName())
-            .warmupIterations(5)
-            .measurementIterations(10)
-            .mode(Mode.SampleTime)
-            .forks(1)
-            .build();
-
-        new Runner(opt).run();
-    }
 
     private MeterRegistry registry;
 
@@ -66,6 +58,12 @@ public class CounterBenchmark {
     public double countSum() {
         counter.increment();
         return counter.count();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(CounterBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultLongTaskTimerBenchmark.java
@@ -15,14 +15,15 @@
  */
 package io.micrometer.benchmark.core;
 
-import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Locale;
@@ -30,19 +31,13 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-@State(Scope.Benchmark)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(1)
-@BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 3)
 @Measurement(iterations = 3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
 public class DefaultLongTaskTimerBenchmark {
-
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(DefaultLongTaskTimerBenchmark.class.getSimpleName()).build();
-
-        new Runner(opt).run();
-    }
 
     private static final Random random = new Random();
 
@@ -81,6 +76,12 @@ public class DefaultLongTaskTimerBenchmark {
     @Benchmark
     public long stopRandom() {
         return randomSample.stop();
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(DefaultLongTaskTimerBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/GaugeBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/GaugeBenchmark.java
@@ -28,9 +28,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Fork(1)
-@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
 public class GaugeBenchmark {
 
     private MeterRegistry registry;
@@ -61,7 +63,9 @@ public class GaugeBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        new Runner(new OptionsBuilder().include(GaugeBenchmark.class.getSimpleName()).build()).run();
+        new Runner(new OptionsBuilder().include(GaugeBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/KeyValuesBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/KeyValuesBenchmark.java
@@ -20,14 +20,13 @@ import io.micrometer.common.KeyValues;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class KeyValuesBenchmark {
@@ -95,8 +94,9 @@ public class KeyValuesBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(KeyValuesBenchmark.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(KeyValuesBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/KeyValuesMergeBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/KeyValuesMergeBenchmark.java
@@ -19,14 +19,13 @@ import io.micrometer.common.KeyValues;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -45,8 +44,9 @@ public class KeyValuesMergeBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(KeyValuesMergeBenchmark.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(KeyValuesMergeBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/LogbackMetricsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/LogbackMetricsBenchmark.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 2)
 @Measurement(iterations = 2)
 @BenchmarkMode(Mode.SampleTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Benchmark)
 public class LogbackMetricsBenchmark {
 

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRegistrationBenchmark.java
@@ -24,27 +24,18 @@ import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-@State(Scope.Benchmark)
 @Fork(1)
 @Warmup(iterations = 2)
 @Measurement(iterations = 5)
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(2)
+@State(Scope.Benchmark)
 public class MeterRegistrationBenchmark {
-
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(MeterRegistrationBenchmark.class.getSimpleName())
-            .addProfiler(GCProfiler.class)
-            .build();
-
-        new Runner(opt).run();
-    }
 
     MeterRegistry registry = new SimpleMeterRegistry();
 
@@ -84,6 +75,12 @@ public class MeterRegistrationBenchmark {
     @Benchmark
     public Meter registerExistingWithProvider() {
         return counterMeterProvider.withTag("k1", "v1");
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(MeterRegistrationBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRemovalBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/MeterRemovalBenchmark.java
@@ -22,25 +22,16 @@ import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-@State(Scope.Benchmark)
 @Fork(1)
 @Warmup(iterations = 2)
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
 public class MeterRemovalBenchmark {
-
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(MeterRemovalBenchmark.class.getSimpleName())
-            .addProfiler(GCProfiler.class)
-            .build();
-
-        new Runner(opt).run();
-    }
 
     @Param({ "10000", "100000" })
     int meterCount;
@@ -65,6 +56,12 @@ public class MeterRemovalBenchmark {
     @BenchmarkMode(Mode.SingleShotTime)
     public Meter remove() {
         return registry.remove(registry.counter("counter", "key", String.valueOf(meterCount / 2)));
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(MeterRemovalBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationBenchmark.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.benchmark.core;
 
-import java.util.concurrent.TimeUnit;
-
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
@@ -31,11 +29,15 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import java.util.concurrent.TimeUnit;
+
 @Fork(1)
-@Threads(4)
-@State(Scope.Benchmark)
+@Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(4)
+@State(Scope.Benchmark)
 public class ObservationBenchmark {
 
     SimpleMeterRegistry meterRegistry;

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationKeyValuesBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/ObservationKeyValuesBenchmark.java
@@ -20,16 +20,20 @@ import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(4)
+@State(Scope.Benchmark)
 public class ObservationKeyValuesBenchmark {
 
     private static final KeyValues KEY_VALUES = KeyValues.of("key1", "value1", "key2", "value2", "key3", "value3",
@@ -75,19 +79,14 @@ public class ObservationKeyValuesBenchmark {
         return observation.getContext().getLowCardinalityKeyValues();
     }
 
-    public static void main(String[] args) throws RunnerException {
-        Options options = new OptionsBuilder().include(ObservationKeyValuesBenchmark.class.getSimpleName())
-            .warmupIterations(3)
-            .measurementIterations(5)
-            .mode(Mode.SampleTime)
-            .forks(1)
-            .build();
-
-        new Runner(options).run();
-    }
-
     static class TestContext extends Observation.Context {
 
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(ObservationKeyValuesBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsBenchmark.java
@@ -20,14 +20,13 @@ import io.micrometer.core.instrument.Tags;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class TagsBenchmark {
@@ -91,8 +90,9 @@ public class TagsBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(TagsBenchmark.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(TagsBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsMergeBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TagsMergeBenchmark.java
@@ -19,14 +19,13 @@ import io.micrometer.core.instrument.Tags;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
 @Fork(1)
-@Measurement(iterations = 2)
 @Warmup(iterations = 2)
+@Measurement(iterations = 2)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -45,8 +44,9 @@ public class TagsMergeBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(TagsMergeBenchmark.class.getSimpleName()).build();
-        new Runner(opt).run();
+        new Runner(new OptionsBuilder().include(TagsMergeBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TimerBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/TimerBenchmark.java
@@ -22,25 +22,17 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.concurrent.TimeUnit;
 
-@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.SampleTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
 public class TimerBenchmark {
-
-    public static void main(String[] args) throws RunnerException {
-        Options opt = new OptionsBuilder().include(TimerBenchmark.class.getSimpleName())
-            .warmupIterations(5)
-            .measurementIterations(10)
-            .mode(Mode.SampleTime)
-            .forks(1)
-            .build();
-
-        new Runner(opt).run();
-    }
 
     private MeterRegistry registry;
 
@@ -71,6 +63,12 @@ public class TimerBenchmark {
 
     int doSomething() {
         return 923 + 123;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(TimerBenchmark.class.getSimpleName())
+            // .addProfiler(GCProfiler.class)
+            .build()).run();
     }
 
 }


### PR DESCRIPTION
- Upgrade `me.champeau.jmh` plugin to `0.7.3`
- Remove gradle overrides and use config defined by the benchmarks
- Make it possible to define the benchmark(s) to run
- Make it possible to define the profiler(s) to use
- Make benchmark config more consistent (using annotations)
- Make IDE execution support more consistent (through `main` method)

So we can do these:
```sh
./gradlew :micrometer-benchmarks-core:jmh -PjmhIncludes=io.micrometer.benchmark.core.CounterBenchmark
```
```sh
./gradlew :micrometer-benchmarks-core:jmh -PjmhIncludes=io.micrometer.benchmark.core.CounterBenchmark -PjmhProfilers=gc
```