### PR TITLE
Upgrade to Shadow plugin 9.3.2

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradleup.shadow' version '8.3.9'
+    id 'com.gradleup.shadow' version '9.3.2'
 }
 
 dependencies {
@@ -36,13 +36,14 @@ nebulaPublishVerification {
 }
 
 shadowJar {
-    configurations = [project.configurations.compileClasspath]
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    configurations.set([project.configurations.compileClasspath])
     archiveClassifier.set('')
     dependencies {
-        include(dependency('io.projectreactor:'))
-        include(dependency('io.projectreactor.netty:'))
-        include(dependency('org.reactivestreams:reactive-streams'))
-        include(dependency('io.netty:'))
+        include(dependency('io.projectreactor:.*'))
+        include(dependency('io.projectreactor.netty:.*'))
+        include(dependency('org.reactivestreams:reactive-streams:.*'))
+        include(dependency('io.netty:.*'))
         // see gh-5953
         exclude("META-INF/maven/**")
         exclude("META-INF/io.netty.versions.properties")


### PR DESCRIPTION
See https://gradleup.com/shadow/changes/.

The diff with the 1.17.0-M3 JAR is:

```diff
--- META-INF/MANIFEST.MF
+++ META-INF/MANIFEST.MF
@@ -1,25 +1,26 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: micrometer.registry.statsd
-Implementation-Title: io.micrometer#micrometer-registry-statsd;1.17.0-M3
-Implementation-Version: 1.17.0-M3
-Built-Status: candidate
-Built-By: circleci
-Built-OS: Linux
-Build-Timezone: Etc/UTC
-Build-Date-UTC: 2026-03-10T03:25:07.260010422Z
-Build-Date: 2026-03-10_03:25:07
+Implementation-Title: io.micrometer#micrometer-registry-statsd;1.17.0-SN
+ APSHOT
+Implementation-Version: 1.17.0-SNAPSHOT
+Built-Status: integration
+Built-By: tludwig
+Built-OS: Mac OS X
+Build-Timezone: Asia/Tokyo
+Build-Date-UTC: 2026-03-11T09:59:46.117141Z
+Build-Date: 2026-03-11_18:59:46
 Gradle-Version: 9.4.0
-Module-Origin: git@github.com:micrometer-metrics/micrometer.git
-Change: 3a05952
-Full-Change: 3a059522717fd5b527d9dcb8fe8ba27b9a9a236f
-Branch: HEAD
-Build-Host: 7d883ed01468
-Build-Job: deploy
-Build-Number: 65303
-Build-Id: 65303
-Build-Url: https://circleci.com/gh/micrometer-metrics/micrometer/65303
-Created-By: 21.0.9+10-LTS (Eclipse Adoptium)
+Module-Origin: git@github.com:shakuzen/micrometer.git
+Change: e0f2632
+Full-Change: e0f263248a0b195ba9d0e3b8d13b091defc96071
+Branch: shadow-upgrade
+Build-Host: PGVYQGXNYX
+Build-Job: LOCAL
+Build-Number: LOCAL
+Build-Id: LOCAL
+Build-Url: PGVYQGXNYX/LOCAL
+Created-By: 21.0.10 (Eclipse Adoptium)
 Module-Owner: tludwig@vmware.com,jivanov@vmware.com
 Module-Email: tludwig@vmware.com,jivanov@vmware.com
 X-Compile-Target-JDK: 1.8
 X-Compile-Source-JDK: 1.8
@@ -57,8 +58,7 @@
  ctor.util.context;version="[3.5,4)",reactor.util.retry;version="[3.5,4)
  "
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.8))"
 Bundle-SymbolicName: micrometer-registry-statsd
-Bundle-Version: 1.17.0.M3
+Bundle-Version: 1.17.0.SNAPSHOT
 Bundle-Name: micrometer-registry-statsd
-Module-Source:

--- META-INF/micrometer-registry-statsd.properties
+++ META-INF/micrometer-registry-statsd.properties
@@ -1,1 +1,1 @@
-FILE SHA-1: 30396a597fb3a9518f043ab06ab3f24d342c309f
+FILE SHA-1: 580f8b0481572c654dd9f5cae548d5d582582d99
--- META-INF/services/io.micrometer.shaded.reactor.blockhound.integration.BlockHoundIntegration
+++ META-INF/services/io.micrometer.shaded.reactor.blockhound.integration.BlockHoundIntegration
@@ -2,26 +2,19 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
 #   https://www.apache.org/licenses/LICENSE-2.0
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 io.micrometer.shaded.reactor.core.scheduler.ReactorBlockHoundIntegration
 # Copyright 2019 The Netty Project
-#
 # The Netty Project licenses this file to you under the Apache License,
 # version 2.0 (the "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at:
-#
-#   https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
```

Closes #6938