### PR TITLE
Relax time limit for PushMeterRegistryTest.closeRespectsInterrupt()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -243,7 +243,7 @@ class PushMeterRegistryTest {
         Thread closeThread = new Thread(registry::close, "simulatedShutdownHookThread");
         closeThread.start();
         // close is blocked (waiting for publish to finish)
-        await().atMost(Duration.ofMillis(100))
+        await().atMost(Duration.ofMillis(500))
             .pollInterval(1, MILLISECONDS)
             .untilAsserted(() -> assertThat(closeThread.getState()).isEqualTo(Thread.State.WAITING));
 


### PR DESCRIPTION
The test seems to be flaky as the time might be too short in a constrained environment like CircleCI.

See https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/11149/workflows/45382a6a-75a2-4625-ba71-33d81ea9498d/jobs/61093