### PR TITLE
Remove @NullUnmarked workaround for NullAway bug on generic types

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterRegistryConfigValidator.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/config/MeterRegistryConfigValidator.java
@@ -17,8 +17,7 @@ package io.micrometer.core.instrument.config;
 
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.config.validate.ValidationException;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.function.Function;
@@ -56,9 +55,8 @@ public class MeterRegistryConfigValidator {
      * @return A function which, given a configuration instance, validates the property.
      */
     @SuppressWarnings("unchecked")
-    @NullUnmarked
-    public static <M extends @NonNull MeterRegistryConfig, T> Function<M, Validated<T>> check(@NonNull String property,
-            Function<M, T> getter) {
+    public static <M extends MeterRegistryConfig, T extends @Nullable Object> Function<M, Validated<T>> check(
+            String property, Function<M, T> getter) {
         return config -> {
             try {
                 return Validated.valid(config.prefix() + '.' + property, getter.apply(config));
@@ -70,9 +68,8 @@ public class MeterRegistryConfigValidator {
         };
     }
 
-    @NullUnmarked
-    public static <M extends @NonNull MeterRegistryConfig, T> Function<M, Validated<T>> checkRequired(
-            @NonNull String property, Function<M, T> getter) {
+    public static <M extends MeterRegistryConfig, T extends @Nullable Object> Function<M, Validated<T>> checkRequired(
+            String property, Function<M, T> getter) {
         return check(property, getter).andThen(Validated::required);
     }
 


### PR DESCRIPTION
The upstream NullAway bug (uber/NullAway#1075) affecting inference for calls to generic methods has been fixed in v0.12.10, and Micrometer already uses v0.13.1. Remove the `@NullUnmarked` workarounds in `MeterRegistryConfigValidator` and use proper JSpecify annotations: replace `@NullUnmarked` with `T extends @Nullable Object` on `check()` and `checkRequired()`.

Closes gh-6404