### PR TITLE
Stabilize CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,28 +4,28 @@ executors:
   jdk24-executor:
     working_directory: ~/micrometer
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError" -Dscan.uploadInBackground=false -Dorg.gradle.workers.max=2'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.workers.max=2'
     resource_class: medium+
     docker:
       - image: cimg/openjdk:24.0.2
   circle-jdk-executor:
     working_directory: ~/micrometer
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dscan.uploadInBackground=false -Dorg.gradle.workers.max=2'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.workers.max=2'
     resource_class: medium+
     docker:
       - image: cimg/openjdk:21.0.8
   circle-jdk17-executor:
     working_directory: ~/micrometer
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dscan.uploadInBackground=false -Dorg.gradle.workers.max=2'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.workers.max=2'
     resource_class: medium+
     docker:
       - image: cimg/openjdk:17.0.16
   circle-jdk11-executor:
     working_directory: ~/micrometer
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dscan.uploadInBackground=false -Dorg.gradle.workers.max=2'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.workers.max=2'
     resource_class: medium+
     docker:
       - image: cimg/openjdk:11.0.28
@@ -33,7 +33,7 @@ executors:
   concurrency-tests-executor:
     working_directory: ~/micrometer
     environment:
-      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dscan.uploadInBackground=false -Dorg.gradle.workers.max=2'
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2g -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.workers.max=2'
     resource_class: large
     docker:
       - image: cimg/openjdk:21.0.8


### PR DESCRIPTION
We are getting consistent build failures on CircleCI on pull request builds now, and limited build failures on branches. This is strange because nothing has changed in the source that should affect build behavior. It appears the builds are failing with an OOM. This adds some diagnostics, tries to curb OOMs by limiting Gradle workers, and increases resources for the concurrency-test job.