### PR TITLE
fix: Ensure OTLP histogram count is exactly the sum of buckets count

### DIFF
--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -219,17 +219,26 @@ class OtlpMetricConverter {
             histogramDataPoint.setMax(max);
         }
 
-        // if histogram enabled, add histogram buckets
-        for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
-            if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
-                // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
-                // there should be a
-                // bucket count representing values between last bucket and
-                // POSITIVE_INFINITY.
-                histogramDataPoint
-                    .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
+        if (histogramSnapshot.histogramCounts().length > 0) {
+            // Ignore count from the CumulativeTimer since it may be out of sync with the
+            // count from the histogram
+            // buckets because the record operation is not atomic.
+            long bucketsCount = 0L;
+            // if histogram enabled, add histogram buckets
+            for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
+                if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
+                    // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
+                    // there should be a
+                    // bucket count representing values between last bucket and
+                    // POSITIVE_INFINITY.
+                    histogramDataPoint
+                        .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
+                }
+                long bCount = (long) countAtBucket.count();
+                histogramDataPoint.addBucketCounts(bCount);
+                bucketsCount += bCount;
             }
-            histogramDataPoint.addBucketCounts((long) countAtBucket.count());
+            histogramDataPoint.setCount(bucketsCount);
         }
 
         setHistogramDataPoint(metricBuilder, histogramDataPoint.build());
@@ -254,10 +263,20 @@ class OtlpMetricConverter {
         // Currently, micrometer doesn't support negative recordings hence we will only
         // add positive buckets.
         if (!exponentialHistogramSnapShot.positive().isEmpty()) {
+            // Ignore count from the CumulativeTimer since it may be out of sync with the
+            // count from the histogram
+            // buckets because the record operation is not atomic.
+            long bucketsCount = exponentialHistogramSnapShot.zeroCount();
             exponentialDataPoint.setPositive(ExponentialHistogramDataPoint.Buckets.newBuilder()
                 .addAllBucketCounts(exponentialHistogramSnapShot.positive().bucketCounts())
                 .setOffset(exponentialHistogramSnapShot.positive().offset())
                 .build());
+            bucketsCount += exponentialHistogramSnapShot.positive()
+                .bucketCounts()
+                .stream()
+                .mapToLong(Long::longValue)
+                .sum();
+            exponentialDataPoint.setCount(bucketsCount);
         }
 
         if (isDelta()) {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -185,17 +185,26 @@ class OtlpMetricConverter {
             histogramDataPoint.setMax(max);
         }
 
-        // if histogram enabled, add histogram buckets
-        for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
-            if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
-                // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
-                // there should be a
-                // bucket count representing values between last bucket and
-                // POSITIVE_INFINITY.
-                histogramDataPoint
-                    .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
+        if (histogramSnapshot.histogramCounts().length > 0) {
+            // Ignore count from the CumulativeTimer since it may be out of sync with the
+            // count from the histogram
+            // buckets because the record operation is not atomic.
+            long bucketsCount = 0L;
+            // if histogram enabled, add histogram buckets
+            for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
+                if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
+                    // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
+                    // there should be a
+                    // bucket count representing values between last bucket and
+                    // POSITIVE_INFINITY.
+                    histogramDataPoint
+                        .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
+                }
+                long bCount = (long) countAtBucket.count();
+                histogramDataPoint.addBucketCounts(bCount);
+                bucketsCount += bCount;
             }
-            histogramDataPoint.addBucketCounts((long) countAtBucket.count());
+            histogramDataPoint.setCount(bucketsCount);
         }
 
         setHistogramDataPoint(metricBuilder, histogramDataPoint.build());
@@ -219,10 +228,20 @@ class OtlpMetricConverter {
         // Currently, micrometer doesn't support negative recordings hence we will only
         // add positive buckets.
         if (!exponentialHistogramSnapShot.positive().isEmpty()) {
+            // Ignore count from the CumulativeTimer since it may be out of sync with the
+            // count from the histogram
+            // buckets because the record operation is not atomic.
+            long bucketsCount = exponentialHistogramSnapShot.zeroCount();
             exponentialDataPoint.setPositive(ExponentialHistogramDataPoint.Buckets.newBuilder()
                 .addAllBucketCounts(exponentialHistogramSnapShot.positive().bucketCounts())
                 .setOffset(exponentialHistogramSnapShot.positive().offset())
                 .build());
+            bucketsCount += exponentialHistogramSnapShot.positive()
+                .bucketCounts()
+                .stream()
+                .mapToLong(Long::longValue)
+                .sum();
+            exponentialDataPoint.setCount(bucketsCount);
         }
 
         if (isDelta()) {

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -186,17 +186,15 @@ class OtlpMetricConverter {
         }
 
         if (histogramSnapshot.histogramCounts().length > 0) {
-            // Ignore count from the CumulativeTimer since it may be out of sync with the
-            // count from the histogram
-            // buckets because the record operation is not atomic.
+            // OTLP requires the histogram count to equal the sum of the bucket counts.
+            // Micrometer HistogramSnapshot's count may not be equal because they are not
+            // updated atomically.
             long bucketsCount = 0L;
-            // if histogram enabled, add histogram buckets
             for (CountAtBucket countAtBucket : histogramSnapshot.histogramCounts()) {
                 if (countAtBucket.bucket() != Double.POSITIVE_INFINITY) {
                     // OTLP expects explicit bounds to not contain POSITIVE_INFINITY but
-                    // there should be a
-                    // bucket count representing values between last bucket and
-                    // POSITIVE_INFINITY.
+                    // there should be a bucket count representing values between last
+                    // bucket and POSITIVE_INFINITY.
                     histogramDataPoint
                         .addExplicitBounds(isTimeBased ? countAtBucket.bucket(baseTimeUnit) : countAtBucket.bucket());
                 }
@@ -228,9 +226,9 @@ class OtlpMetricConverter {
         // Currently, micrometer doesn't support negative recordings hence we will only
         // add positive buckets.
         if (!exponentialHistogramSnapShot.positive().isEmpty()) {
-            // Ignore count from the CumulativeTimer since it may be out of sync with the
-            // count from the histogram
-            // buckets because the record operation is not atomic.
+            // OTLP requires the histogram count to equal the sum of the bucket counts.
+            // Micrometer HistogramSnapshot's count may not be equal because they are not
+            // updated atomically.
             long bucketsCount = exponentialHistogramSnapShot.zeroCount();
             exponentialDataPoint.setPositive(ExponentialHistogramDataPoint.Buckets.newBuilder()
                 .addAllBucketCounts(exponentialHistogramSnapShot.positive().bucketCounts())

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMetricConverterTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMetricConverterTest.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.HistogramSnapshot;
-import io.micrometer.core.instrument.distribution.HistogramSupport;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.registry.otlp.internal.ExponentialHistogramSnapShot;
 import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMetricConverterTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMetricConverterTest.java
@@ -17,15 +17,28 @@ package io.micrometer.registry.otlp;
 
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.NamingConvention;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.HistogramSupport;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.registry.otlp.internal.ExponentialHistogramSnapShot;
+import io.opentelemetry.proto.metrics.v1.ExponentialHistogramDataPoint;
+import io.opentelemetry.proto.metrics.v1.HistogramDataPoint;
 import io.opentelemetry.proto.metrics.v1.Metric;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class OtlpMetricConverterTest {
 
@@ -189,6 +202,106 @@ class OtlpMetricConverterTest {
             .satisfies(metric -> assertThat(metric.getSummary().getDataPointsList()).singleElement()
                 .satisfies(dataPoint -> assertThat(dataPoint.getQuantileValuesList()).singleElement()
                     .satisfies(valueAtQuantile -> assertThat(valueAtQuantile.getValue()).isEqualTo(5))));
+    }
+
+    static class CustomDistributionSummary extends AbstractDistributionSummary
+            implements OtlpHistogramSupport, StartTimeAwareMeter {
+
+        private final HistogramSnapshot snapshot;
+
+        private final @Nullable ExponentialHistogramSnapShot expoSnapshot;
+
+        CustomDistributionSummary(Id id, Clock clock, HistogramSnapshot snapshot,
+                @Nullable ExponentialHistogramSnapShot expoSnapshot) {
+            super(id, clock, DistributionStatisticConfig.DEFAULT, 1.0, false);
+            this.snapshot = snapshot;
+            this.expoSnapshot = expoSnapshot;
+        }
+
+        @Override
+        public HistogramSnapshot takeSnapshot() {
+            return snapshot;
+        }
+
+        @Override
+        public @Nullable ExponentialHistogramSnapShot getExponentialHistogramSnapShot() {
+            return expoSnapshot;
+        }
+
+        @Override
+        public long getStartTimeNanos() {
+            return 0;
+        }
+
+        @Override
+        protected void recordNonNegative(double amount) {
+        }
+
+        @Override
+        public long count() {
+            return snapshot.count();
+        }
+
+        @Override
+        public double totalAmount() {
+            return snapshot.total();
+        }
+
+        @Override
+        public double max() {
+            return snapshot.max();
+        }
+
+    }
+
+    @Test
+    void histogramCountShouldBeSumOfBucketCounts() {
+        Meter.Id id = new Meter.Id("test.histogram", Tags.empty(), null, null, Meter.Type.DISTRIBUTION_SUMMARY);
+        HistogramSnapshot snapshot = new HistogramSnapshot(10, 100, 20, new ValueAtPercentile[0],
+                new CountAtBucket[] { new CountAtBucket(10.0, 3.0), new CountAtBucket(20.0, 5.0) }, null);
+
+        CustomDistributionSummary summary = new CustomDistributionSummary(id, mockClock, snapshot, null);
+
+        otlpMetricConverter.addMeter(summary);
+        List<Metric> metrics = otlpMetricConverter.getAllMetrics();
+
+        assertThat(metrics).singleElement().satisfies(metric -> {
+            HistogramDataPoint point = metric.getHistogram().getDataPoints(0);
+            // Sum of bucket counts is 3 + 5 = 8, while snapshot.count() is 10.
+            assertThat(point.getCount()).isEqualTo(8);
+        });
+    }
+
+    @Test
+    void exponentialHistogramCountShouldBeSumOfBucketCounts() {
+        Meter.Id id = new Meter.Id("test.exponential.histogram", Tags.empty(), null, null,
+                Meter.Type.DISTRIBUTION_SUMMARY);
+        HistogramSnapshot snapshot = new HistogramSnapshot(10, 100, 20, new ValueAtPercentile[0], new CountAtBucket[0],
+                null);
+
+        ExponentialHistogramSnapShot expoSnapshot = mock(ExponentialHistogramSnapShot.class);
+        when(expoSnapshot.scale()).thenReturn(2);
+        when(expoSnapshot.zeroCount()).thenReturn(1L);
+        when(expoSnapshot.zeroThreshold()).thenReturn(0.0);
+
+        ExponentialHistogramSnapShot.ExponentialBuckets positiveBuckets = mock(
+                ExponentialHistogramSnapShot.ExponentialBuckets.class);
+        when(positiveBuckets.isEmpty()).thenReturn(false);
+        when(positiveBuckets.bucketCounts()).thenReturn(Arrays.asList(2L, 5L));
+        when(positiveBuckets.offset()).thenReturn(0);
+        when(expoSnapshot.positive()).thenReturn(positiveBuckets);
+
+        CustomDistributionSummary summary = new CustomDistributionSummary(id, mockClock, snapshot, expoSnapshot);
+
+        otlpMetricConverter.addMeter(summary);
+        List<Metric> metrics = otlpMetricConverter.getAllMetrics();
+
+        assertThat(metrics).singleElement().satisfies(metric -> {
+            ExponentialHistogramDataPoint point = metric.getExponentialHistogram().getDataPoints(0);
+            // Sum of zeroCount (1) + positive bucket counts (2 + 5 = 7) = 8, while
+            // snapshot.count() is 10.
+            assertThat(point.getCount()).isEqualTo(8);
+        });
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/micrometer-metrics/micrometer/issues/6006, see issue comments for more explanations.