### PR TITLE
Relax time limit for PushMeterRegistryTest.waitForScheduledPublishToFinish_whenClosedWhilePublishIsInProgress()

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -175,7 +175,7 @@ class PushMeterRegistryTest {
         Thread closeThread = new Thread(registry::close, "simulatedShutdownHookThread");
         closeThread.start();
         // close is blocked (waiting for publish to finish)
-        await().atMost(config.step())
+        await().atMost(Duration.ofMillis(500))
             .pollInterval(1, MILLISECONDS)
             .untilAsserted(() -> assertThat(closeThread.getState()).isEqualTo(Thread.State.WAITING));
         // allow publish to finish


### PR DESCRIPTION
The `PushMeterRegistryTest.waitForScheduledPublishToFinish_whenClosedWhilePublishIsInProgress()` seems to be suffering from the same problem with the `PushMeterRegistryTest.closeRespectsInterrupt()`.

See gh-7044
See also https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/11154/workflows/baa357fa-b987-4bea-8392-a7cfd3992f32/jobs/61123