### PR TITLE
Fix custom test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,9 @@ subprojects {
         }
 
         tasks.withType(Test).configureEach {
+            // https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_tasks_may_no_longer_execute_expected_tests
+            testClassesDirs = testing.suites.test.sources.output.classesDirs
+            classpath = testing.suites.test.sources.runtimeClasspath
             testLogging.exceptionFormat = 'full'
             develocity.testRetry {
                 maxFailures = 5


### PR DESCRIPTION
Before Gradle 9, it was possible to create Test tasks without any additional configuration. By convention, Gradle used the classpath and test classes from the test source set.

The convention has been removed in Gradle 9, but builds will not fail if they were relying on this behavior. Gradle 9 will execute no tests because it has no test classes configured.

To return to the previous behavior, we must explicitly configure the Test tasks and define the testClassesDirs and the classpath.

Test related tasks that are/might be involved:
- `dockerTest`
- `stackdriverTest`
- `shenandoahTest`
- `generationalShenandoahTest`
- `zgcTest`
- `zgcGenerationalTest`
- `openj9BalancedTest`
- `openj9ConcurrentScavengeTest`
- `reflectiveTests`
- `testOSGi`

See https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#test_tasks_may_no_longer_execute_expected_tests