### PR TITLE
Upgrade to ubuntu-2404:2026.02.2 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ executors:
     working_directory: ~/micrometer
     machine:
       image: ubuntu-2404:2026.02.2
-    resource_class: large
+    resource_class: arm.medium
 
 commands:
   gradlew-build:


### PR DESCRIPTION
This PR upgrades to `ubuntu-2404:2026.02.2` in CircleCI.