### PR TITLE
Add OtlpMeterRegistry constructor for custom OtlpHttpMetricsSender

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -118,7 +118,8 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         this(config, clock, threadFactory, new OtlpHttpMetricsSender(new HttpUrlConnectionSender()), null);
     }
 
-    public OtlpMeterRegistry(OtlpConfig config, Clock clock, ThreadFactory threadFactory, OtlpHttpMetricsSender otlpHttpMetricsSender) {
+    public OtlpMeterRegistry(OtlpConfig config, Clock clock, ThreadFactory threadFactory,
+                             OtlpHttpMetricsSender otlpHttpMetricsSender) {
         this(config, clock, threadFactory, otlpHttpMetricsSender, null);
     }
 


### PR DESCRIPTION
Currently OtlpMeterRegistry only provides constructors with a built in OtlpHttpMetricsSender using JDK HttpUrlConnectionSender. Allowing a constructor also for a provided OtlpHttpMetricsSender could allow to use more efficient http clients implementation than the JDK one.