### PR TITLE
Setup continuous builds for Antora

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -94,6 +94,7 @@ tasks.create('generateAntoraResources') {
 
 tasks.named('antora') {
     dependsOn 'generateAntoraResources', 'test'
+    inputs.files('modules')
 }
 
 jar {


### PR DESCRIPTION
Gradle supports [continuous builds][1] for tasks that has known inputs (so that it can detect changes in those input files). When we try to run `gradle antora --continuous`, it only works if you make changes in `docs/src/test` since that's the only known input folder for Gradle (because of the test task we have), if you make any changes in the `.adoc` files (`docs/modules` dir), Gradle will not rerun the tasks since it does not know about those files.

This change adds the module folder to the inputs of the antora task so that Gradle will watch them as well.

[1]: https://docs.gradle.org/current/userguide/continuous_builds.html