### PR TITLE
docs: document Jakarta Mail instrumentation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -49,6 +49,7 @@
 ** xref:reference/jms.adoc[JMS]
 ** xref:reference/jvm.adoc[JVM]
 ** xref:reference/kafka.adoc[Kafka]
+** xref:reference/mail.adoc[Jakarta Mail]
 ** xref:reference/logging.adoc[Logging]
 ** xref:reference/mongodb.adoc[MongoDB]
 ** xref:reference/netty.adoc[Netty]

--- a/docs/modules/ROOT/pages/observation/projects.adoc
+++ b/docs/modules/ROOT/pages/observation/projects.adoc
@@ -23,6 +23,7 @@ Micrometer Observation is used to instrument various projects. Below you can fin
 | Jersey | https://github.com/eclipse-ee4j/jersey/pull/5391[PR]
 | Jetty | https://github.com/micrometer-metrics/micrometer/pull/3416[PR]
 | JMS | https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsInstrumentation.java[Repo]
+| Jakarta Mail | https://github.com/micrometer-metrics/micrometer/tree/main/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/mail[Repo]
 | Kotlin Coroutines | https://github.com/micrometer-metrics/micrometer/pull/3256[PR]
 | Lettuce | https://github.com/lettuce-io/lettuce-core/commit/6604fbe9e9cff476806c50716e17803e11d1e0ca[Commit]
 | Micronaut | https://github.com/micronaut-projects/micronaut-micrometer/issues/492[Issue]

--- a/docs/modules/ROOT/pages/reference/mail.adoc
+++ b/docs/modules/ROOT/pages/reference/mail.adoc
@@ -1,0 +1,86 @@
+[[overview]]
+= Jakarta Mail Instrumentation
+
+Micrometer provides Jakarta Mail instrumentation.
+
+== Installing
+
+It is recommended to use the BOM provided by Micrometer (or your framework if any), you can see how to configure it xref:../installing.adoc[here]. The examples below assume you are using a BOM.
+
+=== Gradle
+
+After the BOM is xref:../installing.adoc[configured], add the following dependency:
+
+[source,groovy]
+----
+implementation 'io.micrometer:micrometer-jakarta9'
+----
+
+NOTE: The version is not needed for this dependency since it is defined by the BOM.
+
+=== Maven
+
+After the BOM is xref:../installing.adoc[configured], add the following dependency:
+
+[source,xml]
+----
+<dependency>
+  <groupId>io.micrometer</groupId>
+  <artifactId>micrometer-jakarta9</artifactId>
+</dependency>
+----
+
+NOTE: The version is not needed for this dependency since it is defined by the BOM.
+
+== Usage
+
+Here is how a Jakarta Mail `Transport` can be instrumented for observability:
+
+[source,java]
+----
+import io.micrometer.jakarta9.instrument.mail.InstrumentedTransport;
+
+Session session = Session.getInstance(new Properties());
+ObservationRegistry registry = ...
+
+Transport original = session.getTransport("smtp");
+Transport transport = new InstrumentedTransport(session, original, registry);
+
+transport.connect("smtp.example.com", 587, "username", "password");
+
+MimeMessage message = new MimeMessage(session);
+message.setFrom("from@example.com");
+message.setRecipients(Message.RecipientType.TO, "to@example.com");
+message.setSubject("Hello");
+message.setText("Mail from Micrometer instrumentation");
+
+// this operation will create a "mail.send" observation
+transport.sendMessage(message, message.getAllRecipients());
+----
+
+== Observations
+
+This instrumentation creates the `"mail.send"` observation when
+`jakarta.mail.Transport.sendMessage` is called.
+
+.Low cardinality keys
+[cols="a,a"]
+|===
+|Name | Description
+|`server.address` |(SMTP) server address used for sending mails.
+|`server.port` |(SMTP) server port used for sending mails.
+|`network.protocol.name` |Network protocol used for sending mails.
+|===
+
+.High cardinality keys
+[cols="a,a"]
+|===
+|Name | Description
+|`smtp.message.from` |Sender of the mail.
+|`smtp.message.to` |Primary (TO) recipient(s) of the mail.
+|`smtp.message.cc` |Carbon copy (CC) recipient(s) of the mail.
+|`smtp.message.bcc` |Blind carbon copy (BCC) recipient(s) of the mail.
+|`smtp.message.newsgroups` |Newsgroup (Usenet news) recipient(s) of the mail.
+|`smtp.message.subject` |Subject line of the mail.
+|`smtp.message.id` |Message ID received from the SMTP server.
+|===


### PR DESCRIPTION
## Summary
- add a new reference page for Jakarta Mail instrumentation
- register the page in docs navigation
- add Jakarta Mail to the Observation instrumented projects table

## Verification
- ./gradlew :docs:antora

Closes #6485