### PR TITLE
Add immutable noop Observation.Context

### DIFF
--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopContext.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import io.micrometer.common.lang.Nullable;
+
+import java.util.function.Function;
+
+/**
+ * A special {@link Observation.Context} that should be used only in special cases where
+ * Observations are disabled/noop. It is an immutable implementation, it will not modify
+ * the internals of the context.
+ *
+ * @author Jonatan Ivanov
+ */
+class NoopContext extends Observation.Context {
+
+    static final NoopContext INSTANCE = new NoopContext();
+
+    private NoopContext() {
+    }
+
+    @Override
+    public void setName(String name) {
+    }
+
+    @Override
+    public void setContextualName(@Nullable String contextualName) {
+    }
+
+    @Override
+    public void setParentObservation(@Nullable ObservationView parentObservation) {
+    }
+
+    @Override
+    void setParentFromCurrentObservation(ObservationRegistry registry) {
+    }
+
+    @Override
+    public void setError(Throwable error) {
+    }
+
+    @Override
+    public <T> Observation.Context put(Object key, T object) {
+        return this;
+    }
+
+    @Override
+    @Nullable
+    public Object remove(Object key) {
+        return null;
+    }
+
+    @Override
+    public <T> T computeIfAbsent(Object key, Function<Object, ? extends T> mappingFunction) {
+        return mappingFunction.apply(key);
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public Observation.Context addLowCardinalityKeyValue(KeyValue keyValue) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context addHighCardinalityKeyValue(KeyValue keyValue) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context removeLowCardinalityKeyValue(String keyName) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context removeHighCardinalityKeyValue(String keyName) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context addLowCardinalityKeyValues(KeyValues keyValues) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context addHighCardinalityKeyValues(KeyValues keyValues) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context removeLowCardinalityKeyValues(String... keyNames) {
+        return this;
+    }
+
+    @Override
+    public Observation.Context removeHighCardinalityKeyValues(String... keyNames) {
+        return this;
+    }
+
+}

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NoopObservation.java
@@ -29,8 +29,6 @@ import io.micrometer.common.lang.Nullable;
  */
 final class NoopObservation implements Observation {
 
-    private static final Context CONTEXT = new Context();
-
     @Override
     public Observation contextualName(@Nullable String contextualName) {
         return this;
@@ -83,7 +81,7 @@ final class NoopObservation implements Observation {
 
     @Override
     public Context getContext() {
-        return CONTEXT;
+        return NoopContext.INSTANCE;
     }
 
     @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java
@@ -1043,6 +1043,7 @@ public interface Observation extends ObservationView {
          * @return the previous value associated with the key, or null if there was no
          * mapping for the key
          */
+        @Nullable
         public Object remove(Object key) {
             return this.map.remove(key);
         }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/NoopContextTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/NoopContextTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link NoopContext}.
+ */
+class NoopContextTests {
+
+    @Test
+    void observationFromNoopRegistryShouldReturnNoopContext() {
+        assertThat(Observation.start("test", ObservationRegistry.NOOP).getContext()).isNotNull()
+            .isSameAs(NoopContext.INSTANCE);
+    }
+
+    @Test
+    void observationWithoutHandlerShouldReturnNoopContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        assertThat(Observation.start("test", registry).getContext()).isNotNull().isSameAs(NoopContext.INSTANCE);
+    }
+
+    @Test
+    void ignoredObservationShouldReturnNoopContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        registry.observationConfig().observationPredicate((name, context) -> false);
+        assertThat(Observation.start("test", registry).getContext()).isNotNull().isSameAs(NoopContext.INSTANCE);
+    }
+
+    @Test
+    void observationShouldNotReturnNoopContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        assertThat(Observation.start("test", registry).getContext()).isNotNull().isNotSameAs(NoopContext.INSTANCE);
+    }
+
+    @Test
+    void mutatorsShouldNotMutateContext() {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(context -> true);
+        Observation.Context context = NoopContext.INSTANCE;
+
+        context.setName("name");
+        assertThat(context.getName()).isNull();
+
+        context.setContextualName("contextualName");
+        assertThat(context.getContextualName()).isNull();
+
+        context.setError(new IllegalStateException("simulated"));
+        assertThat(context.getError()).isNull();
+
+        context.setParentObservation(Observation.start("parent", registry));
+        assertThat(context.getParentObservation()).isNull();
+
+        Observation parent = Observation.start("parent", registry);
+        try (Observation.Scope ignored = parent.openScope()) {
+            context.setParentFromCurrentObservation(registry);
+            assertThat(registry.getCurrentObservation()).isNotNull().isSameAs(parent);
+            assertThat(context.getParentObservation()).isNull();
+        }
+
+        context.addLowCardinalityKeyValue(KeyValue.of("lckv1", "lckv1"));
+        context.addLowCardinalityKeyValues(KeyValues.of("lckv2", "lckv2"));
+        assertThat(context.getLowCardinalityKeyValues()).isEmpty();
+
+        context.addHighCardinalityKeyValue(KeyValue.of("hckv1", "hckv1"));
+        context.addHighCardinalityKeyValues(KeyValues.of("hckv2", "hckv2"));
+        assertThat(context.getHighCardinalityKeyValues()).isEmpty();
+
+        context.put("testKey1", "testValue1");
+        assertThat((String) context.get("testKey1")).isNull();
+
+        context.computeIfAbsent("testKey2", key -> "testValue2");
+        assertThat((String) context.get("testKey2")).isNull();
+
+        // remove and clear methods are not tested
+    }
+
+}


### PR DESCRIPTION
Before this change the `Observation.Context` instance used for noop observations were mutable.
This can be a source of memory leaks if the user gets a noop Observation and writes the context directly:
```java
Observation observation = Observation.start("test", ObservationRegistry.NOOP);
assertThat(observation.getContext()).isSameAs(Observation.Context.EMPTY);
observation.getContext().put("key", "value"); // this should not do anything
assertThat(observation.getContext().<String>get("key")).isEqualTo("value"); // this should fail
```
This change introduces an immutable and noop `Observation.Context` implementation.

See https://github.com/micrometer-metrics/micrometer/pull/7105#discussion_r2715764858