### PR TITLE
Remove unused length parameter from Tags/KeyValues#isSortedSet

### DIFF
--- a/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/KeyValues.java
@@ -64,18 +64,13 @@ public final class KeyValues implements Iterable<KeyValue> {
     }
 
     /**
-     * Checks if the first {@code length} elements of the {@code keyValues} array form an
-     * ordered set of key-values.
+     * Checks if the {@code keyValues} array forms an ordered set of key-values.
      * @param keyValues an array of key-values.
-     * @param length the number of elements to check.
-     * @return {@code true} if the first {@code length} elements of {@code keyValues} form
-     * an ordered set; otherwise {@code false}.
+     * @return {@code true} if {@code keyValues} forms an ordered set; otherwise
+     * {@code false}.
      */
-    private static boolean isSortedSet(KeyValue[] keyValues, int length) {
-        if (length > keyValues.length) {
-            return false;
-        }
-        for (int i = 0; i < length - 1; i++) {
+    private static boolean isSortedSet(KeyValue[] keyValues) {
+        for (int i = 0; i < keyValues.length - 1; i++) {
             int cmp = keyValues[i].compareTo(keyValues[i + 1]);
             if (cmp >= 0) {
                 return false;
@@ -92,12 +87,12 @@ public final class KeyValues implements Iterable<KeyValue> {
      * key-values.
      */
     private static KeyValues toKeyValues(KeyValue[] keyValues) {
-        int len = keyValues.length;
-        if (!isSortedSet(keyValues, len)) {
+        if (!isSortedSet(keyValues)) {
             Arrays.sort(keyValues);
-            len = dedup(keyValues);
+            int len = dedup(keyValues);
+            return new KeyValues(keyValues, len);
         }
-        return new KeyValues(keyValues, len);
+        return new KeyValues(keyValues, keyValues.length);
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Tags.java
@@ -61,18 +61,12 @@ public final class Tags implements Iterable<Tag> {
     }
 
     /**
-     * Checks if the first {@code length} elements of the {@code tags} array form an
-     * ordered set of tags.
+     * Checks if the {@code tags} array forms an ordered set of tags.
      * @param tags an array of tags.
-     * @param length the number of elements to check.
-     * @return {@code true} if the first {@code length} elements of {@code tags} form an
-     * ordered set; otherwise {@code false}.
+     * @return {@code true} if {@code tags} forms an ordered set; otherwise {@code false}.
      */
-    private static boolean isSortedSet(Tag[] tags, int length) {
-        if (length > tags.length) {
-            return false;
-        }
-        for (int i = 0; i < length - 1; i++) {
+    private static boolean isSortedSet(Tag[] tags) {
+        for (int i = 0; i < tags.length - 1; i++) {
             int cmp = tags[i].compareTo(tags[i + 1]);
             if (cmp >= 0) {
                 return false;
@@ -88,12 +82,12 @@ public final class Tags implements Iterable<Tag> {
      * @return a {@code Tags} instance with a deduplicated and ordered set of tags.
      */
     private static Tags toTags(Tag[] tags) {
-        int len = tags.length;
-        if (!isSortedSet(tags, len)) {
+        if (!isSortedSet(tags)) {
             Arrays.sort(tags);
-            len = dedup(tags);
+            int len = dedup(tags);
+            return new Tags(tags, len);
         }
-        return new Tags(tags, len);
+        return new Tags(tags, tags.length);
     }
 
     /**


### PR DESCRIPTION
## Summary

Remove the unused `length` parameter from `isSortedSet()` in both `Tags` and `KeyValues` classes.

The `length` parameter was never used with a value different from the array's actual length, making it superfluous. This simplification also improves API consistency:

- `Arrays.sort(tags)` - operates on the full array
- `dedup(tags)` - operates on the full array
- `isSortedSet(tags)` - now also operates on the full array (previously accepted a length parameter that was always `tags.length`)

### Changes

- **Tags.java**: Simplified `isSortedSet(Tag[] tags, int length)` to `isSortedSet(Tag[] tags)`
- **KeyValues.java**: Simplified `isSortedSet(KeyValue[] keyValues, int length)` to `isSortedSet(KeyValue[] keyValues)`
- Removed dead code: the check `if (length > tags.length)` could never be true since `length` was always equal to `tags.length`
- Updated `toTags()` and `toKeyValues()` methods accordingly