### PR TITLE
Add tests for invalid and edge cases in DurationValidator

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/config/DurationValidatorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/config/DurationValidatorTest.java
@@ -53,4 +53,36 @@ class DurationValidatorTest {
             .isEqualByComparingTo(Duration.ofDays(2).plus(Duration.ofHours(3)).plus(Duration.ofMinutes(4)));
     }
 
+    @Test
+    void blankValueIsInvalid() {
+        assertThat(validate("dur", " ").isInvalid()).isTrue();
+        assertThat(validate("dur", "").isInvalid()).isTrue();
+    }
+
+    @Test
+    void malformedDurationIsInvalid() {
+        assertThat(validate("dur", "not-a-duration").isInvalid()).isTrue();
+    }
+
+    @Test
+    void missingUnitIsInvalid() {
+        assertThat(validate("dur", "42").isInvalid()).isTrue();
+    }
+
+    @Test
+    void invalidUnitIsInvalid() {
+        assertThat(validate("dur", "10xy").isInvalid()).isTrue();
+    }
+
+    @Test
+    void invalidIsoDurationIsInvalid() {
+        assertThat(validate("dur", "PT10X").isInvalid()).isTrue();
+    }
+
+    @Test
+    void nullValueIsValid() {
+        assertThat(validate("dur", null).isValid()).isTrue();
+        assertThat(validate("dur", null).get()).isNull();
+    }
+
 }


### PR DESCRIPTION
DurationValidator is responsible for validating externally supplied
duration configuration values (e.g. management.metrics.export.*.step).

The current tests focus on successful parsing scenarios but do not
verify behavior for malformed or invalid inputs.

This PR adds tests covering several validation paths, including:

- blank values
- malformed duration strings
- missing duration units
- invalid time units
- invalid ISO-8601 durations
- null values

These tests improve coverage of validation logic and help prevent
regressions in configuration parsing.

No production code changes are included.