### PR TITLE
Introduce per-convention meter convention types and builder pattern

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -14,7 +14,7 @@
 ** xref:concepts/long-task-timers.adoc[Long Task Timers]
 ** xref:concepts/histogram-quantiles.adoc[Histograms and Percentiles]
 ** xref:concepts/meter-provider.adoc[Meter Provider]
-** xref:concepts/meter-convention.adoc[Meter Convention]
+** xref:concepts/meter-convention.adoc[Meter Conventions]
 ** xref:concepts/high-cardinality-tags-detector.adoc[High Cardinality Tags Detector]
 * xref:implementations.adoc[Implementations]
 ** xref:implementations/appOptics.adoc[AppOptics]

--- a/docs/modules/ROOT/pages/concepts/meter-convention.adoc
+++ b/docs/modules/ROOT/pages/concepts/meter-convention.adoc
@@ -1,7 +1,56 @@
-[[meter-convention]]
-= Meter Convention
+[[meter-conventions]]
+= Meter Conventions
 
-While `MeterFilter` can be used to customize the name and tags (collectively, the convention) of Meters in any instrumentation, it can be more convenient and robust to customize the convention for a common instrumentation more directly.
-This is the purpose of the `MeterConvention`.
+While `MeterFilter` can be used to customize the name and tags (collectively, the convention) of meters in any instrumentation, configuring meter conventions directly on binders allows you to customize the meters before registration.
 
-For examples of its usage in instrumentation provided by Micrometer as well as examples of different implementations of a convention for an instrumentation, see the xref:../reference/jvm.adoc#meter-conventions[JVM metrics].
+== Overview
+
+A meter convention interface defines the canonical name and tags for a specific meter.
+Each meter has a dedicated convention interface (such as `JvmMemoryUsedMeterConvention` or `JvmClassCountMeterConvention`).
+
+`MeterBinder` implementations that support meter conventions provide a `builder()` API to configure:
+
+* Individual meter conventions
+* Common or extra tags applied across all meters produced by the binder
+* Standard convention presets (such as OpenTelemetry semantic conventions)
+
+== Customizing Meter Conventions
+
+Convention interfaces may provide static `of(...)` factory methods to conveniently create custom conventions inline without implementing full classes:
+
+[source, java]
+----
+ClassLoaderMetrics metrics = ClassLoaderMetrics.builder()
+    .classCountConvention(JvmClassCountMeterConvention.of("custom.class.count", Tags.of("type", "count")))
+    .classLoadedConvention(JvmClassLoadedMeterConvention.of("custom.class.loaded"))
+    .classUnloadedConvention(JvmClassUnloadedMeterConvention.of("custom.class.unloaded"))
+    .build();
+----
+
+For conventions that derive tags from a runtime context object (such as `MemoryPoolMXBean` or `Thread.State`), the `of(...)` factory method accepts a function that maps the context to `Tags`:
+
+[source, java]
+----
+JvmMemoryMetrics metrics = JvmMemoryMetrics.builder()
+    .memoryUsedConvention(JvmMemoryUsedMeterConvention.of("custom.memory.used",
+            pool -> Tags.of("custom.pool", pool.getName())))
+    .build();
+----
+
+== Semantic Conventions
+
+Micrometer provides convention implementations, including defaults based on historical Micrometer conventions and implementations following OpenTelemetry semantic conventions.
+
+For examples of available conventions and OpenTelemetry configuration, see xref:../reference/jvm.adoc#meter-conventions[JVM metrics].
+
+== Relationship with Naming Conventions
+
+A meter convention is distinct from a xref:./naming.adoc[Naming Convention]:
+
+* **Meter Convention**: Defines the canonical metric name and semantic tag keys and values for a specific meter before it is registered (for example, `jvm.memory.used` with tag `jvm.memory.type=heap`).
+* **Naming Convention (`NamingConvention`)**: Transforms that canonical name and tag keys into the syntax and format required by a specific monitoring system (for example, `jvm_memory_used_bytes` for Prometheus vs. `jvmMemoryUsed` for Atlas).
+
+== When to Use Meter Conventions vs. Observation Conventions
+
+* Use **Meter Conventions** for instrumentation instrumented directly with the metrics API, such as gauges, state-derived function counters, or resource meters (for example, JVM memory, thread states, CPU load).
+* If you are timing an operation or instrumenting a request lifecycle, use the xref:../observation/introduction.adoc[Observation API] and xref:../observation/components.adoc#micrometer-observation-convention-example[Observation Conventions] instead.

--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -95,19 +95,19 @@ ProcessorMetrics.builder().openTelemetryConventions().build().bindTo(registry);
 You can also configure individual OpenTelemetry convention implementations on each binder builder:
 
 * `ClassLoaderMetrics`:
-** `OpenTelemetryJvmClassCountMeterConvention`
-** `OpenTelemetryJvmClassLoadedMeterConvention`
-** `OpenTelemetryJvmClassUnloadedMeterConvention`
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclasscount[`OpenTelemetryJvmClassCountMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclassloaded[`OpenTelemetryJvmClassLoadedMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclassunloaded[`OpenTelemetryJvmClassUnloadedMeterConvention`]
 * `JvmMemoryMetrics`:
-** `OpenTelemetryJvmMemoryUsedMeterConvention`
-** `OpenTelemetryJvmMemoryCommittedMeterConvention`
-** `OpenTelemetryJvmMemoryMaxMeterConvention`
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemoryused[`OpenTelemetryJvmMemoryUsedMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemorycommitted[`OpenTelemetryJvmMemoryCommittedMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemorylimit[`OpenTelemetryJvmMemoryMaxMeterConvention`]
 * `JvmThreadMetrics`:
-** `OpenTelemetryJvmThreadCountMeterConvention`
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount[`OpenTelemetryJvmThreadCountMeterConvention`]
 * `ProcessorMetrics`:
-** `OpenTelemetryJvmCpuTimeMeterConvention`
-** `OpenTelemetryJvmCpuCountMeterConvention`
-** `OpenTelemetryJvmCpuLoadMeterConvention`
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcputime[`OpenTelemetryJvmCpuTimeMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcpucount[`OpenTelemetryJvmCpuCountMeterConvention`]
+** https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcpurecent_utilization[`OpenTelemetryJvmCpuLoadMeterConvention`]
 
 === Customizing Individual Conventions
 

--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -69,24 +69,59 @@ To use the following `ExecutorService` instances, `--add-opens java.base/java.ut
 
 See also the general xref:../concepts/meter-convention.adoc[Meter Conventions] documentation.
 
-The following `MeterBinder` implementations have a constructor to customize the convention used for some or all of the meters they produce.
-This can be used as an alternative to customizing the Meter names and tags with a `MeterFilter`.
+The following `MeterBinder` implementations provide a `builder()` to customize the convention used for some or all of the meters they produce:
 
 * `ClassLoaderMetrics`
 * `JvmMemoryMetrics`
 * `JvmThreadMetrics`
-* `ProcessorMetrics`
+* `ProcessorMetrics` (see also xref:./system.adoc#system-processor[System Processor Metrics])
+
+This can be used as an alternative to customizing Meter names and tags with a `MeterFilter`.
 
 === OpenTelemetry Semantic Conventions
 
-We provide `MeterConvention` implementations of the applicable https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/[OpenTelemetry semantic conventions for JVM metrics] that have been marked stable as of the version 1.37.0.
-These can be passed to the constructors of the above binders to change the convention from the default.
-Use the following classes:
+Micrometer provides implementations of the applicable https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/[OpenTelemetry semantic conventions for JVM metrics] that have been marked stable as of version 1.44.0.
 
-* `OpenTelemetryJvmClassLoadingMeterConventions`
-* `OpenTelemetryJvmMemoryMeterConventions`
-* `OpenTelemetryJvmThreadMeterConventions`
-* `OpenTelemetryJvmCpuMeterConventions`
+Applicable binders have builders that provide a convenience method `openTelemetryConventions()` for configuring the available OpenTelemetry semantic conventions:
+
+[source, java]
+----
+ClassLoaderMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+JvmMemoryMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+JvmThreadMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+ProcessorMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+----
+
+You can also configure individual OpenTelemetry convention implementations on each binder builder:
+
+* `ClassLoaderMetrics`:
+** `OpenTelemetryJvmClassCountMeterConvention`
+** `OpenTelemetryJvmClassLoadedMeterConvention`
+** `OpenTelemetryJvmClassUnloadedMeterConvention`
+* `JvmMemoryMetrics`:
+** `OpenTelemetryJvmMemoryUsedMeterConvention`
+** `OpenTelemetryJvmMemoryCommittedMeterConvention`
+** `OpenTelemetryJvmMemoryMaxMeterConvention`
+* `JvmThreadMetrics`:
+** `OpenTelemetryJvmThreadCountMeterConvention`
+* `ProcessorMetrics`:
+** `OpenTelemetryJvmCpuTimeMeterConvention`
+** `OpenTelemetryJvmCpuCountMeterConvention`
+** `OpenTelemetryJvmCpuLoadMeterConvention`
+
+=== Customizing Individual Conventions
+
+You can customize individual conventions using the builder and static `of(...)` factory methods on the convention interfaces:
+
+[source, java]
+----
+ClassLoaderMetrics.builder()
+    .classCountConvention(JvmClassCountMeterConvention.of("custom.class.count", Tags.of("type", "count")))
+    .classLoadedConvention(JvmClassLoadedMeterConvention.of("custom.class.loaded"))
+    .classUnloadedConvention(JvmClassUnloadedMeterConvention.of("custom.class.unloaded"))
+    .build()
+    .bindTo(registry);
+----
 
 == Java 21 Metrics
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterConvention.java
@@ -38,9 +38,11 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <C> context type used to derive tags
  * @since 1.16.0
+ * @deprecated use specific per-convention interfaces instead
  */
 // Work around NullAway. C might be Void, and thus we pass null to getTags.
 @NullUnmarked
+@Deprecated
 public interface MeterConvention<C extends @Nullable Object> {
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/SimpleMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/SimpleMeterConvention.java
@@ -26,7 +26,10 @@ import java.util.function.Function;
  *
  * @param <C> context type from which tags can be derived
  * @since 1.16.0
+ * @deprecated use specific per-convention types or their static {@code of(...)} methods
+ * instead
  */
+@Deprecated
 public class SimpleMeterConvention<C extends @Nullable Object> implements MeterConvention<C> {
 
     private final String name;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
@@ -106,7 +106,7 @@ public class ClassLoaderMetrics implements MeterBinder {
         ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
 
         Gauge.builder(classCountConvention.getName(), classLoadingBean, ClassLoadingMXBean::getLoadedClassCount)
-            .tags(classCountConvention.getTags(null))
+            .tags(classCountConvention.getTags())
             .tags(extraTags)
             .description("The number of classes that are currently loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
@@ -114,7 +114,7 @@ public class ClassLoaderMetrics implements MeterBinder {
 
         FunctionCounter
             .builder(classUnloadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
-            .tags(classUnloadedConvention.getTags(null))
+            .tags(classUnloadedConvention.getTags())
             .tags(extraTags)
             .description("The number of classes unloaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
@@ -122,7 +122,7 @@ public class ClassLoaderMetrics implements MeterBinder {
 
         FunctionCounter
             .builder(classLoadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getTotalLoadedClassCount)
-            .tags(classLoadedConvention.getTags(null))
+            .tags(classLoadedConvention.getTags())
             .tags(extraTags)
             .description("The number of classes loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
@@ -19,8 +19,17 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadingMeterConventions;
-import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmClassLoadingMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmClassCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmClassLoadedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmClassUnloadedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmClassCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmClassLoadedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmClassUnloadedMeterConvention;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
@@ -32,13 +41,20 @@ import java.lang.management.ManagementFactory;
  */
 public class ClassLoaderMetrics implements MeterBinder {
 
-    private final JvmClassLoadingMeterConventions conventions;
+    private final Tags extraTags;
+
+    private final JvmClassCountMeterConvention classCountConvention;
+
+    private final JvmClassLoadedMeterConvention classLoadedConvention;
+
+    private final JvmClassUnloadedMeterConvention classUnloadedConvention;
 
     /**
      * Class loader metrics with the default convention.
      */
     public ClassLoaderMetrics() {
-        this(new MicrometerJvmClassLoadingMeterConventions());
+        this(Tags.empty(), new MicrometerJvmClassCountMeterConvention(), new MicrometerJvmClassLoadedMeterConvention(),
+                new MicrometerJvmClassUnloadedMeterConvention());
     }
 
     /**
@@ -46,44 +62,157 @@ public class ClassLoaderMetrics implements MeterBinder {
      * @param extraTags additional tags to add to metrics registered by this binder
      */
     public ClassLoaderMetrics(Iterable<Tag> extraTags) {
-        this(new MicrometerJvmClassLoadingMeterConventions(Tags.of(extraTags)));
+        this(Tags.of(extraTags), new MicrometerJvmClassCountMeterConvention(),
+                new MicrometerJvmClassLoadedMeterConvention(), new MicrometerJvmClassUnloadedMeterConvention());
     }
 
     /**
      * Class loader metrics registered by this binder will use the provided convention.
      * @param conventions custom convention to apply
      * @since 1.16.0
+     * @deprecated use {@link #builder()} to provide individual conventions
      */
+    @Deprecated
     public ClassLoaderMetrics(JvmClassLoadingMeterConventions conventions) {
-        this.conventions = conventions;
+        this.extraTags = Tags.empty();
+        MeterConvention<Object> count = conventions.currentClassCountConvention();
+        this.classCountConvention = JvmClassCountMeterConvention.of(count.getName(), count.getTags(null));
+        MeterConvention<Object> loaded = conventions.loadedConvention();
+        this.classLoadedConvention = JvmClassLoadedMeterConvention.of(loaded.getName(), loaded.getTags(null));
+        MeterConvention<Object> unloaded = conventions.unloadedConvention();
+        this.classUnloadedConvention = JvmClassUnloadedMeterConvention.of(unloaded.getName(), unloaded.getTags(null));
+    }
+
+    private ClassLoaderMetrics(Tags extraTags, JvmClassCountMeterConvention classCountConvention,
+            JvmClassLoadedMeterConvention classLoadedConvention,
+            JvmClassUnloadedMeterConvention classUnloadedConvention) {
+        this.extraTags = extraTags;
+        this.classCountConvention = classCountConvention;
+        this.classLoadedConvention = classLoadedConvention;
+        this.classUnloadedConvention = classUnloadedConvention;
+    }
+
+    /**
+     * Create a new builder for {@link ClassLoaderMetrics}.
+     * @return a new builder
+     * @since 1.18.0
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
     public void bindTo(MeterRegistry registry) {
         ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
 
-        MeterConvention<Object> currentClassCountConvention = conventions.currentClassCountConvention();
-        Gauge.builder(currentClassCountConvention.getName(), classLoadingBean, ClassLoadingMXBean::getLoadedClassCount)
-            .tags(currentClassCountConvention.getTags(null))
+        Gauge.builder(classCountConvention.getName(), classLoadingBean, ClassLoadingMXBean::getLoadedClassCount)
+            .tags(classCountConvention.getTags(null))
+            .tags(extraTags)
             .description("The number of classes that are currently loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
 
-        MeterConvention<Object> unloadedConvention = conventions.unloadedConvention();
         FunctionCounter
-            .builder(unloadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
-            .tags(unloadedConvention.getTags(null))
+            .builder(classUnloadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
+            .tags(classUnloadedConvention.getTags(null))
+            .tags(extraTags)
             .description("The number of classes unloaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
 
-        MeterConvention<Object> loadedConvention = conventions.loadedConvention();
         FunctionCounter
-            .builder(loadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getTotalLoadedClassCount)
-            .tags(loadedConvention.getTags(null))
+            .builder(classLoadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getTotalLoadedClassCount)
+            .tags(classLoadedConvention.getTags(null))
+            .tags(extraTags)
             .description("The number of classes loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
+    }
+
+    /**
+     * Builder for {@link ClassLoaderMetrics}.
+     *
+     * @since 1.18.0
+     */
+    public static class Builder {
+
+        private Tags extraTags = Tags.empty();
+
+        private @Nullable JvmClassCountMeterConvention classCountConvention;
+
+        private @Nullable JvmClassLoadedMeterConvention classLoadedConvention;
+
+        private @Nullable JvmClassUnloadedMeterConvention classUnloadedConvention;
+
+        Builder() {
+        }
+
+        /**
+         * Extra tags to add to meters registered by this binder.
+         * @param extraTags tags to add
+         * @return this builder
+         */
+        public Builder extraTags(Iterable<? extends Tag> extraTags) {
+            this.extraTags = Tags.of(extraTags);
+            return this;
+        }
+
+        /**
+         * Custom convention for the current class count meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder classCountConvention(JvmClassCountMeterConvention convention) {
+            this.classCountConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the classes loaded (total) meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder classLoadedConvention(JvmClassLoadedMeterConvention convention) {
+            this.classLoadedConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the classes unloaded meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder classUnloadedConvention(JvmClassUnloadedMeterConvention convention) {
+            this.classUnloadedConvention = convention;
+            return this;
+        }
+
+        /**
+         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
+         * can still be overridden by calling the specific convention methods after this
+         * one.
+         * @return this builder
+         */
+        public Builder openTelemetryConventions() {
+            this.classCountConvention = new OpenTelemetryJvmClassCountMeterConvention();
+            this.classLoadedConvention = new OpenTelemetryJvmClassLoadedMeterConvention();
+            this.classUnloadedConvention = new OpenTelemetryJvmClassUnloadedMeterConvention();
+            return this;
+        }
+
+        /**
+         * Build a new {@link ClassLoaderMetrics} instance.
+         * @return a new {@link ClassLoaderMetrics}
+         */
+        public ClassLoaderMetrics build() {
+            return new ClassLoaderMetrics(extraTags,
+                    classCountConvention != null ? classCountConvention : new MicrometerJvmClassCountMeterConvention(),
+                    classLoadedConvention != null ? classLoadedConvention
+                            : new MicrometerJvmClassLoadedMeterConvention(),
+                    classUnloadedConvention != null ? classUnloadedConvention
+                            : new MicrometerJvmClassUnloadedMeterConvention());
+        }
+
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
@@ -58,7 +58,9 @@ public class ClassLoaderMetrics implements MeterBinder {
     }
 
     /**
-     * Class loader metrics using the default convention with extra tags added.
+     * Class loader metrics using the default convention with extra tags added. If a
+     * conflict occurs between extra tags and convention tags, the convention tag takes
+     * precedence.
      * @param extraTags additional tags to add to metrics registered by this binder
      */
     public ClassLoaderMetrics(Iterable<Tag> extraTags) {
@@ -106,24 +108,24 @@ public class ClassLoaderMetrics implements MeterBinder {
         ClassLoadingMXBean classLoadingBean = ManagementFactory.getClassLoadingMXBean();
 
         Gauge.builder(classCountConvention.getName(), classLoadingBean, ClassLoadingMXBean::getLoadedClassCount)
-            .tags(classCountConvention.getTags())
             .tags(extraTags)
+            .tags(classCountConvention.getTags())
             .description("The number of classes that are currently loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
 
         FunctionCounter
             .builder(classUnloadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getUnloadedClassCount)
-            .tags(classUnloadedConvention.getTags())
             .tags(extraTags)
+            .tags(classUnloadedConvention.getTags())
             .description("The number of classes unloaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
 
         FunctionCounter
             .builder(classLoadedConvention.getName(), classLoadingBean, ClassLoadingMXBean::getTotalLoadedClassCount)
-            .tags(classLoadedConvention.getTags())
             .tags(extraTags)
+            .tags(classLoadedConvention.getTags())
             .description("The number of classes loaded in the Java virtual machine")
             .baseUnit(BaseUnits.CLASSES)
             .register(registry);
@@ -148,7 +150,8 @@ public class ClassLoaderMetrics implements MeterBinder {
         }
 
         /**
-         * Extra tags to add to meters registered by this binder.
+         * Extra tags to add to meters registered by this binder. If a conflict occurs
+         * between extra tags and convention tags, the convention tag takes precedence.
          * @param extraTags tags to add
          * @return this builder
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetrics.java
@@ -191,10 +191,13 @@ public class ClassLoaderMetrics implements MeterBinder {
         }
 
         /**
-         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
-         * can still be overridden by calling the specific convention methods after this
-         * one.
+         * Use OpenTelemetry semantic conventions for applicable meters that have a stable
+         * semantic convention as of the version documented in
+         * {@link io.micrometer.core.instrument.binder.jvm.convention.otel the otel
+         * conventions package}. Individual conventions can still be overridden by calling
+         * the specific convention methods after this one.
          * @return this builder
+         * @see io.micrometer.core.instrument.binder.jvm.convention.otel
          */
         public Builder openTelemetryConventions() {
             this.classCountConvention = new OpenTelemetryJvmClassCountMeterConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -22,8 +22,17 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryCommittedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMaxMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMeterConventions;
-import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmMemoryMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryUsedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmMemoryCommittedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmMemoryMaxMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmMemoryUsedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmMemoryCommittedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmMemoryMaxMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmMemoryUsedMeterConvention;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.management.*;
 
@@ -41,10 +50,15 @@ public class JvmMemoryMetrics implements MeterBinder {
 
     private final Tags extraTags;
 
-    private final JvmMemoryMeterConventions conventions;
+    private final JvmMemoryUsedMeterConvention memoryUsedConvention;
+
+    private final JvmMemoryCommittedMeterConvention memoryCommittedConvention;
+
+    private final JvmMemoryMaxMeterConvention memoryMaxConvention;
 
     public JvmMemoryMetrics() {
-        this(Tags.empty(), new MicrometerJvmMemoryMeterConventions());
+        this(Tags.empty(), new MicrometerJvmMemoryUsedMeterConvention(),
+                new MicrometerJvmMemoryCommittedMeterConvention(), new MicrometerJvmMemoryMaxMeterConvention());
     }
 
     /**
@@ -52,7 +66,8 @@ public class JvmMemoryMetrics implements MeterBinder {
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public JvmMemoryMetrics(Iterable<Tag> extraTags) {
-        this(extraTags, new MicrometerJvmMemoryMeterConventions(Tags.of(extraTags)));
+        this(Tags.of(extraTags), new MicrometerJvmMemoryUsedMeterConvention(),
+                new MicrometerJvmMemoryCommittedMeterConvention(), new MicrometerJvmMemoryMaxMeterConvention());
     }
 
     /**
@@ -63,10 +78,35 @@ public class JvmMemoryMetrics implements MeterBinder {
      * @param extraTags these will be added to meters not covered by the convention
      * @param conventions custom conventions for applicable metrics
      * @since 1.16.0
+     * @deprecated use {@link #builder()} to provide individual conventions
      */
+    @Deprecated
     public JvmMemoryMetrics(Iterable<? extends Tag> extraTags, JvmMemoryMeterConventions conventions) {
         this.extraTags = Tags.of(extraTags);
-        this.conventions = conventions;
+        MeterConvention<MemoryPoolMXBean> used = conventions.getMemoryUsedConvention();
+        this.memoryUsedConvention = JvmMemoryUsedMeterConvention.of(used.getName(), used::getTags);
+        MeterConvention<MemoryPoolMXBean> committed = conventions.getMemoryCommittedConvention();
+        this.memoryCommittedConvention = JvmMemoryCommittedMeterConvention.of(committed.getName(), committed::getTags);
+        MeterConvention<MemoryPoolMXBean> max = conventions.getMemoryMaxConvention();
+        this.memoryMaxConvention = JvmMemoryMaxMeterConvention.of(max.getName(), max::getTags);
+    }
+
+    private JvmMemoryMetrics(Tags extraTags, JvmMemoryUsedMeterConvention memoryUsedConvention,
+            JvmMemoryCommittedMeterConvention memoryCommittedConvention,
+            JvmMemoryMaxMeterConvention memoryMaxConvention) {
+        this.extraTags = extraTags;
+        this.memoryUsedConvention = memoryUsedConvention;
+        this.memoryCommittedConvention = memoryCommittedConvention;
+        this.memoryMaxConvention = memoryMaxConvention;
+    }
+
+    /**
+     * Create a new builder for {@link JvmMemoryMetrics}.
+     * @return a new builder
+     * @since 1.18.0
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -94,33 +134,118 @@ public class JvmMemoryMetrics implements MeterBinder {
         }
 
         for (MemoryPoolMXBean memoryPoolBean : ManagementFactory.getPlatformMXBeans(MemoryPoolMXBean.class)) {
-            MeterConvention<MemoryPoolMXBean> memoryUsedConvention = conventions.getMemoryUsedConvention();
             Gauge
                 .builder(memoryUsedConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getUsed))
                 .tags(memoryUsedConvention.getTags(memoryPoolBean))
+                .tags(extraTags)
                 .description("The amount of used memory")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
 
-            MeterConvention<MemoryPoolMXBean> memoryCommittedConvention = conventions.getMemoryCommittedConvention();
             Gauge
                 .builder(memoryCommittedConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getCommitted))
                 .tags(memoryCommittedConvention.getTags(memoryPoolBean))
+                .tags(extraTags)
                 .description("The amount of memory in bytes that is committed for the Java virtual machine to use")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
 
-            MeterConvention<MemoryPoolMXBean> memoryMaxConvention = conventions.getMemoryMaxConvention();
             Gauge
                 .builder(memoryMaxConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getMax))
                 .tags(memoryMaxConvention.getTags(memoryPoolBean))
+                .tags(extraTags)
                 .description("The maximum amount of memory in bytes that can be used for memory management")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
         }
+    }
+
+    /**
+     * Builder for {@link JvmMemoryMetrics}.
+     *
+     * @since 1.18.0
+     */
+    public static class Builder {
+
+        private Tags extraTags = Tags.empty();
+
+        private @Nullable JvmMemoryUsedMeterConvention memoryUsedConvention;
+
+        private @Nullable JvmMemoryCommittedMeterConvention memoryCommittedConvention;
+
+        private @Nullable JvmMemoryMaxMeterConvention memoryMaxConvention;
+
+        Builder() {
+        }
+
+        /**
+         * Extra tags to add to meters registered by this binder.
+         * @param extraTags tags to add
+         * @return this builder
+         */
+        public Builder extraTags(Iterable<? extends Tag> extraTags) {
+            this.extraTags = Tags.of(extraTags);
+            return this;
+        }
+
+        /**
+         * Custom convention for the memory used meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder memoryUsedConvention(JvmMemoryUsedMeterConvention convention) {
+            this.memoryUsedConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the memory committed meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder memoryCommittedConvention(JvmMemoryCommittedMeterConvention convention) {
+            this.memoryCommittedConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the memory max meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder memoryMaxConvention(JvmMemoryMaxMeterConvention convention) {
+            this.memoryMaxConvention = convention;
+            return this;
+        }
+
+        /**
+         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
+         * can still be overridden by calling the specific convention methods after this
+         * one.
+         * @return this builder
+         */
+        public Builder openTelemetryConventions() {
+            this.memoryUsedConvention = new OpenTelemetryJvmMemoryUsedMeterConvention();
+            this.memoryCommittedConvention = new OpenTelemetryJvmMemoryCommittedMeterConvention();
+            this.memoryMaxConvention = new OpenTelemetryJvmMemoryMaxMeterConvention();
+            return this;
+        }
+
+        /**
+         * Build a new {@link JvmMemoryMetrics} instance.
+         * @return a new {@link JvmMemoryMetrics}
+         */
+        public JvmMemoryMetrics build() {
+            return new JvmMemoryMetrics(extraTags,
+                    memoryUsedConvention != null ? memoryUsedConvention : new MicrometerJvmMemoryUsedMeterConvention(),
+                    memoryCommittedConvention != null ? memoryCommittedConvention
+                            : new MicrometerJvmMemoryCommittedMeterConvention(),
+                    memoryMaxConvention != null ? memoryMaxConvention : new MicrometerJvmMemoryMaxMeterConvention());
+        }
+
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -224,10 +224,13 @@ public class JvmMemoryMetrics implements MeterBinder {
         }
 
         /**
-         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
-         * can still be overridden by calling the specific convention methods after this
-         * one.
+         * Use OpenTelemetry semantic conventions for applicable meters that have a stable
+         * semantic convention as of the version documented in
+         * {@link io.micrometer.core.instrument.binder.jvm.convention.otel the otel
+         * conventions package}. Individual conventions can still be overridden by calling
+         * the specific convention methods after this one.
          * @return this builder
+         * @see io.micrometer.core.instrument.binder.jvm.convention.otel
          */
         public Builder openTelemetryConventions() {
             this.memoryUsedConvention = new OpenTelemetryJvmMemoryUsedMeterConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetrics.java
@@ -62,7 +62,8 @@ public class JvmMemoryMetrics implements MeterBinder {
     }
 
     /**
-     * Uses the default convention with the provided extra tags.
+     * Uses the default convention with the provided extra tags. If a conflict occurs
+     * between extra tags and convention tags, the convention tag takes precedence.
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public JvmMemoryMetrics(Iterable<Tag> extraTags) {
@@ -137,8 +138,8 @@ public class JvmMemoryMetrics implements MeterBinder {
             Gauge
                 .builder(memoryUsedConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getUsed))
-                .tags(memoryUsedConvention.getTags(memoryPoolBean))
                 .tags(extraTags)
+                .tags(memoryUsedConvention.getTags(memoryPoolBean))
                 .description("The amount of used memory")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
@@ -146,8 +147,8 @@ public class JvmMemoryMetrics implements MeterBinder {
             Gauge
                 .builder(memoryCommittedConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getCommitted))
-                .tags(memoryCommittedConvention.getTags(memoryPoolBean))
                 .tags(extraTags)
+                .tags(memoryCommittedConvention.getTags(memoryPoolBean))
                 .description("The amount of memory in bytes that is committed for the Java virtual machine to use")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
@@ -155,8 +156,8 @@ public class JvmMemoryMetrics implements MeterBinder {
             Gauge
                 .builder(memoryMaxConvention.getName(), memoryPoolBean,
                         (mem) -> getUsageValue(mem, MemoryUsage::getMax))
-                .tags(memoryMaxConvention.getTags(memoryPoolBean))
                 .tags(extraTags)
+                .tags(memoryMaxConvention.getTags(memoryPoolBean))
                 .description("The maximum amount of memory in bytes that can be used for memory management")
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
@@ -182,7 +183,8 @@ public class JvmMemoryMetrics implements MeterBinder {
         }
 
         /**
-         * Extra tags to add to meters registered by this binder.
+         * Extra tags to add to meters registered by this binder. If a conflict occurs
+         * between extra tags and convention tags, the convention tag takes precedence.
          * @param extraTags tags to add
          * @return this builder
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -23,8 +23,11 @@ import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadCountMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadMeterConventions;
-import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmThreadMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmThreadCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmThreadCountMeterConvention;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -42,7 +45,7 @@ public class JvmThreadMetrics implements MeterBinder {
 
     private final Tags extraTags;
 
-    private final JvmThreadMeterConventions conventions;
+    private final JvmThreadCountMeterConvention threadCountConvention;
 
     public JvmThreadMetrics() {
         this(emptyList());
@@ -53,7 +56,7 @@ public class JvmThreadMetrics implements MeterBinder {
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public JvmThreadMetrics(Iterable<Tag> extraTags) {
-        this(extraTags, new MicrometerJvmThreadMeterConventions(Tags.of(extraTags)));
+        this(Tags.of(extraTags), new MicrometerJvmThreadCountMeterConvention());
     }
 
     /**
@@ -63,10 +66,27 @@ public class JvmThreadMetrics implements MeterBinder {
      * @param extraTags extra tags to add to meters not covered by the conventions
      * @param conventions custom conventions for applicable meters
      * @since 1.16.0
+     * @deprecated use {@link #builder()} to provide individual conventions
      */
+    @Deprecated
     public JvmThreadMetrics(Iterable<? extends Tag> extraTags, JvmThreadMeterConventions conventions) {
         this.extraTags = Tags.of(extraTags);
-        this.conventions = conventions;
+        MeterConvention<Thread.State> threadCount = conventions.threadCountConvention();
+        this.threadCountConvention = JvmThreadCountMeterConvention.of(threadCount.getName(), threadCount::getTags);
+    }
+
+    private JvmThreadMetrics(Tags extraTags, JvmThreadCountMeterConvention threadCountConvention) {
+        this.extraTags = extraTags;
+        this.threadCountConvention = threadCountConvention;
+    }
+
+    /**
+     * Create a new builder for {@link JvmThreadMetrics}.
+     * @return a new builder
+     * @since 1.18.0
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -99,10 +119,10 @@ public class JvmThreadMetrics implements MeterBinder {
 
         try {
             threadBean.getAllThreadIds();
-            MeterConvention<Thread.State> threadCountConvention = conventions.threadCountConvention();
             for (Thread.State state : Thread.State.values()) {
                 Gauge.builder(threadCountConvention.getName(), threadBean, (bean) -> getThreadStateCount(bean, state))
                     .tags(threadCountConvention.getTags(state))
+                    .tags(extraTags)
                     .description("The current number of threads")
                     .baseUnit(BaseUnits.THREADS)
                     .register(registry);
@@ -119,6 +139,62 @@ public class JvmThreadMetrics implements MeterBinder {
         return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
             .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state)
             .count();
+    }
+
+    /**
+     * Builder for {@link JvmThreadMetrics}.
+     *
+     * @since 1.18.0
+     */
+    public static class Builder {
+
+        private Tags extraTags = Tags.empty();
+
+        private @Nullable JvmThreadCountMeterConvention threadCountConvention;
+
+        Builder() {
+        }
+
+        /**
+         * Extra tags to add to meters registered by this binder.
+         * @param extraTags tags to add
+         * @return this builder
+         */
+        public Builder extraTags(Iterable<? extends Tag> extraTags) {
+            this.extraTags = Tags.of(extraTags);
+            return this;
+        }
+
+        /**
+         * Custom convention for the thread count meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder threadCountConvention(JvmThreadCountMeterConvention convention) {
+            this.threadCountConvention = convention;
+            return this;
+        }
+
+        /**
+         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
+         * can still be overridden by calling the specific convention methods after this
+         * one.
+         * @return this builder
+         */
+        public Builder openTelemetryConventions() {
+            this.threadCountConvention = new OpenTelemetryJvmThreadCountMeterConvention();
+            return this;
+        }
+
+        /**
+         * Build a new {@link JvmThreadMetrics} instance.
+         * @return a new {@link JvmThreadMetrics}
+         */
+        public JvmThreadMetrics build() {
+            return new JvmThreadMetrics(extraTags, threadCountConvention != null ? threadCountConvention
+                    : new MicrometerJvmThreadCountMeterConvention());
+        }
+
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -178,10 +178,13 @@ public class JvmThreadMetrics implements MeterBinder {
         }
 
         /**
-         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
-         * can still be overridden by calling the specific convention methods after this
-         * one.
+         * Use OpenTelemetry semantic conventions for applicable meters that have a stable
+         * semantic convention as of the version documented in
+         * {@link io.micrometer.core.instrument.binder.jvm.convention.otel the otel
+         * conventions package}. Individual conventions can still be overridden by calling
+         * the specific convention methods after this one.
          * @return this builder
+         * @see io.micrometer.core.instrument.binder.jvm.convention.otel
          */
         public Builder openTelemetryConventions() {
             this.threadCountConvention = new OpenTelemetryJvmThreadCountMeterConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -52,7 +52,8 @@ public class JvmThreadMetrics implements MeterBinder {
     }
 
     /**
-     * Uses the default convention with the provided extra tags.
+     * Uses the default convention with the provided extra tags. If a conflict occurs
+     * between extra tags and convention tags, the convention tag takes precedence.
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public JvmThreadMetrics(Iterable<Tag> extraTags) {
@@ -121,8 +122,8 @@ public class JvmThreadMetrics implements MeterBinder {
             threadBean.getAllThreadIds();
             for (Thread.State state : Thread.State.values()) {
                 Gauge.builder(threadCountConvention.getName(), threadBean, (bean) -> getThreadStateCount(bean, state))
-                    .tags(threadCountConvention.getTags(state))
                     .tags(extraTags)
+                    .tags(threadCountConvention.getTags(state))
                     .description("The current number of threads")
                     .baseUnit(BaseUnits.THREADS)
                     .register(registry);
@@ -156,7 +157,8 @@ public class JvmThreadMetrics implements MeterBinder {
         }
 
         /**
-         * Extra tags to add to meters registered by this binder.
+         * Extra tags to add to meters registered by this binder. If a conflict occurs
+         * between extra tags and convention tags, the convention tag takes precedence.
          * @param extraTags tags to add
          * @return this builder
          */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassCountMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for the current class count metric (classes currently loaded).
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public interface JvmClassCountMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmClassCountMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmClassCountMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmClassCountMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmClassCountMeterConvention of(String name, Tags tags) {
+        return new JvmClassCountMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassCountMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for the current class count metric (classes currently loaded).
+ * Convention for the current class count metric (classes currently loaded).
  *
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */
-public interface JvmClassCountMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmClassCountMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmClassCountMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmClassCountMeterConvention extends MeterConvention<@Nullable 
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadedMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for JVM classes loaded (total) metrics.
+ * Convention for JVM classes loaded (total) metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */
-public interface JvmClassLoadedMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmClassLoadedMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmClassLoadedMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmClassLoadedMeterConvention extends MeterConvention<@Nullable
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadedMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for JVM classes loaded (total) metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public interface JvmClassLoadedMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmClassLoadedMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmClassLoadedMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmClassLoadedMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmClassLoadedMeterConvention of(String name, Tags tags) {
+        return new JvmClassLoadedMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadingMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassLoadingMeterConventions.java
@@ -22,7 +22,12 @@ import io.micrometer.core.instrument.binder.MeterConvention;
  *
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link JvmClassCountMeterConvention}, {@link JvmClassLoadedMeterConvention}, and
+ * {@link JvmClassUnloadedMeterConvention} with
+ * {@link io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics.Builder} instead
  */
+@Deprecated
 public interface JvmClassLoadingMeterConventions {
 
     MeterConvention<Object> loadedConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassUnloadedMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for JVM classes unloaded metrics.
+ * Convention for JVM classes unloaded metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */
-public interface JvmClassUnloadedMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmClassUnloadedMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmClassUnloadedMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmClassUnloadedMeterConvention extends MeterConvention<@Nullab
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmClassUnloadedMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for JVM classes unloaded metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public interface JvmClassUnloadedMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmClassUnloadedMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmClassUnloadedMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmClassUnloadedMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmClassUnloadedMeterConvention of(String name, Tags tags) {
+        return new JvmClassUnloadedMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuCountMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for CPU count metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public interface JvmCpuCountMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmCpuCountMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmCpuCountMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmCpuCountMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmCpuCountMeterConvention of(String name, Tags tags) {
+        return new JvmCpuCountMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuCountMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for CPU count metrics.
+ * Convention for CPU count metrics.
  *
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */
-public interface JvmCpuCountMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmCpuCountMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmCpuCountMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmCpuCountMeterConvention extends MeterConvention<@Nullable Ob
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuLoadMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for process CPU load metrics.
+ * Convention for process CPU load metrics.
  *
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */
-public interface JvmCpuLoadMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmCpuLoadMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmCpuLoadMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmCpuLoadMeterConvention extends MeterConvention<@Nullable Obj
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuLoadMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for process CPU load metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public interface JvmCpuLoadMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmCpuLoadMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmCpuLoadMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmCpuLoadMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmCpuLoadMeterConvention of(String name, Tags tags) {
+        return new JvmCpuLoadMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuMeterConventions.java
@@ -22,7 +22,11 @@ import io.micrometer.core.instrument.binder.MeterConvention;
  *
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as {@link JvmCpuTimeMeterConvention},
+ * {@link JvmCpuCountMeterConvention}, and {@link JvmCpuLoadMeterConvention} with
+ * {@link io.micrometer.core.instrument.binder.system.ProcessorMetrics.Builder} instead
  */
+@Deprecated
 public interface JvmCpuMeterConventions {
 
     MeterConvention<Object> cpuTimeConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuTimeMeterConvention.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * {@link MeterConvention} for process CPU time metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public interface JvmCpuTimeMeterConvention extends MeterConvention<@Nullable Object> {
+
+    /**
+     * Create a {@link JvmCpuTimeMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmCpuTimeMeterConvention of(String name) {
+        return () -> name;
+    }
+
+    /**
+     * Create a {@link JvmCpuTimeMeterConvention} with the given name and tags.
+     * @param name meter name
+     * @param tags tags for the meter
+     * @return a new convention instance
+     */
+    static JvmCpuTimeMeterConvention of(String name, Tags tags) {
+        return new JvmCpuTimeMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(@Nullable Object context) {
+                return tags;
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmCpuTimeMeterConvention.java
@@ -16,16 +16,28 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
-import org.jspecify.annotations.Nullable;
 
 /**
- * {@link MeterConvention} for process CPU time metrics.
+ * Convention for process CPU time metrics.
  *
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */
-public interface JvmCpuTimeMeterConvention extends MeterConvention<@Nullable Object> {
+public interface JvmCpuTimeMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @return tags to use with the meter
+     */
+    default Tags getTags() {
+        return Tags.empty();
+    }
 
     /**
      * Create a {@link JvmCpuTimeMeterConvention} with the given name.
@@ -50,7 +62,7 @@ public interface JvmCpuTimeMeterConvention extends MeterConvention<@Nullable Obj
             }
 
             @Override
-            public Tags getTags(@Nullable Object context) {
+            public Tags getTags() {
                 return tags;
             }
         };

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryCommittedMeterConvention.java
@@ -16,18 +16,41 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
 
 import java.lang.management.MemoryPoolMXBean;
 import java.util.function.Function;
 
 /**
- * {@link MeterConvention} for JVM memory committed metrics.
+ * Convention for JVM memory committed metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */
-public interface JvmMemoryCommittedMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+public interface JvmMemoryCommittedMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @param memoryPoolBean the memory pool bean from which to derive tags
+     * @return tags to use with the meter
+     */
+    default Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.empty();
+    }
+
+    /**
+     * Create a {@link JvmMemoryCommittedMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmMemoryCommittedMeterConvention of(String name) {
+        return () -> name;
+    }
 
     /**
      * Create a {@link JvmMemoryCommittedMeterConvention} with the given name and tags
@@ -44,8 +67,8 @@ public interface JvmMemoryCommittedMeterConvention extends MeterConvention<Memor
             }
 
             @Override
-            public Tags getTags(MemoryPoolMXBean context) {
-                return tagsFunction.apply(context);
+            public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+                return tagsFunction.apply(memoryPoolBean);
             }
         };
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryCommittedMeterConvention.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.util.function.Function;
+
+/**
+ * {@link MeterConvention} for JVM memory committed metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public interface JvmMemoryCommittedMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+
+    /**
+     * Create a {@link JvmMemoryCommittedMeterConvention} with the given name and tags
+     * function.
+     * @param name meter name
+     * @param tagsFunction function to derive tags from a {@link MemoryPoolMXBean}
+     * @return a new convention instance
+     */
+    static JvmMemoryCommittedMeterConvention of(String name, Function<MemoryPoolMXBean, Tags> tagsFunction) {
+        return new JvmMemoryCommittedMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(MemoryPoolMXBean context) {
+                return tagsFunction.apply(context);
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMaxMeterConvention.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.util.function.Function;
+
+/**
+ * {@link MeterConvention} for JVM memory max metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public interface JvmMemoryMaxMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+
+    /**
+     * Create a {@link JvmMemoryMaxMeterConvention} with the given name and tags function.
+     * @param name meter name
+     * @param tagsFunction function to derive tags from a {@link MemoryPoolMXBean}
+     * @return a new convention instance
+     */
+    static JvmMemoryMaxMeterConvention of(String name, Function<MemoryPoolMXBean, Tags> tagsFunction) {
+        return new JvmMemoryMaxMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(MemoryPoolMXBean context) {
+                return tagsFunction.apply(context);
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMaxMeterConvention.java
@@ -16,18 +16,41 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
 
 import java.lang.management.MemoryPoolMXBean;
 import java.util.function.Function;
 
 /**
- * {@link MeterConvention} for JVM memory max metrics.
+ * Convention for JVM memory max metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */
-public interface JvmMemoryMaxMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+public interface JvmMemoryMaxMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @param memoryPoolBean the memory pool bean from which to derive tags
+     * @return tags to use with the meter
+     */
+    default Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.empty();
+    }
+
+    /**
+     * Create a {@link JvmMemoryMaxMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmMemoryMaxMeterConvention of(String name) {
+        return () -> name;
+    }
 
     /**
      * Create a {@link JvmMemoryMaxMeterConvention} with the given name and tags function.
@@ -43,8 +66,8 @@ public interface JvmMemoryMaxMeterConvention extends MeterConvention<MemoryPoolM
             }
 
             @Override
-            public Tags getTags(MemoryPoolMXBean context) {
-                return tagsFunction.apply(context);
+            public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+                return tagsFunction.apply(memoryPoolBean);
             }
         };
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryMeterConventions.java
@@ -24,7 +24,12 @@ import java.lang.management.MemoryPoolMXBean;
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link JvmMemoryUsedMeterConvention}, {@link JvmMemoryCommittedMeterConvention}, and
+ * {@link JvmMemoryMaxMeterConvention} with
+ * {@link io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics.Builder} instead
  */
+@Deprecated
 public interface JvmMemoryMeterConventions {
 
     MeterConvention<MemoryPoolMXBean> getMemoryUsedConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryUsedMeterConvention.java
@@ -16,18 +16,41 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
 
 import java.lang.management.MemoryPoolMXBean;
 import java.util.function.Function;
 
 /**
- * {@link MeterConvention} for JVM memory used metrics.
+ * Convention for JVM memory used metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */
-public interface JvmMemoryUsedMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+public interface JvmMemoryUsedMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @param memoryPoolBean the memory pool bean from which to derive tags
+     * @return tags to use with the meter
+     */
+    default Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.empty();
+    }
+
+    /**
+     * Create a {@link JvmMemoryUsedMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmMemoryUsedMeterConvention of(String name) {
+        return () -> name;
+    }
 
     /**
      * Create a {@link JvmMemoryUsedMeterConvention} with the given name and tags
@@ -44,8 +67,8 @@ public interface JvmMemoryUsedMeterConvention extends MeterConvention<MemoryPool
             }
 
             @Override
-            public Tags getTags(MemoryPoolMXBean context) {
-                return tagsFunction.apply(context);
+            public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+                return tagsFunction.apply(memoryPoolBean);
             }
         };
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmMemoryUsedMeterConvention.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.util.function.Function;
+
+/**
+ * {@link MeterConvention} for JVM memory used metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public interface JvmMemoryUsedMeterConvention extends MeterConvention<MemoryPoolMXBean> {
+
+    /**
+     * Create a {@link JvmMemoryUsedMeterConvention} with the given name and tags
+     * function.
+     * @param name meter name
+     * @param tagsFunction function to derive tags from a {@link MemoryPoolMXBean}
+     * @return a new convention instance
+     */
+    static JvmMemoryUsedMeterConvention of(String name, Function<MemoryPoolMXBean, Tags> tagsFunction) {
+        return new JvmMemoryUsedMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(MemoryPoolMXBean context) {
+                return tagsFunction.apply(context);
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadCountMeterConvention.java
@@ -16,17 +16,40 @@
 package io.micrometer.core.instrument.binder.jvm.convention;
 
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.binder.MeterConvention;
 
 import java.util.function.Function;
 
 /**
- * {@link MeterConvention} for JVM thread count metrics.
+ * Convention for JVM thread count metrics.
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
  * @since 1.18.0
  */
-public interface JvmThreadCountMeterConvention extends MeterConvention<Thread.State> {
+public interface JvmThreadCountMeterConvention {
+
+    /**
+     * Canonical name of the meter.
+     * @return meter name
+     */
+    String getName();
+
+    /**
+     * Tags specific to this meter convention.
+     * @param state the thread state from which to derive tags
+     * @return tags to use with the meter
+     */
+    default Tags getTags(Thread.State state) {
+        return Tags.empty();
+    }
+
+    /**
+     * Create a {@link JvmThreadCountMeterConvention} with the given name.
+     * @param name meter name
+     * @return a new convention instance
+     */
+    static JvmThreadCountMeterConvention of(String name) {
+        return () -> name;
+    }
 
     /**
      * Create a {@link JvmThreadCountMeterConvention} with the given name and tags
@@ -43,8 +66,8 @@ public interface JvmThreadCountMeterConvention extends MeterConvention<Thread.St
             }
 
             @Override
-            public Tags getTags(Thread.State context) {
-                return tagsFunction.apply(context);
+            public Tags getTags(Thread.State state) {
+                return tagsFunction.apply(state);
             }
         };
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadCountMeterConvention.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterConvention;
+
+import java.util.function.Function;
+
+/**
+ * {@link MeterConvention} for JVM thread count metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+ * @since 1.18.0
+ */
+public interface JvmThreadCountMeterConvention extends MeterConvention<Thread.State> {
+
+    /**
+     * Create a {@link JvmThreadCountMeterConvention} with the given name and tags
+     * function.
+     * @param name meter name
+     * @param tagsFunction function to derive tags from a {@link Thread.State}
+     * @return a new convention instance
+     */
+    static JvmThreadCountMeterConvention of(String name, Function<Thread.State, Tags> tagsFunction) {
+        return new JvmThreadCountMeterConvention() {
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public Tags getTags(Thread.State context) {
+                return tagsFunction.apply(context);
+            }
+        };
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassCountMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Micrometer's historical convention for JVM current class count metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmClassCountMeterConvention implements JvmClassCountMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "jvm.classes.loaded";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassLoadedMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Micrometer's historical convention for JVM classes loaded (total) metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmClassLoadedMeterConvention implements JvmClassLoadedMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "jvm.classes.loaded.count";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassLoadingMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassLoadingMeterConventions.java
@@ -25,7 +25,13 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadingMeterC
  *
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link MicrometerJvmClassCountMeterConvention},
+ * {@link MicrometerJvmClassLoadedMeterConvention}, and
+ * {@link MicrometerJvmClassUnloadedMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class MicrometerJvmClassLoadingMeterConventions implements JvmClassLoadingMeterConventions {
 
     private final Tags extraTags;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmClassUnloadedMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Micrometer's historical convention for JVM classes unloaded metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmClassUnloadedMeterConvention implements JvmClassUnloadedMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "jvm.classes.unloaded";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuCountMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Historical convention used in Micrometer for CPU count metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmCpuCountMeterConvention implements JvmCpuCountMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "system.cpu.count";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuLoadMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Historical convention used in Micrometer for process CPU load metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmCpuLoadMeterConvention implements JvmCpuLoadMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "process.cpu.usage";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuMeterConventions.java
@@ -25,7 +25,13 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuMeterConvention
  *
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link MicrometerJvmCpuTimeMeterConvention},
+ * {@link MicrometerJvmCpuCountMeterConvention}, and
+ * {@link MicrometerJvmCpuLoadMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class MicrometerJvmCpuMeterConventions implements JvmCpuMeterConventions {
 
     private final Tags extraTags;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmCpuTimeMeterConvention.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 VMware, Inc.
+ * Copyright 2026 VMware, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micrometer.core.instrument.binder.jvm.convention;
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
 
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConvention;
 
 /**
- * Get {@link MeterConvention} for thread related metrics.
+ * Historical convention used in Micrometer for process CPU time metrics.
  *
- * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
- * @since 1.16.0
- * @deprecated use {@link JvmThreadCountMeterConvention} with
- * {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics.Builder} instead
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
  */
-@Deprecated
-public interface JvmThreadMeterConventions {
+public class MicrometerJvmCpuTimeMeterConvention implements JvmCpuTimeMeterConvention {
 
-    MeterConvention<Thread.State> threadCountConvention();
+    @Override
+    public String getName() {
+        return "process.cpu.time";
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryCommittedMeterConvention.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryCommittedMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Historical convention used in Micrometer instrumentation for JVM memory committed
+ * metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class MicrometerJvmMemoryCommittedMeterConvention implements JvmMemoryCommittedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.committed";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("id", memoryPoolBean.getName(), "area",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryMaxMeterConvention.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMaxMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Historical convention used in Micrometer instrumentation for JVM memory max metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class MicrometerJvmMemoryMaxMeterConvention implements JvmMemoryMaxMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.max";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("id", memoryPoolBean.getName(), "area",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryMeterConventions.java
@@ -28,7 +28,13 @@ import java.lang.management.MemoryType;
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link MicrometerJvmMemoryUsedMeterConvention},
+ * {@link MicrometerJvmMemoryCommittedMeterConvention}, and
+ * {@link MicrometerJvmMemoryMaxMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class MicrometerJvmMemoryMeterConventions implements JvmMemoryMeterConventions {
 
     protected final Tags extraTags;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmMemoryUsedMeterConvention.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryUsedMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Historical convention used in Micrometer instrumentation for JVM memory used metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class MicrometerJvmMemoryUsedMeterConvention implements JvmMemoryUsedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.used";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("id", memoryPoolBean.getName(), "area",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "nonheap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmThreadCountMeterConvention.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.micrometer;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadCountMeterConvention;
+
+import java.util.Locale;
+
+/**
+ * Historical convention used in Micrometer-provided JVM thread count metrics.
+ *
+ * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+ * @since 1.18.0
+ */
+public class MicrometerJvmThreadCountMeterConvention implements JvmThreadCountMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.threads.states";
+    }
+
+    @Override
+    public Tags getTags(Thread.State state) {
+        return Tags.of("state", state.name().toLowerCase(Locale.ROOT).replace('_', '-'));
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmThreadMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/micrometer/MicrometerJvmThreadMeterConventions.java
@@ -27,7 +27,10 @@ import java.util.Locale;
  *
  * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
  * @since 1.16.0
+ * @deprecated use {@link MicrometerJvmThreadCountMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class MicrometerJvmThreadMeterConventions implements JvmThreadMeterConventions {
 
     private final Tags extraTags;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterConvention;
+
+/**
+ * Convention for JVM current class count metrics based on OpenTelemetry semantic
+ * conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmClassCountMeterConvention implements JvmClassCountMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.class.count";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterCon
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassCountMeterConvention.java
@@ -22,8 +22,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterCon
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclasscount">OpenTelemetry
+ * semantic convention for jvm.class.count</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterConvention;
+
+/**
+ * Convention for JVM classes loaded (total) metrics based on OpenTelemetry semantic
+ * conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmClassLoadedMeterConvention implements JvmClassLoadedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.class.loaded";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterCo
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadedMeterConvention.java
@@ -22,8 +22,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterCo
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclassloaded">OpenTelemetry
+ * semantic convention for jvm.class.loaded</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadingMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassLoadingMeterConventions.java
@@ -28,7 +28,13 @@ import io.micrometer.core.instrument.binder.jvm.convention.micrometer.Micrometer
  * Semantic conventions for JVM metrics v1.37.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link OpenTelemetryJvmClassCountMeterConvention},
+ * {@link OpenTelemetryJvmClassLoadedMeterConvention}, and
+ * {@link OpenTelemetryJvmClassUnloadedMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class OpenTelemetryJvmClassLoadingMeterConventions extends MicrometerJvmClassLoadingMeterConventions {
 
     public OpenTelemetryJvmClassLoadingMeterConventions() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeterConvention;
+
+/**
+ * Convention for JVM classes unloaded metrics based on OpenTelemetry semantic
+ * conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmClassUnloadedMeterConvention implements JvmClassUnloadedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.class.unloaded";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
@@ -22,8 +22,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeter
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmClassUnloadedMeterConvention.java
@@ -22,8 +22,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeter
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmclassunloaded">OpenTelemetry
+ * semantic convention for jvm.class.unloaded</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConvention;
+
+/**
+ * Convention for CPU count metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmCpuCountMeterConvention implements JvmCpuCountMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.cpu.count";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConve
  * Convention for CPU count metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcpucount">OpenTelemetry
+ * semantic convention for jvm.cpu.count</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuCountMeterConvention.java
@@ -21,8 +21,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConve
  * Convention for CPU count metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConvention;
+
+/**
+ * Convention for process CPU load metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmCpuLoadMeterConvention implements JvmCpuLoadMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.cpu.recent_utilization";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
@@ -21,8 +21,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConven
  * Convention for process CPU load metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuLoadMeterConvention.java
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConven
  * Convention for process CPU load metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcpurecent_utilization">OpenTelemetry
+ * semantic convention for jvm.cpu.recent_utilization</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuMeterConventions.java
@@ -28,7 +28,13 @@ import io.micrometer.core.instrument.binder.jvm.convention.micrometer.Micrometer
  * Semantic conventions for JVM metrics v1.37.0</a>
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link OpenTelemetryJvmCpuTimeMeterConvention},
+ * {@link OpenTelemetryJvmCpuCountMeterConvention}, and
+ * {@link OpenTelemetryJvmCpuLoadMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class OpenTelemetryJvmCpuMeterConventions extends MicrometerJvmCpuMeterConventions {
 
     public OpenTelemetryJvmCpuMeterConventions(Tags extraTags) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConvention;
+
+/**
+ * Convention for process CPU time metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmCpuTimeMeterConvention implements JvmCpuTimeMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.cpu.time";
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
@@ -21,8 +21,9 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConven
  * Convention for process CPU time metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmcputime">OpenTelemetry
+ * semantic convention for jvm.cpu.time</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmCpuTimeMeterConvention.java
@@ -21,8 +21,8 @@ import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConven
  * Convention for process CPU time metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.system.ProcessorMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryCommittedMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Convention for JVM memory committed metrics based on OpenTelemetry semantic
+ * conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmMemoryCommittedMeterConvention implements JvmMemoryCommittedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.committed";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("jvm.memory.pool.name", memoryPoolBean.getName(), "jvm.memory.type",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "non_heap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
@@ -26,8 +26,8 @@ import java.lang.management.MemoryType;
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryCommittedMeterConvention.java
@@ -26,8 +26,9 @@ import java.lang.management.MemoryType;
  * conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemorycommitted">OpenTelemetry
+ * semantic convention for jvm.memory.committed</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMaxMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Convention for JVM memory max metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmMemoryMaxMeterConvention implements JvmMemoryMaxMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.limit";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("jvm.memory.pool.name", memoryPoolBean.getName(), "jvm.memory.type",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "non_heap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
@@ -25,8 +25,9 @@ import java.lang.management.MemoryType;
  * Convention for JVM memory max metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemorylimit">OpenTelemetry
+ * semantic convention for jvm.memory.limit</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMaxMeterConvention.java
@@ -25,8 +25,8 @@ import java.lang.management.MemoryType;
  * Convention for JVM memory max metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryMeterConventions.java
@@ -31,7 +31,13 @@ import java.lang.management.MemoryType;
  * Semantic conventions for JVM metrics v1.37.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.16.0
+ * @deprecated use individual convention types such as
+ * {@link OpenTelemetryJvmMemoryUsedMeterConvention},
+ * {@link OpenTelemetryJvmMemoryCommittedMeterConvention}, and
+ * {@link OpenTelemetryJvmMemoryMaxMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class OpenTelemetryJvmMemoryMeterConventions extends MicrometerJvmMemoryMeterConventions {
 
     public OpenTelemetryJvmMemoryMeterConventions(Tags extraTags) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryUsedMeterConvention;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.management.MemoryType;
+
+/**
+ * Convention for JVM memory used metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmMemoryUsedMeterConvention implements JvmMemoryUsedMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.memory.used";
+    }
+
+    @Override
+    public Tags getTags(MemoryPoolMXBean memoryPoolBean) {
+        return Tags.of("jvm.memory.pool.name", memoryPoolBean.getName(), "jvm.memory.type",
+                MemoryType.HEAP.equals(memoryPoolBean.getType()) ? "heap" : "non_heap");
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
@@ -25,8 +25,8 @@ import java.lang.management.MemoryType;
  * Convention for JVM memory used metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmMemoryUsedMeterConvention.java
@@ -25,8 +25,9 @@ import java.lang.management.MemoryType;
  * Convention for JVM memory used metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmmemoryused">OpenTelemetry
+ * semantic convention for jvm.memory.used</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.jvm.convention.otel;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadCountMeterConvention;
+
+import java.util.Locale;
+
+/**
+ * Convention for JVM thread count metrics based on OpenTelemetry semantic conventions.
+ *
+ * @see <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.37.0</a>
+ * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+ * @since 1.18.0
+ */
+public class OpenTelemetryJvmThreadCountMeterConvention implements JvmThreadCountMeterConvention {
+
+    @Override
+    public String getName() {
+        return "jvm.thread.count";
+    }
+
+    @Override
+    public Tags getTags(Thread.State state) {
+        return Tags.of("jvm.thread.state", state.name().toLowerCase(Locale.ROOT));
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
@@ -24,8 +24,9 @@ import java.util.Locale;
  * Convention for JVM thread count metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.44.0</a>
+ * "https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount">OpenTelemetry
+ * semantic convention for jvm.thread.count</a>
+ * @see io.micrometer.core.instrument.binder.jvm.convention.otel
  * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadCountMeterConvention.java
@@ -24,8 +24,8 @@ import java.util.Locale;
  * Convention for JVM thread count metrics based on OpenTelemetry semantic conventions.
  *
  * @see <a href=
- * "https://github.com/open-telemetry/semantic-conventions/blob/v1.37.0/docs/runtime/jvm-metrics.md">OpenTelemetry
- * Semantic conventions for JVM metrics v1.37.0</a>
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic conventions for JVM metrics v1.44.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
  * @since 1.18.0
  */

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadMeterConventions.java
@@ -30,7 +30,10 @@ import java.util.Locale;
  * Semantic conventions for JVM metrics v1.37.0</a>
  * @see io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
  * @since 1.16.0
+ * @deprecated use {@link OpenTelemetryJvmThreadCountMeterConvention} instead
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class OpenTelemetryJvmThreadMeterConventions extends MicrometerJvmThreadMeterConventions {
 
     public OpenTelemetryJvmThreadMeterConventions(Tags extraTags) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/package-info.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/package-info.java
@@ -15,7 +15,9 @@
  */
 
 /**
- * OpenTelemetry semantic convention-related classes for JVM metrics.
+ * OpenTelemetry semantic convention implementations for JVM metrics based on <a href=
+ * "https://github.com/open-telemetry/semantic-conventions/blob/v1.44.0/docs/runtime/jvm-metrics.md">OpenTelemetry
+ * Semantic Conventions for JVM metrics v1.44.0</a>.
  */
 @NullMarked
 package io.micrometer.core.instrument.binder.jvm.convention.otel;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -141,7 +141,7 @@ public class ProcessorMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Runtime runtime = Runtime.getRuntime();
         Gauge.builder(cpuCountConvention.getName(), runtime, Runtime::availableProcessors)
-            .tags(cpuCountConvention.getTags(null))
+            .tags(cpuCountConvention.getTags())
             .tags(extraTags)
             .description("The number of processors available to the Java virtual machine")
             .register(registry);
@@ -163,7 +163,7 @@ public class ProcessorMetrics implements MeterBinder {
 
         if (processCpuUsage != null) {
             Gauge.builder(cpuLoadConvention.getName(), operatingSystemBean, x -> invoke(processCpuUsage))
-                .tags(cpuLoadConvention.getTags(null))
+                .tags(cpuLoadConvention.getTags())
                 .tags(extraTags)
                 .description("The \"recent cpu usage\" for the Java Virtual Machine process")
                 .register(registry);
@@ -171,7 +171,7 @@ public class ProcessorMetrics implements MeterBinder {
 
         if (processCpuTime != null) {
             FunctionCounter.builder(cpuTimeConvention.getName(), operatingSystemBean, x -> invoke(processCpuTime))
-                .tags(cpuTimeConvention.getTags(null))
+                .tags(cpuTimeConvention.getTags())
                 .tags(extraTags)
                 .description("The \"cpu time\" used by the Java Virtual Machine process")
                 .baseUnit("ns")

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -17,9 +17,16 @@ package io.micrometer.core.instrument.binder.system;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.MeterBinder;
-import io.micrometer.core.instrument.binder.MeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuMeterConventions;
-import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmCpuMeterConventions;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmCpuCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmCpuLoadMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmCpuTimeMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmCpuCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmCpuLoadMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmCpuTimeMeterConvention;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.management.ManagementFactory;
@@ -58,7 +65,11 @@ public class ProcessorMetrics implements MeterBinder {
 
     private final Tags extraTags;
 
-    private final JvmCpuMeterConventions conventions;
+    private final JvmCpuTimeMeterConvention cpuTimeConvention;
+
+    private final JvmCpuCountMeterConvention cpuCountConvention;
+
+    private final JvmCpuLoadMeterConvention cpuLoadConvention;
 
     private final OperatingSystemMXBean operatingSystemBean;
 
@@ -79,7 +90,8 @@ public class ProcessorMetrics implements MeterBinder {
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public ProcessorMetrics(Iterable<Tag> extraTags) {
-        this(extraTags, new MicrometerJvmCpuMeterConventions(Tags.of(extraTags)));
+        this(Tags.of(extraTags), new MicrometerJvmCpuTimeMeterConvention(), new MicrometerJvmCpuCountMeterConvention(),
+                new MicrometerJvmCpuLoadMeterConvention());
     }
 
     /**
@@ -89,10 +101,25 @@ public class ProcessorMetrics implements MeterBinder {
      * @param extraTags extra tags to add to meters not covered by the conventions
      * @param conventions custom conventions for applicable meters
      * @since 1.16.0
+     * @deprecated use {@link #builder()} to provide individual conventions
      */
+    @Deprecated
     public ProcessorMetrics(Iterable<? extends Tag> extraTags, JvmCpuMeterConventions conventions) {
-        this.extraTags = Tags.of(extraTags);
-        this.conventions = conventions;
+        this(Tags.of(extraTags),
+                JvmCpuTimeMeterConvention.of(conventions.cpuTimeConvention().getName(),
+                        conventions.cpuTimeConvention().getTags(null)),
+                JvmCpuCountMeterConvention.of(conventions.cpuCountConvention().getName(),
+                        conventions.cpuCountConvention().getTags(null)),
+                JvmCpuLoadMeterConvention.of(conventions.processCpuLoadConvention().getName(),
+                        conventions.processCpuLoadConvention().getTags(null)));
+    }
+
+    private ProcessorMetrics(Tags extraTags, JvmCpuTimeMeterConvention cpuTimeConvention,
+            JvmCpuCountMeterConvention cpuCountConvention, JvmCpuLoadMeterConvention cpuLoadConvention) {
+        this.extraTags = extraTags;
+        this.cpuTimeConvention = cpuTimeConvention;
+        this.cpuCountConvention = cpuCountConvention;
+        this.cpuLoadConvention = cpuLoadConvention;
         this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
         this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
         Method getCpuLoad = detectMethod("getCpuLoad");
@@ -101,12 +128,21 @@ public class ProcessorMetrics implements MeterBinder {
         this.processCpuTime = detectMethod("getProcessCpuTime");
     }
 
+    /**
+     * Create a new builder for {@link ProcessorMetrics}.
+     * @return a new builder
+     * @since 1.18.0
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
     @Override
     public void bindTo(MeterRegistry registry) {
         Runtime runtime = Runtime.getRuntime();
-        MeterConvention<Object> cpuCountConvention = conventions.cpuCountConvention();
         Gauge.builder(cpuCountConvention.getName(), runtime, Runtime::availableProcessors)
             .tags(cpuCountConvention.getTags(null))
+            .tags(extraTags)
             .description("The number of processors available to the Java virtual machine")
             .register(registry);
 
@@ -126,17 +162,17 @@ public class ProcessorMetrics implements MeterBinder {
         }
 
         if (processCpuUsage != null) {
-            MeterConvention<Object> processCpuLoadConvention = conventions.processCpuLoadConvention();
-            Gauge.builder(processCpuLoadConvention.getName(), operatingSystemBean, x -> invoke(processCpuUsage))
-                .tags(processCpuLoadConvention.getTags(null))
+            Gauge.builder(cpuLoadConvention.getName(), operatingSystemBean, x -> invoke(processCpuUsage))
+                .tags(cpuLoadConvention.getTags(null))
+                .tags(extraTags)
                 .description("The \"recent cpu usage\" for the Java Virtual Machine process")
                 .register(registry);
         }
 
         if (processCpuTime != null) {
-            MeterConvention<Object> cpuTimeConvention = this.conventions.cpuTimeConvention();
             FunctionCounter.builder(cpuTimeConvention.getName(), operatingSystemBean, x -> invoke(processCpuTime))
                 .tags(cpuTimeConvention.getTags(null))
+                .tags(extraTags)
                 .description("The \"cpu time\" used by the Java Virtual Machine process")
                 .baseUnit("ns")
                 .register(registry);
@@ -180,6 +216,90 @@ public class ProcessorMetrics implements MeterBinder {
             }
         }
         return null;
+    }
+
+    /**
+     * Builder for {@link ProcessorMetrics}.
+     *
+     * @since 1.18.0
+     */
+    public static class Builder {
+
+        private Tags extraTags = Tags.empty();
+
+        private @Nullable JvmCpuTimeMeterConvention cpuTimeConvention;
+
+        private @Nullable JvmCpuCountMeterConvention cpuCountConvention;
+
+        private @Nullable JvmCpuLoadMeterConvention cpuLoadConvention;
+
+        Builder() {
+        }
+
+        /**
+         * Extra tags to add to meters registered by this binder.
+         * @param extraTags tags to add
+         * @return this builder
+         */
+        public Builder extraTags(Iterable<? extends Tag> extraTags) {
+            this.extraTags = Tags.of(extraTags);
+            return this;
+        }
+
+        /**
+         * Custom convention for the CPU time meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder cpuTimeConvention(JvmCpuTimeMeterConvention convention) {
+            this.cpuTimeConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the CPU count meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder cpuCountConvention(JvmCpuCountMeterConvention convention) {
+            this.cpuCountConvention = convention;
+            return this;
+        }
+
+        /**
+         * Custom convention for the process CPU load meter.
+         * @param convention the convention to use
+         * @return this builder
+         */
+        public Builder cpuLoadConvention(JvmCpuLoadMeterConvention convention) {
+            this.cpuLoadConvention = convention;
+            return this;
+        }
+
+        /**
+         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
+         * can still be overridden by calling the specific convention methods after this
+         * one.
+         * @return this builder
+         */
+        public Builder openTelemetryConventions() {
+            this.cpuTimeConvention = new OpenTelemetryJvmCpuTimeMeterConvention();
+            this.cpuCountConvention = new OpenTelemetryJvmCpuCountMeterConvention();
+            this.cpuLoadConvention = new OpenTelemetryJvmCpuLoadMeterConvention();
+            return this;
+        }
+
+        /**
+         * Build a new {@link ProcessorMetrics} instance.
+         * @return a new {@link ProcessorMetrics}
+         */
+        public ProcessorMetrics build() {
+            return new ProcessorMetrics(extraTags,
+                    cpuTimeConvention != null ? cpuTimeConvention : new MicrometerJvmCpuTimeMeterConvention(),
+                    cpuCountConvention != null ? cpuCountConvention : new MicrometerJvmCpuCountMeterConvention(),
+                    cpuLoadConvention != null ? cpuLoadConvention : new MicrometerJvmCpuLoadMeterConvention());
+        }
+
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -279,10 +279,13 @@ public class ProcessorMetrics implements MeterBinder {
         }
 
         /**
-         * Use OpenTelemetry semantic conventions for all meters. Individual conventions
-         * can still be overridden by calling the specific convention methods after this
-         * one.
+         * Use OpenTelemetry semantic conventions for applicable meters that have a stable
+         * semantic convention as of the version documented in
+         * {@link io.micrometer.core.instrument.binder.jvm.convention.otel the otel
+         * conventions package}. Individual conventions can still be overridden by calling
+         * the specific convention methods after this one.
          * @return this builder
+         * @see io.micrometer.core.instrument.binder.jvm.convention.otel
          */
         public Builder openTelemetryConventions() {
             this.cpuTimeConvention = new OpenTelemetryJvmCpuTimeMeterConvention();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/ProcessorMetrics.java
@@ -86,7 +86,8 @@ public class ProcessorMetrics implements MeterBinder {
     }
 
     /**
-     * Uses the default convention with the provided extra tags.
+     * Uses the default convention with the provided extra tags. If a conflict occurs
+     * between extra tags and convention tags, the convention tag takes precedence.
      * @param extraTags tags to add to each meter's tags produced by this binder
      */
     public ProcessorMetrics(Iterable<Tag> extraTags) {
@@ -141,8 +142,8 @@ public class ProcessorMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Runtime runtime = Runtime.getRuntime();
         Gauge.builder(cpuCountConvention.getName(), runtime, Runtime::availableProcessors)
-            .tags(cpuCountConvention.getTags())
             .tags(extraTags)
+            .tags(cpuCountConvention.getTags())
             .description("The number of processors available to the Java virtual machine")
             .register(registry);
 
@@ -163,16 +164,16 @@ public class ProcessorMetrics implements MeterBinder {
 
         if (processCpuUsage != null) {
             Gauge.builder(cpuLoadConvention.getName(), operatingSystemBean, x -> invoke(processCpuUsage))
-                .tags(cpuLoadConvention.getTags())
                 .tags(extraTags)
+                .tags(cpuLoadConvention.getTags())
                 .description("The \"recent cpu usage\" for the Java Virtual Machine process")
                 .register(registry);
         }
 
         if (processCpuTime != null) {
             FunctionCounter.builder(cpuTimeConvention.getName(), operatingSystemBean, x -> invoke(processCpuTime))
-                .tags(cpuTimeConvention.getTags())
                 .tags(extraTags)
+                .tags(cpuTimeConvention.getTags())
                 .description("The \"cpu time\" used by the Java Virtual Machine process")
                 .baseUnit("ns")
                 .register(registry);
@@ -237,7 +238,8 @@ public class ProcessorMetrics implements MeterBinder {
         }
 
         /**
-         * Extra tags to add to meters registered by this binder.
+         * Extra tags to add to meters registered by this binder. If a conflict occurs
+         * between extra tags and convention tags, the convention tag takes precedence.
          * @param extraTags tags to add
          * @return this builder
          */

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/SimpleMeterConventionTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/SimpleMeterConventionTest.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.*;
 
+@SuppressWarnings("deprecation")
 class SimpleMeterConventionTest {
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetricsTest.java
@@ -19,6 +19,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterConvention;
 import io.micrometer.core.instrument.binder.SimpleMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassLoadedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmClassUnloadedMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmClassLoadingMeterConventions;
 import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmClassLoadingMeterConventions;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -64,6 +67,41 @@ class ClassLoaderMetricsTest {
         assertThat(registry.get("jvm.class.loaded").tags(extraTags).functionCounter().count()).isPositive();
         assertThat(registry.get("jvm.class.unloaded").tags(extraTags).functionCounter().count()).isNotNegative();
         assertThat(registry.get("jvm.class.count").tags(extraTags).gauge().value()).isPositive();
+    }
+
+    @Test
+    void builderDefaults() {
+        ClassLoaderMetrics.builder().build().bindTo(registry);
+
+        assertThat(registry.get("jvm.classes.loaded").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.classes.loaded.count").functionCounter().count()).isPositive();
+        assertThat(registry.get("jvm.classes.unloaded").functionCounter().count()).isNotNegative();
+    }
+
+    @Test
+    void builderWithOpenTelemetryConventions() {
+        ClassLoaderMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+
+        assertThat(registry.get("jvm.class.loaded").functionCounter().count()).isPositive();
+        assertThat(registry.get("jvm.class.unloaded").functionCounter().count()).isNotNegative();
+        assertThat(registry.get("jvm.class.count").gauge().value()).isPositive();
+    }
+
+    @Test
+    void builderWithCustomConventionsAndExtraTags() {
+        Tags extraTags = Tags.of("app", "test");
+        ClassLoaderMetrics.builder()
+            .extraTags(extraTags)
+            .classCountConvention(JvmClassCountMeterConvention.of("custom.class.count", Tags.of("type", "count")))
+            .classLoadedConvention(JvmClassLoadedMeterConvention.of("custom.class.loaded"))
+            .classUnloadedConvention(JvmClassUnloadedMeterConvention.of("custom.class.unloaded"))
+            .build()
+            .bindTo(registry);
+
+        assertThat(registry.get("custom.class.count").tags(extraTags).tag("type", "count").gauge().value())
+            .isPositive();
+        assertThat(registry.get("custom.class.loaded").tags(extraTags).functionCounter().count()).isPositive();
+        assertThat(registry.get("custom.class.unloaded").tags(extraTags).functionCounter().count()).isNotNegative();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/ClassLoaderMetricsTest.java
@@ -105,6 +105,19 @@ class ClassLoaderMetricsTest {
     }
 
     @Test
+    void conventionTagsTakePrecedenceOverConflictingExtraTags() {
+        Tags extraTags = Tags.of("type", "from-extra-tags");
+        ClassLoaderMetrics.builder()
+            .extraTags(extraTags)
+            .classCountConvention(
+                    JvmClassCountMeterConvention.of("custom.class.count", Tags.of("type", "from-convention")))
+            .build()
+            .bindTo(registry);
+
+        assertThat(registry.get("custom.class.count").tag("type", "from-convention").gauge().value()).isPositive();
+    }
+
+    @Test
     void customConventions() {
         new ClassLoaderMetrics(new MyClassLoaderConventions()).bindTo(registry);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -19,6 +19,9 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.BaseUnits;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryCommittedMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryMaxMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmMemoryUsedMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmMemoryMeterConventions;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,50 @@ class JvmMemoryMetricsTest {
 
         assertJvmMemoryMetrics("heap", extraTags);
         assertJvmMemoryMetrics("nonheap", extraTags);
+    }
+
+    @Test
+    void builderDefaults() {
+        JvmMemoryMetrics.builder().build().bindTo(registry);
+
+        assertJvmBufferMetrics("direct");
+        assertJvmBufferMetrics("mapped");
+
+        assertJvmMemoryMetrics("heap");
+        assertJvmMemoryMetrics("nonheap");
+    }
+
+    @Test
+    void builderWithOpenTelemetryConventions() {
+        JvmMemoryMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+
+        assertJvmBufferMetrics("direct");
+        assertJvmBufferMetrics("mapped");
+
+        assertJvmMemoryMetrics("heap", Tags.empty(), true);
+        assertJvmMemoryMetrics("non_heap", Tags.empty(), true);
+    }
+
+    @Test
+    void builderWithCustomConventionsAndExtraTags() {
+        Tags extraTags = Tags.of("app", "test");
+        JvmMemoryMetrics.builder()
+            .extraTags(extraTags)
+            .memoryUsedConvention(JvmMemoryUsedMeterConvention.of("custom.memory.used",
+                    pool -> Tags.of("custom.pool", pool.getName())))
+            .memoryCommittedConvention(JvmMemoryCommittedMeterConvention.of("custom.memory.committed"))
+            .memoryMaxConvention(JvmMemoryMaxMeterConvention.of("custom.memory.max"))
+            .build()
+            .bindTo(registry);
+
+        Gauge memUsed = registry.get("custom.memory.used").tags(extraTags).tagKeys("custom.pool").gauge();
+        assertThat(memUsed.value()).isGreaterThanOrEqualTo(0);
+
+        Gauge memCommitted = registry.get("custom.memory.committed").tags(extraTags).gauge();
+        assertThat(memCommitted.value()).isNotNaN();
+
+        Gauge memMax = registry.get("custom.memory.max").tags(extraTags).gauge();
+        assertThat(memMax.value()).isNotNaN();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmMemoryMetricsTest.java
@@ -105,6 +105,16 @@ class JvmMemoryMetricsTest {
     }
 
     @Test
+    void conventionTagsTakePrecedenceOverConflictingExtraTags() {
+        Tags extraTags = Tags.of("area", "from-extra-tags", "id", "from-extra-tags");
+        new JvmMemoryMetrics(extraTags).bindTo(registry);
+
+        Gauge heapUsed = registry.get("jvm.memory.used").tag("area", "heap").gauge();
+        assertThat(heapUsed.value()).isGreaterThanOrEqualTo(0);
+        assertThat(heapUsed.getId().getTag("area")).isEqualTo("heap");
+    }
+
+    @Test
     void otelMemoryMetrics() {
         Tags extraTags = Tags.empty();
         new JvmMemoryMetrics(extraTags, new OpenTelemetryJvmMemoryMeterConventions(extraTags)).bindTo(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.jvm;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadCountMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmThreadMeterConventions;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,41 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.daemon").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.peak").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.states").tags(extraTags).tag("state", "runnable").gauge().value())
+            .isPositive();
+    }
+
+    @Test
+    void builderDefaults() {
+        JvmThreadMetrics.builder().build().bindTo(registry);
+
+        assertThat(registry.get("jvm.threads.live").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.daemon").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.peak").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.states").tag("state", "runnable").gauge().value()).isPositive();
+    }
+
+    @Test
+    void builderWithOpenTelemetryConventions() {
+        JvmThreadMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+
+        assertThat(registry.get("jvm.threads.live").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.daemon").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.threads.peak").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.thread.count").tag("jvm.thread.state", "runnable").gauge().value()).isPositive();
+    }
+
+    @Test
+    void builderWithCustomConventionsAndExtraTags() {
+        Tags extraTags = Tags.of("app", "test");
+        JvmThreadMetrics.builder()
+            .extraTags(extraTags)
+            .threadCountConvention(JvmThreadCountMeterConvention.of("custom.thread.count",
+                    state -> Tags.of("custom.state", state.name())))
+            .build()
+            .bindTo(registry);
+
+        assertThat(registry.get("jvm.threads.live").tags(extraTags).gauge().value()).isPositive();
+        assertThat(registry.get("custom.thread.count").tags(extraTags).tag("custom.state", "RUNNABLE").gauge().value())
             .isPositive();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.jvm;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadCountMeterConvention;
@@ -115,6 +116,16 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.live").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("custom.thread.count").tags(extraTags).tag("custom.state", "RUNNABLE").gauge().value())
             .isPositive();
+    }
+
+    @Test
+    void conventionTagsTakePrecedenceOverConflictingExtraTags() {
+        Tags extraTags = Tags.of("state", "from-extra-tags");
+        new JvmThreadMetrics(extraTags).bindTo(registry);
+
+        Gauge runnableGauge = registry.get("jvm.threads.states").tag("state", "runnable").gauge();
+        assertThat(runnableGauge.value()).isPositive();
+        assertThat(runnableGauge.getId().getTag("state")).isEqualTo("runnable");
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -17,6 +17,9 @@ package io.micrometer.core.instrument.binder.system;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuLoadMeterConvention;
+import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuTimeMeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.otel.OpenTelemetryJvmCpuMeterConventions;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -86,6 +89,37 @@ class ProcessorMetricsTest {
         await().atMost(Duration.ofMillis(200))
             .untilAsserted(() -> assertThat(registry.get("process.cpu.usage").gauge().value()).isPositive());
         assertThat(registry.get("process.cpu.time").functionCounter().count()).isPositive();
+    }
+
+    @Test
+    void builderDefaults() {
+        ProcessorMetrics.builder().build().bindTo(registry);
+
+        assertThat(registry.get("system.cpu.count").gauge().value()).isPositive();
+        assertThat(registry.get("process.cpu.time").functionCounter().count()).isPositive();
+    }
+
+    @Test
+    void builderWithOpenTelemetryConventions() {
+        ProcessorMetrics.builder().openTelemetryConventions().build().bindTo(registry);
+
+        assertThat(registry.get("jvm.cpu.count").gauge().value()).isPositive();
+        assertThat(registry.get("jvm.cpu.time").functionCounter().count()).isPositive();
+    }
+
+    @Test
+    void builderWithCustomConventionsAndExtraTags() {
+        Tags extraTags = Tags.of("app", "test");
+        ProcessorMetrics.builder()
+            .extraTags(extraTags)
+            .cpuCountConvention(JvmCpuCountMeterConvention.of("custom.cpu.count", Tags.of("type", "core")))
+            .cpuLoadConvention(JvmCpuLoadMeterConvention.of("custom.cpu.load"))
+            .cpuTimeConvention(JvmCpuTimeMeterConvention.of("custom.cpu.time"))
+            .build()
+            .bindTo(registry);
+
+        assertThat(registry.get("custom.cpu.count").tags(extraTags).tag("type", "core").gauge().value()).isPositive();
+        assertThat(registry.get("custom.cpu.time").tags(extraTags).functionCounter().count()).isPositive();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.system;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmCpuCountMeterConvention;
@@ -120,6 +121,20 @@ class ProcessorMetricsTest {
 
         assertThat(registry.get("custom.cpu.count").tags(extraTags).tag("type", "core").gauge().value()).isPositive();
         assertThat(registry.get("custom.cpu.time").tags(extraTags).functionCounter().count()).isPositive();
+    }
+
+    @Test
+    void conventionTagsTakePrecedenceOverConflictingExtraTags() {
+        Tags extraTags = Tags.of("type", "from-extra-tags");
+        ProcessorMetrics.builder()
+            .extraTags(extraTags)
+            .cpuCountConvention(JvmCpuCountMeterConvention.of("custom.cpu.count", Tags.of("type", "from-convention")))
+            .build()
+            .bindTo(registry);
+
+        Gauge cpuCountGauge = registry.get("custom.cpu.count").tag("type", "from-convention").gauge();
+        assertThat(cpuCountGauge.value()).isPositive();
+        assertThat(cpuCountGauge.getId().getTag("type")).isEqualTo("from-convention");
     }
 
     @Test


### PR DESCRIPTION
Replace group interfaces (e.g., JvmMemoryMeterConventions) with specific per-convention interfaces (e.g., JvmMemoryUsedMeterConvention). This resolves issues where the OTel variant extending the Micrometer variant made Spring Boot auto-configuration awkward (the OTel variant is an `instanceof` the Micrometer variant), and where customizing a single meter required implementing the entire group interface.

Each binder now has a builder with per-convention setters and an `openTelemetryConventions()` convenience method. The binder merges extra tags itself so conventions stay purely semantic. Each specific interface provides a static `of()` factory for inline custom implementations.

Group interfaces and their implementations are deprecated in favor of the new per-convention types and builders.

---

The second commit in this PR https://github.com/micrometer-metrics/micrometer/pull/7369/commits/f8fc24528f4236e7d86150f5c8927af2bed4a288 removes `MeterConvention<C>` from the type hierarchy and deprecates it and SimpleMeterConvention. One problem with `MeterConvention` is its type parameter is problematic for conventions that don't derive their tags from any context object that needs to be passed. They have to set the type parameter to `Void` and users of the convention need to pass `null` to the `getTags` method, which is awkward API design that smells. Removing it from the hierarchy solves this problem because each specific convention interface defines the method signature that makes sense for it. There is no current use of a common type. There is no consumer of conventions that acts on a generic `MeterConvention` type. There is no registry of conventions. Each instrumentation needs specific conventions and uses the specific types for those conventions.