### PR TITLE
Add tests for invalid and edge cases in DurationValidator

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/config/DurationValidatorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/config/DurationValidatorTest.java
@@ -53,4 +53,36 @@ class DurationValidatorTest {
             .isEqualByComparingTo(Duration.ofDays(2).plus(Duration.ofHours(3)).plus(Duration.ofMinutes(4)));
     }
 
+    @Test
+    void blankValueIsInvalid() {
+        assertThat(validate("dur", " ").isInvalid()).isTrue();
+        assertThat(validate("dur", "").isInvalid()).isTrue();
+    }
+
+    @Test
+    void malformedDurationIsInvalid() {
+        assertThat(validate("dur", "not-a-duration").isInvalid()).isTrue();
+    }
+
+    @Test
+    void missingUnitIsInvalid() {
+        assertThat(validate("dur", "42").isInvalid()).isTrue();
+    }
+
+    @Test
+    void invalidUnitIsInvalid() {
+        assertThat(validate("dur", "10xy").isInvalid()).isTrue();
+    }
+
+    @Test
+    void invalidIsoDurationIsInvalid() {
+        assertThat(validate("dur", "PT10X").isInvalid()).isTrue();
+    }
+
+    @Test
+    void nullValueIsValid() {
+        assertThat(validate("dur", null).isValid()).isTrue();
+        assertThat(validate("dur", null).get()).isNull();
+    }
+
 }


### PR DESCRIPTION
DurationValidator validates externally supplied duration configuration values. Existing tests cover only successful parsing scenarios.

This change adds tests for several invalid and boundary inputs:
- blank values
- malformed duration strings
- missing units
- invalid units
- invalid ISO8601 durations
- null values

These tests improve coverage of validation paths and help prevent regressions in configuration parsing.

This PR supersedes #7286 and rebases the change on top of the 1.15.x branch as requested.