### PR TITLE
Fix build cache misses in statsd shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,7 +222,9 @@ subprojects {
                             'Branch',
                             'Module-Origin',
                             'Created-By',
-                            'Build-Java-Version'
+                            'Build-Java-Version',
+                            'Build-Timezone',
+                            'Build-Url'
                     ].each {
                         ignoreAttribute it
                         ignoreProperty it

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -33,6 +33,10 @@ nebulaPublishVerification {
     ignore('io.netty:netty-transport-native-kqueue')
 }
 
+tasks.named('jar') {
+    enabled = false
+}
+
 shadowJar {
     configurations = [project.configurations.compileClasspath]
     archiveClassifier.set('')


### PR DESCRIPTION
## Summary
- Disable the `jar` task in `micrometer-registry-statsd` to eliminate overlapping outputs with `shadowJar` (both write to `build/libs/micrometer-registry-statsd-<version>.jar` due to `archiveClassifier.set('')`), which causes build cache misses
- Add `Build-Timezone` and `Build-Url` to MANIFEST.MF normalization to prevent additional cache misses across environments

[Build scan with overlapping outputs](https://ge.solutions-team.gradle.com/s/srojpheqbamum/timeline?cacheability=overlapping-outputs&details=jo55s34dioyvc&hide-timeline&kind=task&outcome=success,failed&sort=longest)