### PR TITLE
Change process.uptime from TimeGauge to FunctionCounter

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/UptimeMetrics.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.system;
 
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.TimeGauge;
@@ -53,9 +54,10 @@ public class UptimeMetrics implements MeterBinder {
 
     @Override
     public void bindTo(MeterRegistry registry) {
-        TimeGauge.builder("process.uptime", runtimeMXBean, TimeUnit.MILLISECONDS, RuntimeMXBean::getUptime)
+        FunctionCounter.builder("process.uptime", runtimeMXBean, RuntimeMXBean::getUptime)
             .tags(tags)
             .description("The uptime of the Java virtual machine")
+            .baseUnit("ms")
             .register(registry);
 
         TimeGauge.builder("process.start.time", runtimeMXBean, TimeUnit.MILLISECONDS, RuntimeMXBean::getStartTime)

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/UptimeMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/UptimeMetricsTest.java
@@ -40,7 +40,7 @@ class UptimeMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
         new UptimeMetrics().bindTo(registry);
 
-        registry.get("process.uptime").timeGauge();
+        registry.get("process.uptime").functionCounter();
         registry.get("process.start.time").timeGauge();
     }
 
@@ -53,7 +53,7 @@ class UptimeMetricsTest {
         MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
         new UptimeMetrics(runtimeMXBean, emptyList()).bindTo(registry);
 
-        assertThat(registry.get("process.uptime").timeGauge().value()).isEqualTo(1.337);
+        assertThat(registry.get("process.uptime").functionCounter().count()).isEqualTo(1337.0);
         assertThat(registry.get("process.start.time").timeGauge().value()).isEqualTo(4.711);
         // end::example[]
     }


### PR DESCRIPTION
## Summary

Changed `process.uptime` meter from `TimeGauge` to `FunctionCounter` in `UptimeMetrics`. Semantically, `process.uptime` is a monotonically increasing accumulated value, making `FunctionCounter` the more appropriate meter type — matching the discussion in PR #7297.

## What changed

### UptimeMetrics.java
- Changed meter type from `TimeGauge` to `FunctionCounter`
- Added `.baseUnit("ms")` for consistency with the native unit returned by `RuntimeMXBean::getUptime`


### UptimeMetricsTest.java
- Updated test assertions from `.timeGauge()` to `.functionCounter()`
- Adjusted expected value from `1.337` (converted to seconds) to `1337.0` (raw milliseconds from mock)

## Breaking change note

For registries that treat gauges and counters differently, this is a breaking change for `process.uptime`. Users monitoring this metric may need to update their dashboards or alerting rules. The issue #7346 notes this was a consideration and it may be appropriate to wait for 2.0 for this change, but the semantic correctness makes it worth proposing now.


## Fixes

Fixes #7346