### PR TITLE
Add Dynamic Tag Support in Log4j2Metrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument.binder.logging;
 
-import com.google.common.collect.Iterables;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.Counter;
@@ -68,7 +67,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private final List<PropertyChangeListener> changeListeners = new CopyOnWriteArrayList<>();
 
-    private final Iterable<LogInterceptor> logInterceptors;
+    private final List<LogInterceptor> logInterceptors;
 
     public Log4j2Metrics() {
         this(emptyList());
@@ -82,7 +81,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         this(tags, loggerContext, emptyList());
     }
 
-    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, Iterable<LogInterceptor> logInterceptors) {
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, List<LogInterceptor> logInterceptors) {
         this.tags = tags;
         this.loggerContext = loggerContext;
         this.logInterceptors = logInterceptors;
@@ -182,7 +181,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         private final IncrementLogCounterStrategy incrementLogCounterStrategy;
 
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, Iterable<LogInterceptor> logInterceptors) {
+        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, List<LogInterceptor> logInterceptors) {
             this.incrementLogCounterStrategy = IncrementLogCounterFactory.getIncrementLogCounterStrategy(registry, tags,
                     logInterceptors);
         }
@@ -204,8 +203,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 class IncrementLogCounterFactory {
 
     public static IncrementLogCounterStrategy getIncrementLogCounterStrategy(MeterRegistry registry, Iterable<Tag> tags,
-            Iterable<LogInterceptor> logInterceptors) {
-        if (Iterables.isEmpty(logInterceptors)) {
+            List<LogInterceptor> logInterceptors) {
+        if (logInterceptors.isEmpty()) {
             return new StaticLogCounter(registry, tags);
         }
         else {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.logging;
 
+import com.google.common.collect.Iterables;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.Counter;
@@ -56,10 +57,6 @@ import static java.util.Collections.emptyList;
  * @since 1.1.0
  */
 public class Log4j2Metrics implements MeterBinder, AutoCloseable {
-
-    private static final String METER_NAME = "log4j2.events";
-
-    private static final String METER_DESCRIPTION = "Number of log events";
 
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Log4j2Metrics.class);
 
@@ -183,16 +180,11 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     static class MetricsFilter extends AbstractFilter {
 
-        private final MeterRegistry registry;
-
-        private final Iterable<Tag> tags;
-
-        private final Iterable<LogInterceptor> logInterceptors;
+        private final IncrementLogCounterStrategy incrementLogCounterStrategy;
 
         MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, Iterable<LogInterceptor> logInterceptors) {
-            this.registry = registry;
-            this.tags = tags;
-            this.logInterceptors = logInterceptors;
+            this.incrementLogCounterStrategy = IncrementLogCounterFactory.getIncrementLogCounterStrategy(registry, tags,
+                    logInterceptors);
         }
 
         @Override
@@ -202,22 +194,153 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         }
 
         private void incrementCounter(LogEvent event) {
-            List<Tag> dynamicTags = new ArrayList<>();
-            for (LogInterceptor logInterceptor : logInterceptors) {
-                dynamicTags.addAll(logInterceptor.getTagFromLogs(event));
-            }
-
-            Counter counter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags(dynamicTags)
-                .tags("level", event.getLevel().getStandardLevel().name().toLowerCase(Locale.ROOT))
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            counter.increment();
+            incrementLogCounterStrategy.incrementCounter(event);
         }
 
+    }
+
+}
+
+class IncrementLogCounterFactory {
+
+    public static IncrementLogCounterStrategy getIncrementLogCounterStrategy(MeterRegistry registry, Iterable<Tag> tags,
+            Iterable<LogInterceptor> logInterceptors) {
+        if (Iterables.isEmpty(logInterceptors)) {
+            return new StaticLogCounter(registry, tags);
+        }
+        else {
+            return new DynamicLogCounter(registry, tags, logInterceptors);
+        }
+    }
+
+}
+
+interface IncrementLogCounterStrategy {
+
+    String METER_DESCRIPTION = "Number of log events";
+
+    String METER_NAME = "log4j2.events";
+
+    void incrementCounter(LogEvent event);
+
+}
+
+class StaticLogCounter implements IncrementLogCounterStrategy {
+
+    private final Counter fatalCounter;
+
+    private final Counter errorCounter;
+
+    private final Counter warnCounter;
+
+    private final Counter infoCounter;
+
+    private final Counter debugCounter;
+
+    private final Counter traceCounter;
+
+    StaticLogCounter(MeterRegistry registry, Iterable<Tag> tags) {
+        fatalCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "fatal")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        errorCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "error")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        warnCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "warn")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        infoCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "info")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        debugCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "debug")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        traceCounter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags("level", "trace")
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+    }
+
+    @Override
+    public void incrementCounter(LogEvent event) {
+        switch (event.getLevel().getStandardLevel()) {
+            case FATAL:
+                fatalCounter.increment();
+                break;
+            case ERROR:
+                errorCounter.increment();
+                break;
+            case WARN:
+                warnCounter.increment();
+                break;
+            case INFO:
+                infoCounter.increment();
+                break;
+            case DEBUG:
+                debugCounter.increment();
+                break;
+            case TRACE:
+                traceCounter.increment();
+                break;
+            default:
+                break;
+        }
+    }
+
+}
+
+class DynamicLogCounter implements IncrementLogCounterStrategy {
+
+    private final MeterRegistry registry;
+
+    private final Iterable<Tag> tags;
+
+    private final Iterable<LogInterceptor> logInterceptors;
+
+    DynamicLogCounter(MeterRegistry registry, Iterable<Tag> tags, Iterable<LogInterceptor> logInterceptors) {
+        this.registry = registry;
+        this.tags = tags;
+        this.logInterceptors = logInterceptors;
+    }
+
+    @Override
+    public void incrementCounter(LogEvent event) {
+        List<Tag> dynamicTags = new ArrayList<>();
+        for (LogInterceptor logInterceptor : logInterceptors) {
+            dynamicTags.addAll(logInterceptor.getTagFromLogs(event));
+        }
+
+        Counter counter = Counter.builder(METER_NAME)
+            .tags(tags)
+            .tags(dynamicTags)
+            .tags("level", event.getLevel().getStandardLevel().name().toLowerCase(Locale.ROOT))
+            .description(METER_DESCRIPTION)
+            .baseUnit(BaseUnits.EVENTS)
+            .register(registry);
+
+        counter.increment();
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -71,7 +71,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private final List<PropertyChangeListener> changeListeners = new CopyOnWriteArrayList<>();
 
-    private final List<LogInterceptor> logInterceptors;
+    private final Iterable<LogInterceptor> logInterceptors;
 
     public Log4j2Metrics() {
         this(emptyList());
@@ -85,7 +85,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         this(tags, loggerContext, emptyList());
     }
 
-    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, List<LogInterceptor> logInterceptors) {
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, Iterable<LogInterceptor> logInterceptors) {
         this.tags = tags;
         this.loggerContext = loggerContext;
         this.logInterceptors = logInterceptors;
@@ -187,9 +187,9 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         private final Iterable<Tag> tags;
 
-        private final List<LogInterceptor> logInterceptors;
+        private final Iterable<LogInterceptor> logInterceptors;
 
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, List<LogInterceptor> logInterceptors) {
+        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, Iterable<LogInterceptor> logInterceptors) {
             this.registry = registry;
             this.tags = tags;
             this.logInterceptors = logInterceptors;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -32,8 +32,10 @@ import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -50,6 +52,7 @@ import static java.util.Collections.emptyList;
  * "https://github.com/micrometer-metrics/micrometer/issues/2176">micrometer#2176</a>
  * @author Steven Sheehy
  * @author Johnny Lim
+ * @author Harsh Verma
  * @since 1.1.0
  */
 public class Log4j2Metrics implements MeterBinder, AutoCloseable {
@@ -68,6 +71,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private final List<PropertyChangeListener> changeListeners = new CopyOnWriteArrayList<>();
 
+    private final List<LogInterceptor> logInterceptors;
+
     public Log4j2Metrics() {
         this(emptyList());
     }
@@ -77,8 +82,13 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
     }
 
     public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext) {
+        this(tags, loggerContext, emptyList());
+    }
+
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext, List<LogInterceptor> logInterceptors) {
         this.tags = tags;
         this.loggerContext = loggerContext;
+        this.logInterceptors = logInterceptors;
     }
 
     @Override
@@ -135,7 +145,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private MetricsFilter getOrCreateMetricsFilterAndStart(MeterRegistry registry) {
         return metricsFilters.computeIfAbsent(registry, r -> {
-            MetricsFilter metricsFilter = new MetricsFilter(r, tags);
+            MetricsFilter metricsFilter = new MetricsFilter(r, tags, logInterceptors);
             metricsFilter.start();
             return metricsFilter;
         });
@@ -173,60 +183,16 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     static class MetricsFilter extends AbstractFilter {
 
-        private final Counter fatalCounter;
+        private final MeterRegistry registry;
 
-        private final Counter errorCounter;
+        private final Iterable<Tag> tags;
 
-        private final Counter warnCounter;
+        private final List<LogInterceptor> logInterceptors;
 
-        private final Counter infoCounter;
-
-        private final Counter debugCounter;
-
-        private final Counter traceCounter;
-
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
-            fatalCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "fatal")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            errorCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "error")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            warnCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "warn")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            infoCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "info")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            debugCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "debug")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
-
-            traceCounter = Counter.builder(METER_NAME)
-                .tags(tags)
-                .tags("level", "trace")
-                .description(METER_DESCRIPTION)
-                .baseUnit(BaseUnits.EVENTS)
-                .register(registry);
+        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, List<LogInterceptor> logInterceptors) {
+            this.registry = registry;
+            this.tags = tags;
+            this.logInterceptors = logInterceptors;
         }
 
         @Override
@@ -236,28 +202,20 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
         }
 
         private void incrementCounter(LogEvent event) {
-            switch (event.getLevel().getStandardLevel()) {
-                case FATAL:
-                    fatalCounter.increment();
-                    break;
-                case ERROR:
-                    errorCounter.increment();
-                    break;
-                case WARN:
-                    warnCounter.increment();
-                    break;
-                case INFO:
-                    infoCounter.increment();
-                    break;
-                case DEBUG:
-                    debugCounter.increment();
-                    break;
-                case TRACE:
-                    traceCounter.increment();
-                    break;
-                default:
-                    break;
+            List<Tag> dynamicTags = new ArrayList<>();
+            for (LogInterceptor logInterceptor : logInterceptors) {
+                dynamicTags.addAll(logInterceptor.getTagFromLogs(event));
             }
+
+            Counter counter = Counter.builder(METER_NAME)
+                .tags(tags)
+                .tags(dynamicTags)
+                .tags("level", event.getLevel().getStandardLevel().name().toLowerCase(Locale.ROOT))
+                .description(METER_DESCRIPTION)
+                .baseUnit(BaseUnits.EVENTS)
+                .register(registry);
+
+            counter.increment();
         }
 
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogInterceptor.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Tag;
+import org.apache.logging.log4j.core.LogEvent;
+import java.util.List;
+
+/**
+ * {@link Log4j2Metrics} uses this interface to get tags from the log events. This is used
+ * to get tags like exception name from the log events and add them to the metrics.
+ * author: Harsh Verma
+ *
+ * @since 1.16.4
+ */
+public interface LogInterceptor {
+
+    List<Tag> getTagFromLogs(LogEvent event);
+
+}

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -18,6 +18,8 @@ package io.micrometer.core.instrument.binder.logging;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.logging.log4j.Level;
@@ -35,11 +37,14 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 /**
@@ -47,6 +52,7 @@ import static org.awaitility.Awaitility.await;
  *
  * @author Steven Sheehy
  * @author Johnny Lim
+ * @author Harsh Verma
  */
 class Log4j2MetricsTest {
 
@@ -68,7 +74,7 @@ class Log4j2MetricsTest {
         new Log4j2Metrics().bindTo(registry);
         // end::setup[]
 
-        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
 
         // tag::example[]
         Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
@@ -84,8 +90,35 @@ class Log4j2MetricsTest {
         assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
         assertThat(registry.get("log4j2.events").tags("level", "fatal").counter().count()).isEqualTo(1.0);
         assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1.0);
-        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(0.0);
-        assertThat(registry.get("log4j2.events").tags("level", "trace").counter().count()).isEqualTo(0.0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").tags("level", "debug").counter())
+            .isInstanceOf(MeterNotFoundException.class);
+        assertThatThrownBy(() -> registry.get("log4j2.events").tags("level", "trace").counter())
+            .isInstanceOf(MeterNotFoundException.class);
+        // end::example[]
+    }
+
+    @Test
+    void log4j2LevelMetricsWithDynamicTags() {
+        // tag::setup[]
+        List<LogInterceptor> logInterceptorList = new ArrayList<>();
+        logInterceptorList.add(event -> List
+            .of(Tag.of("exception", event.getThrown() != null ? event.getThrown().getClass().getSimpleName() : "NA")));
+        new Log4j2Metrics(emptyList(), (LoggerContext) LogManager.getContext(false), logInterceptorList)
+            .bindTo(registry);
+        // end::setup[]
+
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+
+        // tag::example[]
+        Configurator.setLevel(Log4j2MetricsTest.class.getName(), Level.INFO);
+        Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
+        logger.error("error", NullPointerException::new);
+
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events")
+            .tags("level", "error", "exception", "NullPointerException")
+            .counter()
+            .count()).isEqualTo(1.0);
         // end::example[]
     }
 
@@ -101,7 +134,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
 
         additivityDisabledLogger.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
@@ -118,7 +151,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
 
         logger.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
@@ -131,7 +164,7 @@ class Log4j2MetricsTest {
         Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
         logger.isErrorEnabled();
 
-        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(0.0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
     }
 
     @Test
@@ -163,7 +196,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics(emptyList(), loggerContext).bindTo(registry);
 
-        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
         logger1.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
     }
@@ -179,7 +212,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0);
+        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
         logger.info("Hello, world!");
         logger.info("Hello, world!");
         logger.info("Hello, world!");

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -74,7 +74,7 @@ class Log4j2MetricsTest {
         new Log4j2Metrics().bindTo(registry);
         // end::setup[]
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
 
         // tag::example[]
         Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
@@ -90,10 +90,8 @@ class Log4j2MetricsTest {
         assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
         assertThat(registry.get("log4j2.events").tags("level", "fatal").counter().count()).isEqualTo(1.0);
         assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(1.0);
-        assertThatThrownBy(() -> registry.get("log4j2.events").tags("level", "debug").counter())
-            .isInstanceOf(MeterNotFoundException.class);
-        assertThatThrownBy(() -> registry.get("log4j2.events").tags("level", "trace").counter())
-            .isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "trace").counter().count()).isEqualTo(0.0);
         // end::example[]
     }
 
@@ -134,7 +132,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
 
         additivityDisabledLogger.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
@@ -151,7 +149,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
 
         logger.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
@@ -164,7 +162,7 @@ class Log4j2MetricsTest {
         Logger logger = LogManager.getLogger(Log4j2MetricsTest.class);
         logger.isErrorEnabled();
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
     }
 
     @Test
@@ -196,7 +194,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics(emptyList(), loggerContext).bindTo(registry);
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
         logger1.info("Hello, world!");
         assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1);
     }
@@ -212,7 +210,7 @@ class Log4j2MetricsTest {
 
         new Log4j2Metrics().bindTo(registry);
 
-        assertThatThrownBy(() -> registry.get("log4j2.events").counter()).isInstanceOf(MeterNotFoundException.class);
+        assertThat(registry.get("log4j2.events").counter().count()).isEqualTo(0.0);
         logger.info("Hello, world!");
         logger.info("Hello, world!");
         logger.info("Hello, world!");


### PR DESCRIPTION
Adding a support of adding tag on runtime using log events in Log4j2Metrics. This will allow us to send the tags like exception name, Kafka partition, ... as a tag.