### PR TITLE
Revert version for Logback 1.2.x to 1.2.13

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -168,7 +168,7 @@ kafkaJunit = { module = "com.github.charithe:kafka-junit", version.ref = "kafka-
 kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.7.3" }
 latencyUtils = { module = "org.latencyutils:LatencyUtils", version.ref = "latency-utils" }
 lmaxDisruptor = "com.lmax:disruptor:3.4.4"
-logback12 = { module = "ch.qos.logback:logback-classic", version = "1.5.26" }
+logback12 = { module = "ch.qos.logback:logback-classic", version = "1.2.13" }
 logbackLatest = {module = "ch.qos.logback:logback-classic", version.ref = "logback-latest" }
 log4j = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 mavenResolverConnectorBasic = { module = "org.apache.maven.resolver:maven-resolver-connector-basic", version.ref = "maven-resolver" }

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -226,6 +226,8 @@ dependencies {
     testImplementation libs.retrofit2
 
     testImplementation libs.aspectjweaver
+
+    testImplementation libs.logbackLatest
 }
 
 tasks.register("shenandoahTest", Test) {


### PR DESCRIPTION
This PR reverts the version for Logback 1.2.x to 1.2.13 as it seems that #6770 has changed it to 1.5.26 accidentally.