### PR TITLE
Prometheus: construct MetricMetadata and Labels on meter creation

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -60,6 +60,10 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
+    public String getConventionName() {
+        return conventionName;
+    }
+
     public void add(Meter.Id id, Child child, MetricFamilyDescriptor... registeredFamilies) {
         children.put(id, child);
         this.registeredFamilies.put(id, Arrays.asList(registeredFamilies));

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -96,7 +96,7 @@ class MicrometerCollector implements MultiCollector {
         Map<String, Family> families = new HashMap<>();
 
         for (Child child : children.values()) {
-            child.samples(conventionName)
+            child.samples()
                 .forEach(family -> families.compute(family.getConventionName(),
                         (name, matchingFamily) -> matchingFamily != null
                                 ? matchingFamily.addSamples(family.dataPointSnapshots) : family));
@@ -112,7 +112,7 @@ class MicrometerCollector implements MultiCollector {
 
     interface Child {
 
-        Stream<Family<?>> samples(String conventionName);
+        Stream<Family<?>> samples();
 
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -48,7 +48,7 @@ class MicrometerCollector implements MultiCollector {
 
     private final Map<Meter.Id, List<MetricFamilyDescriptor>> registeredFamilies = new ConcurrentHashMap<>();
 
-    private final String conventionName;
+    final String conventionName;
 
     // the id of the meter used to create this MicrometerCollector
     private final Meter.Id originalMeterId;
@@ -58,10 +58,6 @@ class MicrometerCollector implements MultiCollector {
     MicrometerCollector(String name, Meter.Id id) {
         this.conventionName = name;
         this.originalMeterId = id;
-    }
-
-    public String getConventionName() {
-        return conventionName;
     }
 
     public void add(Meter.Id id, Child child, MetricFamilyDescriptor... registeredFamilies) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -221,7 +221,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
@@ -242,7 +242,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                     id.getDescription());
             String conventionNameMax = conventionName + "_max";
@@ -267,7 +267,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
+                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                     createdTimestampMillis)));
@@ -296,7 +296,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
+                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
                                     familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
@@ -340,7 +340,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
                 familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
@@ -379,7 +379,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
@@ -399,7 +399,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
@@ -423,7 +423,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
 
             for (Measurement measurement : measurements) {
-                CustomMeterMetric metric = customMeterMetric(collector.getConventionName(), measurement.getStatistic());
+                CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
 
                 // De-duplicate names: metrics with the same Prometheus name will use the
                 // same descriptor and metadata
@@ -552,7 +552,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
-        String conventionName = collector.getConventionName();
+        String conventionName = collector.conventionName;
         MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                 id.getDescription());
         String conventionNameMax = conventionName + "_max";

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -46,8 +46,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -218,15 +219,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         PrometheusCounter counter = new PrometheusCounter(id, exemplarSamplerFactory);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
-            collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
-                                    counter.exemplar(), createdTimestampMillis))),
-                    familyDescriptor(MetricType.COUNTER, getConventionName(id), tagKeys, id.getDescription()));
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
+                    tagKeys, id.getDescription());
+            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                    new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis))),
+                    familyDescriptor);
         });
         return counter;
     }
@@ -238,9 +238,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 distributionStatisticConfig, scale, exemplarSamplerFactory);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+                    id.getDescription());
+            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE,
+                    getConventionName(id) + "_max", tagKeys, id.getDescription());
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -261,10 +265,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues),
-                                    exemplars, createdTimestampMillis)));
+                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
+                                    createdTimestampMillis)));
                 }
                 else {
                     List<Double> buckets = new ArrayList<>();
@@ -292,9 +295,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
-                                    getMetadata(family.conventionName, id.getDescription()), family.dataPointSnapshots),
-                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                    Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                                    familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
+                                    exemplars, createdTimestampMillis)));
 
                     // TODO: Add support back for VictoriaMetrics
                     // Previously we had low-level control so a histogram was just
@@ -307,13 +310,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
 
                 families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                        family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new GaugeDataPointSnapshot(summary.max(), Labels.of(tagKeys, tagValues), null)));
+                        family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
+                        new GaugeDataPointSnapshot(summary.max(), labels, null)));
 
                 return families.build();
-            }, familyDescriptor(primaryType, getConventionName(id), tagKeys, id.getDescription()),
-                    familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max", tagKeys, id.getDescription()));
+            }, familyDescriptor, familyDescriptorMax);
         });
 
         return summary;
@@ -334,22 +335,26 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             ToDoubleFunction<T> valueFunction) {
         Gauge gauge = new DefaultGauge<>(id, obj, valueFunction);
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
-                collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                        family -> new InfoSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))),
-                        familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys, id.getDescription()));
-            }
-            else {
+                familyDescriptor = familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys,
+                        id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                        family.dataPointSnapshots),
-                                new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))),
-                        familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys, id.getDescription()));
+                                family -> new InfoSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                                new InfoDataPointSnapshot(labels))),
+                        familyDescriptor);
+            }
+            else {
+                familyDescriptor = familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys,
+                        id.getDescription());
+                collector.add(id,
+                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                                family -> new GaugeSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                                new GaugeDataPointSnapshot(gauge.value(), labels, null))),
+                        familyDescriptor);
             }
         });
         return gauge;
@@ -370,15 +375,16 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 totalTimeFunctionUnit, getBaseTimeUnit());
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, getConventionName(id),
+                    tagKeys, id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
+                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
-                                    Quantiles.EMPTY, Labels.of(tagKeys, tagValues), null, createdTimestampMillis))),
-                    familyDescriptor(MetricType.SUMMARY, getConventionName(id), tagKeys, id.getDescription()));
+                                    Quantiles.EMPTY, labels, null, createdTimestampMillis))),
+                    familyDescriptor);
         });
         return ft;
     }
@@ -388,15 +394,15 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         FunctionCounter fc = new CumulativeFunctionCounter<>(id, obj, countFunction);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
+                    tagKeys, id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
-                                    createdTimestampMillis))),
-                    familyDescriptor(MetricType.COUNTER, getConventionName(id), tagKeys, id.getDescription()));
+                            family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis))),
+                    familyDescriptor);
         });
         return fc;
     }
@@ -408,45 +414,49 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             List<String> statKeys = new ArrayList<>(tagKeys);
             statKeys.add("statistic");
-            List<MetricFamilyDescriptor> registrationDescriptors = new ArrayList<>();
-            String name = getConventionName(id);
-            Set<String> descriptorNames = new HashSet<>();
+
+            Map<String, MetricFamilyDescriptor> prometheusNameToDescriptor = new LinkedHashMap<>();
+            List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
+
             for (Measurement measurement : measurements) {
-                MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
-                        statKeys);
-                // de-duplicate names
-                if (descriptorNames.add(descriptor.getPrometheusName())) {
-                    registrationDescriptors.add(descriptor);
+                CustomMeterMetric metric = customMeterMetric(collector.getConventionName(), measurement.getStatistic());
+
+                // De-duplicate names: metrics with the same Prometheus name will use the
+                // same descriptor and metadata
+                MetricFamilyDescriptor candidateDescriptor = familyDescriptor(metric.metricType, metric.name, statKeys,
+                        id.getDescription());
+                MetricFamilyDescriptor descriptor;
+                if (prometheusNameToDescriptor.containsKey(candidateDescriptor.getPrometheusName())) {
+                    descriptor = prometheusNameToDescriptor.get(candidateDescriptor.getPrometheusName());
                 }
+                else {
+                    descriptor = candidateDescriptor;
+                    prometheusNameToDescriptor.put(descriptor.getPrometheusName(), descriptor);
+                }
+
+                List<String> statValues = new ArrayList<>(tagValues);
+                statValues.add(measurement.getStatistic().toString());
+                customMeasurements.add(new CustomMeterMeasurement(measurement, metric, descriptor.getMetadata(),
+                        Labels.of(statKeys, statValues)));
             }
+
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-                for (Measurement measurement : measurements) {
-                    List<String> statValues = new ArrayList<>(tagValues);
-                    statValues.add(measurement.getStatistic().toString());
-                    families.add(customMeterFamily(id, conventionName, measurement.getStatistic(),
-                            Labels.of(statKeys, statValues), measurement.getValue()));
+                for (CustomMeterMeasurement measurement : customMeasurements) {
+                    families.add(customMeterFamily(measurement));
                 }
                 return families.build();
-            }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
+            }, prometheusNameToDescriptor.values().toArray(new MetricFamilyDescriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
-            Collection<String> labelNames) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
-    }
-
-    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
-            Labels labels, double value) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        if (metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(id, metric, labels, value);
+    private MicrometerCollector.Family<?> customMeterFamily(CustomMeterMeasurement measurement) {
+        if (measurement.metric.metricType == MetricType.COUNTER) {
+            return customCounterFamily(measurement);
         }
-        return customGaugeFamily(id, metric, labels, value);
+        return customGaugeFamily(measurement);
     }
 
     private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
@@ -470,21 +480,19 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
-            CustomMeterMetric metric, Labels labels, double value) {
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
+            CustomMeterMeasurement measurement) {
         long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
+        return new MicrometerCollector.Family<>(measurement.metric.name,
+                family -> new CounterSnapshot(measurement.metadata, family.dataPointSnapshots),
+                new CounterDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null,
+                        createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, CustomMeterMetric metric,
-            Labels labels, double value) {
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new GaugeDataPointSnapshot(value, labels, null));
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(CustomMeterMeasurement measurement) {
+        return new MicrometerCollector.Family<>(measurement.metric.name,
+                family -> new GaugeSnapshot(measurement.metadata, family.dataPointSnapshots),
+                new GaugeDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null));
     }
 
     private static final class CustomMeterMetric {
@@ -496,6 +504,26 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         private CustomMeterMetric(String name, MetricType metricType) {
             this.name = name;
             this.metricType = metricType;
+        }
+
+    }
+
+    private static final class CustomMeterMeasurement {
+
+        private final Measurement measurement;
+
+        private final CustomMeterMetric metric;
+
+        private final MetricMetadata metadata;
+
+        private final Labels labels;
+
+        private CustomMeterMeasurement(Measurement measurement, CustomMeterMetric metric, MetricMetadata metadata,
+                Labels labels) {
+            this.measurement = measurement;
+            this.metric = metric;
+            this.metadata = metadata;
+            this.labels = labels;
         }
 
     }
@@ -517,8 +545,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             boolean forLongTaskTimer) {
         long createdTimestampMillis = clock.wallTime();
         List<String> tagKeys = tagKeys(id);
+        Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
+        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+                id.getDescription());
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max",
+                tagKeys, id.getDescription());
         collector.add(id, (conventionName) -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -540,9 +573,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
-                        family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues), exemplars,
+                        family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                        new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                 createdTimestampMillis)));
             }
             else {
@@ -571,9 +603,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
                         family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(forLongTaskTimer,
-                                getMetadata(family.conventionName, id.getDescription()), family.dataPointSnapshots),
-                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                                familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
+                                exemplars, createdTimestampMillis)));
 
                 // TODO: Add support back for VictoriaMetrics
                 // Previously we had low-level control so a histogram was just
@@ -586,18 +618,17 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                    family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                            family.dataPointSnapshots),
-                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), Labels.of(tagKeys, tagValues),
-                            null)));
+                    family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
+                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null)));
 
             return families.build();
-        }, familyDescriptor(primaryType, getConventionName(id), tagKeys, id.getDescription()),
-                familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max", tagKeys, id.getDescription()));
+        }, familyDescriptor, familyDescriptorMax);
     }
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
             @Nullable String description) {
+        // Unit is intentionally not set, see:
+        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
     }
 
@@ -629,12 +660,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 getPrometheusRegistry().unregister(collector);
             }
         }
-    }
-
-    private MetricMetadata getMetadata(String name, @Nullable String description) {
-        // Unit is intentionally not set, see:
-        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return new MetricMetadata(name, helpText(description), null);
     }
 
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -618,6 +618,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
             @Nullable String description) {
+        // NB: For custom meters that use `getMetadata`, the metadata inside the
+        // descriptor should be consistent with the one returned by `getMetadata`.
+
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
@@ -628,6 +631,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * {@link MetricFamilyDescriptor} returned from {@link familyDescriptor}.
      */
     private MetricMetadata getMetadata(String name, @Nullable String description) {
+        // The returned metadata should be consistent with the metadata in the
+        // `MetricFamilyDescriptor`.
         return new MetricMetadata(name, helpText(description), null);
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -46,9 +46,8 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -418,49 +417,53 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             List<String> statKeys = new ArrayList<>(tagKeys);
             statKeys.add("statistic");
-
-            Map<String, MetricFamilyDescriptor> prometheusNameToDescriptor = new LinkedHashMap<>();
-            List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
-
+            List<MetricFamilyDescriptor> registrationDescriptors = new ArrayList<>();
+            String name = collector.conventionName;
+            Set<String> descriptorNames = new HashSet<>();
             for (Measurement measurement : measurements) {
-                CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
-
-                // De-duplicate names: metrics with the same Prometheus name will use the
-                // same descriptor and metadata
-                MetricFamilyDescriptor candidateDescriptor = familyDescriptor(metric.metricType, metric.name, statKeys,
-                        id.getDescription());
-                MetricFamilyDescriptor descriptor;
-                if (prometheusNameToDescriptor.containsKey(candidateDescriptor.getPrometheusName())) {
-                    descriptor = prometheusNameToDescriptor.get(candidateDescriptor.getPrometheusName());
+                MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
+                        statKeys);
+                // de-duplicate names
+                if (descriptorNames.add(descriptor.getPrometheusName())) {
+                    registrationDescriptors.add(descriptor);
                 }
-                else {
-                    descriptor = candidateDescriptor;
-                    prometheusNameToDescriptor.put(descriptor.getPrometheusName(), descriptor);
-                }
-
-                List<String> statValues = new ArrayList<>(tagValues);
-                statValues.add(measurement.getStatistic().toString());
-                customMeasurements.add(new CustomMeterMeasurement(measurement, metric, descriptor.getMetadata(),
-                        Labels.of(statKeys, statValues)));
             }
-
             collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-                for (CustomMeterMeasurement measurement : customMeasurements) {
-                    families.add(customMeterFamily(measurement));
+                for (Measurement measurement : measurements) {
+                    // NB: Unlike all the other meters, where `MetricMetadata` and
+                    // `Labels` are constructed once at registration time, for custom
+                    // meters they are obtained on each scrape. We might construct them at
+                    // registration time and cache them, but this would force us to deal
+                    // with potentially misbehaving `Iterable<Measurement>` (which may
+                    // return different measurements or in different order, breaking
+                    // contract of `Meter#measure`). Custom meters should be rare, so
+                    // this should be a relatively minor performance hit.
+                    List<String> statValues = new ArrayList<>(tagValues);
+                    statValues.add(measurement.getStatistic().toString());
+                    families.add(customMeterFamily(id, collector.conventionName, measurement.getStatistic(),
+                            Labels.of(statKeys, statValues), measurement.getValue()));
                 }
                 return families.build();
-            }, prometheusNameToDescriptor.values().toArray(new MetricFamilyDescriptor[0]));
+            }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MicrometerCollector.Family<?> customMeterFamily(CustomMeterMeasurement measurement) {
-        if (measurement.metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(measurement);
+    private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
+            Collection<String> labelNames) {
+        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
+        return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
+    }
+
+    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
+            Labels labels, double value) {
+        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
+        if (metric.metricType == MetricType.COUNTER) {
+            return customCounterFamily(id, metric, labels, value);
         }
-        return customGaugeFamily(measurement);
+        return customGaugeFamily(id, metric, labels, value);
     }
 
     private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
@@ -484,19 +487,21 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
-            CustomMeterMeasurement measurement) {
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
+            CustomMeterMetric metric, Labels labels, double value) {
         long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(measurement.metric.name,
-                family -> new CounterSnapshot(measurement.metadata, family.dataPointSnapshots),
-                new CounterDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null,
-                        createdTimestampMillis));
+        return new MicrometerCollector.Family<>(metric.name,
+                family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
+                        family.dataPointSnapshots),
+                new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(CustomMeterMeasurement measurement) {
-        return new MicrometerCollector.Family<>(measurement.metric.name,
-                family -> new GaugeSnapshot(measurement.metadata, family.dataPointSnapshots),
-                new GaugeDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null));
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, CustomMeterMetric metric,
+            Labels labels, double value) {
+        return new MicrometerCollector.Family<>(metric.name,
+                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
+                        family.dataPointSnapshots),
+                new GaugeDataPointSnapshot(value, labels, null));
     }
 
     private static final class CustomMeterMetric {
@@ -508,26 +513,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         private CustomMeterMetric(String name, MetricType metricType) {
             this.name = name;
             this.metricType = metricType;
-        }
-
-    }
-
-    private static final class CustomMeterMeasurement {
-
-        private final Measurement measurement;
-
-        private final CustomMeterMetric metric;
-
-        private final MetricMetadata metadata;
-
-        private final Labels labels;
-
-        private CustomMeterMeasurement(Measurement measurement, CustomMeterMetric metric, MetricMetadata metadata,
-                Labels labels) {
-            this.measurement = measurement;
-            this.metric = metric;
-            this.metadata = metadata;
-            this.labels = labels;
         }
 
     }
@@ -636,6 +621,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
+    }
+
+    /**
+     * Used only for custom meters; all other meters' metadata is obtained through
+     * {@link MetricFamilyDescriptor} returned from {@link familyDescriptor}.
+     */
+    private MetricMetadata getMetadata(String name, @Nullable String description) {
+        return new MetricMetadata(name, helpText(description), null);
     }
 
     private String helpText(@Nullable String description) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -221,9 +221,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
-                    tagKeys, id.getDescription());
-            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
+                    id.getDescription());
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                     family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                     new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis))),
                     familyDescriptor);
@@ -241,11 +242,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                     id.getDescription());
-            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE,
-                    getConventionName(id) + "_max", tagKeys, id.getDescription());
-            collector.add(id, (conventionName) -> {
+            String conventionNameMax = conventionName + "_max";
+            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
+                    id.getDescription());
+            collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
                 final ValueAtPercentile[] percentileValues = summary.takeSnapshot().percentileValues();
@@ -264,7 +267,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(conventionName,
+                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                     createdTimestampMillis)));
@@ -293,7 +296,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(conventionName,
+                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
                                     familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
@@ -309,7 +312,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     // bucket name is hardcoded to le.
                 }
 
-                families.add(new MicrometerCollector.Family<>(conventionName + "_max",
+                families.add(new MicrometerCollector.Family<>(conventionNameMax,
                         family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
                         new GaugeDataPointSnapshot(summary.max(), labels, null)));
 
@@ -337,21 +340,20 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
+            String conventionName = collector.getConventionName();
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
-                familyDescriptor = familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys,
-                        id.getDescription());
+                familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new InfoSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                                 new InfoDataPointSnapshot(labels))),
                         familyDescriptor);
             }
             else {
-                familyDescriptor = familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys,
-                        id.getDescription());
+                familyDescriptor = familyDescriptor(MetricType.GAUGE, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new GaugeSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                                 new GaugeDataPointSnapshot(gauge.value(), labels, null))),
                         familyDescriptor);
@@ -377,10 +379,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, getConventionName(id),
-                    tagKeys, id.getDescription());
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
+                    id.getDescription());
             collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
                                     Quantiles.EMPTY, labels, null, createdTimestampMillis))),
@@ -396,10 +399,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
-                    tagKeys, id.getDescription());
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
+                    id.getDescription());
             collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis))),
                     familyDescriptor);
@@ -440,7 +444,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                         Labels.of(statKeys, statValues)));
             }
 
-            collector.add(id, (conventionName) -> {
+            collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
                 for (CustomMeterMeasurement measurement : customMeasurements) {
                     families.add(customMeterFamily(measurement));
@@ -548,11 +552,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
-        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+        String conventionName = collector.getConventionName();
+        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                 id.getDescription());
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max",
-                tagKeys, id.getDescription());
-        collector.add(id, (conventionName) -> {
+        String conventionNameMax = conventionName + "_max";
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
+                id.getDescription());
+        collector.add(id, () -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
             HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
@@ -617,7 +623,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 // bucket name is hardcoded to le.
             }
 
-            families.add(new MicrometerCollector.Family<>(conventionName + "_max",
+            families.add(new MicrometerCollector.Family<>(conventionNameMax,
                     family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
                     new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null)));
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -48,7 +48,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                     family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                     sample)));
         }
@@ -69,10 +69,10 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(sample2Id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -91,10 +91,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -113,10 +113,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -135,10 +135,10 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -153,7 +153,7 @@ class MicrometerCollectorTest {
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of("k", "v"), null, 0);
         collector.add(id,
-                (conventionName) -> Stream.of(new MicrometerCollector.Family<>("my_counter",
+                () -> Stream.of(new MicrometerCollector.Family<>("my_counter",
                         family -> new CounterSnapshot(new MetricMetadata(family.conventionName),
                                 family.dataPointSnapshots),
                         sample)),

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -48,7 +48,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                     family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                     sample)));
         }
@@ -69,10 +69,10 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -91,10 +91,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -113,10 +113,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -135,10 +135,10 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 


### PR DESCRIPTION
Currently `MetricMetadata` and `Labels` are constructed on each scrape. The downsides of this are
* unnecessary allocation of these two objects themselves
* unnecessary validation of the metric name and label names via `PrometheusNaming.validateMetricName` and `PrometheusNaming.isValidLabelName`
	* which perform UTF-8 validation via `StandardCharsets.UTF_8.newEncoder().canEncode(name)`
	    * which in turn allocates the encoder and a `CharBuffer` to hold the encoded string data, and consumes CPU to perform the validation

In fact these objects can only be constructed once because the `conventionName` is actually fixed (`MicrometerCollector#conventionName` is final), and both `tagKeys` and `tagValues` are already computed once.

The first commit implements the pre-construction of `MetricMetadata` and labels.

The second commit removes the `conventionName` from `MicrometerCollector$Child` signature. Since we pre-create the `MetricMetadata` using the `conventionName`, we already assume that `conventionName` is immutable, so passing it on every scrape seems unnecessary.

Fixes #7450