### PR TITLE
Use per-thread scope stack in ObservationValidator LIFO validation

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
@@ -50,7 +50,7 @@ class ObservationValidator implements ObservationHandler<Context> {
 
     private final Map<String, Set<String>> lowCardinalityKeysByObservationName;
 
-    private final Deque<Context> scopedContexts;
+    private final ThreadLocal<Deque<Context>> scopedContexts;
 
     private final Set<Capability> capabilities;
 
@@ -58,7 +58,7 @@ class ObservationValidator implements ObservationHandler<Context> {
         this.consumer = ObservationValidator::throwInvalidObservationException;
         this.supportsContextPredicate = context -> !(context instanceof NullContext);
         this.lowCardinalityKeysByObservationName = new HashMap<>();
-        this.scopedContexts = new ArrayDeque<>();
+        this.scopedContexts = ThreadLocal.withInitial(ArrayDeque::new);
         this.capabilities = capabilities;
     }
 
@@ -93,7 +93,7 @@ class ObservationValidator implements ObservationHandler<Context> {
         // In some cases (Reactor) scope open can happen after the observation is stopped
         checkIfObservationWasStarted("Invalid scope opening", context);
         if (capabilities.contains(SCOPES_SHOULD_BE_CLOSED_IN_REVERSE_ORDER_OF_OPENING)) {
-            scopedContexts.push(context);
+            scopedContexts.get().push(context);
         }
         if (capabilities.contains(SCOPES_SHOULD_BE_OPENED_AND_CLOSED_ON_THE_SAME_THREAD)) {
             history.addCurrentThreadToScopeOpeningThreadIds();
@@ -106,7 +106,7 @@ class ObservationValidator implements ObservationHandler<Context> {
         // In some cases (Reactor) scope close can happen after the observation is stopped
         checkIfObservationWasStarted("Invalid scope closing", context);
         if (capabilities.contains(SCOPES_SHOULD_BE_CLOSED_IN_REVERSE_ORDER_OF_OPENING)) {
-            Context currentContext = scopedContexts.pollFirst();
+            Context currentContext = scopedContexts.get().pollFirst();
             if (currentContext != null && currentContext != context) {
                 consumer.accept(new ValidationResult("Invalid scope closing order: Observation '" + context.getName()
                         + "' had its scope closed before the most recently opened scope for Observation '"
@@ -132,7 +132,7 @@ class ObservationValidator implements ObservationHandler<Context> {
         // In some cases (Reactor) scope reset can happen after the observation is stopped
         checkIfObservationWasStarted("Invalid scope resetting", context);
         if (capabilities.contains(SCOPES_SHOULD_BE_CLOSED_IN_REVERSE_ORDER_OF_OPENING)) {
-            scopedContexts.removeIf(ctx -> ctx == context);
+            scopedContexts.get().removeIf(ctx -> ctx == context);
         }
         if (capabilities.contains(SCOPES_SHOULD_BE_OPENED_AND_CLOSED_ON_THE_SAME_THREAD)) {
             history.clearScopeOpeningThreadIds();

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -22,6 +22,7 @@ import io.micrometer.observation.Observation.Scope;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -409,6 +410,55 @@ class ObservationValidatorTests {
         innerScope.close();
         innerObservation.stop();
         outerObservation.stop();
+    }
+
+    @Test
+    void siblingScopesOnDifferentThreadsShouldBeValid() throws InterruptedException {
+        TestObservationRegistry registry = TestObservationRegistry.builder()
+            .validateScopesClosedInReverseOrderOfOpening(true)
+            .build();
+
+        CountDownLatch scopeOneOpenLatch = new CountDownLatch(1);
+        CountDownLatch scopeTwoOpenLatch = new CountDownLatch(1);
+        CountDownLatch scopeOneCloseLatch = new CountDownLatch(1);
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread thread1 = new Thread(() -> {
+            Observation observation1 = Observation.start("one", registry);
+            try {
+                Scope scope1 = observation1.openScope();
+                scopeOneOpenLatch.countDown();
+                scopeTwoOpenLatch.await();
+                scope1.close();
+                scopeOneCloseLatch.countDown();
+                observation1.stop();
+            }
+            catch (Throwable t) {
+                error.set(t);
+                scopeOneCloseLatch.countDown();
+            }
+        });
+        Thread thread2 = new Thread(() -> {
+            try {
+                scopeOneOpenLatch.await();
+                Observation observation2 = Observation.start("two", registry);
+                Scope scope2 = observation2.openScope();
+                scopeTwoOpenLatch.countDown();
+                scopeOneCloseLatch.await();
+                scope2.close();
+                observation2.stop();
+            }
+            catch (Throwable t) {
+                // noop
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        assertThat(error.get()).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary

The LIFO scope ordering validation in `ObservationValidator` used a single global `Deque<Context>`, which produced false positives when observations ran in parallel on different threads (sibling scopes).

This replaces the global stack with a `ThreadLocal<Deque<Context>>` so that each thread tracks its own scope ordering independently.

## Changes

- `ObservationValidator`: `Deque<Context>` → `ThreadLocal<Deque<Context>>` with `ThreadLocal.withInitial(ArrayDeque::new)`
- `ObservationValidatorTests`: Add `siblingScopesOnDifferentThreadsShouldBeValid` test that verifies parallel observations on separate threads no longer trigger false positives

Closes gh-7288