### PR TITLE
fix: replace TimeGauge with FunctionTimer for cache.load.duration in CaffeineCacheMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -182,8 +182,11 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
             .register(registry);
 
         if (cache instanceof LoadingCache) {
-            // dividing these gives you a measure of load latency
-            TimeGauge.builder("cache.load.duration", cache, TimeUnit.NANOSECONDS, c -> c.stats().totalLoadTime())
+            // totalLoadTime() and loadCount() are ever-increasing monotonic values;
+            // FunctionTimer correctly represents them as a summary (count + total time)
+            // and allows backends to convert nanoseconds to their preferred time unit.
+            FunctionTimer.builder("cache.load.duration", cache,
+                        c -> c.stats().loadCount(), c -> c.stats().totalLoadTime(), TimeUnit.NANOSECONDS)
                 .tags(getTagsWithCacheName())
                 .description("The time the cache has spent loading new values")
                 .register(registry);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -20,9 +20,9 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.TimeGauge;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.testsupport.system.CapturedOutput;
@@ -71,9 +71,11 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         assertThat(evictionWeight.count()).isEqualTo((double) stats.evictionWeight());
 
         // specific to LoadingCache instance
-        TimeGauge loadDuration = fetch(registry, "cache.load.duration").timeGauge();
-        assertThat(loadDuration.value(TimeUnit.NANOSECONDS)).isCloseTo((double) stats.totalLoadTime(),
+        // cache.load.duration is a FunctionTimer: totalLoadTime() is ever-increasing
+        FunctionTimer loadDuration = fetch(registry, "cache.load.duration").functionTimer();
+        assertThat(loadDuration.totalTime(TimeUnit.NANOSECONDS)).isCloseTo((double) stats.totalLoadTime(),
                 Offset.offset(0.1));
+        assertThat(loadDuration.count()).isEqualTo((double) stats.loadCount());
 
         FunctionCounter successfulLoad = fetch(registry, "cache.load", Tags.of("result", "success")).functionCounter();
         assertThat(successfulLoad.count()).isEqualTo((double) stats.loadSuccessCount());
@@ -100,7 +102,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
                 "testCache", expectedTag);
         metrics.bindTo(meterRegistry);
 
-        assertThat(meterRegistry.find("cache.load.duration").timeGauge()).isNull();
+        assertThat(meterRegistry.find("cache.load.duration").functionTimer()).isNull();
         assertThat(output).doesNotContain(
                 "The cache 'testCache' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
     }


### PR DESCRIPTION
## Problem

`CaffeineCacheMetrics` registers `cache.load.duration` as a `TimeGauge` backed by `CacheStats.totalLoadTime()`:

```java
TimeGauge.builder("cache.load.duration", cache, TimeUnit.NANOSECONDS, c -> c.stats().totalLoadTime())
```

`totalLoadTime()` is documented as an ever-increasing monotonic counter (cumulative nanoseconds spent loading). A `TimeGauge` is semantically for an _instantaneous_ current value — not a running total. Using it here means:

- Prometheus emits `# TYPE cache_load_duration_seconds gauge` — backends can't compute rates correctly
- The value never decreases so it looks like a counter behaving as a gauge
- The count of loads is available separately via `cache.load` counters but not paired with the duration

## Fix

Use `FunctionTimer` as suggested by @jonatan-ivanov in the issue:

```java
FunctionTimer.builder("cache.load.duration", cache,
        c -> c.stats().loadCount(), c -> c.stats().totalLoadTime(), TimeUnit.NANOSECONDS)
```

This:
- Correctly models the cumulative (count, totalTime) summary
- Lets backends convert nanoseconds to their preferred unit automatically
- Enables proper rate-of-change queries (e.g. `rate(cache_load_duration_seconds_sum[5m])`)
- Prometheus emits `# TYPE cache_load_duration_seconds summary`

## Testing

Updated `CaffeineCacheMetricsTest` to assert `functionTimer()` instead of `timeGauge()`, and validates both `totalTime()` and `count()`.

Fixes #5803