### PR TITLE
Add runtime tag support to Log4j2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -17,18 +17,14 @@ package io.micrometer.core.instrument.binder.logging;
 
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 
 import java.beans.PropertyChangeListener;
@@ -50,19 +46,18 @@ import static java.util.Collections.emptyList;
  * "https://github.com/micrometer-metrics/micrometer/issues/2176">micrometer#2176</a>
  * @author Steven Sheehy
  * @author Johnny Lim
+ * @author Harsh Verma
  * @since 1.1.0
  */
 public class Log4j2Metrics implements MeterBinder, AutoCloseable {
-
-    private static final String METER_NAME = "log4j2.events";
-
-    private static final String METER_DESCRIPTION = "Number of log events";
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Log4j2Metrics.class);
 
     private final Iterable<Tag> tags;
 
     private final LoggerContext loggerContext;
+
+    private final List<LogEventInterceptor> logEventInterceptors;
 
     private final ConcurrentMap<MeterRegistry, MetricsFilter> metricsFilters = new ConcurrentHashMap<>();
 
@@ -77,8 +72,14 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
     }
 
     public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext) {
+        this(tags, loggerContext, emptyList());
+    }
+
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext,
+            List<LogEventInterceptor> logEventInterceptors) {
         this.tags = tags;
         this.loggerContext = loggerContext;
+        this.logEventInterceptors = logEventInterceptors;
     }
 
     @Override
@@ -135,7 +136,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private MetricsFilter getOrCreateMetricsFilterAndStart(MeterRegistry registry) {
         return metricsFilters.computeIfAbsent(registry, r -> {
-            MetricsFilter metricsFilter = new MetricsFilter(r, tags);
+            MetricsFilter metricsFilter = logEventInterceptors.isEmpty() ? new StaticTagMetricsFilter(r, tags)
+                    : new RunTimeTagMetricsFilter(r, tags, logEventInterceptors);
             metricsFilter.start();
             return metricsFilter;
         });
@@ -169,97 +171,6 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
                     metricsFilters.values().forEach(loggerConfig::removeFilter);
                 }
             });
-    }
-
-    static class MetricsFilter extends AbstractFilter {
-
-        private final Counter fatalCounter;
-
-        private final Counter errorCounter;
-
-        private final Counter warnCounter;
-
-        private final Counter infoCounter;
-
-        private final Counter debugCounter;
-
-        private final Counter traceCounter;
-
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
-            fatalCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "fatal")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            errorCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "error")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            warnCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "warn")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            infoCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "info")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            debugCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "debug")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            traceCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "trace")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-        }
-
-        @Override
-        public Result filter(LogEvent event) {
-            incrementCounter(event);
-            return Result.NEUTRAL;
-        }
-
-        private void incrementCounter(LogEvent event) {
-            switch (event.getLevel().getStandardLevel()) {
-                case FATAL:
-                    fatalCounter.increment();
-                    break;
-                case ERROR:
-                    errorCounter.increment();
-                    break;
-                case WARN:
-                    warnCounter.increment();
-                    break;
-                case INFO:
-                    infoCounter.increment();
-                    break;
-                case DEBUG:
-                    debugCounter.increment();
-                    break;
-                case TRACE:
-                    traceCounter.increment();
-                    break;
-                default:
-                    break;
-            }
-        }
-
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogEventInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogEventInterceptor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Tag;
+import org.apache.logging.log4j.core.LogEvent;
+
+import java.util.List;
+
+/**
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+public interface LogEventInterceptor {
+
+    public List<Tag> getTagsForLogEvent(LogEvent logEvent);
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/MetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/MetricsFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+
+/**
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+abstract class MetricsFilter extends AbstractFilter {
+
+    protected static final String METER_NAME = "log4j2.events";
+
+    protected static final String METER_DESCRIPTION = "Number of log events";
+
+    @Override
+    public Result filter(LogEvent event) {
+        incrementCounter(event);
+        return Result.NEUTRAL;
+    }
+
+    protected abstract void incrementCounter(LogEvent event);
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/RunTimeTagMetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/RunTimeTagMetricsFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import org.apache.logging.log4j.core.LogEvent;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+public class RunTimeTagMetricsFilter extends MetricsFilter {
+
+    private final Iterable<LogEventInterceptor> logEventInterceptors;
+
+    private final List<Tag> tagsForLogEvent;
+
+    private final MeterRegistry registry;
+
+    RunTimeTagMetricsFilter(MeterRegistry registry, Iterable<Tag> tags,
+            Iterable<LogEventInterceptor> logEventInterceptors) {
+        super();
+        this.tagsForLogEvent = new ArrayList<>();
+        for (Tag tag : tags) {
+            tagsForLogEvent.add(tag);
+        }
+        this.logEventInterceptors = logEventInterceptors;
+        this.registry = registry;
+    }
+
+    @Override
+    protected void incrementCounter(LogEvent event) {
+        ArrayList<Tag> tagsForLogEvent = new ArrayList<>(this.tagsForLogEvent);
+        for (LogEventInterceptor logEventInterceptor : logEventInterceptors) {
+            tagsForLogEvent.addAll(logEventInterceptor.getTagsForLogEvent(event));
+        }
+        Counter.builder(METER_NAME)
+            .tags(tagsForLogEvent)
+            .tags("level", event.getLevel().getStandardLevel().name().toLowerCase())
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry)
+            .increment();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/StaticTagMetricsFilter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/StaticTagMetricsFilter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import org.apache.logging.log4j.core.LogEvent;
+
+/**
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+public class StaticTagMetricsFilter extends MetricsFilter {
+
+    private final Counter fatalCounter;
+
+    private final Counter errorCounter;
+
+    private final Counter warnCounter;
+
+    private final Counter infoCounter;
+
+    private final Counter debugCounter;
+
+    private final Counter traceCounter;
+
+    StaticTagMetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
+        super();
+        fatalCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "fatal")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        errorCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "error")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        warnCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "warn")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        infoCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "info")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        debugCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "debug")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        traceCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "trace")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+    }
+
+    @Override
+    protected void incrementCounter(LogEvent event) {
+        switch (event.getLevel().getStandardLevel()) {
+            case FATAL:
+                fatalCounter.increment();
+                break;
+            case ERROR:
+                errorCounter.increment();
+                break;
+            case WARN:
+                warnCounter.increment();
+                break;
+            case INFO:
+                infoCounter.increment();
+                break;
+            case DEBUG:
+                debugCounter.increment();
+                break;
+            case TRACE:
+                traceCounter.increment();
+                break;
+            default:
+                break;
+        }
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -47,6 +47,7 @@ import static org.awaitility.Awaitility.await;
  *
  * @author Steven Sheehy
  * @author Johnny Lim
+ * @author Harsh Verma
  */
 class Log4j2MetricsTest {
 
@@ -223,10 +224,10 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics(emptyList(), loggerContext).bindTo(registry);
         Iterator<Filter> rootFilters = loggerContext.getRootLogger().getFilters();
-        Log4j2Metrics.MetricsFilter rootFilter = (Log4j2Metrics.MetricsFilter) rootFilters.next();
+        MetricsFilter rootFilter = (MetricsFilter) rootFilters.next();
         assertThat(rootFilters.hasNext()).isFalse();
 
-        Log4j2Metrics.MetricsFilter logger1Filter = (Log4j2Metrics.MetricsFilter) loggerContext.getConfiguration()
+        MetricsFilter logger1Filter = (MetricsFilter) loggerContext.getConfiguration()
             .getLoggerConfig(logger1.getName())
             .getFilter();
         assertThat(logger1Filter).isEqualTo(rootFilter);
@@ -303,7 +304,7 @@ class Log4j2MetricsTest {
 
             // Should have added filter to configuration
             Filter oldFilter = oldConfiguration.getRootLogger().getFilter();
-            assertThat(oldFilter).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
+            assertThat(oldFilter).isInstanceOf(MetricsFilter.class);
 
             // This will reload the configuration to default
             context.reconfigure();
@@ -317,7 +318,7 @@ class Log4j2MetricsTest {
             // Should have removed filter from old configuration, adding it to the new
             assertThat(oldConfiguration.getRootLogger().getFilter()).isNull();
             Filter newFilter = newConfiguration.getRootLogger().getFilter();
-            assertThat(newFilter).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
+            assertThat(newFilter).isInstanceOf(MetricsFilter.class);
         }
     }
 
@@ -388,7 +389,7 @@ class Log4j2MetricsTest {
 
         context.updateLoggers(configuration);
 
-        assertThat(addedLoggerConfig.getFilter()).isInstanceOf(Log4j2Metrics.MetricsFilter.class);
+        assertThat(addedLoggerConfig.getFilter()).isInstanceOf(MetricsFilter.class);
 
         logger.debug("test");
         assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(1);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/RunTimeTagMetricsFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/RunTimeTagMetricsFilterTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RunTimeTagMetricsFilter}.
+ *
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+class RunTimeTagMetricsFilterTest {
+
+    private MeterRegistry registry;
+
+    private RunTimeTagMetricsFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+    }
+
+    @Test
+    void incrementsCounterWithStaticTags() {
+        filter = new RunTimeTagMetricsFilter(registry, Collections.singletonList(Tag.of("application", "testApp")),
+                Collections.emptyList());
+
+        LogEvent event = createLogEvent(Level.INFO);
+        filter.filter(event);
+
+        Counter counter = registry.get("log4j2.events").tags("level", "info").tags("application", "testApp").counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void incrementsCounterWithDynamicTags() {
+        LogEventInterceptor interceptor = (logEvent) -> {
+            if (logEvent.getThrown() != null) {
+                return Collections.singletonList(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            return Collections.emptyList();
+        };
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.emptyList(), Collections.singletonList(interceptor));
+
+        LogEvent event = createLogEventWithException(Level.INFO, new NullPointerException());
+        filter.filter(event);
+
+        Counter counter = registry.get("log4j2.events")
+            .tags("level", "info")
+            .tags("exception", "NullPointerException")
+            .counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void incrementsCounterWithBothStaticAndDynamicTags() {
+        LogEventInterceptor interceptor = (logEvent) -> {
+            if (logEvent.getThrown() != null) {
+                return Collections.singletonList(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            return Collections.emptyList();
+        };
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.singletonList(Tag.of("application", "testApp")),
+                Collections.singletonList(interceptor));
+
+        LogEvent event = createLogEventWithException(Level.ERROR, new java.io.IOException());
+        filter.filter(event);
+
+        Counter counter = registry.get("log4j2.events")
+            .tags("level", "error")
+            .tags("application", "testApp")
+            .tags("exception", "IOException")
+            .counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void multipleInterceptorsAddMultipleTags() {
+        LogEventInterceptor exceptionInterceptor = (logEvent) -> {
+            if (logEvent.getThrown() != null) {
+                return Collections.singletonList(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            return Collections.emptyList();
+        };
+        LogEventInterceptor statusInterceptor = (logEvent) -> Collections.singletonList(Tag.of("outcome", "failure"));
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.emptyList(),
+                Arrays.asList(exceptionInterceptor, statusInterceptor));
+
+        LogEvent event = createLogEventWithException(Level.WARN, new java.sql.SQLException());
+        filter.filter(event);
+
+        Counter counter = registry.get("log4j2.events")
+            .tags("level", "warn")
+            .tags("exception", "SQLException")
+            .tags("outcome", "failure")
+            .counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void interceptorReturnsMultipleTags() {
+        LogEventInterceptor interceptor = (logEvent) -> {
+            List<Tag> tags = new ArrayList<>();
+            if (logEvent.getThrown() != null) {
+                tags.add(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            tags.add(Tag.of("operation", "database_query"));
+            return tags;
+        };
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.emptyList(), Collections.singletonList(interceptor));
+
+        LogEvent event = createLogEventWithException(Level.DEBUG, new java.util.concurrent.TimeoutException());
+        filter.filter(event);
+
+        Counter counter = registry.get("log4j2.events")
+            .tags("level", "debug")
+            .tags("exception", "TimeoutException")
+            .tags("operation", "database_query")
+            .counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void multipleEventsWithDifferentDynamicTags() {
+        LogEventInterceptor interceptor = (logEvent) -> {
+            if (logEvent.getThrown() != null) {
+                return Collections.singletonList(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            return Collections.emptyList();
+        };
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.emptyList(), Collections.singletonList(interceptor));
+
+        filter.filter(createLogEventWithException(Level.INFO, new java.io.IOException()));
+        filter.filter(createLogEventWithException(Level.INFO, new java.sql.SQLException()));
+
+        Counter counter1 = registry.get("log4j2.events")
+            .tags("level", "info")
+            .tags("exception", "IOException")
+            .counter();
+        Counter counter2 = registry.get("log4j2.events")
+            .tags("level", "info")
+            .tags("exception", "SQLException")
+            .counter();
+
+        assertThat(counter1.count()).isEqualTo(1.0);
+        assertThat(counter2.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void differentLogLevelsCreateSeparateCounters() {
+        filter = new RunTimeTagMetricsFilter(registry, Collections.singletonList(Tag.of("app", "test")),
+                Collections.emptyList());
+
+        filter.filter(createLogEvent(Level.INFO));
+        filter.filter(createLogEvent(Level.ERROR));
+        filter.filter(createLogEvent(Level.WARN));
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").tags("app", "test").counter().count())
+            .isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "error").tags("app", "test").counter().count())
+            .isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "warn").tags("app", "test").counter().count())
+            .isEqualTo(1.0);
+    }
+
+    @Test
+    void meterHasCorrectMetadata() {
+        filter = new RunTimeTagMetricsFilter(registry, Collections.emptyList(), Collections.emptyList());
+
+        LogEvent event = createLogEvent(Level.INFO);
+        filter.filter(event);
+
+        Meter meter = registry.get("log4j2.events").tags("level", "info").meter();
+        assertThat(meter.getId().getBaseUnit()).isEqualTo(BaseUnits.EVENTS);
+        assertThat(meter.getId().getDescription()).isEqualTo("Number of log events");
+    }
+
+    @Test
+    void multipleEventsWithSameTagsIncrementSameCounter() {
+        LogEventInterceptor interceptor = (logEvent) -> {
+            if (logEvent.getThrown() != null) {
+                return Collections.singletonList(Tag.of("exception", logEvent.getThrown().getClass().getSimpleName()));
+            }
+            return Collections.emptyList();
+        };
+
+        filter = new RunTimeTagMetricsFilter(registry, Collections.singletonList(Tag.of("app", "test")),
+                Collections.singletonList(interceptor));
+
+        filter.filter(createLogEventWithException(Level.INFO, new NullPointerException()));
+        filter.filter(createLogEventWithException(Level.INFO, new NullPointerException()));
+        filter.filter(createLogEventWithException(Level.INFO, new NullPointerException()));
+
+        Counter counter = registry.get("log4j2.events")
+            .tags("level", "info")
+            .tags("app", "test")
+            .tags("exception", "NullPointerException")
+            .counter();
+        assertThat(counter.count()).isEqualTo(3.0);
+    }
+
+    private LogEvent createLogEvent(Level level) {
+        return Log4jLogEvent.newBuilder()
+            .setLevel(level)
+            .setMessage(new SimpleMessage("Test message"))
+            .setLoggerName("test.logger")
+            .build();
+    }
+
+    private LogEvent createLogEventWithException(Level level, Throwable throwable) {
+        return Log4jLogEvent.newBuilder()
+            .setLevel(level)
+            .setMessage(new SimpleMessage("Test message"))
+            .setLoggerName("test.logger")
+            .setThrown(throwable)
+            .build();
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/StaticTagMetricsFilterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/StaticTagMetricsFilterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StaticTagMetricsFilter}.
+ *
+ * @author Harsh Verma
+ * @since 1.16.5
+ */
+class StaticTagMetricsFilterTest {
+
+    private MeterRegistry registry;
+
+    private StaticTagMetricsFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+        filter = new StaticTagMetricsFilter(registry, Collections.singletonList(Tag.of("application", "testApp")));
+    }
+
+    @Test
+    void allLevelsCanBeIncrementedIndependently() {
+        filter.filter(createLogEvent(Level.FATAL));
+        filter.filter(createLogEvent(Level.ERROR));
+        filter.filter(createLogEvent(Level.WARN));
+        filter.filter(createLogEvent(Level.INFO));
+        filter.filter(createLogEvent(Level.DEBUG));
+        filter.filter(createLogEvent(Level.TRACE));
+
+        assertThat(registry.get("log4j2.events").tags("level", "fatal").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "trace").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void multipleEventsIncrementCountersCorrectly() {
+        filter.filter(createLogEvent(Level.ERROR));
+        filter.filter(createLogEvent(Level.ERROR));
+        filter.filter(createLogEvent(Level.WARN));
+        filter.filter(createLogEvent(Level.INFO));
+
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(2.0);
+        assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(0.0);
+    }
+
+    @Test
+    void customTagsAreApplied() {
+        filter.filter(createLogEvent(Level.INFO));
+
+        Counter counter = registry.get("log4j2.events").tags("level", "info").tags("application", "testApp").counter();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    private LogEvent createLogEvent(Level level) {
+        return Log4jLogEvent.newBuilder()
+            .setLevel(level)
+            .setMessage(new SimpleMessage("Test message"))
+            .setLoggerName("test.logger")
+            .build();
+    }
+
+}


### PR DESCRIPTION
## Summary
Introduces `LogEventInterceptor` interface to enable dynamic tag extraction from log events at runtime, allowing users to add custom tags like exception class names, thread names, or other contextual information.

## Changes
- **New**: `LogEventInterceptor` interface for runtime tag extraction
- **Refactored**: Split internal `MetricsFilter` into:
  - `StaticTagMetricsFilter` - Pre-creates counters (original behavior, used when no interceptors)
  - `RunTimeTagMetricsFilter` - Creates counters dynamically with interceptor-provided tags
  - `MetricsFilter` - Abstract base class with common filter logic
- **Backward compatible**: Existing constructors unchanged, default behavior preserved
