### PR TITLE
Add option for time-based FunctionCounter

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -154,6 +154,20 @@ FunctionCounter counter = FunctionCounter
     .register(registry);
 ----
 
+If the function tracks a time value, you can use `timeUnit` on the builder to create a `FunctionCounter` that scales its value to the registry's base time unit. This is analogous to how `TimeGauge` works, and provides a way to register monotonically increasing time values (like `jvm.gc.cpu.time` or `process.cpu.time`) in a way that automatically scales to the preferred time unit of the metrics backend.
+
+[source, java]
+----
+MyCounterState state = ...;
+
+FunctionCounter counter = FunctionCounter
+    .builder("counter.time", state, state -> state.totalTime())
+    .timeUnit(TimeUnit.NANOSECONDS) // optional, scales the value to the registry's base time unit
+    .description("a description of what this counter does") // optional
+    .tags("region", "test") // optional
+    .register(registry);
+----
+
 WARNING: Attempting to construct a function-tracking counter with a primitive number or one of its `java.lang` object forms is always incorrect. These numbers are immutable. Thus, the function-tracking counter cannot ever be changed. Attempting to "re-register" the function-tracking counter with a different number does not work, as the registry maintains only one meter for each unique combination of name and tags. "Re-registering" a function-tracking counter can happen indirectly for example as the result of a `MeterFilter` modifying the name and/or the tags of two different function-tracking counters so that they will be the same after the filter is applied.
 
 Attempting to "re-register" a function-tracking counter will result in a warning like this:

--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -160,8 +160,7 @@ If the function tracks a time value, you can use `timeUnit` on the builder to cr
 ----
 MyCounterState state = ...;
 
-FunctionCounter counter = FunctionCounter
-    .builder("counter.time", state, state -> state.totalTime())
+FunctionCounter.builder("counter.time", state, state -> state.totalTime())
     .timeUnit(TimeUnit.NANOSECONDS) // optional, scales the value to the registry's base time unit
     .description("a description of what this counter does") // optional
     .tags("region", "test") // optional

--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -154,14 +154,13 @@ FunctionCounter counter = FunctionCounter
     .register(registry);
 ----
 
-If the function tracks a time value, you can use `timeUnit` on the builder to create a `FunctionCounter` that scales its value to the registry's base time unit. This is analogous to how `TimeGauge` works, and provides a way to register monotonically increasing time values (like `jvm.gc.cpu.time` or `process.cpu.time`) in a way that automatically scales to the preferred time unit of the metrics backend.
+If the function tracks a time value, you can specify the time unit of the value returned by the function when calling `FunctionCounter.builder(...)`. This creates a `FunctionCounter` that automatically scales its time-based count to the registry's base time unit. This is analogous to how `TimeGauge` works, and provides a way to register monotonically increasing time values (e.g. `RuntimeMXBean::getUptime`) in a way that automatically scales to the preferred time unit of the metrics backend.
 
 [source, java]
 ----
 MyCounterState state = ...;
 
-FunctionCounter.builder("counter.time", state, state -> state.totalTime())
-    .timeUnit(TimeUnit.NANOSECONDS) // optional, scales the value to the registry's base time unit
+FunctionCounter.builder("counter.time", state, state -> state.totalTime(), TimeUnit.NANOSECONDS)
     .description("a description of what this counter does") // optional
     .tags("region", "test") // optional
     .register(registry);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -121,6 +121,7 @@ public interface FunctionCounter extends Meter {
          * the {@link MeterRegistry}.
          * @param timeUnit time unit of the provided function return value.
          * @return The counter builder with added time unit.
+         * @since 1.17.0
          */
         public Builder<T> timeUnit(@Nullable TimeUnit timeUnit) {
             this.functionTimeUnit = timeUnit;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -107,6 +107,7 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
+         * Use this if the unit is not time. Otherwise, use {@link #timeUnit(TimeUnit)}.
          * @param unit Base unit of the eventual counter.
          * @return The counter builder with added base unit.
          */
@@ -118,7 +119,8 @@ public interface FunctionCounter extends Meter {
         /**
          * Only set this if this function counter is time-based. This will be used to
          * convert from the time unit provided by the function to the base time unit for
-         * the {@link MeterRegistry}.
+         * the {@link MeterRegistry}. If this is set, any {@link #baseUnit(String)} will
+         * be ignored and the registry's base time unit will be used instead.
          * @param timeUnit time unit of the provided function return value.
          * @return The counter builder with added time unit.
          * @since 1.17.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -61,7 +61,7 @@ public interface FunctionCounter extends Meter {
 
         private @Nullable String baseUnit;
 
-        private @Nullable TimeUnit baseTimeUnit;
+        private @Nullable TimeUnit functionTimeUnit;
 
         private Builder(String name, T obj, ToDoubleFunction<T> f) {
             this.name = name;
@@ -116,11 +116,12 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
-         * @param timeUnit Base time unit of the eventual counter.
-         * @return The counter builder with added base time unit.
+         * Only set this if this function counter is time-based. This will be used to convert from the time unit provided by the function to the base time unit for the {@link MeterRegistry}.
+         * @param timeUnit time unit of the provided function return value.
+         * @return The counter builder with added time unit.
          */
-        public Builder<T> baseTimeUnit(@Nullable TimeUnit timeUnit) {
-            this.baseTimeUnit = timeUnit;
+        public Builder<T> timeUnit(@Nullable TimeUnit timeUnit) {
+            this.functionTimeUnit = timeUnit;
             return this;
         }
 
@@ -134,10 +135,9 @@ public interface FunctionCounter extends Meter {
          * @return A new or existing function counter.
          */
         public FunctionCounter register(MeterRegistry registry) {
-            if (baseTimeUnit != null) {
+            if (functionTimeUnit != null) {
                 return registry.more()
-                    .timeFunctionCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj, baseTimeUnit,
-                            f);
+                    .functionTimeCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj, functionTimeUnit, f);
             }
             return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -116,7 +116,9 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
-         * Only set this if this function counter is time-based. This will be used to convert from the time unit provided by the function to the base time unit for the {@link MeterRegistry}.
+         * Only set this if this function counter is time-based. This will be used to
+         * convert from the time unit provided by the function to the base time unit for
+         * the {@link MeterRegistry}.
          * @param timeUnit time unit of the provided function return value.
          * @return The counter builder with added time unit.
          */
@@ -137,7 +139,8 @@ public interface FunctionCounter extends Meter {
         public FunctionCounter register(MeterRegistry registry) {
             if (functionTimeUnit != null) {
                 return registry.more()
-                    .functionTimeCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj, functionTimeUnit, f);
+                    .functionTimeCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj,
+                            functionTimeUnit, f);
             }
             return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 
 /**
@@ -59,6 +60,8 @@ public interface FunctionCounter extends Meter {
         private @Nullable String description;
 
         private @Nullable String baseUnit;
+
+        private @Nullable TimeUnit baseTimeUnit;
 
         private Builder(String name, T obj, ToDoubleFunction<T> f) {
             this.name = name;
@@ -113,6 +116,15 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
+         * @param timeUnit Base time unit of the eventual counter.
+         * @return The counter builder with added base time unit.
+         */
+        public Builder<T> baseTimeUnit(@Nullable TimeUnit timeUnit) {
+            this.baseTimeUnit = timeUnit;
+            return this;
+        }
+
+        /**
          * Add the function counter to a single registry, or return an existing function
          * counter in that registry. The returned function counter will be unique for each
          * registry, but each registry is guaranteed to only create one function counter
@@ -122,6 +134,11 @@ public interface FunctionCounter extends Meter {
          * @return A new or existing function counter.
          */
         public FunctionCounter register(MeterRegistry registry) {
+            if (baseTimeUnit != null) {
+                return registry.more()
+                    .timeFunctionCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj, baseTimeUnit,
+                            f);
+            }
             return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -28,8 +28,36 @@ import java.util.function.ToDoubleFunction;
  */
 public interface FunctionCounter extends Meter {
 
+    /**
+     * Build a function-tracking counter that produces a monotonically increasing count
+     * from the state object.
+     * @param name The counter's name.
+     * @param obj State object used to compute a count.
+     * @param f Function that produces a monotonically increasing count from the state
+     * object.
+     * @param <T> The type of the state object.
+     * @return A new function counter builder.
+     */
     static <T> Builder<T> builder(String name, T obj, ToDoubleFunction<T> f) {
         return new Builder<>(name, obj, f);
+    }
+
+    /**
+     * Build a function-tracking counter for a function that tracks monotonically
+     * increasing time. The time value will automatically scale to the base time unit
+     * expected by each registry implementation.
+     * @param name The counter's name.
+     * @param obj State object used to compute a value.
+     * @param objToCountFunction Function that produces a monotonically increasing time
+     * count from the state object.
+     * @param sourceUnit Time unit of the value returned by the count function.
+     * @param <T> The type of the state object.
+     * @return A new time-based function counter builder.
+     * @since 1.18.0
+     */
+    static <T> TimeBasedBuilder<T> builder(String name, T obj, ToDoubleFunction<T> objToCountFunction,
+            TimeUnit sourceUnit) {
+        return new TimeBasedBuilder<>(name, obj, objToCountFunction, sourceUnit);
     }
 
     /**
@@ -60,8 +88,6 @@ public interface FunctionCounter extends Meter {
         private @Nullable String description;
 
         private @Nullable String baseUnit;
-
-        private @Nullable TimeUnit functionTimeUnit;
 
         private Builder(String name, T obj, ToDoubleFunction<T> f) {
             this.name = name;
@@ -107,7 +133,9 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
-         * Use this if the unit is not time. Otherwise, use {@link #timeUnit(TimeUnit)}.
+         * Use this if the unit is not time. If the unit is time, use a time-based builder
+         * instead:
+         * {@link FunctionCounter#builder(String, Object, ToDoubleFunction, TimeUnit)}.
          * @param unit Base unit of the eventual counter.
          * @return The counter builder with added base unit.
          */
@@ -117,35 +145,93 @@ public interface FunctionCounter extends Meter {
         }
 
         /**
-         * Only set this if this function counter is time-based. This will be used to
-         * convert from the time unit provided by the function to the base time unit for
-         * the {@link MeterRegistry}. If this is set, any {@link #baseUnit(String)} will
-         * be ignored and the registry's base time unit will be used instead.
-         * @param timeUnit time unit of the provided function return value.
-         * @return The counter builder with added time unit.
-         * @since 1.17.0
+         * Register the function counter with the registry. If a meter with the same name
+         * and tags is already registered, the existing function counter is returned and
+         * this registration call has no effect.
+         * @param registry Registry to register the function counter with.
+         * @return The registered function counter.
          */
-        public Builder<T> timeUnit(@Nullable TimeUnit timeUnit) {
-            this.functionTimeUnit = timeUnit;
+        public FunctionCounter register(MeterRegistry registry) {
+            return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
+        }
+
+    }
+
+    /**
+     * Fluent builder for function counters that count monotonically increasing time.
+     *
+     * @param <T> The type of the state object from which the counter value is extracted.
+     * @since 1.18.0
+     */
+    class TimeBasedBuilder<T> {
+
+        private final String name;
+
+        private final ToDoubleFunction<T> objToCountFunction;
+
+        private Tags tags = Tags.empty();
+
+        private final T obj;
+
+        private @Nullable String description;
+
+        private final TimeUnit sourceUnit;
+
+        private TimeBasedBuilder(String name, T obj, ToDoubleFunction<T> objToCountFunction, TimeUnit sourceUnit) {
+            this.name = name;
+            this.obj = obj;
+            this.objToCountFunction = objToCountFunction;
+            this.sourceUnit = sourceUnit;
+        }
+
+        /**
+         * @param tags Must be an even number of arguments representing key/value pairs of
+         * tags.
+         * @return The function counter builder with added tags.
+         */
+        public TimeBasedBuilder<T> tags(String... tags) {
+            return tags(Tags.of(tags));
+        }
+
+        /**
+         * @param tags Tags to add to the eventual function counter.
+         * @return The function counter builder with added tags.
+         */
+        public TimeBasedBuilder<T> tags(Iterable<Tag> tags) {
+            this.tags = this.tags.and(tags);
             return this;
         }
 
         /**
-         * Add the function counter to a single registry, or return an existing function
-         * counter in that registry. The returned function counter will be unique for each
-         * registry, but each registry is guaranteed to only create one function counter
-         * for the same combination of name and tags.
-         * @param registry A registry to add the function counter to, if it doesn't
-         * already exist.
-         * @return A new or existing function counter.
+         * @param key The tag key.
+         * @param value The tag value.
+         * @return The function counter builder with a single added tag.
+         */
+        public TimeBasedBuilder<T> tag(String key, String value) {
+            this.tags = tags.and(key, value);
+            return this;
+        }
+
+        /**
+         * @param description Description text of the eventual function counter.
+         * @return The function counter builder with added description.
+         */
+        public TimeBasedBuilder<T> description(@Nullable String description) {
+            this.description = description;
+            return this;
+        }
+
+        /**
+         * Register the function counter with the registry. If a meter with the same name
+         * and tags is already registered, the existing function counter is returned and
+         * this registration call has no effect.
+         * @param registry Registry to register the function counter with.
+         * @return The registered function counter.
          */
         public FunctionCounter register(MeterRegistry registry) {
-            if (functionTimeUnit != null) {
-                return registry.more()
-                    .functionTimeCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj,
-                            functionTimeUnit, f);
-            }
-            return registry.more().counter(new Meter.Id(name, tags, baseUnit, description, Type.COUNTER), obj, f);
+            return registry.more()
+                .functionTimeCounter(new Meter.Id(name, tags, null, description, Type.COUNTER), obj, objToCountFunction,
+                        sourceUnit);
         }
 
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/FunctionCounter.java
@@ -163,19 +163,19 @@ public interface FunctionCounter extends Meter {
      * @param <T> The type of the state object from which the counter value is extracted.
      * @since 1.18.0
      */
-    class TimeBasedBuilder<T> {
+    final class TimeBasedBuilder<T> {
 
         private final String name;
 
+        private final T obj;
+
         private final ToDoubleFunction<T> objToCountFunction;
+
+        private final TimeUnit sourceUnit;
 
         private Tags tags = Tags.empty();
 
-        private final T obj;
-
         private @Nullable String description;
-
-        private final TimeUnit sourceUnit;
 
         private TimeBasedBuilder(String name, T obj, ToDoubleFunction<T> objToCountFunction, TimeUnit sourceUnit) {
             this.name = name;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1176,8 +1176,8 @@ public abstract class MeterRegistry {
         }
 
         /**
-         * A counter that tracks a time value, to be scaled to the {@link MeterRegistry}'s
-         * base time unit.
+         * A function-based counter that tracks a time value, to be scaled to the
+         * {@link MeterRegistry}'s base time unit.
          * @param id The identifier for this function counter.
          * @param obj State object used to compute a value.
          * @param functionTimeUnit The unit of time produced by the count function.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1176,24 +1176,23 @@ public abstract class MeterRegistry {
         }
 
         /**
-         * A counter that tracks a time value, to be scaled to the monitoring system's base
+         * A counter that tracks a time value, to be scaled to the {@link MeterRegistry}'s base
          * time unit.
          * @param id The identifier for this function counter.
          * @param obj State object used to compute a value.
-         * @param timeFunctionUnit The base unit of time produced by the count function.
+         * @param functionTimeUnit The unit of time produced by the count function.
          * @param countFunction Function that produces a monotonically increasing counter
          * value from the state object.
-         * @param <T> The type of the state object from which the counter value is
-         * extracted.
+         * @param <T> The type of the state object from which the counter value is extracted.
          * @return A new or existing function counter.
          */
-        <T> FunctionCounter timeFunctionCounter(Meter.Id id, T obj, TimeUnit timeFunctionUnit,
-                ToDoubleFunction<T> countFunction) {
+        <T> FunctionCounter functionTimeCounter(Meter.Id id, T obj, TimeUnit functionTimeUnit,
+                                                ToDoubleFunction<T> countFunction) {
             return registerMeterIfNecessary(FunctionCounter.class, id,
                     (registry, mappedId) -> {
                         Meter.Id withUnit = mappedId.withBaseUnit(registry.getBaseTimeUnitStr());
                         return registry.newFunctionCounter(withUnit, obj,
-                                obj2 -> TimeUtils.convert(countFunction.applyAsDouble(obj2), timeFunctionUnit,
+                                obj2 -> TimeUtils.convert(countFunction.applyAsDouble(obj2), functionTimeUnit,
                                         registry.getBaseTimeUnit()));
                     },
                     NoopFunctionCounter::new);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1176,6 +1176,30 @@ public abstract class MeterRegistry {
         }
 
         /**
+         * A counter that tracks a time value, to be scaled to the monitoring system's base
+         * time unit.
+         * @param id The identifier for this function counter.
+         * @param obj State object used to compute a value.
+         * @param timeFunctionUnit The base unit of time produced by the count function.
+         * @param countFunction Function that produces a monotonically increasing counter
+         * value from the state object.
+         * @param <T> The type of the state object from which the counter value is
+         * extracted.
+         * @return A new or existing function counter.
+         */
+        <T> FunctionCounter timeFunctionCounter(Meter.Id id, T obj, TimeUnit timeFunctionUnit,
+                ToDoubleFunction<T> countFunction) {
+            return registerMeterIfNecessary(FunctionCounter.class, id,
+                    (registry, mappedId) -> {
+                        Meter.Id withUnit = mappedId.withBaseUnit(registry.getBaseTimeUnitStr());
+                        return registry.newFunctionCounter(withUnit, obj,
+                                obj2 -> TimeUtils.convert(countFunction.applyAsDouble(obj2), timeFunctionUnit,
+                                        registry.getBaseTimeUnit()));
+                    },
+                    NoopFunctionCounter::new);
+        }
+
+        /**
          * A timer that tracks monotonically increasing functions for count and totalTime.
          * @param name Name of the timer being registered.
          * @param tags Sequence of dimensions for breaking down the name.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1176,26 +1176,24 @@ public abstract class MeterRegistry {
         }
 
         /**
-         * A counter that tracks a time value, to be scaled to the {@link MeterRegistry}'s base
-         * time unit.
+         * A counter that tracks a time value, to be scaled to the {@link MeterRegistry}'s
+         * base time unit.
          * @param id The identifier for this function counter.
          * @param obj State object used to compute a value.
          * @param functionTimeUnit The unit of time produced by the count function.
          * @param countFunction Function that produces a monotonically increasing counter
          * value from the state object.
-         * @param <T> The type of the state object from which the counter value is extracted.
+         * @param <T> The type of the state object from which the counter value is
+         * extracted.
          * @return A new or existing function counter.
          */
         <T> FunctionCounter functionTimeCounter(Meter.Id id, T obj, TimeUnit functionTimeUnit,
-                                                ToDoubleFunction<T> countFunction) {
-            return registerMeterIfNecessary(FunctionCounter.class, id,
-                    (registry, mappedId) -> {
-                        Meter.Id withUnit = mappedId.withBaseUnit(registry.getBaseTimeUnitStr());
-                        return registry.newFunctionCounter(withUnit, obj,
-                                obj2 -> TimeUtils.convert(countFunction.applyAsDouble(obj2), functionTimeUnit,
-                                        registry.getBaseTimeUnit()));
-                    },
-                    NoopFunctionCounter::new);
+                ToDoubleFunction<T> countFunction) {
+            return registerMeterIfNecessary(FunctionCounter.class, id, (registry, mappedId) -> {
+                Meter.Id withUnit = mappedId.withBaseUnit(registry.getBaseTimeUnitStr());
+                return registry.newFunctionCounter(withUnit, obj, obj2 -> TimeUtils
+                    .convert(countFunction.applyAsDouble(obj2), functionTimeUnit, registry.getBaseTimeUnit()));
+            }, NoopFunctionCounter::new);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1180,15 +1180,15 @@ public abstract class MeterRegistry {
          * {@link MeterRegistry}'s base time unit.
          * @param id The identifier for this function counter.
          * @param obj State object used to compute a value.
-         * @param functionTimeUnit The unit of time produced by the count function.
          * @param countFunction Function that produces a monotonically increasing counter
          * value from the state object.
+         * @param functionTimeUnit The unit of time produced by the count function.
          * @param <T> The type of the state object from which the counter value is
          * extracted.
          * @return A new or existing function counter.
          */
-        <T> FunctionCounter functionTimeCounter(Meter.Id id, T obj, TimeUnit functionTimeUnit,
-                ToDoubleFunction<T> countFunction) {
+        <T> FunctionCounter functionTimeCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction,
+                TimeUnit functionTimeUnit) {
             return registerMeterIfNecessary(FunctionCounter.class, id, (registry, mappedId) -> {
                 Meter.Id withUnit = mappedId.withBaseUnit(registry.getBaseTimeUnitStr());
                 return registry.newFunctionCounter(withUnit, obj, obj2 -> TimeUtils

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
@@ -31,7 +31,7 @@ class FunctionCounterTest {
 
         AtomicLong n = new AtomicLong(1000);
         FunctionCounter c = FunctionCounter.builder("my.time.counter", n, AtomicLong::doubleValue)
-            .baseTimeUnit(TimeUnit.MILLISECONDS)
+            .timeUnit(TimeUnit.MILLISECONDS)
             .register(registry);
 
         assertThat(c.getId().getBaseUnit()).isEqualTo("seconds");

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FunctionCounterTest {
+
+    @Test
+    void hasBaseTimeUnit() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+
+        AtomicLong n = new AtomicLong(1000);
+        FunctionCounter c = FunctionCounter.builder("my.time.counter", n, AtomicLong::doubleValue)
+            .baseTimeUnit(TimeUnit.MILLISECONDS)
+            .register(registry);
+
+        assertThat(c.getId().getBaseUnit()).isEqualTo("seconds");
+        assertThat(c.count()).isEqualTo(1.0);
+    }
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
@@ -19,16 +19,17 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class FunctionCounterTest {
 
-    @Test
-    void hasBaseTimeUnit() {
-        MeterRegistry registry = new SimpleMeterRegistry();
+    MeterRegistry registry = new SimpleMeterRegistry();
 
+    @Test
+    void convertsCountUsingTimeUnit() {
         AtomicLong n = new AtomicLong(1000);
         FunctionCounter c = FunctionCounter.builder("my.time.counter", n, AtomicLong::doubleValue)
             .timeUnit(TimeUnit.MILLISECONDS)
@@ -36,6 +37,28 @@ class FunctionCounterTest {
 
         assertThat(c.getId().getBaseUnit()).isEqualTo("seconds");
         assertThat(c.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void timeUnitTakesPrecedenceOverBaseUnit() {
+        FunctionCounter functionCounter = FunctionCounter
+            .builder("my.time.counter", new AtomicInteger(), AtomicInteger::doubleValue)
+            .timeUnit(TimeUnit.MILLISECONDS)
+            .baseUnit("milliseconds")
+            .register(registry);
+
+        // SimpleMeterRegistry has baseTimeUnit of seconds
+        assertThat(functionCounter.getId().getBaseUnit()).isEqualTo("seconds");
+    }
+
+    @Test
+    void baseUnitNotIgnoredWhenTimeUnitIsNull() {
+        FunctionCounter functionCounter = FunctionCounter
+            .builder("jdbc.connections.created", new AtomicInteger(), AtomicInteger::doubleValue)
+            .baseUnit("connections")
+            .register(registry);
+
+        assertThat(functionCounter.getId().getBaseUnit()).isEqualTo("connections");
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.instrument.util.TimeUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -30,29 +31,28 @@ class FunctionCounterTest {
 
     @Test
     void convertsCountUsingTimeUnit() {
-        AtomicLong n = new AtomicLong(1000);
-        FunctionCounter c = FunctionCounter.builder("my.time.counter", n, AtomicLong::doubleValue)
-            .timeUnit(TimeUnit.MILLISECONDS)
+        long countInMs = 1000;
+        AtomicLong n = new AtomicLong(countInMs);
+        FunctionCounter c = FunctionCounter
+            .builder("my.time.counter", n, AtomicLong::doubleValue, TimeUnit.MILLISECONDS)
             .register(registry);
 
-        assertThat(c.getId().getBaseUnit()).isEqualTo("seconds");
-        assertThat(c.count()).isEqualTo(1.0);
+        double countInSeconds = TimeUtils.convert((double) countInMs, TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+        assertThat(c.count()).describedAs("SimpleMeterRegistry has baseTimeUnit of seconds").isEqualTo(countInSeconds);
     }
 
     @Test
-    void timeUnitTakesPrecedenceOverBaseUnit() {
+    void registryBaseTimeUnitIsUsed() {
         FunctionCounter functionCounter = FunctionCounter
-            .builder("my.time.counter", new AtomicInteger(), AtomicInteger::doubleValue)
-            .timeUnit(TimeUnit.MILLISECONDS)
-            .baseUnit("milliseconds")
+            .builder("my.time.counter", new AtomicInteger(), AtomicInteger::doubleValue, TimeUnit.MILLISECONDS)
             .register(registry);
 
-        // SimpleMeterRegistry has baseTimeUnit of seconds
-        assertThat(functionCounter.getId().getBaseUnit()).isEqualTo("seconds");
+        assertThat(functionCounter.getId().getBaseUnit()).describedAs("SimpleMeterRegistry has baseTimeUnit of seconds")
+            .isEqualTo("seconds");
     }
 
     @Test
-    void baseUnitNotIgnoredWhenTimeUnitIsNull() {
+    void baseUnitNotIgnoredWhenNotTimeBased() {
         FunctionCounter functionCounter = FunctionCounter
             .builder("jdbc.connections.created", new AtomicInteger(), AtomicInteger::doubleValue)
             .baseUnit("connections")

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/FunctionCounterTest.java
@@ -61,4 +61,69 @@ class FunctionCounterTest {
         assertThat(functionCounter.getId().getBaseUnit()).isEqualTo("connections");
     }
 
+    @Test
+    void tagsAndDescriptionPreservedForTimeBasedCounter() {
+        FunctionCounter functionCounter = FunctionCounter
+            .builder("my.time.counter", new AtomicInteger(), AtomicInteger::doubleValue, TimeUnit.MILLISECONDS)
+            .tags("env", "prod")
+            .tag("region", "us-east")
+            .description("Time-based counter description")
+            .register(registry);
+
+        assertThat(functionCounter.getId().getTag("env")).isEqualTo("prod");
+        assertThat(functionCounter.getId().getTag("region")).isEqualTo("us-east");
+        assertThat(functionCounter.getId().getDescription()).isEqualTo("Time-based counter description");
+    }
+
+    @Test
+    void scalesToDifferentRegistryBaseUnits() {
+        MeterRegistry millisRegistry = new SimpleMeterRegistry() {
+            @Override
+            protected TimeUnit getBaseTimeUnit() {
+                return TimeUnit.MILLISECONDS;
+            }
+        };
+
+        AtomicLong state = new AtomicLong(5000);
+
+        FunctionCounter secondsCounter = FunctionCounter
+            .builder("my.time.counter", state, AtomicLong::doubleValue, TimeUnit.MILLISECONDS)
+            .register(registry);
+
+        FunctionCounter millisCounter = FunctionCounter
+            .builder("my.time.counter", state, AtomicLong::doubleValue, TimeUnit.MILLISECONDS)
+            .register(millisRegistry);
+
+        assertThat(secondsCounter.count()).isEqualTo(5.0);
+        assertThat(millisCounter.count()).isEqualTo(5000.0);
+        assertThat(millisCounter.getId().getBaseUnit()).isEqualTo("milliseconds");
+    }
+
+    @Test
+    void reRegistrationReturnsExistingInstance() {
+        AtomicLong state1 = new AtomicLong(100);
+        AtomicLong state2 = new AtomicLong(200);
+
+        FunctionCounter counter1 = FunctionCounter
+            .builder("my.time.counter", state1, AtomicLong::doubleValue, TimeUnit.MILLISECONDS)
+            .register(registry);
+
+        FunctionCounter counter2 = FunctionCounter
+            .builder("my.time.counter", state2, AtomicLong::doubleValue, TimeUnit.MILLISECONDS)
+            .register(registry);
+
+        assertThat(counter2).isSameAs(counter1);
+        assertThat(counter2.count()).isEqualTo(0.1);
+    }
+
+    @Test
+    void handlesFractionalTimeValues() {
+        AtomicLong micros = new AtomicLong(1500);
+        FunctionCounter counter = FunctionCounter
+            .builder("my.time.counter", micros, AtomicLong::doubleValue, TimeUnit.MICROSECONDS)
+            .register(registry);
+
+        assertThat(counter.count()).isEqualTo(0.0015);
+    }
+
 }


### PR DESCRIPTION
Without this change, FunctionCounters that track time do not get converted to the registry's base time unit. That's unexpected for some users. Prometheus, for example, expects time to be in seconds, but many (all?) current metrics are not in that base unit because the underlying function does not return seconds. Even if it did, another registry may expect a different time unit.

* Add a `TimeBasedBuilder` to FunctionCounter and a static `builder` overload that takes a `TimeUnit` along with the `ToDoubleFunction`
* Add package-private method `functionTimeCounter` to `MeterRegistry.More` to create a `FunctionCounter` that scales its value to the registry's base time unit
* This is analogous to how `TimeGauge` works, and provides a way to register monotonically increasing time values (like `jvm.gc.cpu.time` or `process.cpu.time`) in a way that automatically scales to the preferred time unit of the metrics backend.

See comments on https://github.com/micrometer-metrics/micrometer/pull/7297 for background motivating this change.

An alternative would be introducing a dedicated type such as `FunctionTimeCounter` which would perhaps make the feature more discoverable but obviously has more public API to support when the difference to a `FunctionCounter` is tiny.