### PR TITLE
Add dependency version verification task for legacy versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,6 +486,26 @@ nexusPublishing {
     }
 }
 
+tasks.register('verifyDependencyVersions') {
+    doLast {
+        assertDependencyVersionPrefix(libs.jooq, '3.14.')
+        assertDependencyVersionPrefix(libs.logback12, '1.2.')
+    }
+}
+
+private static void assertDependencyVersionPrefix(def dependencySupplier, def expectedVersionPrefix) {
+    def dependency = dependencySupplier.get()
+    assert dependency.version.startsWith(expectedVersionPrefix)
+}
+
+tasks.register('check') {
+    dependsOn verifyDependencyVersions
+}
+
+tasks.register('build') {
+    dependsOn check
+}
+
 wrapper {
     gradleVersion = '8.14.3'
 }


### PR DESCRIPTION
This PR adds a verification task for the legacy Logback version.

See https://github.com/micrometer-metrics/micrometer/pull/7134#issuecomment-3814611122