### PR TITLE
Mark CaffeineCacheMetrics generics with nullability

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -44,7 +44,7 @@ import java.util.function.ToLongFunction;
  * @see CaffeineStatsCounter
  */
 @NullMarked
-public class CaffeineCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder<C> {
+public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache<K, V>> extends CacheMeterBinder<C> {
 
     private static final String DESCRIPTION_CACHE_LOAD = "The number of times cache lookup methods have successfully loaded a new value or failed to load a new value, either because no value was found or an exception was thrown while loading";
 


### PR DESCRIPTION
This matches the nullability behavior of newer versions of Caffeine: https://github.com/ben-manes/caffeine/blob/fc36e9a1ad4a016b231911e4f27649d2ef8b3b17/caffeine/src/main/java/com/github/benmanes/caffeine/cache/Cache.java#L44

An explanation of the nullability behavior of JSpecify regarding generics is available at https://jspecify.dev/docs/user-guide/#declaring-generics

Fixes #6973