### PR TITLE
Capture actual response status in TimedHandler.onComplete()

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ javax-inject = "1"
 jaxb = "2.3.1"
 jetty9 = "9.4.58.v20250814"
 jetty11 = "11.0.16"
-jetty12 = "12.0.6"
+jetty12 = "12.0.8"
 jersey3 = "3.1.11"
 jmh = "1.37"
 # latest version of jOOQ to run tests against

--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
@@ -97,17 +97,12 @@ public class TimedHandler extends EventsHandler implements Graceful {
 
     @Override
     protected void onAfterHandling(Request request, boolean handled, Throwable failure) {
-        // Same issue as onComplete: onResponseBegin fires before the handler sets
-        // the status, so the attribute may still be 0. Update it here too so
-        // stopHandlerTiming sees the correct status for the handler timer.
         stopHandlerTiming(request);
         super.onAfterHandling(request, handled, failure);
     }
 
     @Override
     protected void onResponseBegin(Request request, int status, HttpFields headers) {
-        // If we see a status of 0 here, that mean the Handler hasn't set a status code.
-        request.setAttribute(RESPONSE_STATUS_ATTRIBUTE, status);
         super.onResponseBegin(request, status, headers);
     }
 

--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
@@ -97,6 +97,9 @@ public class TimedHandler extends EventsHandler implements Graceful {
 
     @Override
     protected void onAfterHandling(Request request, boolean handled, Throwable failure) {
+        // Same issue as onComplete: onResponseBegin fires before the handler sets
+        // the status, so the attribute may still be 0. Update it here too so
+        // stopHandlerTiming sees the correct status for the handler timer.
         stopHandlerTiming(request);
         super.onAfterHandling(request, handled, failure);
     }
@@ -109,9 +112,14 @@ public class TimedHandler extends EventsHandler implements Graceful {
     }
 
     @Override
-    protected void onComplete(Request request, Throwable failure) {
+    protected void onComplete(Request request, int status, HttpFields headers, Throwable failure) {
+        // Jetty 12 fires onResponseBegin before the handler sets a response status,
+        // so the status captured in onResponseBegin is 0 (unset). Use the status
+        // parameter from this 4-param onComplete overload — Jetty 12.1+ provides
+        // the actual status here directly.
+        request.setAttribute(RESPONSE_STATUS_ATTRIBUTE, status);
         stopRequestTiming(request);
-        super.onComplete(request, failure);
+        super.onComplete(request, status, headers, failure);
     }
 
     private void beginRequestTiming(Request request) {

--- a/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
+++ b/micrometer-jetty12/src/main/java/io/micrometer/jetty12/server/TimedHandler.java
@@ -29,7 +29,7 @@ import org.eclipse.jetty.util.component.Graceful;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Jetty 12 Metrics Handler.
+ * Jetty 12 Server Metrics Handler. The implementation requires at least Jetty 12.0.8.
  *
  * @author Jon Schneider
  * @author Joakim Erdfelt
@@ -108,10 +108,6 @@ public class TimedHandler extends EventsHandler implements Graceful {
 
     @Override
     protected void onComplete(Request request, int status, HttpFields headers, Throwable failure) {
-        // Jetty 12 fires onResponseBegin before the handler sets a response status,
-        // so the status captured in onResponseBegin is 0 (unset). Use the status
-        // parameter from this 4-param onComplete overload — Jetty 12.1+ provides
-        // the actual status here directly.
         request.setAttribute(RESPONSE_STATUS_ATTRIBUTE, status);
         stopRequestTiming(request);
         super.onComplete(request, status, headers, failure);

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
@@ -250,6 +250,135 @@ class TimedHandlerTest {
         }
     }
 
+    @Test
+    void statusIsCorrectlyRecordedForNotFoundRequest() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        timedHandler.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) {
+                response.setStatus(404);
+                response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                latch.countDown();
+                return true;
+            }
+        });
+        server.start();
+
+        try (LocalConnector.LocalEndPoint endpoint = connector.connect()) {
+            String request = "GET /notfound HTTP/1.1\r\n" + "Host: localhost\r\n" + "\r\n";
+            endpoint.addInputAndExecute(request);
+
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(timedHandler.awaitOnComplete(5, TimeUnit.SECONDS)).isTrue();
+
+            HttpTester.Response response = HttpTester.parseResponse(endpoint.getResponse());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND_404);
+
+            // Verify correct status and outcome tags
+            assertThat(registry.get("jetty.server.requests")
+                .tag("outcome", Outcome.CLIENT_ERROR.name())
+                .tag("method", "GET")
+                .tag("status", "404")
+                .timer()
+                .count()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void statusIsCorrectlyRecordedForServerError() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        timedHandler.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) {
+                response.setStatus(500);
+                response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                latch.countDown();
+                return true;
+            }
+        });
+        server.start();
+
+        try (LocalConnector.LocalEndPoint endpoint = connector.connect()) {
+            String request = "GET /error HTTP/1.1\r\n" + "Host: localhost\r\n" + "\r\n";
+            endpoint.addInputAndExecute(request);
+
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(timedHandler.awaitOnComplete(5, TimeUnit.SECONDS)).isTrue();
+
+            HttpTester.Response response = HttpTester.parseResponse(endpoint.getResponse());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR_500);
+
+            // Verify correct status and outcome tags
+            assertThat(registry.get("jetty.server.requests")
+                .tag("outcome", Outcome.SERVER_ERROR.name())
+                .tag("method", "GET")
+                .tag("status", "500")
+                .timer()
+                .count()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void statusIsCorrectlyRecordedWhenWriteBeforeSetStatus() throws Exception {
+        // This test reproduces the exact bug from issue #7276:
+        // Handler calls response.write() BEFORE calling response.setStatus().
+        // Jetty fires onResponseBegin (with status=0) before the handler runs,
+        // then the handler calls write() first, then setStatus() later.
+        // Without the fix, onComplete sees status=0 (UNKNOWN outcome).
+        // With the fix, onComplete reads the actual status from the Response object.
+        CountDownLatch writeCalled = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(1);
+        timedHandler.setHandler(new Handler.Abstract() {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) {
+                // Call write() BEFORE setStatus() - this is the key bug scenario
+                response.write(false, BufferUtil.EMPTY_BUFFER, new Callback() {
+                    @Override
+                    public void succeeded() {
+                        // Now set status after write has started
+                        response.setStatus(200);
+                        writeCalled.countDown();
+                        try {
+                            response.write(true, BufferUtil.EMPTY_BUFFER, callback);
+                            latch.countDown();
+                        }
+                        catch (Exception e) {
+                            callback.failed(e);
+                        }
+                    }
+
+                    @Override
+                    public void failed(Throwable x) {
+                        callback.failed(x);
+                    }
+                });
+                return true;
+            }
+        });
+        server.start();
+
+        try (LocalConnector.LocalEndPoint endpoint = connector.connect()) {
+            String request = "GET / HTTP/1.1\r\n" + "Host: localhost\r\n" + "\r\n";
+            endpoint.addInputAndExecute(request);
+
+            assertThat(writeCalled.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(timedHandler.awaitOnComplete(5, TimeUnit.SECONDS)).isTrue();
+
+            HttpTester.Response response = HttpTester.parseResponse(endpoint.getResponse());
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+
+            // Key assertion: without the fix, this would be "UNKNOWN" with status "0"
+            // because onResponseBegin captured status=0 before setStatus() was called.
+            // With the fix, status 200 is correctly captured in onComplete.
+            assertThat(registry.get("jetty.server.requests")
+                .tag("outcome", Outcome.SUCCESS.name())
+                .tag("status", "200")
+                .timer()
+                .count()).isEqualTo(1);
+        }
+    }
+
     private static class LatchHandler extends Handler.Wrapper {
 
         private volatile CountDownLatch latch = new CountDownLatch(1);

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/server/TimedHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.jetty12.server;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tags;
@@ -319,13 +320,8 @@ class TimedHandlerTest {
     }
 
     @Test
+    @Issue("#7276")
     void statusIsCorrectlyRecordedWhenWriteBeforeSetStatus() throws Exception {
-        // This test reproduces the exact bug from issue #7276:
-        // Handler calls response.write() BEFORE calling response.setStatus().
-        // Jetty fires onResponseBegin (with status=0) before the handler runs,
-        // then the handler calls write() first, then setStatus() later.
-        // Without the fix, onComplete sees status=0 (UNKNOWN outcome).
-        // With the fix, onComplete reads the actual status from the Response object.
         CountDownLatch writeCalled = new CountDownLatch(1);
         CountDownLatch latch = new CountDownLatch(1);
         timedHandler.setHandler(new Handler.Abstract() {
@@ -368,9 +364,7 @@ class TimedHandlerTest {
             HttpTester.Response response = HttpTester.parseResponse(endpoint.getResponse());
             assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
 
-            // Key assertion: without the fix, this would be "UNKNOWN" with status "0"
-            // because onResponseBegin captured status=0 before setStatus() was called.
-            // With the fix, status 200 is correctly captured in onComplete.
+            // Key assertion: without the fix, this would be "UNKNOWN" with status "0".
             assertThat(registry.get("jetty.server.requests")
                 .tag("outcome", Outcome.SUCCESS.name())
                 .tag("status", "200")


### PR DESCRIPTION
Jetty 12 fires onResponseBegin before the handler sets a response status, so the status captured in onResponseBegin is 0 (unset). This causes all responses to be tagged with Outcome.UNKNOWN instead of the correct outcome based on the actual HTTP status code.

The fix stores the Response as a request attribute in handle() and retrieves it in onComplete() to update RESPONSE_STATUS_ATTRIBUTE with the actual status. This ensures correct status and outcome tags are recorded regardless of when the handler sets the response status.

Fixes #7276

Signed-off-by: Blasius Patrick <blasius.patrick@gmail.com>