### PR TITLE
Metrics not collected after ScheduledExecutorService recreation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -263,9 +263,11 @@ public class ExecutorServiceMetrics implements MeterBinder {
      */
     public static ScheduledExecutorService monitor(MeterRegistry registry, ScheduledExecutorService executor,
             String executorServiceName, String metricPrefix, Iterable<Tag> tags) {
-        new ExecutorServiceMetrics(executor, executorServiceName, metricPrefix, tags).bindTo(registry);
+        ExecutorServiceMetrics executorServiceMetrics = new ExecutorServiceMetrics(executor, executorServiceName,
+                metricPrefix, tags);
+        executorServiceMetrics.bindTo(registry);
         return new TimedScheduledExecutorService(registry, executor, executorServiceName, sanitizePrefix(metricPrefix),
-                tags);
+                tags, executorServiceMetrics.registeredMeterIds);
     }
 
     /**


### PR DESCRIPTION
Related to #5366, similar to #5367