### PR TITLE
Document DefaultMeterObservationHandler

### DIFF
--- a/docs/modules/ROOT/pages/observation/components.adoc
+++ b/docs/modules/ROOT/pages/observation/components.adoc
@@ -5,6 +5,7 @@ In this section we will describe main components related to Micrometer Observati
 
 * <<micrometer-observation-context, Observation Context>>
 * <<micrometer-observation-handler, Observation Handler>>
+* <<micrometer-observation-default-meter-handler, DefaultMeterObservationHandler>>
 * <<micrometer-observation-events, Signaling Errors and Arbitrary Events>>
 * <<micrometer-observation-convention-example, Observation Convention>>
 * <<micrometer-observation-predicates-filters, Observation Predicates and Filters>>
@@ -116,6 +117,34 @@ You can also take full control of the scoping mechanism:
 [source,java,subs=+attributes]
 -----
 include::{include-java}/observation/ObservationHandlerTests.java[tags=manual_scoping,indent=0]
+-----
+
+[[micrometer-observation-default-meter-handler]]
+=== DefaultMeterObservationHandler
+
+Micrometer provides `DefaultMeterObservationHandler`, an `ObservationHandler` implementation that automatically creates metrics from Observations.
+When registered on an `ObservationRegistry`, it translates Observation lifecycle events into the following meter types:
+
+* **Timer** (`<observation-name>`) -- Created on `stop`. Records the duration between `start` and `stop`. Tagged with all low cardinality key values and an `error` tag (set to the exception class name if an error was recorded, or `none` otherwise).
+* **LongTaskTimer** (`<observation-name>.active`) -- Created on `start`. Tracks the duration of in-progress observations. Stopped when the observation is stopped. Only tagged with low cardinality key values that are available at the time of `start`.
+* **Counter** (`<observation-name>.<event-name>`) -- Incremented when an event is signaled via `Observation.event(Event)`. Tagged with all low cardinality key values available at the time of the event.
+
+NOTE: Only low cardinality key values are used as meter tags. High cardinality key values are not included in meters because they can cause a cardinality explosion in the metrics backend.
+
+WARNING: Since the `LongTaskTimer` is created in the `onStart` method, it can only contain tags that are available by that time. Any low cardinality key values added after calling `start` on the `Observation` will not be included as tags on the `LongTaskTimer`.
+
+The following example shows how to register `DefaultMeterObservationHandler` and the metrics it creates:
+
+[source,java,subs=+attributes]
+-----
+include::{include-java}/observation/ObservationHandlerTests.java[tags=default_meter_handler,indent=0]
+-----
+
+If you do not need the `LongTaskTimer` (for example, to reduce the number of created meters), you can disable it using `IgnoredMeters`:
+
+[source,java,subs=+attributes]
+-----
+include::{include-java}/observation/ObservationHandlerTests.java[tags=default_meter_handler_ignore_ltt,indent=0]
 -----
 
 [[micrometer-observation-events]]

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
@@ -103,6 +103,52 @@ class ObservationHandlerTests {
     }
 
     @Test
+    void default_meter_observation_handler() {
+        // tag::default_meter_handler[]
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry registry = ObservationRegistry.create();
+        // Register DefaultMeterObservationHandler to create metrics from observations
+        registry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+
+        // Perform an observation
+        Observation observation = Observation.createNotStarted("my.operation", registry)
+            .lowCardinalityKeyValue("region", "us-east-1");
+        observation.start(); // LongTaskTimer "my.operation.active" starts here
+        observation.event(Observation.Event.of("my.event")); // Counter
+                                                             // "my.operation.my.event"
+                                                             // incremented
+        observation.stop(); // Timer "my.operation" and LongTaskTimer stop
+
+        // Verify metrics were created:
+        // Timer: my.operation (with tags: region=us-east-1, error=none)
+        assertThat(meterRegistry.get("my.operation").timer().count()).isEqualTo(1);
+        // Counter: my.operation.my.event (with tags: region=us-east-1)
+        assertThat(meterRegistry.get("my.operation.my.event").counter().count()).isEqualTo(1);
+        // end::default_meter_handler[]
+    }
+
+    @Test
+    void default_meter_observation_handler_ignore_long_task_timer() {
+        // tag::default_meter_handler_ignore_ltt[]
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry registry = ObservationRegistry.create();
+        // You can disable the LongTaskTimer if you don't need it
+        registry.observationConfig()
+            .observationHandler(new DefaultMeterObservationHandler(meterRegistry,
+                    DefaultMeterObservationHandler.IgnoredMeters.LONG_TASK_TIMER));
+
+        Observation.createNotStarted("my.operation", registry)
+            .lowCardinalityKeyValue("region", "us-east-1")
+            .start()
+            .stop();
+
+        // Timer is created, but no LongTaskTimer
+        assertThat(meterRegistry.get("my.operation").timer().count()).isEqualTo(1);
+        assertThat(meterRegistry.find("my.operation.active").longTaskTimer()).isNull();
+        // end::default_meter_handler_ignore_ltt[]
+    }
+
+    @Test
     void error_and_event() {
         // tag::error_and_event[]
         ObservationRegistry registry = ObservationRegistry.create();


### PR DESCRIPTION
## Summary

- Add documentation for `DefaultMeterObservationHandler` to the Observation Components page
- Explain the three meter types it creates from Observations:
  - **Timer** (`<name>`) - records duration on stop, with low cardinality tags + error tag
  - **LongTaskTimer** (`<name>.active`) - tracks in-progress duration from start
  - **Counter** (`<name>.<event>`) - incremented on event signals
- Include notes about low cardinality vs high cardinality key values and the LongTaskTimer tag timing caveat
- Add code examples demonstrating basic usage and `IgnoredMeters.LONG_TASK_TIMER` configuration

## Test plan

- [x] Doc test examples compile successfully
- [x] Code formatting passes (`checkFormat`)

Closes gh-6361