### PR TITLE
Add executor.delayed gauge for ForkJoinPool on Java 25+

### DIFF
--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -55,6 +55,7 @@ another. The reported value underestimates the actual total number of steals whe
 * `executor.running` (`Gauge`): An estimate of the number of worker threads that are not blocked but are waiting to join tasks or for other managed synchronization threads.
 * `executor.parallelism` (`Gauge`): The targeted parallelism level of this pool.
 * `executor.pool.size` (`Gauge`): The current number of threads in the pool.
+* `executor.delayed` (`Gauge`): An estimate of the number of delayed (including periodic) tasks scheduled but not yet ready for execution. Available on Java 25+.
 
 To use the following `ExecutorService` instances, `--add-opens java.base/java.util.concurrent=ALL-UNNAMED` is required:
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -62,6 +62,7 @@ import static java.util.stream.Collectors.toSet;
  * @author Jon Schneider
  * @author Clint Checketts
  * @author Johnny Lim
+ * @author Daeho Kwon
  */
 public class ExecutorServiceMetrics implements MeterBinder {
 
@@ -70,6 +71,8 @@ public class ExecutorServiceMetrics implements MeterBinder {
     private static final String METHOD_NAME_THREAD_PER_TASK_EXECUTOR_THREAD_COUNT = "threadCount";
 
     private static final @Nullable MethodHandle METHOD_HANDLE_THREAD_COUNT_FROM_THREAD_PER_TASK_EXECUTOR = getMethodHandleForThreadCountFromThreadPerTaskExecutor();
+
+    private static final @Nullable MethodHandle METHOD_HANDLE_FJP_GET_DELAYED_TASK_COUNT = getMethodHandleForDelayedTaskCount();
 
     private static boolean allowIllegalReflectiveAccess = true;
 
@@ -459,6 +462,17 @@ public class ExecutorServiceMetrics implements MeterBinder {
                     .baseUnit(BaseUnits.THREADS)
                     .register(registry));
         registeredMeterIds.addAll(meters.stream().map(Meter::getId).collect(toSet()));
+
+        // getDelayedTaskCount() was added in Java 25; only register when available
+        if (METHOD_HANDLE_FJP_GET_DELAYED_TASK_COUNT != null) {
+            Meter delayedGauge = Gauge
+                .builder(metricPrefix + "executor.delayed", fj, ExecutorServiceMetrics::getDelayedTaskCount)
+                .tags(tags)
+                .description("An estimate of the number of delayed tasks scheduled but not yet ready for execution")
+                .baseUnit(BaseUnits.TASKS)
+                .register(registry);
+            registeredMeterIds.add(delayedGauge.getId());
+        }
     }
 
     private void monitorThreadPerTaskExecutor(MeterRegistry registry, ExecutorService executorService) {
@@ -493,6 +507,25 @@ public class ExecutorServiceMetrics implements MeterBinder {
             Class<?> clazz = Class.forName(CLASS_NAME_THREAD_PER_TASK_EXECUTOR);
             Method method = clazz.getMethod(METHOD_NAME_THREAD_PER_TASK_EXECUTOR_THREAD_COUNT);
             method.setAccessible(true);
+            return MethodHandles.lookup().unreflect(method);
+        }
+        catch (Throwable e) {
+            return null;
+        }
+    }
+
+    private static long getDelayedTaskCount(ForkJoinPool pool) {
+        try {
+            return (long) Objects.requireNonNull(METHOD_HANDLE_FJP_GET_DELAYED_TASK_COUNT).invoke(pool);
+        }
+        catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static @Nullable MethodHandle getMethodHandleForDelayedTaskCount() {
+        try {
+            Method method = ForkJoinPool.class.getMethod("getDelayedTaskCount");
             return MethodHandles.lookup().unreflect(method);
         }
         catch (Throwable e) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetricsTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.binder.jvm;
 
 import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
@@ -26,6 +27,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -43,6 +45,7 @@ import static org.awaitility.Awaitility.await;
  * @author Jon Schneider
  * @author Johnny Lim
  * @author Sebastian Lövdahl
+ * @author Daeho Kwon
  */
 class ExecutorServiceMetricsTest {
 
@@ -355,6 +358,39 @@ class ExecutorServiceMetricsTest {
 
         assertThat(queued).isEqualTo(2.0);
 
+        pool.shutdown();
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_25)
+    @DisplayName("ForkJoinPool executor.delayed gauge reflects delayed tasks on Java 25+")
+    @Test
+    void forkJoinPoolDelayedTaskCountMetric() {
+        ForkJoinPool pool = new ForkJoinPool(1);
+        ExecutorServiceMetrics.monitor(registry, pool, "myFjp", userTags);
+
+        Gauge gauge = registry.get("executor.delayed").tags(userTags).tag("name", "myFjp").gauge();
+        assertThat(gauge.value()).isEqualTo(0.0);
+
+        ScheduledFuture<?> future = ((ScheduledExecutorService) pool).schedule(() -> {
+        }, 10, TimeUnit.SECONDS);
+        try {
+            await().untilAsserted(() -> assertThat(gauge.value()).isEqualTo(1.0));
+        }
+        finally {
+            future.cancel(true);
+            pool.shutdown();
+        }
+
+        await().untilAsserted(() -> assertThat(gauge.value()).isEqualTo(0.0));
+    }
+
+    @DisabledForJreRange(min = JRE.JAVA_25)
+    @DisplayName("ForkJoinPool executor.delayed gauge is not registered on Java versions before 25")
+    @Test
+    void forkJoinPoolDelayedGaugeNotRegisteredBeforeJava25() {
+        ForkJoinPool pool = new ForkJoinPool(1);
+        ExecutorServiceMetrics.monitor(registry, pool, "myFjp", userTags);
+        assertThatThrownBy(() -> registry.get("executor.delayed").gauge()).isInstanceOf(MeterNotFoundException.class);
         pool.shutdown();
     }
 


### PR DESCRIPTION
## Summary

Closes #6381

- Adds `executor.delayed` gauge for `ForkJoinPool` using `getDelayedTaskCount()` introduced in Java 25
- The gauge is conditionally registered via reflection, so it remains compatible with Java versions before 25
- Updates documentation to describe the new metric