### PR TITLE
Close HighCardinalityTagsDetector only once by the MeterRegistry

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -1215,10 +1215,9 @@ public abstract class MeterRegistry {
                     meter.close();
                 }
             }
-        }
-
-        if (highCardinalityTagsDetector != null) {
-            highCardinalityTagsDetector.close();
+            if (highCardinalityTagsDetector != null) {
+                highCardinalityTagsDetector.close();
+            }
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -26,12 +26,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
-
-import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link MeterRegistry}.
@@ -359,22 +358,16 @@ class MeterRegistryTest {
     }
 
     @Test
-    @Issue("https://github.com/micrometer-metrics/micrometer/issues/7409")
-    void closeShouldOnlyCloseHighCardinalityTagsDetectorOnce() {
-        AtomicInteger closeCount = new AtomicInteger();
-        HighCardinalityTagsDetector detector = new HighCardinalityTagsDetector(registry, Long.MAX_VALUE,
-                Duration.ofHours(1)) {
-            @Override
-            public void close() {
-                closeCount.incrementAndGet();
-            }
-        };
-        registry.config().withHighCardinalityTagsDetector(registry -> detector);
+    @Issue("#7409")
+    void registryCloseShouldCloseHighCardinalityTagsDetectorOnlyOnce() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        HighCardinalityTagsDetector detector = mock(HighCardinalityTagsDetector.class);
+        registry.config().withHighCardinalityTagsDetector(mr -> detector);
 
         registry.close();
         registry.close();
 
-        assertThat(closeCount.get()).isEqualTo(1);
+        verify(detector, times(1)).close();
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterRegistryTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -355,6 +356,25 @@ class MeterRegistryTest {
             .describedAs("If the meter-filter doesn't alter the meter creation, meters are never unmarked "
                     + "from staleness and we end up paying the additional cost every time")
             .isEmpty();
+    }
+
+    @Test
+    @Issue("https://github.com/micrometer-metrics/micrometer/issues/7409")
+    void closeShouldOnlyCloseHighCardinalityTagsDetectorOnce() {
+        AtomicInteger closeCount = new AtomicInteger();
+        HighCardinalityTagsDetector detector = new HighCardinalityTagsDetector(registry, Long.MAX_VALUE,
+                Duration.ofHours(1)) {
+            @Override
+            public void close() {
+                closeCount.incrementAndGet();
+            }
+        };
+        registry.config().withHighCardinalityTagsDetector(registry -> detector);
+
+        registry.close();
+        registry.close();
+
+        assertThat(closeCount.get()).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
## Summary
Move `highCardinalityTagsDetector.close()` inside the `if (closed.compareAndSet(false, true))` guard block in `MeterRegistry.close()`, preventing duplicate log output when frameworks like Spring Boot call close() multiple times.

## Fix
`MeterRegistry.close()` was calling `highCardinalityTagsDetector.close()` outside the closed-guard, causing `HighCardinalityTagsDetector.shutdown()` to log "Stopping HighCardinalityTagsDetector" every time close() was invoked — even on subsequent calls after the first.

## Test
Added `closeShouldOnlyCloseHighCardinalityTagsDetectorOnce()` test in `MeterRegistryTest.java` that registers a detector and calls `registry.close()` twice, verifying the detector's close is only invoked once.

Fixes https://github.com/micrometer-metrics/micrometer/issues/7409