### PR TITLE
Reduce flakiness of StatsdMeterRegistryPublishTest

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -141,7 +141,7 @@ class StatsdMeterRegistryPublishTest {
         // For UDP, the first change seems to be lost frequently somehow.
         Counter.builder("another.counter").register(meterRegistry).increment();
 
-        if (protocol == StatsdProtocol.UDS_DATAGRAM) {
+        if (protocol == StatsdProtocol.TCP || protocol == StatsdProtocol.UDS_DATAGRAM) {
             await().until(() -> meterRegistry.statsdConnection.get() != firstClient);
         }
 


### PR DESCRIPTION
~It's not clear why this await behavior was not applied in the case of UDP protocol, but removing the conditional that excludes that seems to fix flakiness of this test.~

Upgrading the version of Netty has resolved the underlying flakiness seen in the test and at least from running it 15 times or so locally and a few times on the CI it appears stable.

Find an available port instead of using a fixed port that might not be available.