### PR TITLE
Fix GraalVM 25 reflection hint for getCpuLoad

### DIFF
--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
@@ -1,14 +1,8 @@
 [
   {
-    "condition": { "typeReachable" : "java.io.Serial" },
     "name":"com.sun.management.OperatingSystemMXBean",
     "methods":[
-      {"name":"getCpuLoad","parameterTypes":[] }
-    ]
-  },
-  {
-    "name":"com.sun.management.OperatingSystemMXBean",
-    "methods":[
+      {"name":"getCpuLoad","parameterTypes":[] },
       {"name":"getProcessCpuLoad","parameterTypes":[] },
       {"name":"getSystemCpuLoad","parameterTypes":[] }
     ]


### PR DESCRIPTION
Resolves #7316

In GraalVM 25, the `typeReachable` condition for `java.io.Serial` evaluates to `false` because it is a `SOURCE` retention annotation, meaning it is never present in the bytecode. This causes `getCpuLoad` to be omitted from the reflection configuration, throwing a `MissingReflectionRegistrationError` when Micrometer tries to invoke it.

This PR removes the condition and merges `getCpuLoad` into the main `OperatingSystemMXBean` reflection configuration. The condition was originally added for Java 11 compatibility, but since Java 11 is no longer supported by Spring Boot 3 or GraalVM 25, it is safe to remove it.

Made with [Cursor](https://cursor.com)