### PR TITLE
Clear the state of the ObservationValidator

### DIFF
--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/ObservationValidator.java
@@ -44,22 +44,22 @@ import static io.micrometer.observation.tck.TestObservationRegistry.Capability.*
  */
 class ObservationValidator implements ObservationHandler<Context> {
 
+    private final Set<Capability> capabilities;
+
     private final Consumer<ValidationResult> consumer;
 
     private final Predicate<Context> supportsContextPredicate;
 
     private final Map<String, Set<String>> lowCardinalityKeysByObservationName;
 
-    private final ThreadLocal<Deque<Context>> scopedContexts;
-
-    private final Set<Capability> capabilities;
+    private ThreadLocal<Deque<Context>> scopedContexts;
 
     ObservationValidator(Set<Capability> capabilities) {
+        this.capabilities = capabilities;
         this.consumer = ObservationValidator::throwInvalidObservationException;
         this.supportsContextPredicate = context -> !(context instanceof NullContext);
         this.lowCardinalityKeysByObservationName = new HashMap<>();
         this.scopedContexts = ThreadLocal.withInitial(ArrayDeque::new);
-        this.capabilities = capabilities;
     }
 
     @Override
@@ -154,6 +154,11 @@ class ObservationValidator implements ObservationHandler<Context> {
     @Override
     public boolean supportsContext(Context context) {
         return supportsContextPredicate.test(context);
+    }
+
+    void clear() {
+        this.lowCardinalityKeysByObservationName.clear();
+        this.scopedContexts = ThreadLocal.withInitial(ArrayDeque::new);
     }
 
     private History addHistoryElement(Context context, EventName eventName) {

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -37,12 +37,17 @@ import static io.micrometer.observation.tck.TestObservationRegistry.Capability.O
 public final class TestObservationRegistry
         implements ObservationRegistry, AssertProvider<TestObservationRegistryAssert> {
 
-    private final ObservationRegistry delegate = ObservationRegistry.create();
+    private final ObservationRegistry delegate;
 
-    private final StoringObservationHandler handler = new StoringObservationHandler();
+    private final StoringObservationHandler handler;
+
+    private final ObservationValidator validator;
 
     private TestObservationRegistry(Set<Capability> capabilities) {
-        observationConfig().observationHandler(this.handler).observationHandler(new ObservationValidator(capabilities));
+        this.delegate = ObservationRegistry.create();
+        this.handler = new StoringObservationHandler();
+        this.validator = new ObservationValidator(capabilities);
+        observationConfig().observationHandler(this.handler).observationHandler(this.validator);
     }
 
     /**
@@ -86,11 +91,12 @@ public final class TestObservationRegistry
     }
 
     /**
-     * Clears the stored {@link Observation.Context}.
+     * Clears the stored {@link Observation.Context} and the state of the validator.
      * @since 1.11.0
      */
     public void clear() {
-        getContexts().clear();
+        this.handler.clear();
+        this.validator.clear();
     }
 
     /**
@@ -107,7 +113,7 @@ public final class TestObservationRegistry
 
     private static class StoringObservationHandler implements ObservationHandler<Observation.Context> {
 
-        final Queue<TestObservationContext> contexts = new ConcurrentLinkedQueue<>();
+        private final Queue<TestObservationContext> contexts = new ConcurrentLinkedQueue<>();
 
         @Override
         public void onStart(Observation.Context context) {
@@ -133,6 +139,10 @@ public final class TestObservationRegistry
                 .filter(testContext -> testContext.getContext() == context)
                 .findFirst()
                 .ifPresent(testContext -> testContext.addEvent(event));
+        }
+
+        private void clear() {
+            this.contexts.clear();
         }
 
     }

--- a/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
+++ b/micrometer-observation-test/src/test/java/io/micrometer/observation/tck/ObservationValidatorTests.java
@@ -258,8 +258,12 @@ class ObservationValidatorTests {
         Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
     }
 
-    private void verifyThatValidateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeysWorks(
-            TestObservationRegistry registry) {
+    @Test
+    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysWhenEnabledUsingTheBuilder() {
+        TestObservationRegistry registry = TestObservationRegistry.builder()
+            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(true)
+            .build();
+
         Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
         assertThatThrownBy(() -> Observation.createNotStarted("test", registry).start().stop())
             .isExactlyInstanceOf(InvalidObservationException.class)
@@ -274,22 +278,6 @@ class ObservationValidatorTests {
                     "Using a consistent set of low cardinality keys for Observations with the same name is recommended best practice if metrics will be produced from the Observations.");
 
         Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value2").start().stop();
-    }
-
-    @Test
-    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysIfEnabledUsingTheBuilder() {
-        TestObservationRegistry registry = TestObservationRegistry.builder()
-            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(true)
-            .build();
-        verifyThatValidateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeysWorks(registry);
-    }
-
-    @Test
-    void observationsWithTheSameNameShouldHaveTheSameSetOfLowCardinalityKeysWhenEnabledUsingTheBuilder() {
-        TestObservationRegistry registry = TestObservationRegistry.builder()
-            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(true)
-            .build();
-        verifyThatValidateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeysWorks(registry);
     }
 
     @Test
@@ -474,6 +462,27 @@ class ObservationValidatorTests {
         scope2.close();
         scope1.close();
         observation.stop();
+    }
+
+    @Test
+    void validatorShouldLoseStateWhenCleared() {
+        TestObservationRegistry registry = TestObservationRegistry.builder()
+            .validateObservationsWithTheSameNameHavingTheSameSetOfLowCardinalityKeys(true)
+            .validateScopesClosedInReverseOrderOfOpening(true)
+            .build();
+
+        // verify if the validator forgets low cardinality key-values
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key1", "value1").start().stop();
+        registry.clear();
+        Observation.createNotStarted("test", registry).lowCardinalityKeyValue("key2", "value2").start().stop();
+
+        // verify if the validator forgets the opened scopes
+        Observation outerObservation = Observation.start("outerObservation", registry);
+        Scope outerScope = outerObservation.openScope();
+        Scope innerScope = Observation.start("innerObservation", registry).openScope();
+        registry.clear();
+        outerScope.close();
+        innerScope.close();
     }
 
 }


### PR DESCRIPTION
In gh-7295 a ThreadLocal was introduced and elements are only added to it, never removed.

Also, it was reported in gh-6713 that in some cases reusing TestObservationRegistry can trigger validation issues since the validator remembers all the low cardinality key-values that were recorded previously.

Both of the issues can be worked around by creating a new TestObservationRegistry instance, however in some cases clearing its memory might be more convenient.

See gh-7295
See gh-6713