### PR TITLE
Remove lastScope field and deprecated implementations from SimpleObservation

### DIFF
--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationRegistryAssertTests.java
@@ -17,6 +17,7 @@ package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
@@ -38,6 +39,13 @@ class ObservationRegistryAssertTests {
 
         registry.observationConfig().observationHandler(c -> true); // prevent Noop
                                                                     // instances
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up the thread-local current observation scope after each test to prevent
+        // thread pollution and ensure test isolation.
+        registry.setCurrentObservationScope(null);
     }
 
     @Test

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -20,6 +20,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Event;
 import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -37,6 +38,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ObservationValidatorTests {
 
     private final ObservationRegistry registry = TestObservationRegistry.create();
+
+    @AfterEach
+    void tearDown() {
+        // Clean up the thread-local current observation scope after each test to prevent
+        // thread pollution and ensure test isolation.
+        registry.setCurrentObservationScope(null);
+    }
 
     @Test
     void doubleStartShouldBeInvalid() {
@@ -166,15 +174,6 @@ class ObservationValidatorTests {
         // localObservationScope in the SimpleObservationRegistry. Otherwise, it will
         // pollute it and could affect other tests.
         scope.close();
-    }
-
-    @Test
-    @SuppressWarnings("resource")
-    void scopeResetAfterStopShouldBeValid() {
-        Observation observation = Observation.start("test", registry);
-        Scope scope = observation.openScope();
-        observation.stop();
-        scope.reset();
     }
 
     @Test

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/TestObservationRegistryAssertTests.java
@@ -22,6 +22,7 @@ import io.micrometer.observation.ObservationRegistry;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.BDDAssertions;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
@@ -34,6 +35,13 @@ import static org.assertj.core.api.BDDAssertions.then;
 class TestObservationRegistryAssertTests {
 
     TestObservationRegistry registry = TestObservationRegistry.create();
+
+    @AfterEach
+    void tearDown() {
+        // Clean up the thread-local current observation scope after each test to prevent
+        // thread pollution and ensure test isolation.
+        registry.setCurrentObservationScope(null);
+    }
 
     @Test
     void should_clear_context_entries() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/NullObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/NullObservation.java
@@ -47,16 +47,6 @@ public class NullObservation extends SimpleObservation {
     }
 
     @Override
-    void notifyOnScopeMakeCurrent() {
-        // Don't want to call handlers
-    }
-
-    @Override
-    void notifyOnScopeReset() {
-        // Don't want to call handlers
-    }
-
-    @Override
     void notifyOnObservationStopped(Context context) {
         // Don't want to call handlers
     }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationView.java
@@ -44,7 +44,8 @@ public interface ObservationView {
      * Pops the last scope attached to this {@link ObservationView} in this thread.
      * @return scope for this {@link ObservationView}, {@code null} if there was no scope
      * @since 1.10.6
-     * @deprecated This method will be removed in a future release.
+     * @deprecated This method will be removed in a future release. Do not call it. Do not
+     * implement it.
      */
     @Deprecated
     default Observation.@Nullable Scope getEnclosingScope() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -27,8 +27,6 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default implementation of {@link Observation}.
@@ -52,8 +50,6 @@ class SimpleObservation implements Observation {
     private final Deque<ObservationHandler> handlers;
 
     private final Collection<ObservationFilter> filters;
-
-    final Map<Thread, Scope> lastScope = new ConcurrentHashMap<>();
 
     SimpleObservation(String name, ObservationRegistry registry, Context context) {
         this.registry = registry;
@@ -192,14 +188,14 @@ class SimpleObservation implements Observation {
     public Scope openScope() {
         Scope scope = new SimpleScope(this.registry, this);
         notifyOnScopeOpened();
-        lastScope.put(Thread.currentThread(), scope);
         return scope;
     }
 
     @Override
     @Deprecated
     public @Nullable Scope getEnclosingScope() {
-        return lastScope.get(Thread.currentThread());
+        // TODO log deprecation warning
+        return null;
     }
 
     @Override
@@ -247,22 +243,6 @@ class SimpleObservation implements Observation {
         }
     }
 
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    void notifyOnScopeMakeCurrent() {
-        for (ObservationHandler handler : this.handlers) {
-            handler.onScopeOpened(this.context);
-        }
-    }
-
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    void notifyOnScopeReset() {
-        for (ObservationHandler handler : this.handlers) {
-            handler.onScopeReset(this.context);
-        }
-    }
-
     @SuppressWarnings("unchecked")
     void notifyOnObservationStopped(Context context) {
         // We're closing from end till the beginning - e.g. we started with handlers with
@@ -301,13 +281,6 @@ class SimpleObservation implements Observation {
         public void close() {
             if (currentObservation instanceof SimpleObservation) {
                 SimpleObservation observation = (SimpleObservation) currentObservation;
-                SimpleScope lastScopeForThisObservation = getLastScope(this);
-                if (lastScopeForThisObservation != null) {
-                    observation.lastScope.put(Thread.currentThread(), lastScopeForThisObservation);
-                }
-                else {
-                    observation.lastScope.remove(Thread.currentThread());
-                }
                 observation.notifyOnScopeClosed();
             }
             else if (currentObservation != null && !currentObservation.isNoop()) {
@@ -319,31 +292,10 @@ class SimpleObservation implements Observation {
             this.registry.setCurrentObservationScope(previousObservationScope);
         }
 
-        private @Nullable SimpleScope getLastScope(SimpleScope simpleScope) {
-            SimpleScope scope = simpleScope;
-            do {
-                scope = (SimpleScope) scope.previousObservationScope;
-            }
-            while (scope != null && !this.currentObservation.equals(scope.currentObservation));
-            return scope;
-        }
-
         @Override
         @Deprecated
         public void reset() {
-            SimpleScope scope = this;
-            if (scope.currentObservation instanceof SimpleObservation) {
-                SimpleObservation simpleObservation = (SimpleObservation) scope.currentObservation;
-                do {
-                    // We don't want to remove any enclosing scopes when resetting
-                    // we just want to remove any scopes if they are present (that's why
-                    // we're not calling scope#close)
-                    simpleObservation.notifyOnScopeReset();
-                    scope = (SimpleScope) scope.previousObservationScope;
-                }
-                while (scope != null);
-            }
-            registry.setCurrentObservationScope(null);
+            // TODO log deprecation warning
         }
 
         /**
@@ -366,31 +318,7 @@ class SimpleObservation implements Observation {
         @Override
         @Deprecated
         public void makeCurrent() {
-            SimpleScope scope = this;
-            do {
-                // We don't want to remove any enclosing scopes when resetting
-                // we just want to remove any scopes if they are present (that's why we're
-                // not calling scope#close)
-                if (scope.currentObservation instanceof SimpleObservation) {
-                    ((SimpleObservation) scope.currentObservation).notifyOnScopeReset();
-                }
-                scope = (SimpleScope) scope.previousObservationScope;
-            }
-            while (scope != null);
-
-            Deque<SimpleScope> scopes = new ArrayDeque<>();
-            scope = this;
-            do {
-                scopes.addFirst(scope);
-                scope = (SimpleScope) scope.previousObservationScope;
-            }
-            while (scope != null);
-            for (SimpleScope simpleScope : scopes) {
-                if (simpleScope.currentObservation instanceof SimpleObservation) {
-                    ((SimpleObservation) simpleScope.currentObservation).notifyOnScopeMakeCurrent();
-                }
-            }
-            this.registry.setCurrentObservationScope(this);
+            // TODO log deprecation warning
         }
 
         @Override

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -21,7 +21,6 @@ import io.micrometer.common.util.StringUtils;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
-import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayDeque;
@@ -194,12 +193,13 @@ class SimpleObservation implements Observation {
         return scope;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     @Deprecated
     public @Nullable Scope getEnclosingScope() {
         getEnclosingScopeLogger.log(
-                "getEnclosingScope() is deprecated, will always return null, and will be removed in a future release. Please do not use it.");
-        return null;
+                "getEnclosingScope() is deprecated, will always return a no-op scope, and will be removed in a future release. Please do not use it.");
+        return Scope.NOOP;
     }
 
     @Override
@@ -307,23 +307,6 @@ class SimpleObservation implements Observation {
                     "reset() is deprecated, will do nothing, and will be removed in a future release. Please do not use it.");
         }
 
-        /**
-         * This method is called e.g. via
-         * {@link ObservationThreadLocalAccessor#restore(Observation)}. In that case,
-         * we're calling {@link ObservationThreadLocalAccessor#reset()} first, and we're
-         * closing all the scopes, HOWEVER those are called on the Observation scope that
-         * was present there in thread local at the time of calling the method, NOT on the
-         * scope that we want to make current (that one can contain some leftovers from
-         * previous scope openings like creation of e.g. Brave scope in the TracingContext
-         * that is there inside the Observation's Context.
-         *
-         * When we want to go back to the enclosing scope and want to make that scope
-         * current we need to be sure that there are no remaining scoped objects inside
-         * Observation's context. This is why BEFORE rebuilding the scope structure we
-         * need to notify the handlers to clear them first (again this is a separate scope
-         * to the one that was cleared by the reset method) via calling
-         * {@link ObservationHandler#onScopeReset(Context)}.
-         */
         @Override
         @Deprecated
         public void makeCurrent() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/SimpleObservation.java
@@ -20,6 +20,7 @@ import io.micrometer.common.KeyValue;
 import io.micrometer.common.util.StringUtils;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
 import org.jspecify.annotations.Nullable;
 
@@ -38,6 +39,8 @@ import java.util.Iterator;
  * @since 1.10.0
  */
 class SimpleObservation implements Observation {
+
+    private static final WarnThenDebugLogger getEnclosingScopeLogger = new WarnThenDebugLogger(SimpleObservation.class);
 
     final ObservationRegistry registry;
 
@@ -194,7 +197,8 @@ class SimpleObservation implements Observation {
     @Override
     @Deprecated
     public @Nullable Scope getEnclosingScope() {
-        // TODO log deprecation warning
+        getEnclosingScopeLogger.log(
+                "getEnclosingScope() is deprecated, will always return null, and will be removed in a future release. Please do not use it.");
         return null;
     }
 
@@ -259,6 +263,10 @@ class SimpleObservation implements Observation {
 
         private static final InternalLogger log = InternalLoggerFactory.getInstance(SimpleScope.class);
 
+        private static final WarnThenDebugLogger resetLogger = new WarnThenDebugLogger(SimpleScope.class);
+
+        private static final WarnThenDebugLogger makeCurrentLogger = new WarnThenDebugLogger(SimpleScope.class);
+
         final ObservationRegistry registry;
 
         private final Observation currentObservation;
@@ -295,7 +303,8 @@ class SimpleObservation implements Observation {
         @Override
         @Deprecated
         public void reset() {
-            // TODO log deprecation warning
+            resetLogger.log(
+                    "reset() is deprecated, will do nothing, and will be removed in a future release. Please do not use it.");
         }
 
         /**
@@ -318,7 +327,8 @@ class SimpleObservation implements Observation {
         @Override
         @Deprecated
         public void makeCurrent() {
-            // TODO log deprecation warning
+            makeCurrentLogger.log(
+                    "makeCurrent() is deprecated, will do nothing, and will be removed in a future release. Please do not use it.");
         }
 
         @Override

--- a/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
@@ -129,23 +129,6 @@ class CurrentObservationTest {
     }
 
     @Test
-    void nestedScopes_makeCurrent() {
-        Observation observation = Observation.createNotStarted("test.observation", registry);
-        assertThat(registry.getCurrentObservationScope()).isNull();
-        try (Observation.Scope scopeA = observation.openScope()) {
-            assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
-            try (Observation.Scope scopeB = observation.openScope()) {
-                assertThat(registry.getCurrentObservationScope()).isSameAs(scopeB);
-
-                scopeA.makeCurrent();
-                assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
-            }
-            assertThat(registry.getCurrentObservationScope()).isSameAs(scopeA);
-        }
-        assertThat(registry.getCurrentObservationScope()).isNull();
-    }
-
-    @Test
     void currentShouldBePropagatedAcrossThreads() throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {

--- a/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/contextpropagation/ObservationThreadLocalAccessorTests.java
@@ -83,21 +83,18 @@ class ObservationThreadLocalAccessorTests {
         try (Observation.Scope scope = child.openScope()) {
             thenCurrentObservationHasParent(parent, child);
             thenCurrentScopeHasParent(null);
-            then(child.getEnclosingScope()).isSameAs(scope);
+            then(observationRegistry.getCurrentObservationScope()).isSameAs(scope);
         }
-        then(child.getEnclosingScope()).isNull();
         thenCurrentObservationIsNull();
 
         try (Observation.Scope scope = other1.openScope()) {
             try (Observation.Scope scope2 = child.openScope()) {
                 thenCurrentObservationHasParent(parent, child);
-                then(child.getEnclosingScope()).isSameAs(scope2);
+                then(observationRegistry.getCurrentObservationScope()).isSameAs(scope2);
             }
-            then(child.getEnclosingScope()).isNull();
-            then(other1.getEnclosingScope()).isSameAs(scope);
+            then(observationRegistry.getCurrentObservationScope()).isSameAs(scope);
         }
 
-        then(child.getEnclosingScope()).isNull();
         thenCurrentObservationIsNull();
 
         // when context captured
@@ -105,7 +102,7 @@ class ObservationThreadLocalAccessorTests {
         try (Observation.Scope scope = other2.openScope()) {
             try (Observation.Scope scope2 = child.openScope()) {
                 thenCurrentObservationHasParent(parent, child);
-                then(child.getEnclosingScope()).isSameAs(scope2);
+                then(observationRegistry.getCurrentObservationScope()).isSameAs(scope2);
                 container = ContextSnapshotFactory.builder()
                     .captureKeyPredicate(key -> true)
                     .contextRegistry(registry)
@@ -114,18 +111,17 @@ class ObservationThreadLocalAccessorTests {
             }
         }
 
-        then(child.getEnclosingScope()).isNull();
         thenCurrentObservationIsNull();
 
         // when first scope created
         try (ContextSnapshot.Scope scope = container.setThreadLocals()) {
             thenCurrentObservationHasParent(parent, child);
             Scope inScope = thenCurrentScopeHasParent(null);
-            then(child.getEnclosingScope()).isNotNull();
+            then(observationRegistry.getCurrentObservationScope()).isNotNull();
 
             // when second, nested scope created
             try (ContextSnapshot.Scope scope2 = container.setThreadLocals()) {
-                then(child.getEnclosingScope()).isNotNull();
+                then(observationRegistry.getCurrentObservationScope()).isNotNull();
                 thenCurrentObservationHasParent(parent, child);
                 Scope inSecondScope = thenCurrentScopeHasParent(inScope);
 
@@ -145,16 +141,13 @@ class ObservationThreadLocalAccessorTests {
                     .captureFrom(new HashMap<>());
                 withClearing.wrap(this::thenCurrentObservationIsNullObservation).run();
 
-                then(child.getEnclosingScope()).isNotNull();
+                then(observationRegistry.getCurrentObservationScope()).isNotNull();
                 thenCurrentObservationHasParent(parent, child);
             }
             then(scopeParent(inScope)).isNull();
         }
 
         thenCurrentObservationIsNull();
-
-        then(child.getEnclosingScope()).isNull();
-        then(parent.getEnclosingScope()).isNull();
 
         // when we're going through the null scope when there was no previous value in TL
         ContextSnapshot withClearing = ContextSnapshotFactory.builder()
@@ -163,14 +156,12 @@ class ObservationThreadLocalAccessorTests {
             .captureFrom(new HashMap<>());
         withClearing.wrap(this::thenCurrentObservationIsNull).run();
 
-        then(child.getEnclosingScope()).isNull();
-        then(parent.getEnclosingScope()).isNull();
+        thenCurrentObservationIsNull();
 
         child.stop();
         parent.stop();
 
-        then(child.getEnclosingScope()).isNull();
-        then(parent.getEnclosingScope()).isNull();
+        thenCurrentObservationIsNull();
     }
 
     @Test
@@ -203,7 +194,6 @@ class ObservationThreadLocalAccessorTests {
         }
         then(calledHandler.get()).isEqualTo("handler 1");
 
-        then(child.getEnclosingScope()).isNull();
         thenCurrentObservationIsNull();
 
         child.stop();


### PR DESCRIPTION
This is a follow-up to #7255. With removing the `lastScopes` field on `SimpleObservation`, we avoid CPU cycles tracking info that is never used and we save memory per `SimpleObservation` instance.

## JOL
We go from 40 bytes per instance to 32 bytes object overhead. See JOL output below. (with [CompactObjectHeaders](https://openjdk.org/jeps/519), it gets down to 24 bytes)

```
io.micrometer.observation.SimpleObservation object internals:
OFF  SZ                            TYPE DESCRIPTION                    VALUE
  0   8                                 (object header: mark)          N/A
  8   4                                 (object header: class)         N/A
 12   4             ObservationRegistry SimpleObservation.registry     N/A
 16   4                         Context SimpleObservation.context      N/A
 20   4           ObservationConvention SimpleObservation.convention   N/A
 24   4       Deque<ObservationHandler> SimpleObservation.handlers     N/A
 28   4   Collection<ObservationFilter> SimpleObservation.filters      N/A
Instance size: 32 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

<details><summary>Previous JOL output</summary>
<p>

```
io.micrometer.observation.SimpleObservation object internals:
OFF  SZ                            TYPE DESCRIPTION                    VALUE
  0   8                                 (object header: mark)          N/A
  8   4                                 (object header: class)         N/A
 12   4             ObservationRegistry SimpleObservation.registry     N/A
 16   4                         Context SimpleObservation.context      N/A
 20   4           ObservationConvention SimpleObservation.convention   N/A
 24   4       Deque<ObservationHandler> SimpleObservation.handlers     N/A
 28   4   Collection<ObservationFilter> SimpleObservation.filters      N/A
 32   4              Map<Thread, Scope> SimpleObservation.lastScope    N/A
 36   4                                 (object alignment gap)         
Instance size: 40 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

</p>
</details> 

## Benchmarks

We see allocation savings of 72 bytes per operation (explained by the object layout difference above and one less ConcurrentHashMap being instantiated). Note that is irrespective of the number of key-values used, so it will be a higher percent savings for Observations with less key-values.

### This PR

```
ObservationBenchmark.observation                          avgt    2     96.621           ns/op
ObservationBenchmark.observation:gc.alloc.rate.norm       avgt    2    672.000            B/op
```

### `1.17.0-M3`

```
ObservationBenchmark.observation                          avgt    2     96.910           ns/op
ObservationBenchmark.observation:gc.alloc.rate.norm       avgt    2    744.000            B/op
```