### PR TITLE
Docs: Align AsciiDoc callout syntax

### DIFF
--- a/docs/modules/ROOT/pages/concepts/meter-filters.adoc
+++ b/docs/modules/ROOT/pages/concepts/meter-filters.adoc
@@ -71,7 +71,7 @@ Meter filters are applied in the order in which they are configured on the regis
 ----
 registry.config()
     .meterFilter(MeterFilter.acceptNameStartsWith("http"))
-    .meterFilter(MeterFilter.deny()); <1>
+    .meterFilter(MeterFilter.deny());
 ----
 ====
 

--- a/docs/modules/ROOT/pages/concepts/registry.adoc
+++ b/docs/modules/ROOT/pages/concepts/registry.adoc
@@ -32,9 +32,9 @@ composite.add(simple); <2>
 compositeCounter.increment(); <3>
 ----
 
-1. Increments are NOOP'd until there is a registry in the composite. The counter's count still yields 0 at this point.
-2. A counter named `counter` is registered to the simple registry.
-3. The simple registry counter is incremented, along with counters for any other registries in the composite.
+<1> Increments are NOOP'd until there is a registry in the composite. The counter's count still yields 0 at this point.
+<2> A counter named `counter` is registered to the simple registry.
+<3> The simple registry counter is incremented, along with counters for any other registries in the composite.
 ====
 
 == Global Registry
@@ -64,7 +64,7 @@ class MyApplication {
 }
 ----
 
-1. Wherever possible (and especially where instrumentation performance is critical), store `Meter` instances in fields to avoid a lookup on their name or tags on each use.
-2. When tags need to be determined from local context, you have no choice but to construct or lookup the Meter inside your method body. The lookup cost is just a single hash lookup, so it is acceptable for most use cases.
-3. It is OK to add registries _after_ meters have been created with code like `Metrics.counter(...)`. These meters are added to each registry, as it is bound to the global composite.
+<1> Wherever possible (and especially where instrumentation performance is critical), store `Meter` instances in fields to avoid a lookup on their name or tags on each use.
+<2> When tags need to be determined from local context, you have no choice but to construct or lookup the Meter inside your method body. The lookup cost is just a single hash lookup, so it is acceptable for most use cases.
+<3> It is OK to add registries _after_ meters have been created with code like `Metrics.counter(...)`. These meters are added to each registry, as it is bound to the global composite.
 ====


### PR DESCRIPTION
# Summary
This PR refactors the markup in example blocks to ensure that code callouts are correctly recognized and rendered by Antora/Asciidoctor.

# Problem
The current documentation uses a manual ordered list (1., 2., etc.) for code explanations. This causes two issues:

Broken Links: The interactive links between the code tags (<1>) and the descriptions do not function.

Rendering Issues: The callout icons (e.g., the stylized "❶") do not appear in the description list, making the documentation less readable and inconsistent with the Spring official style.

# Changes
Updated manual numeric lists to standard AsciiDoc callout list syntax (<1>, <2>, etc.).

Ensured all code snippets and their respective callouts are encapsulated within ==== (Example blocks) for proper visual grouping.