### PR TITLE
Improve FunctionCounter scrape error diagnostics

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -395,8 +395,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
         catch (IllegalArgumentException ex) {
             if (value < 0.0) {
-                throw new IllegalArgumentException("Failed to create Prometheus function counter snapshot for meter '"
-                        + id.getName() + "': " + ex.getMessage(), ex);
+                throw new IllegalArgumentException(
+                        "Failed to create Prometheus function counter snapshot for meter '" + id.getName() + "'", ex);
             }
             throw ex;
         }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -380,13 +380,26 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
-            collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                            getMetadata(conventionName, id.getDescription()), new CounterDataPointSnapshot(fc.count(),
-                                    Labels.of(tagKeys, tagValues), null, createdTimestampMillis))));
+            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
+                    getMetadata(conventionName, id.getDescription()),
+                    newFunctionCounterDataPointSnapshot(id, fc.count(), tagKeys, tagValues, createdTimestampMillis))));
         });
         return fc;
+    }
+
+    private CounterDataPointSnapshot newFunctionCounterDataPointSnapshot(Meter.Id id, double value,
+            List<String> tagKeys, List<String> tagValues, long createdTimestampMillis) {
+        try {
+            return new CounterDataPointSnapshot(value, Labels.of(tagKeys, tagValues), null, createdTimestampMillis);
+        }
+        catch (IllegalArgumentException ex) {
+            if (value < 0.0) {
+                throw new IllegalArgumentException("Failed to create Prometheus function counter snapshot for meter '"
+                        + id.getName() + "': " + ex.getMessage(), ex);
+            }
+            throw ex;
+        }
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -450,6 +450,20 @@ class PrometheusMeterRegistryTest {
         assertThat(registry.scrape()).contains("api_requests_total 1.0");
     }
 
+    @Test
+    void functionCounterNegativeValueIncludesMeterNameInScrapeException() {
+        AtomicInteger value = new AtomicInteger(1);
+        FunctionCounter.builder("api.requests", value, AtomicInteger::doubleValue).register(registry);
+
+        assertThat(registry.scrape()).contains("api_requests_total 1.0");
+
+        value.set(-2);
+
+        assertThatThrownBy(registry::scrape).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("api.requests")
+            .hasMessageContaining("-2.0: counters cannot have a negative value");
+    }
+
     private Condition<Iterable<? extends MetricSnapshot>> withNameAndQuantile(String name) {
         return new Condition<>(
                 metricSnapshots -> ((MetricSnapshots) metricSnapshots).stream()

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -459,9 +459,10 @@ class PrometheusMeterRegistryTest {
 
         value.set(-2);
 
-        assertThatThrownBy(registry::scrape).isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("api.requests")
-            .hasMessageContaining("-2.0: counters cannot have a negative value");
+        Throwable thrown = catchThrowable(registry::scrape);
+
+        assertThat(thrown).isInstanceOf(IllegalArgumentException.class).hasMessageContaining("api.requests");
+        assertThat(thrown).hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     private Condition<Iterable<? extends MetricSnapshot>> withNameAndQuantile(String name) {


### PR DESCRIPTION
## Summary

Improve diagnostics when a Prometheus `FunctionCounter` produces a negative value during scrape. (Issue https://github.com/prometheus/client_java/issues/1090)

Previously, the scrape failed with:

`-2.0: counters cannot have a negative value`

This made it hard to identify which meter was responsible.

This change preserves the existing fail-fast behavior, but enriches the exception message with the Micrometer meter name.

## What changed

- Enrich the `IllegalArgumentException` raised from the `FunctionCounter` Prometheus export path with the meter name
- Add test covering the negative `FunctionCounter` scrape scenario
- Now the exception message looks like `Failed to create Prometheus function counter snapshot for meter 'api.requests': -2.0: counters cannot have a negative value`

## Verification

Verified with a PrometheusMeterRegistryTest and small Spring Boot demo app with this Micrometer branch