### PR TITLE
Rework KafkaMetrics based on Kafka's MetricsReporter

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsReporter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsReporter.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.kafka;
+
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
+import io.micrometer.core.instrument.*;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.jspecify.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.micrometer.core.instrument.Meter.Type.OTHER;
+
+public class KafkaMetricsReporter implements MetricsReporter {
+
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(KafkaMetricsReporter.class);
+
+    private static final WarnThenDebugLogger warnThenDebugLogger = new WarnThenDebugLogger(KafkaMetricsReporter.class);
+
+    static final String METRIC_NAME_PREFIX = "kafka.";
+    static final String METRIC_GROUP_APP_INFO = "app-info";
+    static final String METRIC_GROUP_METRICS_COUNT = "kafka-metrics-count";
+    static final String VERSION_METRIC_NAME = "version";
+    static final String START_TIME_METRIC_NAME = "start-time-ms";
+    static final String KAFKA_VERSION_TAG_NAME = "kafka.version";
+    static final String DEFAULT_VALUE = "unknown";
+
+    private static final Set<Class<?>> counterMeasurableClasses = new HashSet<>();
+
+    static {
+        Set<String> classNames = new HashSet<>();
+        classNames.add("org.apache.kafka.common.metrics.stats.CumulativeSum");
+        classNames.add("org.apache.kafka.common.metrics.stats.CumulativeCount");
+
+        for (String className : classNames) {
+            try {
+                counterMeasurableClasses.add(Class.forName(className));
+            }
+            catch (ClassNotFoundException e) {
+                // Class doesn't exist in this version of kafka client - skip
+            }
+        }
+    }
+
+    private static final AtomicReference<MeterRegistry> DEFAULT_REGISTRY = new AtomicReference<>();
+
+    private final Map<MetricName, KafkaMetric> metrics = new ConcurrentHashMap<>();
+
+    private final Set<Meter.Id> registeredMeterIds = ConcurrentHashMap.newKeySet();
+
+    private String kafkaVersion = DEFAULT_VALUE;
+
+    private @Nullable MeterRegistry registry;
+
+    /**
+     * Sets the default MeterRegistry to be used by all KafkaMetricsReporter instances.
+     *
+     * <p>
+     * This method must be called before creating any Kafka clients that use this
+     * reporter.
+     * @param registry the MeterRegistry to use
+     */
+    public static void setDefaultMeterRegistry(MeterRegistry registry) {
+        DEFAULT_REGISTRY.set(registry);
+    }
+
+    /**
+     * Returns the default MeterRegistry.
+     * @return the default MeterRegistry, or null if not set
+     */
+    public static @Nullable MeterRegistry getDefaultMeterRegistry() {
+        return DEFAULT_REGISTRY.get();
+    }
+
+    /**
+     * Called by Kafka to configure this reporter with client properties.
+     * @param configs the Kafka client configuration
+     */
+    @Override
+    public void configure(Map<String, ?> configs) {
+        // Get MeterRegistry
+        this.registry = DEFAULT_REGISTRY.get();
+        if (this.registry == null) {
+            // Fallback to global registry
+            this.registry = Metrics.globalRegistry;
+            log.warn("No MeterRegistry set via setDefaultMeterRegistry(). Using global registry.");
+        }
+    }
+
+    /**
+     * Called by Kafka with all existing metrics when the reporter is initialized.
+     * @param metrics list of existing Kafka metrics
+     */
+    @Override
+    public void init(List<KafkaMetric> metrics) {
+        // First pass: extract version and start-time from app-info group
+        for (KafkaMetric metric : metrics) {
+            MetricName name = metric.metricName();
+            if (METRIC_GROUP_APP_INFO.equals(name.group())) {
+                if (VERSION_METRIC_NAME.equals(name.name())) {
+                    Object value = metric.metricValue();
+                    if (value instanceof String) {
+                        this.kafkaVersion = (String) value;
+                    }
+                }
+                else if (START_TIME_METRIC_NAME.equals(name.name())) {
+                    registerMetric(metric);
+                }
+            }
+        }
+
+        // Second pass: register all other metrics
+        for (KafkaMetric metric : metrics) {
+            MetricName name = metric.metricName();
+            if (!METRIC_GROUP_APP_INFO.equals(name.group())
+                    || (!VERSION_METRIC_NAME.equals(name.name()) && !START_TIME_METRIC_NAME.equals(name.name()))) {
+                registerMetric(metric);
+            }
+        }
+    }
+
+    /**
+     * Called by Kafka when a metric is added or updated.
+     * @param metric the added or updated metric
+     */
+    @Override
+    public void metricChange(KafkaMetric metric) {
+        MetricName name = metric.metricName();
+
+        // Update version if app-info version metric
+        if (METRIC_GROUP_APP_INFO.equals(name.group()) && VERSION_METRIC_NAME.equals(name.name())) {
+            Object value = metric.metricValue();
+            if (value instanceof String) {
+                this.kafkaVersion = (String) value;
+            }
+            return;
+        }
+
+        registerMetric(metric);
+    }
+
+    /**
+     * Called by Kafka when a metric is removed.
+     * @param metric the removed metric
+     */
+    @Override
+    public void metricRemoval(KafkaMetric metric) {
+        MetricName metricName = metric.metricName();
+
+        // Remove from our metrics map
+        metrics.remove(metricName);
+
+        // Remove from registry
+        if (registry != null) {
+            Meter.Id id = meterIdForComparison(metricName);
+            registry.remove(id);
+            registeredMeterIds.remove(id);
+        }
+    }
+
+    /**
+     * Called by Kafka when the reporter is closed.
+     */
+    @Override
+    public void close() {
+        if (registry != null) {
+            for (Meter.Id id : registeredMeterIds) {
+                registry.remove(id);
+            }
+        }
+        registeredMeterIds.clear();
+        metrics.clear();
+    }
+
+    @Override
+    public void contextChange(MetricsContext metricsContext) {
+        // No op
+    }
+
+    private void registerMetric(KafkaMetric metric) {
+        if (registry == null) {
+            return;
+        }
+
+        MetricName metricName = metric.metricName();
+
+        // Filter out non-numeric values
+        if (!(metric.metricValue() instanceof Number)) {
+            return;
+        }
+
+        // Filter out metadata groups
+        if (METRIC_GROUP_APP_INFO.equals(metricName.group()) && !START_TIME_METRIC_NAME.equals(metricName.name())) {
+            return;
+        }
+        if (METRIC_GROUP_METRICS_COUNT.equals(metricName.group())) {
+            return;
+        }
+
+        // Check if already registered
+        Meter.Id existingId = meterIdForComparison(metricName);
+        if (registeredMeterIds.contains(existingId)) {
+            // Update the metric reference
+            metrics.put(metricName, metric);
+            return;
+        }
+
+        // Handle tag count comparison (Kafka has metrics with varying tag counts)
+        String meterName = meterName(metricName);
+        List<Tag> meterTagsList = meterTags(metricName);
+
+        for (Meter existingMeter : registry.getMeters()) {
+            if (existingMeter.getId().getName().equals(meterName)) {
+                List<Tag> existingTags = existingMeter.getId().getTags();
+
+                if (existingTags.size() < meterTagsList.size()) {
+                    // Remove meter with fewer tags
+                    registry.remove(existingMeter.getId());
+                    registeredMeterIds.remove(existingMeter.getId());
+                }
+                else if (existingTags.size() > meterTagsList.size()) {
+                    // Don't register this metric as there's one with more tags
+                    return;
+                }
+                else if (new HashSet<>(existingTags).containsAll(meterTagsList)) {
+                    // Already exists with same tags
+                    metrics.put(metricName, metric);
+                    return;
+                }
+            }
+        }
+
+        // Store metric for value retrieval
+        metrics.put(metricName, metric);
+
+        // Register the meter
+        try {
+            Meter meter = bindMeter(registry, metric, meterName, meterTagsList);
+            registeredMeterIds.add(meter.getId());
+        }
+        catch (Exception ex) {
+            String message = ex.getMessage();
+            if (message != null && message.contains("Prometheus requires")) {
+                warnThenDebugLogger.log(() -> "Failed to bind meter: " + meterName + " " + meterTagsList
+                        + ". However, this could happen and might be restored in the next refresh.");
+            }
+            else {
+                log.warn("Failed to bind meter: " + meterName + " " + meterTagsList + ".", ex);
+            }
+        }
+    }
+
+    private Meter bindMeter(MeterRegistry registry, KafkaMetric metric, String meterName, Iterable<Tag> tags) {
+        MetricName metricName = metric.metricName();
+        Class<? extends Measurable> measurableClass = getMeasurableClass(metric);
+
+        if ((measurableClass == null && meterName.endsWith("total"))
+                || (measurableClass != null && counterMeasurableClasses.contains(measurableClass))) {
+            return registerCounter(registry, metricName, meterName, tags);
+        }
+
+        return registerGauge(registry, metricName, meterName, tags);
+    }
+
+    private Gauge registerGauge(MeterRegistry registry, MetricName metricName, String meterName, Iterable<Tag> tags) {
+        return Gauge.builder(meterName, metrics, m -> toDouble(m.get(metricName)))
+            .tags(tags)
+            .description(metricName.description())
+            .register(registry);
+    }
+
+    private FunctionCounter registerCounter(MeterRegistry registry, MetricName metricName, String meterName,
+            Iterable<Tag> tags) {
+        return FunctionCounter.builder(meterName, metrics, m -> toDouble(m.get(metricName)))
+            .tags(tags)
+            .description(metricName.description())
+            .register(registry);
+    }
+
+    private double toDouble(@Nullable KafkaMetric metric) {
+        if (metric == null) {
+            return Double.NaN;
+        }
+        Object metricValue = metric.metricValue();
+        if (metricValue == null) {
+            return Double.NaN;
+        }
+        if (!(metricValue instanceof Number)) {
+            return Double.NaN;
+        }
+        return ((Number) metricValue).doubleValue();
+    }
+
+    private static @Nullable Class<? extends Measurable> getMeasurableClass(KafkaMetric metric) {
+        try {
+            return metric.measurable().getClass();
+        }
+        catch (IllegalStateException ex) {
+            return null;
+        }
+    }
+
+    private List<Tag> meterTags(MetricName metricName) {
+        List<Tag> tags = new ArrayList<>();
+        metricName.tags().forEach((key, value) -> tags.add(Tag.of(key.replace('-', '.'), value)));
+        tags.add(Tag.of(KAFKA_VERSION_TAG_NAME, kafkaVersion));
+        return tags;
+    }
+
+    private String meterName(MetricName metricName) {
+        String name = METRIC_NAME_PREFIX + metricName.group() + "." + metricName.name();
+        return name.replaceAll("-metrics", "").replace('-', '.');
+    }
+
+    private Meter.Id meterIdForComparison(MetricName metricName) {
+        return new Meter.Id(meterName(metricName), Tags.of(meterTags(metricName)), null, null, OTHER);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsReporterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsReporterTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2020 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.kafka;
+
+import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Value;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaMetricsReporterTest {
+
+    private KafkaMetricsReporter reporter;
+
+    private MeterRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry();
+        KafkaMetricsReporter.setDefaultMeterRegistry(registry);
+        reporter = new KafkaMetricsReporter();
+        reporter.configure(Collections.emptyMap());
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (reporter != null) {
+            reporter.close();
+        }
+    }
+
+    @Test
+    void shouldRegisterMetricsOnInit() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getName()).isEqualTo("kafka.b.a");
+    }
+
+    @Test
+    void shouldRegisterMetricOnMetricChange() {
+        // Given
+        reporter.init(Collections.emptyList());
+        KafkaMetric metric = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0);
+
+        // When
+        reporter.metricChange(metric);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    @Test
+    void shouldRemoveMetricOnMetricRemoval() {
+        // Given
+        KafkaMetric metric = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0);
+        reporter.init(Collections.singletonList(metric));
+        assertThat(registry.getMeters()).hasSize(1);
+
+        // When
+        reporter.metricRemoval(metric);
+
+        // Then
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    void shouldRemoveAllMetersOnClose() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0));
+        metrics.add(createKafkaMetric("d", "e", "f", Collections.emptyMap(), 2.0));
+        reporter.init(metrics);
+        assertThat(registry.getMeters()).hasSize(2);
+
+        // When
+        reporter.close();
+
+        // Then
+        assertThat(registry.getMeters()).isEmpty();
+    }
+
+    @Test
+    void shouldNotAddAppInfoMetrics() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0));
+        metrics.add(createKafkaMetric("version", KafkaMetricsReporter.METRIC_GROUP_APP_INFO, "version",
+                Collections.emptyMap(), 0.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    @Test
+    void shouldExtractKafkaVersionFromAppInfo() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTag("kafka.version")).isEqualTo("unknown");
+    }
+
+    @Test
+    void shouldRemoveOlderMeterWithLessTags() {
+        // Given
+        KafkaMetric metricWithoutTags = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0);
+        reporter.init(Collections.singletonList(metricWithoutTags));
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTags()).hasSize(1);
+
+        // When
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("key0", "value0");
+        KafkaMetric metricWithTags = createKafkaMetric("a", "b", "c", tags, 2.0);
+        reporter.metricChange(metricWithTags);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTags()).hasSize(2);
+    }
+
+    @Test
+    void shouldRemoveMeterWithLessTags() {
+        // Given
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("key0", "value0");
+        KafkaMetric metricWithTags = createKafkaMetric("a", "b", "c", tags, 1.0);
+        KafkaMetric metricWithoutTags = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 2.0);
+
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(metricWithoutTags);
+        metrics.add(metricWithTags);
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTags()).hasSize(2);
+    }
+
+    @Test
+    void shouldBindMetersWithSameTags() {
+        // Given
+        Map<String, String> firstTags = new LinkedHashMap<>();
+        firstTags.put("key0", "value0");
+        Map<String, String> secondTags = new LinkedHashMap<>();
+        secondTags.put("key0", "value1");
+
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", firstTags, 1.0));
+        metrics.add(createKafkaMetric("a", "b", "c", secondTags, 2.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(2);
+    }
+
+    @Issue("#1968")
+    @Test
+    void shouldBindMetersWithDifferentClientIds() {
+        // Given
+        Map<String, String> firstTags = new LinkedHashMap<>();
+        firstTags.put("key0", "value0");
+        firstTags.put("client-id", "client0");
+        Map<String, String> secondTags = new LinkedHashMap<>();
+        secondTags.put("key0", "value0");
+        secondTags.put("client-id", "client1");
+
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", firstTags, 1.0));
+        metrics.add(createKafkaMetric("a", "b", "c", secondTags, 2.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(2);
+    }
+
+    @Issue("#2212")
+    @Test
+    void shouldRemoveMeterWithLessTagsWithMultipleClients() {
+        // Given
+        Map<String, String> firstTags = new LinkedHashMap<>();
+        firstTags.put("key0", "value0");
+        firstTags.put("client-id", "client0");
+        Map<String, String> secondTags = new LinkedHashMap<>();
+        secondTags.put("key0", "value0");
+        secondTags.put("client-id", "client1");
+
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", firstTags, 1.0));
+        metrics.add(createKafkaMetric("a", "b", "c", secondTags, 2.0));
+        reporter.init(metrics);
+        assertThat(registry.getMeters()).hasSize(2);
+
+        // When
+        Map<String, String> firstTagsWithMore = new LinkedHashMap<>();
+        firstTagsWithMore.put("key0", "value0");
+        firstTagsWithMore.put("client-id", "client0");
+        firstTagsWithMore.put("key1", "value1");
+        Map<String, String> secondTagsWithMore = new LinkedHashMap<>();
+        secondTagsWithMore.put("key0", "value0");
+        secondTagsWithMore.put("client-id", "client1");
+        secondTagsWithMore.put("key1", "value1");
+
+        reporter.metricChange(createKafkaMetric("a", "b", "c", firstTagsWithMore, 3.0));
+        reporter.metricChange(createKafkaMetric("a", "b", "c", secondTagsWithMore, 4.0));
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(2);
+        registry.getMeters()
+            .forEach(meter -> assertThat(meter.getId().getTags()).extracting(Tag::getKey)
+                .containsOnly("key0", "key1", "client.id", "kafka.version"));
+    }
+
+    @Test
+    void shouldUpdateMetricReferenceOnMetricChange() {
+        // Given
+        KafkaMetric oldMetric = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0);
+        reporter.init(Collections.singletonList(oldMetric));
+
+        Gauge gauge = registry.find("kafka.b.a").gauge();
+        assertThat(gauge).isNotNull();
+        assertThat(gauge.value()).isEqualTo(1.0);
+
+        // When
+        KafkaMetric newMetric = createKafkaMetric("a", "b", "c", Collections.emptyMap(), 99.0);
+        reporter.metricChange(newMetric);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(gauge.value()).isEqualTo(99.0);
+    }
+
+    @Test
+    void shouldNotAddKafkaMetricsCountGroup() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0));
+        metrics.add(createKafkaMetric("count", KafkaMetricsReporter.METRIC_GROUP_METRICS_COUNT, "count",
+                Collections.emptyMap(), 10.0));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+    }
+
+    @Test
+    void shouldRegisterStartTimeMetricFromAppInfo() {
+        // Given
+        List<KafkaMetric> metrics = new ArrayList<>();
+        metrics.add(createKafkaMetric(KafkaMetricsReporter.START_TIME_METRIC_NAME,
+                KafkaMetricsReporter.METRIC_GROUP_APP_INFO, "start time", Collections.emptyMap(),
+                (double) System.currentTimeMillis()));
+
+        // When
+        reporter.init(metrics);
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getName()).contains("start.time.ms");
+    }
+
+    @Test
+    void shouldUseGlobalRegistryWhenNoDefaultSet() {
+        // Given
+        SimpleMeterRegistry tempRegistry = new SimpleMeterRegistry();
+        KafkaMetricsReporter.setDefaultMeterRegistry(tempRegistry);
+        KafkaMetricsReporter newReporter = new KafkaMetricsReporter();
+
+        // When
+        newReporter.configure(Collections.emptyMap());
+        newReporter.init(Collections.singletonList(createKafkaMetric("a", "b", "c", Collections.emptyMap(), 1.0)));
+
+        // Then
+        assertThat(tempRegistry.getMeters()).hasSize(1);
+
+        newReporter.close();
+    }
+
+    @Test
+    void shouldConvertHyphensToDotsInMeterName() {
+        // Given
+        KafkaMetric metric = createKafkaMetric("records-lag-max", "consumer-fetch-manager-metrics", "description",
+                Collections.emptyMap(), 100.0);
+
+        // When
+        reporter.init(Collections.singletonList(metric));
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getName())
+            .isEqualTo("kafka.consumer.fetch.manager.records.lag.max");
+    }
+
+    @Test
+    void shouldConvertHyphensToDotsInTagKeys() {
+        // Given
+        Map<String, String> tags = new LinkedHashMap<>();
+        tags.put("client-id", "my-consumer");
+        KafkaMetric metric = createKafkaMetric("a", "b", "c", tags, 1.0);
+
+        // When
+        reporter.init(Collections.singletonList(metric));
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTag("client.id")).isEqualTo("my-consumer");
+    }
+
+    @Test
+    void shouldRegisterGaugeForMetricsEndingWithTotal() {
+        // Given
+        KafkaMetric metric = createKafkaMetric("bytes-consumed-total", "consumer-fetch-manager-metrics", "description",
+                Collections.emptyMap(), 1000.0);
+
+        // When
+        reporter.init(Collections.singletonList(metric));
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        Meter meter = registry.getMeters().get(0);
+        assertThat(meter.getId().getName()).endsWith("total");
+        assertThat(meter).isInstanceOf(Gauge.class);
+    }
+
+    @Test
+    void shouldRegisterFunctionCounterForCumulativeSumMetrics() {
+        // Given
+        MetricName metricName = new MetricName("bytes-consumed-total", "consumer-fetch-manager-metrics", "description",
+                Collections.emptyMap());
+        CumulativeSum cumulativeSum = new CumulativeSum();
+        cumulativeSum.record(new MetricConfig(), 1000.0, System.currentTimeMillis());
+        KafkaMetric metric = new KafkaMetric(this, metricName, cumulativeSum, new MetricConfig(), Time.SYSTEM);
+
+        // When
+        reporter.init(Collections.singletonList(metric));
+
+        // Then
+        assertThat(registry.getMeters()).hasSize(1);
+        Meter meter = registry.getMeters().get(0);
+        assertThat(meter).isInstanceOf(FunctionCounter.class);
+    }
+
+    private KafkaMetric createKafkaMetric(String name, String group, String description, Map<String, String> tags,
+            double value) {
+        MetricName metricName = new MetricName(name, group, description, tags);
+        Value kafkaValue = new Value();
+        kafkaValue.record(new MetricConfig(), value, System.currentTimeMillis());
+        return new KafkaMetric(this, metricName, kafkaValue, new MetricConfig(), Time.SYSTEM);
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR introduces `KafkaMetricsReporter`, a new implementation that leverages Kafka's native `MetricsReporter` interface to collect Kafka client metrics into Micrometer.

## Motivation

The existing `KafkaMetrics` class relies on a polling-based approach that requires:
- A `Supplier` to periodically fetch metrics from Kafka clients
- A scheduled executor to run `checkAndBindMetrics()` at regular intervals
- Manual cleanup and meter lifecycle management

By implementing Kafka's `MetricsReporter` interface directly, we can:
- Receive metric changes in real-time via callbacks (`metricChange`, `metricRemoval`)
- Eliminate the need for polling and scheduled executors
- Simplify integration with Kafka clients through the `metric.reporters` configuration

## Usage

```java
// Set the registry before creating Kafka clients
KafkaMetricsReporter.setDefaultMeterRegistry(meterRegistry);

// Configure Kafka client
Properties props = new Properties();
props.put(ConsumerConfig.METRIC_REPORTER_CLASSES_CONFIG, 
          KafkaMetricsReporter.class.getName());
// ... other configs

KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
```

## Discussion: Usage Pattern

I'd like to get feedback on the usage pattern for the new `MetricsReporter` implementation.

Unlike the existing `KafkaClientMetrics` binder, which wraps an already instantiated Producer/Consumer, the `MetricsReporter` interface is designed to be instantiated and managed by the Kafka client's lifecycle.

Kafka clients instantiate reporters via reflection inside their constructor based on the `metric.reporters` property. Once the client is initialized, there is no public API to inject or add a reporter dynamically.

As a result, users must configure the reporter class via properties **before** creating the client instance. The "post-construction binding" pattern (e.g., `binder.bindTo(registry)`) is not supported with the `MetricsReporter` architecture.

I'd appreciate any feedback on whether this implementation direction aligns with the project's goals.

If there are concerns or suggestions for a different approach, please let me know—I'm happy to revise the implementation accordingly.

---
See https://github.com/micrometer-metrics/micrometer/issues/6502