### PR TITLE
docs: add UDS configuration guide for StatsD (#5730)

### DIFF
--- a/docs/modules/ROOT/pages/implementations/statsD.adoc
+++ b/docs/modules/ROOT/pages/implementations/statsD.adoc
@@ -99,17 +99,7 @@ StatsdConfig config = new StatsdConfig() {
 MeterRegistry registry = new StatsdMeterRegistry(config, Clock.SYSTEM);
 ----
 
-*Spring Boot configuration example (`application.yml`):*
 
-[source,yaml]
-----
-management:
-  metrics:
-    export:
-      statsd:
-        protocol: uds_datagram
-        host: /var/run/datadog/dsd.socket
-----
 
 === Using Apache Kafka for Line Sink
 


### PR DESCRIPTION
### Description

This PR documents how to configure the StatsD registry to use Unix Domain Socket (UDS) datagrams.

It adds:
- A brief explanation of UDS support.
- A note clarifying that the `host` must be an absolute path (without a `unix://` prefix).
- Configuration examples for both Java and Spring Boot (`application.yml`).

Closes #5730