### PR TITLE
Harmonize @Nullable annotations in okhttp instrumentation

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/DefaultOkHttpObservationConvention.java
@@ -76,9 +76,10 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         Request request = state != null ? state.request : null;
         Response response = state != null ? state.response : null;
         IOException exception = state != null ? state.exception : null;
-        Function<Request, String> urlMapper = context.getUrlMapper();
+        Function<@Nullable Request, String> urlMapper = context.getUrlMapper();
         Iterable<KeyValue> extraTags = context.getExtraTags();
-        Iterable<BiFunction<Request, Response, KeyValue>> contextSpecificTags = context.getContextSpecificTags();
+        Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags = context
+            .getContextSpecificTags();
         Iterable<KeyValue> unknownRequestTags = context.getUnknownRequestTags();
         boolean includeHostTag = context.isIncludeHostTag();
         // TODO: Tags to key values and back - maybe we can improve this?
@@ -98,7 +99,7 @@ public class DefaultOkHttpObservationConvention implements OkHttpObservationConv
         return keyValues;
     }
 
-    private String getUriTag(Function<Request, String> urlMapper, @Nullable Request request) {
+    private String getUriTag(Function<@Nullable Request, String> urlMapper, @Nullable Request request) {
         if (request == null) {
             return TAG_VALUE_UNKNOWN;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpContext.java
@@ -37,11 +37,11 @@ import java.util.function.Supplier;
 public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Response>
         implements Supplier<OkHttpContext> {
 
-    private final Function<Request, String> urlMapper;
+    private final Function<@Nullable Request, String> urlMapper;
 
     private final Iterable<KeyValue> extraTags;
 
-    private final Iterable<BiFunction<Request, Response, KeyValue>> contextSpecificTags;
+    private final Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags;
 
     private final Iterable<KeyValue> unknownRequestTags;
 
@@ -51,8 +51,8 @@ public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Re
 
     private OkHttpObservationInterceptor.@Nullable CallState state;
 
-    public OkHttpContext(Function<Request, String> urlMapper, Iterable<KeyValue> extraTags,
-            Iterable<BiFunction<Request, Response, KeyValue>> contextSpecificTags,
+    public OkHttpContext(Function<@Nullable Request, String> urlMapper, Iterable<KeyValue> extraTags,
+            Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags,
             Iterable<KeyValue> unknownRequestTags, boolean includeHostTag, Request originalRequest) {
         super((carrier, key, value) -> {
             if (carrier != null) {
@@ -75,7 +75,7 @@ public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Re
         return state;
     }
 
-    public Function<Request, String> getUrlMapper() {
+    public Function<@Nullable Request, String> getUrlMapper() {
         return urlMapper;
     }
 
@@ -83,7 +83,7 @@ public class OkHttpContext extends RequestReplySenderContext<Request.Builder, Re
         return extraTags;
     }
 
-    public Iterable<BiFunction<Request, Response, KeyValue>> getContextSpecificTags() {
+    public Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> getContextSpecificTags() {
         return contextSpecificTags;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpMetricsEventListener.java
@@ -89,11 +89,11 @@ public class OkHttpMetricsEventListener extends EventListener {
 
     private final String requestsMetricName;
 
-    private final Function<Request, String> urlMapper;
+    private final Function<@Nullable Request, String> urlMapper;
 
     private final Iterable<Tag> extraTags;
 
-    private final Iterable<BiFunction<Request, Response, Tag>> contextSpecificTags;
+    private final Iterable<BiFunction<@Nullable Request, @Nullable Response, Tag>> contextSpecificTags;
 
     private final Iterable<Tag> unknownRequestTags;
 
@@ -103,13 +103,14 @@ public class OkHttpMetricsEventListener extends EventListener {
     final ConcurrentMap<Call, CallState> callState = new ConcurrentHashMap<>();
 
     protected OkHttpMetricsEventListener(MeterRegistry registry, String requestsMetricName,
-            Function<Request, String> urlMapper, Iterable<Tag> extraTags,
-            Iterable<BiFunction<Request, Response, Tag>> contextSpecificTags) {
+            Function<@Nullable Request, String> urlMapper, Iterable<Tag> extraTags,
+            Iterable<BiFunction<@Nullable Request, @Nullable Response, Tag>> contextSpecificTags) {
         this(registry, requestsMetricName, urlMapper, extraTags, contextSpecificTags, emptyList(), true);
     }
 
-    OkHttpMetricsEventListener(MeterRegistry registry, String requestsMetricName, Function<Request, String> urlMapper,
-            Iterable<Tag> extraTags, Iterable<BiFunction<Request, Response, Tag>> contextSpecificTags,
+    OkHttpMetricsEventListener(MeterRegistry registry, String requestsMetricName,
+            Function<@Nullable Request, String> urlMapper, Iterable<Tag> extraTags,
+            Iterable<BiFunction<@Nullable Request, @Nullable Response, Tag>> contextSpecificTags,
             Iterable<String> requestTagKeys, boolean includeHostTag) {
         this.registry = registry;
         this.requestsMetricName = requestsMetricName;
@@ -259,12 +260,12 @@ public class OkHttpMetricsEventListener extends EventListener {
 
         private final String name;
 
-        private Function<Request, String> uriMapper = (request) -> Optional.ofNullable(request.header(URI_PATTERN))
-            .orElse(KeyValue.NONE_VALUE);
+        private Function<@Nullable Request, String> uriMapper = (
+                request) -> Optional.ofNullable(request).map(rq -> rq.header(URI_PATTERN)).orElse(KeyValue.NONE_VALUE);
 
         private Tags tags = Tags.empty();
 
-        private Collection<BiFunction<Request, Response, Tag>> contextSpecificTags = new ArrayList<>();
+        private Collection<BiFunction<@Nullable Request, @Nullable Response, Tag>> contextSpecificTags = new ArrayList<>();
 
         private boolean includeHostTag = true;
 
@@ -297,12 +298,12 @@ public class OkHttpMetricsEventListener extends EventListener {
          * @return this builder
          * @since 1.5.0
          */
-        public Builder tag(BiFunction<Request, Response, Tag> contextSpecificTag) {
+        public Builder tag(BiFunction<@Nullable Request, @Nullable Response, Tag> contextSpecificTag) {
             this.contextSpecificTags.add(contextSpecificTag);
             return this;
         }
 
-        public Builder uriMapper(Function<Request, String> uriMapper) {
+        public Builder uriMapper(Function<@Nullable Request, String> uriMapper) {
             this.uriMapper = uriMapper;
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptor.java
@@ -43,11 +43,11 @@ public class OkHttpObservationInterceptor implements Interceptor {
 
     private final String requestMetricName;
 
-    private final Function<Request, String> urlMapper;
+    private final Function<@Nullable Request, String> urlMapper;
 
     private final Iterable<KeyValue> extraTags;
 
-    private final Iterable<BiFunction<Request, Response, KeyValue>> contextSpecificTags;
+    private final Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags;
 
     private final Iterable<KeyValue> unknownRequestTags;
 
@@ -55,9 +55,9 @@ public class OkHttpObservationInterceptor implements Interceptor {
 
     public OkHttpObservationInterceptor(ObservationRegistry registry,
             @Nullable OkHttpObservationConvention observationConvention, String requestsMetricName,
-            Function<Request, String> urlMapper, Iterable<KeyValue> extraTags,
-            Iterable<BiFunction<Request, Response, KeyValue>> contextSpecificTags, Iterable<String> requestTagKeys,
-            boolean includeHostTag) {
+            Function<@Nullable Request, String> urlMapper, Iterable<KeyValue> extraTags,
+            Iterable<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags,
+            Iterable<String> requestTagKeys, boolean includeHostTag) {
         this.registry = registry;
         this.observationConvention = observationConvention;
         this.requestMetricName = requestsMetricName;
@@ -139,12 +139,12 @@ public class OkHttpObservationInterceptor implements Interceptor {
 
         private final ObservationRegistry registry;
 
-        private Function<Request, String> uriMapper = (request) -> Optional.ofNullable(request.header(URI_PATTERN))
-            .orElse(KeyValue.NONE_VALUE);
+        private Function<@Nullable Request, String> uriMapper = (
+                request) -> Optional.ofNullable(request).map(rq -> rq.header(URI_PATTERN)).orElse(KeyValue.NONE_VALUE);
 
         private KeyValues tags = KeyValues.empty();
 
-        private Collection<BiFunction<Request, Response, KeyValue>> contextSpecificTags = new ArrayList<>();
+        private final Collection<BiFunction<@Nullable Request, @Nullable Response, KeyValue>> contextSpecificTags = new ArrayList<>();
 
         private boolean includeHostTag = true;
 
@@ -183,12 +183,13 @@ public class OkHttpObservationInterceptor implements Interceptor {
          * @param contextSpecificTag function to create a context-specific tag
          * @return this builder
          */
-        public OkHttpObservationInterceptor.Builder tag(BiFunction<Request, Response, KeyValue> contextSpecificTag) {
+        public OkHttpObservationInterceptor.Builder tag(
+                BiFunction<@Nullable Request, @Nullable Response, KeyValue> contextSpecificTag) {
             this.contextSpecificTags.add(contextSpecificTag);
             return this;
         }
 
-        public OkHttpObservationInterceptor.Builder uriMapper(Function<Request, String> uriMapper) {
+        public OkHttpObservationInterceptor.Builder uriMapper(Function<@Nullable Request, String> uriMapper) {
             this.uriMapper = uriMapper;
             return this;
         }


### PR DESCRIPTION
This is a just firefighting and not a proper fix.
The proper fix would be non-null request and nullable response but fixing that seems to be a very deep rabbit hole and also involves breaking changes.

Closes gh-7373