### PR TITLE
Cache hash code in Tags class

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -50,6 +50,16 @@ public final class Tags implements Iterable<Tag> {
     private final int length;
 
     /**
+     * Cache of the hash code for this {@code Tags} instance.
+     */
+    private int hash;
+
+    /**
+     * Flag indicating whether the hash code has been computed and is zero.
+     */
+    private boolean hashIsZero;
+
+    /**
      * A constructor that initializes a {@code Tags} object with a sorted set of tags and
      * its length.
      * @param sortedSet an ordered set of unique tags by key
@@ -277,11 +287,20 @@ public final class Tags implements Iterable<Tag> {
 
     @Override
     public int hashCode() {
-        int result = 1;
-        for (int i = 0; i < length; i++) {
-            result = 31 * result + sortedSet[i].hashCode();
+        int h = hash;
+        if (h == 0 && !hashIsZero) {
+            h = 1;
+            for (int i = 0; i < length; i++) {
+                h = 31 * h + sortedSet[i].hashCode();
+            }
+            if (h == 0) {
+                hashIsZero = true;
+            }
+            else {
+                hash = h;
+            }
         }
-        return result;
+        return h;
     }
 
     @Override


### PR DESCRIPTION
Implements lazy hash code caching following the JDK String pattern for immutable `Tags` class. The hash is computed once on first access and cached for subsequent calls, improving performance for `Tags` instances that are frequently used in hash-based collections.

When I look at this method, the Meter ID, which contains Tags, I see the ID is often times used in Map/Set Collections as the key, which means `hashcode` and `equals` are invoked regularly.

https://github.com/micrometer-metrics/micrometer/blob/90051e7ea59eef34eb948e2b3d8af12eef0600a3/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java#L185-L197

As an example, the ID of this collection is involved with Map/Set collections several times in this one function.

https://github.com/micrometer-metrics/micrometer/blob/90051e7ea59eef34eb948e2b3d8af12eef0600a3/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java#L681-L746

The `Tags` class already has a similar shortcut for the `equals` method whereby it does not have to compare every value when the Tags value is re-used.

https://github.com/micrometer-metrics/micrometer/blob/90051e7ea59eef34eb948e2b3d8af12eef0600a3/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java#L292-L294

This PR brings parity by caching the hash code value as well.