### PR TITLE
Improve exemplars sizing and add exemplarsSize config

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/Base2ExponentialHistogram.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/Base2ExponentialHistogram.java
@@ -82,8 +82,8 @@ abstract class Base2ExponentialHistogram implements Histogram, OtlpExemplarsSupp
         this.scale = maxScale;
         this.maxBucketsCount = maxBucketsCount;
         this.baseUnit = baseUnit;
-        this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(16, baseUnit != null)
-                : null;
+        this.exemplarSampler = exemplarSamplerFactory != null
+                ? exemplarSamplerFactory.create(maxBucketsCount, baseUnit != null) : null;
         this.zeroThreshold = getZeroThreshHoldFromMinExpectedValue(minimumExpectedValue, baseUnit);
 
         this.circularCountHolder = new CircularCountHolder(maxBucketsCount);

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpConfig.java
@@ -17,6 +17,7 @@ package io.micrometer.registry.otlp;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
+import io.micrometer.core.instrument.config.validate.InvalidReason;
 import io.micrometer.core.instrument.config.validate.Validated;
 import io.micrometer.core.instrument.push.PushRegistryConfig;
 
@@ -34,6 +35,7 @@ import static io.micrometer.core.instrument.config.validate.PropertyValidator.*;
  *
  * @author Tommy Ludwig
  * @author Lenin Jaganathan
+ * @author Jonatan Ivanov
  * @since 1.9.0
  */
 public interface OtlpConfig extends PushRegistryConfig {
@@ -234,8 +236,8 @@ public interface OtlpConfig extends PushRegistryConfig {
      * {@link HistogramFlavor#EXPLICIT_BUCKET_HISTOGRAM} is used for the supported meters.
      * When this is set to {@link HistogramFlavor#BASE2_EXPONENTIAL_BUCKET_HISTOGRAM} and
      * {@code publishPercentileHistogram} is enabled
-     * {@link io.micrometer.registry.otlp.internal.Base2ExponentialHistogram} is used for
-     * recording distributions.
+     * {@link io.micrometer.registry.otlp.Base2ExponentialHistogram} is used for recording
+     * distributions.
      * <p>
      * Note: If specific SLO's are configured, this property is not honored and
      * {@link HistogramFlavor#EXPLICIT_BUCKET_HISTOGRAM} is used for those meters.
@@ -291,6 +293,17 @@ public interface OtlpConfig extends PushRegistryConfig {
     }
 
     /**
+     * Max number of exemplars per time series. Histograms use their own strategy for the
+     * number of exemplars and may ignore this value.
+     * @return exemplarsSize
+     *
+     * @since 1.17.0
+     */
+    default int exemplarsSize() {
+        return getInteger(this, "exemplarsSize").orElse(1);
+    }
+
+    /**
      * Max scale to use for exponential histograms, if configured.
      * @return maxScale
      * @see #histogramFlavor()
@@ -341,7 +354,9 @@ public interface OtlpConfig extends PushRegistryConfig {
                 check("aggregationTemporality", OtlpConfig::aggregationTemporality),
                 check("compressionMode", OtlpConfig::compressionMode),
                 check("histogramFlavorPerMeter", OtlpConfig::histogramFlavorPerMeter),
-                check("maxBucketsPerMeter", OtlpConfig::maxBucketsPerMeter));
+                check("maxBucketsPerMeter", OtlpConfig::maxBucketsPerMeter),
+                check("exemplarsSize", OtlpConfig::exemplarsSize).andThen(validated -> validated
+                    .invalidateWhen(value -> value <= 0, "exemplarsSize must be positive!", InvalidReason.MALFORMED)));
     }
 
     default TimeUnit baseTimeUnit() {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeCounter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeCounter.java
@@ -33,7 +33,7 @@ class OtlpCumulativeCounter extends CumulativeCounter implements StartTimeAwareM
     OtlpCumulativeCounter(Id id, Clock clock, @Nullable OtlpExemplarSamplerFactory exemplarSamplerFactory) {
         super(id);
         this.startTimeNanos = TimeUnit.MILLISECONDS.toNanos(clock.wallTime());
-        this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(16, false) : null;
+        this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(false) : null;
     }
 
     @Override

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeDistributionSummary.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeDistributionSummary.java
@@ -40,7 +40,7 @@ class OtlpCumulativeDistributionSummary extends CumulativeDistributionSummary
             this.exemplarSampler = null;
         }
         else {
-            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(1, false) : null;
+            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(false) : null;
         }
     }
 

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeTimer.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpCumulativeTimer.java
@@ -42,7 +42,7 @@ class OtlpCumulativeTimer extends CumulativeTimer
             this.exemplarSampler = null;
         }
         else {
-            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(1, true) : null;
+            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(true) : null;
         }
     }
 

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpExemplarSampler.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpExemplarSampler.java
@@ -45,6 +45,12 @@ class OtlpExemplarSampler implements ExemplarSampler {
 
     private final DoubleUnaryOperator converter;
 
+    OtlpExemplarSampler(ExemplarContextProvider exemplarContextProvider, Clock clock, OtlpConfig config,
+            DoubleUnaryOperator converter) {
+        this(exemplarContextProvider, clock, new Exemplars(clock, config.step().toMillis(), config.exemplarsSize()),
+                converter);
+    }
+
     OtlpExemplarSampler(ExemplarContextProvider exemplarContextProvider, Clock clock, OtlpConfig config, int size,
             DoubleUnaryOperator converter) {
         this(exemplarContextProvider, clock, new Exemplars(clock, config.step().toMillis(), size), converter);

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpExemplarSamplerFactory.java
@@ -38,12 +38,17 @@ class OtlpExemplarSamplerFactory {
         this.baseTimeUnit = config.baseTimeUnit();
     }
 
-    ExemplarSampler create(int size, boolean timeBased) {
-        return new OtlpExemplarSampler(exemplarContextProvider, clock, config, size, converter(timeBased));
+    ExemplarSampler create(boolean timeBased) {
+        return new OtlpExemplarSampler(exemplarContextProvider, clock, config, converter(timeBased));
     }
 
     ExemplarSampler create(double[] buckets, boolean timeBased) {
         return new OtlpExemplarSampler(exemplarContextProvider, clock, config, buckets, converter(timeBased));
+    }
+
+    ExemplarSampler create(int maxBucketsCount, boolean timeBased) {
+        int size = Math.max(config.exemplarsSize(), maxBucketsCount / 4);
+        return new OtlpExemplarSampler(exemplarContextProvider, clock, config, size, converter(timeBased));
     }
 
     private DoubleUnaryOperator converter(boolean timeBased) {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepCounter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepCounter.java
@@ -29,7 +29,7 @@ class OtlpStepCounter extends StepCounter implements OtlpExemplarsSupport {
 
     OtlpStepCounter(Id id, Clock clock, long stepMillis, @Nullable OtlpExemplarSamplerFactory exemplarSamplerFactory) {
         super(id, clock, stepMillis);
-        this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(16, false) : null;
+        this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(false) : null;
     }
 
     @Override

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepDistributionSummary.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepDistributionSummary.java
@@ -56,7 +56,7 @@ class OtlpStepDistributionSummary extends AbstractDistributionSummary
             this.exemplarSampler = null;
         }
         else {
-            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(1, false) : null;
+            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(false) : null;
         }
     }
 

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepTimer.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpStepTimer.java
@@ -57,7 +57,7 @@ class OtlpStepTimer extends AbstractTimer implements OtlpHistogramSupport, OtlpE
             this.exemplarSampler = null;
         }
         else {
-            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(1, true) : null;
+            this.exemplarSampler = exemplarSamplerFactory != null ? exemplarSamplerFactory.create(true) : null;
         }
     }
 

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpConfigTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.registry.otlp;
 
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
+import io.micrometer.core.instrument.config.validate.InvalidReason;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -237,6 +238,36 @@ class OtlpConfigTest {
 
         OtlpConfig otlpConfig = properties::get;
         assertThat(otlpConfig.validate().isValid()).isFalse();
+    }
+
+    @Test
+    void exemplarsSizeShouldHaveDefault() {
+        OtlpConfig otlpConfig = k -> null;
+        assertThat(otlpConfig.validate().isValid()).isTrue();
+        assertThat(otlpConfig.exemplarsSize()).isEqualTo(1);
+    }
+
+    @Test
+    void exemplarsSizeShouldBePositive() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otlp.exemplarsSize", "-1");
+        OtlpConfig otlpConfig = properties::get;
+        assertThat(otlpConfig.validate().isValid()).isFalse();
+        assertThat(otlpConfig.validate().failures()).singleElement().satisfies(failure -> {
+            assertThat(failure.getMessage()).isEqualTo("exemplarsSize must be positive!");
+            assertThat(failure.getProperty()).isEqualTo("otlp.exemplarsSize");
+            assertThat(failure.getReason()).isSameAs(InvalidReason.MALFORMED);
+            assertThat(failure.getValue()).isEqualTo(-1);
+        });
+    }
+
+    @Test
+    void exemplarsSizeShouldBeOverridden() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("otlp.exemplarsSize", "3");
+        OtlpConfig otlpConfig = properties::get;
+        assertThat(otlpConfig.validate().isValid()).isTrue();
+        assertThat(otlpConfig.exemplarsSize()).isEqualTo(3);
     }
 
     @Test

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpCumulativeMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpCumulativeMeterRegistryTest.java
@@ -38,7 +38,18 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
 
     @Override
     protected OtlpConfig otlpConfig() {
-        return OtlpConfig.DEFAULT;
+        return new OtlpConfig() {
+
+            @Override
+            public int exemplarsSize() {
+                return 4;
+            }
+
+            @Override
+            public @Nullable String get(String key) {
+                return null;
+            }
+        };
     }
 
     @Override
@@ -51,7 +62,7 @@ class OtlpCumulativeMeterRegistryTest extends OtlpMeterRegistryTest {
             }
 
             @Override
-            public @Nullable String get(final String key) {
+            public @Nullable String get(String key) {
                 return null;
             }
         };

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -62,6 +62,12 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
     @Override
     protected OtlpConfig otlpConfig() {
         return new OtlpConfig() {
+
+            @Override
+            public int exemplarsSize() {
+                return 4;
+            }
+
             @Override
             public AggregationTemporality aggregationTemporality() {
                 return DELTA;

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpExemplarSamplerTests.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpExemplarSamplerTests.java
@@ -48,6 +48,11 @@ class OtlpExemplarSamplerTests {
         }
 
         @Override
+        public int exemplarsSize() {
+            return 4;
+        }
+
+        @Override
         public @Nullable String get(@NonNull String key) {
             return null;
         }
@@ -60,11 +65,9 @@ class OtlpExemplarSamplerTests {
     private final OtlpExemplarSamplerFactory factory = new OtlpExemplarSamplerFactory(contextProvider, clock, config);
 
     @Nested
-    class FixedSizeSamplerTests {
+    class FixedSizedCounterSamplerTests {
 
-        private static final int SIZE = 16;
-
-        private final ExemplarSampler sampler = factory.create(SIZE, false);
+        private final ExemplarSampler sampler = factory.create(false);
 
         private final ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
 
@@ -190,10 +193,10 @@ class OtlpExemplarSamplerTests {
         @RepeatedTest(10)
         void multipleRecordingsShouldBeRandomlySampled() {
             assertThat(sampler.collectExemplars()).isEmpty();
-            recorder.recordRandomMeasurements(5);
+            recorder.recordRandomMeasurements(config.exemplarsSize());
             assertThat(sampler.collectExemplars()).isEmpty();
             clock.add(STEP);
-            assertThat(sampler.collectExemplars()).doesNotHaveDuplicates().hasSizeBetween(1, 5);
+            assertThat(sampler.collectExemplars()).doesNotHaveDuplicates().hasSizeBetween(1, config.exemplarsSize());
         }
 
         @Test
@@ -251,10 +254,169 @@ class OtlpExemplarSamplerTests {
         @RepeatedTest(10)
         void samplerCanBeFilled() {
             assertThat(sampler.collectExemplars()).isEmpty();
+            // likely to fill 4 exemplars
+            recorder.recordRandomMeasurements(10_000);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).hasSize(config.exemplarsSize());
+        }
+
+        @RepeatedTest(10)
+        void samplerUsesSizeFromConfig() {
+            OtlpConfig config = new OtlpConfig() {
+                @Override
+                public @NonNull Duration step() {
+                    return STEP;
+                }
+
+                @Override
+                public int exemplarsSize() {
+                    return 4;
+                }
+
+                @Override
+                public @Nullable String get(@NonNull String key) {
+                    return null;
+                }
+            };
+            ExemplarSampler sampler = new OtlpExemplarSamplerFactory(contextProvider, clock, config).create(false);
+            ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
+
+            assertThat(sampler.collectExemplars()).isEmpty();
+            recorder.recordRandomMeasurements(10_000);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).hasSize(4);
+        }
+
+        @RepeatedTest(10)
+        void samplerUsesDefaultSizeFromConfig() {
+            OtlpConfig config = new OtlpConfig() {
+                @Override
+                public @NonNull Duration step() {
+                    return STEP;
+                }
+
+                @Override
+                public @Nullable String get(@NonNull String key) {
+                    return null;
+                }
+            };
+            ExemplarSampler sampler = new OtlpExemplarSamplerFactory(contextProvider, clock, config).create(false);
+            ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
+
+            assertThat(sampler.collectExemplars()).isEmpty();
+            recorder.recordRandomMeasurements(10_000);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).hasSize(1);
+        }
+
+    }
+
+    @Nested
+    class FixedSizedExponentialHistogramSamplerTests {
+
+        private final ExemplarSampler sampler = factory.create(config.maxBucketCount(), false);
+
+        private final ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
+
+        @Test
+        void firstRecordingShouldBeAlwaysSampled() {
+            assertThat(sampler.collectExemplars()).isEmpty();
+            Exemplar expected = recorder.record("4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7", 42.0);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+
+            assertThat(sampler.collectExemplars()).singleElement().satisfies(exemplar -> {
+                assertThat(encodeHexString(exemplar.getTraceId())).isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+                assertThat(encodeHexString(exemplar.getSpanId())).isEqualTo("00f067aa0ba902b7");
+                assertThat(exemplar.getAsDouble()).isEqualTo(42.0);
+                assertThat(exemplar.getTimeUnixNano()).isEqualTo(expected.getTimeUnixNano());
+                assertThat(exemplar.getFilteredAttributesList()).isEmpty();
+            });
+        }
+
+        @RepeatedTest(10)
+        void multipleRecordingsShouldBeRandomlySampled() {
+            assertThat(sampler.collectExemplars()).isEmpty();
+            recorder.recordRandomMeasurements(config.exemplarsSize());
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).doesNotHaveDuplicates().hasSizeBetween(1, config.exemplarsSize());
+        }
+
+        @RepeatedTest(10)
+        void samplerCanBeFilled() {
+            assertThat(sampler.collectExemplars()).isEmpty();
+            // likely to fill 40 exemplars
             recorder.recordRandomMeasurements(1_000_000);
             assertThat(sampler.collectExemplars()).isEmpty();
             clock.add(STEP);
-            assertThat(sampler.collectExemplars()).hasSize(16);
+            assertThat(sampler.collectExemplars()).hasSize(40);
+        }
+
+        @RepeatedTest(10)
+        void samplerUsesSizeFromConfig() {
+            OtlpConfig config = new OtlpConfig() {
+                @Override
+                public @NonNull Duration step() {
+                    return STEP;
+                }
+
+                @Override
+                public int maxBucketCount() {
+                    return 16; // -> 16/4 = 4 exemplars
+                }
+
+                @Override
+                public @Nullable String get(@NonNull String key) {
+                    return null;
+                }
+            };
+            ExemplarSampler sampler = new OtlpExemplarSamplerFactory(contextProvider, clock, config)
+                .create(config.maxBucketCount(), false);
+            ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
+
+            assertThat(sampler.collectExemplars()).isEmpty();
+            recorder.recordRandomMeasurements(10_000);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).hasSize(4);
+        }
+
+        @RepeatedTest(10)
+        void samplerUsesMinimumExemplarsSizeFromConfig() {
+            OtlpConfig config = new OtlpConfig() {
+                @Override
+                public @NonNull Duration step() {
+                    return STEP;
+                }
+
+                @Override
+                public int exemplarsSize() {
+                    return 2;
+                }
+
+                @Override
+                public int maxBucketCount() {
+                    return 4; // -> 4/4 = 1 exemplar
+                }
+
+                @Override
+                public @Nullable String get(@NonNull String key) {
+                    return null;
+                }
+            };
+            ExemplarSampler sampler = new OtlpExemplarSamplerFactory(contextProvider, clock, config)
+                .create(config.maxBucketCount(), false);
+            ExemplarTestRecorder recorder = new ExemplarTestRecorder(contextProvider, clock, sampler);
+
+            assertThat(sampler.collectExemplars()).isEmpty();
+            recorder.recordRandomMeasurements(10_000);
+            assertThat(sampler.collectExemplars()).isEmpty();
+            clock.add(STEP);
+            assertThat(sampler.collectExemplars()).hasSize(2);
         }
 
     }

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -46,6 +46,7 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariables
  *
  * @author Tommy Ludwig
  * @author Johnny Lim
+ * @author Jonatan Ivanov
  */
 abstract class OtlpMeterRegistryTest {
 
@@ -234,14 +235,16 @@ abstract class OtlpMeterRegistryTest {
 
     @RepeatedTest(10)
     void multipleCounterRecordingsShouldBeRandomlySampled() {
+        int exemplarsSize = otlpConfig().exemplarsSize();
         Counter counter = Counter.builder("test.counter").register(registry);
-        recorder.recordRandomMeasurements(5, counter::increment);
+        recorder.recordRandomMeasurements(exemplarsSize, counter::increment);
         stepOverNStep(1);
 
         assertThat(writeToMetrics(counter)).singleElement().satisfies(metric -> {
             assertThat(metric.getSum().getDataPointsList()).hasSize(1);
             assertThat(metric.getSum().getDataPoints(0).getExemplarsList()).doesNotHaveDuplicates()
-                .hasSizeBetween(1, 5);
+                .hasSizeBetween(1, exemplarsSize)
+                .allSatisfy(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, (double) exemplarsSize));
         });
     }
 
@@ -298,26 +301,30 @@ abstract class OtlpMeterRegistryTest {
 
     @RepeatedTest(10)
     void multipleDistributionsWithoutHistogramRecordingsShouldBeRandomlySampled() {
+        int exemplarsSize = otlpConfig().exemplarsSize();
+
         Timer timer = Timer.builder("timer").description(METER_DESCRIPTION).tags(Tags.of(meterTag)).register(registry);
-        recorder.recordRandomMeasurements(5, index -> timer.record(Duration.ofMillis(index)));
+        recorder.recordRandomMeasurements(exemplarsSize, index -> timer.record(Duration.ofMillis(index)));
 
         DistributionSummary ds = DistributionSummary.builder("ds")
             .description(METER_DESCRIPTION)
             .tags(Tags.of(meterTag))
             .register(registry);
-        recorder.recordRandomMeasurements(5, ds::record);
+        recorder.recordRandomMeasurements(exemplarsSize, ds::record);
         stepOverNStep(1);
 
         assertThat(writeToMetrics(timer)).filteredOn(Metric::hasHistogram).singleElement().satisfies(metric -> {
             assertThat(metric.getHistogram().getDataPointsList()).hasSize(1);
-            assertThat(metric.getHistogram().getDataPoints(0).getExemplarsList()).singleElement()
-                .satisfies(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, 5.0));
+            assertThat(metric.getHistogram().getDataPoints(0).getExemplarsList()).doesNotHaveDuplicates()
+                .hasSizeBetween(1, exemplarsSize)
+                .allSatisfy(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, (double) exemplarsSize));
         });
 
         assertThat(writeToMetrics(ds)).filteredOn(Metric::hasHistogram).singleElement().satisfies(metric -> {
             assertThat(metric.getHistogram().getDataPointsList()).hasSize(1);
-            assertThat(metric.getHistogram().getDataPoints(0).getExemplarsList()).singleElement()
-                .satisfies(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, 5.0));
+            assertThat(metric.getHistogram().getDataPoints(0).getExemplarsList()).doesNotHaveDuplicates()
+                .hasSizeBetween(1, exemplarsSize)
+                .allSatisfy(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, (double) exemplarsSize));
         });
     }
 
@@ -588,19 +595,20 @@ abstract class OtlpMeterRegistryTest {
 
     @RepeatedTest(10)
     void multipleDistributionsWithExponentialHistogramShouldWriteRandomlySampledExemplars() {
+        int size = otlpConfig().maxBucketCount() / 4;
         Timer timer = Timer.builder("timer")
             .description(METER_DESCRIPTION)
             .tags(Tags.of(meterTag))
             .publishPercentileHistogram()
             .register(registryWithExponentialHistogram);
-        recorder.recordRandomMeasurements(5, index -> timer.record(Duration.ofMillis(index)));
+        recorder.recordRandomMeasurements(size, index -> timer.record(Duration.ofMillis(index)));
 
         DistributionSummary ds = DistributionSummary.builder("ds")
             .description(METER_DESCRIPTION)
             .tags(Tags.of(meterTag))
             .publishPercentileHistogram()
             .register(registryWithExponentialHistogram);
-        recorder.recordRandomMeasurements(5, ds::record);
+        recorder.recordRandomMeasurements(size, ds::record);
 
         stepOverNStep(1);
 
@@ -609,13 +617,15 @@ abstract class OtlpMeterRegistryTest {
             .satisfies(metric -> {
                 assertThat(metric.getExponentialHistogram().getDataPointsList()).hasSize(1);
                 assertThat(metric.getExponentialHistogram().getDataPoints(0).getExemplarsList()).doesNotHaveDuplicates()
-                    .hasSizeBetween(1, 5);
+                    .hasSizeBetween(1, size)
+                    .allSatisfy(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, (double) size));
             });
 
         assertThat(writeToMetrics(ds)).filteredOn(Metric::hasExponentialHistogram).singleElement().satisfies(metric -> {
             assertThat(metric.getExponentialHistogram().getDataPointsList()).hasSize(1);
             assertThat(metric.getExponentialHistogram().getDataPoints(0).getExemplarsList()).doesNotHaveDuplicates()
-                .hasSizeBetween(1, 5);
+                .hasSizeBetween(1, size)
+                .allSatisfy(exemplar -> assertThat(exemplar.getAsDouble()).isBetween(1.0, (double) size));
         });
     }
 


### PR DESCRIPTION
Default exemplar sizes:
- no histogram (counter, timer, distribution summary): 1
- explicit bucket histograms: number of buckets
- exponential histograms: 40 (maxBuckets/4 = 160/4)