### PR TITLE
Add warning when registry is added after meters are already registered

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -15,13 +15,12 @@
  */
 package io.micrometer.core.instrument.composite;
 
+import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import org.jspecify.annotations.Nullable;
-import io.micrometer.common.util.internal.logging.InternalLogger;
-import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -41,7 +40,8 @@ import java.util.function.ToLongFunction;
  */
 public class CompositeMeterRegistry extends MeterRegistry {
 
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(CompositeMeterRegistry.class);
+    private static final WarnThenDebugLogger addRegistryAfterMetersLogger = new WarnThenDebugLogger(
+            CompositeMeterRegistry.class);
 
     private final AtomicBoolean registriesLock = new AtomicBoolean();
 
@@ -140,9 +140,9 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     public CompositeMeterRegistry add(MeterRegistry registry) {
 
-        if (!this.getMeters().isEmpty()) {
-            logger.warn(
-                    "Adding a MeterRegistry after meters are already registered may cause missing metrics in the new registry.");
+        if (addRegistryAfterMetersLogger.isEnabled() && !this.getMeters().isEmpty()) {
+            addRegistryAfterMetersLogger.log(
+                    "A MeterRegistry is being added to this CompositeMeterRegistry that already has registered Meters. Meter recordings (e.g. increments, recordings) that occurred before this registry was added will not be reflected in it. If adding the registry after registering meters was not intentional, update your configuration to add all MeterRegistries to the composite before registering any Meters.");
         }
 
         lock(registriesLock, () -> {


### PR DESCRIPTION
Problem:
When a MeterRegistry is added to a CompositeMeterRegistry after meters have already been registered, those existing meters are not propagated to the newly added registry. This can lead to missing metrics and unexpected behavior.

Solution:
Added a warning log in CompositeMeterRegistry#add(MeterRegistry registry) to notify users when a registry is added after meters already exist.

This helps improve visibility and prevents silent misconfiguration.

Closes https://github.com/micrometer-metrics/micrometer/issues/6908