### PR TITLE
Add logger exclusion support to Log4j2Metrics and LogbackMetrics

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/LoggerExclusionBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/LoggerExclusionBenchmark.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Fork(2)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.SampleTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class LoggerExclusionBenchmark {
+
+    private SimpleMeterRegistry meterRegistry;
+
+    private LogbackMetrics logbackMetrics;
+
+    private LoggerContext loggerContext;
+
+    private Logger logger;
+
+    @Param({ "none", "empty", "small" })
+    private String exclusionMode;
+
+    @Setup
+    public void setup() {
+        meterRegistry = new SimpleMeterRegistry();
+        loggerContext = new LoggerContext();
+        loggerContext.getLogger(Logger.ROOT_LOGGER_NAME).setLevel(Level.INFO);
+
+        switch (exclusionMode) {
+            case "none":
+                logbackMetrics = new LogbackMetrics(Collections.emptyList(), loggerContext);
+                break;
+            case "empty":
+                logbackMetrics = new LogbackMetrics(Collections.emptyList(), loggerContext, Collections.emptySet());
+                break;
+            case "small":
+                logbackMetrics = new LogbackMetrics(Collections.emptyList(), loggerContext,
+                        Set.of("com.example.foo", "com.example.bar"));
+                break;
+        }
+        logbackMetrics.bindTo(meterRegistry);
+
+        logger = loggerContext.getLogger("com.example.app.service");
+    }
+
+    @TearDown
+    public void tearDown() {
+        if (logbackMetrics != null) {
+            logbackMetrics.close();
+        }
+    }
+
+    @Benchmark
+    public void logEvent() {
+        logger.info("benchmark message");
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(LoggerExclusionBenchmark.class.getSimpleName()).build()).run();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -33,12 +33,16 @@ import org.apache.logging.log4j.core.filter.CompositeFilter;
 
 import java.beans.PropertyChangeListener;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 /**
  * {@link MeterBinder} for Apache Log4j 2. Please use at least 2.21.0 since there was a
@@ -64,6 +68,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private final LoggerContext loggerContext;
 
+    private final Set<String> excludedLoggerNames;
+
     private final ConcurrentMap<MeterRegistry, MetricsFilter> metricsFilters = new ConcurrentHashMap<>();
 
     private final List<PropertyChangeListener> changeListeners = new CopyOnWriteArrayList<>();
@@ -77,8 +83,13 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
     }
 
     public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext) {
+        this(tags, loggerContext, emptySet());
+    }
+
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, Set<String> excludedLoggerNames) {
         this.tags = tags;
         this.loggerContext = loggerContext;
+        this.excludedLoggerNames = Collections.unmodifiableSet(new HashSet<>(excludedLoggerNames));
     }
 
     @Override
@@ -135,7 +146,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private MetricsFilter getOrCreateMetricsFilterAndStart(MeterRegistry registry) {
         return metricsFilters.computeIfAbsent(registry, r -> {
-            MetricsFilter metricsFilter = new MetricsFilter(r, tags);
+            MetricsFilter metricsFilter = new MetricsFilter(r, tags, excludedLoggerNames);
             metricsFilter.start();
             return metricsFilter;
         });
@@ -173,6 +184,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     static class MetricsFilter extends AbstractFilter {
 
+        private final Set<String> excludedLoggerNames;
+
         private final Counter fatalCounter;
 
         private final Counter errorCounter;
@@ -185,7 +198,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         private final Counter traceCounter;
 
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
+        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, Set<String> excludedLoggerNames) {
+            this.excludedLoggerNames = excludedLoggerNames;
             fatalCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "fatal")
@@ -231,7 +245,9 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         @Override
         public Result filter(LogEvent event) {
-            incrementCounter(event);
+            if (!excludedLoggerNames.contains(event.getLoggerName())) {
+                incrementCounter(event);
+            }
             return Result.NEUTRAL;
         }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -30,11 +30,15 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.LongAdder;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 /**
  * Metrics instrumentation of Logback log events. Counts the log events with a log level
@@ -49,6 +53,8 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
     private final Iterable<Tag> tags;
 
     private final LoggerContext loggerContext;
+
+    private final Set<String> excludedLoggerNames;
 
     private final Map<MeterRegistry, MetricsTurboFilter> metricsTurboFilters = new HashMap<>();
 
@@ -67,8 +73,13 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
     }
 
     public LogbackMetrics(Iterable<Tag> tags, LoggerContext context) {
+        this(tags, context, emptySet());
+    }
+
+    public LogbackMetrics(Iterable<Tag> tags, LoggerContext context, Set<String> excludedLoggerNames) {
         this.tags = tags;
         this.loggerContext = context;
+        this.excludedLoggerNames = Collections.unmodifiableSet(new HashSet<>(excludedLoggerNames));
 
         loggerContext.addListener(new LoggerContextListener() {
             @Override
@@ -105,7 +116,7 @@ public class LogbackMetrics implements MeterBinder, AutoCloseable {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        MetricsTurboFilter filter = new MetricsTurboFilter(registry, tags);
+        MetricsTurboFilter filter = new MetricsTurboFilter(registry, tags, excludedLoggerNames);
         synchronized (metricsTurboFilters) {
             metricsTurboFilters.put(registry, filter);
             loggerContext.addTurboFilter(filter);
@@ -144,6 +155,8 @@ class MetricsTurboFilter extends TurboFilter {
 
     private static final String METER_DESCRIPTION = "Number of log events that were enabled by the effective log level";
 
+    private final Set<String> excludedLoggerNames;
+
     private final LongAdder errorCount = new LongAdder();
 
     private final LongAdder warnCount = new LongAdder();
@@ -154,7 +167,8 @@ class MetricsTurboFilter extends TurboFilter {
 
     private final LongAdder traceCount = new LongAdder();
 
-    MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags) {
+    MetricsTurboFilter(MeterRegistry registry, Iterable<Tag> tags, Set<String> excludedLoggerNames) {
+        this.excludedLoggerNames = excludedLoggerNames;
         FunctionCounter.builder(METER_NAME, errorCount, LongAdder::doubleValue)
             .tags(tags)
             .tags("level", "error")
@@ -203,7 +217,9 @@ class MetricsTurboFilter extends TurboFilter {
             return FilterReply.NEUTRAL;
         }
 
-        recordMetrics(level);
+        if (!excludedLoggerNames.contains(logger.getName())) {
+            recordMetrics(level);
+        }
 
         return FilterReply.NEUTRAL;
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -366,6 +367,60 @@ class Log4j2MetricsTest {
 
         logger.error("third");
         assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(2);
+    }
+
+    @Issue("#6233")
+    @Test
+    void excludedLoggerShouldNotBeCounted() {
+        LoggerContext loggerContext = new LoggerContext("test");
+        Configuration configuration = loggerContext.getConfiguration();
+        configuration.getRootLogger().setLevel(Level.INFO);
+        loggerContext.updateLoggers(configuration);
+
+        new Log4j2Metrics(emptyList(), loggerContext, Collections.singleton("com.test.excluded")).bindTo(registry);
+
+        Logger excludedLogger = loggerContext.getLogger("com.test.excluded");
+        Logger includedLogger = loggerContext.getLogger("com.test.included");
+
+        excludedLogger.info("should not be counted");
+        includedLogger.info("should be counted");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+    }
+
+    @Issue("#6233")
+    @Test
+    void excludeDoesNotAffectChildLoggers() {
+        LoggerContext loggerContext = new LoggerContext("test");
+        Configuration configuration = loggerContext.getConfiguration();
+        configuration.getRootLogger().setLevel(Level.INFO);
+        loggerContext.updateLoggers(configuration);
+
+        new Log4j2Metrics(emptyList(), loggerContext, Collections.singleton("com.test")).bindTo(registry);
+
+        Logger parentLogger = loggerContext.getLogger("com.test");
+        Logger childLogger = loggerContext.getLogger("com.test.child");
+
+        parentLogger.info("should not be counted");
+        childLogger.info("should be counted");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+    }
+
+    @Issue("#6233")
+    @Test
+    void emptyExcludeSetBehavesLikeDefault() {
+        LoggerContext loggerContext = new LoggerContext("test");
+        Configuration configuration = loggerContext.getConfiguration();
+        configuration.getRootLogger().setLevel(Level.INFO);
+        loggerContext.updateLoggers(configuration);
+
+        new Log4j2Metrics(emptyList(), loggerContext, Collections.emptySet()).bindTo(registry);
+
+        Logger logger = loggerContext.getLogger("com.test");
+        logger.info("should be counted");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
     }
 
     @Issue("#5901")

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -124,6 +126,65 @@ class LogbackMetricsTest {
         logger.atWarn().setMessage("test warn log with fluent builder").log();
 
         assertThat(registry.get("logback.events").tags("level", "warn").functionCounter().count()).isEqualTo(1.0);
+    }
+
+    @Issue("#6233")
+    @Test
+    void excludedLoggerShouldNotBeCounted() {
+        logbackMetrics.close();
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        logbackMetrics = new LogbackMetrics(emptyList(), loggerContext, Collections.singleton("com.test.excluded"));
+        logbackMetrics.bindTo(registry);
+
+        Logger excludedLogger = loggerContext.getLogger("com.test.excluded");
+        excludedLogger.setLevel(Level.INFO);
+        Logger includedLogger = loggerContext.getLogger("com.test.included");
+        includedLogger.setLevel(Level.INFO);
+
+        excludedLogger.info("should not be counted");
+        includedLogger.info("should be counted");
+
+        assertThat(registry.get("logback.events").tags("level", "info").functionCounter().count()).isEqualTo(1.0);
+    }
+
+    @Issue("#6233")
+    @Test
+    void excludeDoesNotAffectChildLoggers() {
+        logbackMetrics.close();
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        logbackMetrics = new LogbackMetrics(emptyList(), loggerContext, Collections.singleton("com.test"));
+        logbackMetrics.bindTo(registry);
+
+        Logger parentLogger = loggerContext.getLogger("com.test");
+        parentLogger.setLevel(Level.INFO);
+        Logger childLogger = loggerContext.getLogger("com.test.child");
+        childLogger.setLevel(Level.INFO);
+
+        parentLogger.info("should not be counted");
+        childLogger.info("should be counted");
+
+        assertThat(registry.get("logback.events").tags("level", "info").functionCounter().count()).isEqualTo(1.0);
+    }
+
+    @Issue("#6233")
+    @Test
+    void emptyExcludeSetBehavesLikeDefault() {
+        logbackMetrics.close();
+        registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        logbackMetrics = new LogbackMetrics(emptyList(), loggerContext, Collections.emptySet());
+        logbackMetrics.bindTo(registry);
+
+        Logger testLogger = loggerContext.getLogger("com.test");
+        testLogger.setLevel(Level.INFO);
+        testLogger.info("should be counted");
+
+        assertThat(registry.get("logback.events").tags("level", "info").functionCounter().count()).isEqualTo(1.0);
     }
 
     @NullMarked


### PR DESCRIPTION
closes gh-6233 
This pr adds the ability to exclude specific loggers from being counted by `Log4j2Metrics` and `LogbackMetrics`. Excluded loggers are matched by exact name using a `HashSet` for O(1) lookup performance.

## Changes
- Add `Set<String> excludeLoggerNames` parameter to `Log4j2Metrics` and `LogbackMetrics` through new constructor overloads.
- Existing constructors delegate with `emptySet()` to maintain backward compatibility.

## Design Decisions
- Exact match over hierarchical matching: as suggested in [issue-comment](https://github.com/micrometer-metrics/micrometer/issues/6233#issuecomment-2877494673), exact match keeps the implementation simple and avoids performance concerns on the hot path
- `Set<String>` over `Predicate<String>`: guarantees high performance(O(1) lookup and zero overhead) when the set is empty.