### PR TITLE
Optimize MeterRegistry getMeters for reduced allocations

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -411,7 +411,7 @@ public abstract class MeterRegistry {
      * @return The set of registered meters.
      */
     public List<Meter> getMeters() {
-        return Collections.unmodifiableList(new ArrayList<>(meterMap.values()));
+        return Collections.unmodifiableList(Arrays.asList(meterMap.values().toArray(new Meter[0])));
     }
 
     /**


### PR DESCRIPTION
Replaces ArrayList copy with Arrays.asList approach to reduce heap allocations when retrieving meters.

Closes gh-7035