### PR TITLE
Fix Prometheus registry metadata for prom-client-java upgrades

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -155,8 +155,8 @@ class MicrometerCollector implements MultiCollector {
 
         private final Set<String> labelNames;
 
-        Descriptor(MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
-            this.prometheusName = metadata.getPrometheusName();
+        Descriptor(String prometheusName, MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+            this.prometheusName = prometheusName;
             this.metricType = metricType;
             this.metadata = metadata;
             this.labelNames = new LinkedHashSet<>(labelNames);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -17,10 +17,12 @@ package io.micrometer.prometheusmetrics;
 
 import io.micrometer.core.instrument.Meter;
 import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -70,6 +72,50 @@ class MicrometerCollector implements MultiCollector {
 
     Meter.Id getOriginalId() {
         return originalMeterId;
+    }
+
+    @Override
+    public List<String> getPrometheusNames() {
+        return Collections.singletonList(conventionName);
+    }
+
+    @Override
+    public @Nullable MetricType getMetricType(String prometheusName) {
+        if (!conventionName.equals(prometheusName)) {
+            return null;
+        }
+        switch (originalMeterId.getType()) {
+            case COUNTER:
+                return MetricType.COUNTER;
+            case TIMER:
+            case LONG_TASK_TIMER:
+            case DISTRIBUTION_SUMMARY:
+                return MetricType.SUMMARY;
+            case GAUGE:
+            case OTHER:
+            default:
+                return MetricType.GAUGE;
+        }
+    }
+
+    @Override
+    public @Nullable Set<String> getLabelNames(String prometheusName) {
+        if (!conventionName.equals(prometheusName)) {
+            return null;
+        }
+        Set<String> names = new HashSet<>();
+        for (io.micrometer.core.instrument.Tag tag : originalMeterId.getConventionTags(new PrometheusNamingConvention())) {
+            names.add(tag.getKey());
+        }
+        return names;
+    }
+
+    @Override
+    public @Nullable MetricMetadata getMetadata(String prometheusName) {
+        if (!conventionName.equals(prometheusName)) {
+            return null;
+        }
+        return new MetricMetadata(conventionName, " ", null);
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -41,6 +41,7 @@ import static java.util.stream.Collectors.toList;
 class MicrometerCollector implements MultiCollector {
 
     private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
+
     private final Map<Meter.Id, List<Descriptor>> descriptors = new ConcurrentHashMap<>();
 
     private final String conventionName;
@@ -79,10 +80,7 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public List<String> getPrometheusNames() {
-        return registrationDescriptors().stream()
-            .map(Descriptor::getPrometheusName)
-            .distinct()
-            .collect(toList());
+        return registrationDescriptors().stream().map(Descriptor::getPrometheusName).distinct().collect(toList());
     }
 
     @Override
@@ -155,7 +153,8 @@ class MicrometerCollector implements MultiCollector {
 
         private final Set<String> labelNames;
 
-        Descriptor(String prometheusName, MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+        Descriptor(String prometheusName, MetricType metricType, MetricMetadata metadata,
+                Collection<String> labelNames) {
             this.prometheusName = prometheusName;
             this.metricType = metricType;
             this.metadata = metadata;
@@ -177,6 +176,7 @@ class MicrometerCollector implements MultiCollector {
         Set<String> getLabelNames() {
             return labelNames;
         }
+
     }
 
     static class Family<T extends DataPointSnapshot> {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -16,6 +16,10 @@
 package io.micrometer.prometheusmetrics;
 
 import io.micrometer.core.instrument.Meter;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.registry.MultiCollector;
 import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
@@ -76,46 +80,58 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public List<String> getPrometheusNames() {
-        return Collections.singletonList(conventionName);
+        return metricSnapshots().stream()
+            .map(snapshot -> snapshot.getMetadata().getPrometheusName())
+            .distinct()
+            .collect(toList());
     }
 
     @Override
     public @Nullable MetricType getMetricType(String prometheusName) {
-        if (!conventionName.equals(prometheusName)) {
-            return null;
+        for (MetricSnapshot snapshot : metricSnapshots()) {
+            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
+                if (snapshot instanceof CounterSnapshot) {
+                    return MetricType.COUNTER;
+                }
+                if (snapshot instanceof InfoSnapshot) {
+                    return MetricType.INFO;
+                }
+                if (snapshot instanceof HistogramSnapshot) {
+                    return MetricType.HISTOGRAM;
+                }
+                if (snapshot instanceof io.prometheus.metrics.model.snapshots.SummarySnapshot) {
+                    return MetricType.SUMMARY;
+                }
+                if (snapshot instanceof GaugeSnapshot) {
+                    return MetricType.GAUGE;
+                }
+                return MetricType.UNKNOWN;
+            }
         }
-        switch (originalMeterId.getType()) {
-            case COUNTER:
-                return MetricType.COUNTER;
-            case TIMER:
-            case LONG_TASK_TIMER:
-            case DISTRIBUTION_SUMMARY:
-                return MetricType.SUMMARY;
-            case GAUGE:
-            case OTHER:
-            default:
-                return MetricType.GAUGE;
-        }
+        return null;
     }
 
     @Override
     public @Nullable Set<String> getLabelNames(String prometheusName) {
-        if (!conventionName.equals(prometheusName)) {
-            return null;
-        }
         Set<String> names = new HashSet<>();
-        for (io.micrometer.core.instrument.Tag tag : originalMeterId.getConventionTags(new PrometheusNamingConvention())) {
-            names.add(tag.getKey());
+        for (MetricSnapshot snapshot : metricSnapshots()) {
+            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
+                for (DataPointSnapshot dataPoint : snapshot.getDataPoints()) {
+                    dataPoint.getLabels().forEach(label -> names.add(label.getName()));
+                }
+            }
         }
-        return names;
+        return names.isEmpty() ? null : names;
     }
 
     @Override
     public @Nullable MetricMetadata getMetadata(String prometheusName) {
-        if (!conventionName.equals(prometheusName)) {
-            return null;
+        for (MetricSnapshot snapshot : metricSnapshots()) {
+            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
+                return snapshot.getMetadata();
+            }
         }
-        return new MetricMetadata(conventionName, " ", null);
+        return null;
     }
 
     @Override
@@ -135,6 +151,10 @@ class MicrometerCollector implements MultiCollector {
             .collect(toList());
 
         return new MetricSnapshots(metricSnapshots);
+    }
+
+    private List<MetricSnapshot> metricSnapshots() {
+        return collect().stream().collect(toList());
     }
 
     interface Child {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -16,10 +16,6 @@
 package io.micrometer.prometheusmetrics;
 
 import io.micrometer.core.instrument.Meter;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
-import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.registry.MultiCollector;
 import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
@@ -45,6 +41,7 @@ import static java.util.stream.Collectors.toList;
 class MicrometerCollector implements MultiCollector {
 
     private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
+    private final Map<Meter.Id, List<Descriptor>> descriptors = new ConcurrentHashMap<>();
 
     private final String conventionName;
 
@@ -58,12 +55,14 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
-    public void add(Meter.Id id, Child child) {
+    public void add(Meter.Id id, Child child, Descriptor... descriptors) {
         children.put(id, child);
+        this.descriptors.put(id, Arrays.asList(descriptors));
     }
 
     public void remove(Meter.Id id) {
         children.remove(id);
+        descriptors.remove(id);
     }
 
     public boolean isEmpty() {
@@ -80,32 +79,17 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public List<String> getPrometheusNames() {
-        return metricSnapshots().stream()
-            .map(snapshot -> snapshot.getMetadata().getPrometheusName())
+        return registrationDescriptors().stream()
+            .map(Descriptor::getPrometheusName)
             .distinct()
             .collect(toList());
     }
 
     @Override
     public @Nullable MetricType getMetricType(String prometheusName) {
-        for (MetricSnapshot snapshot : metricSnapshots()) {
-            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
-                if (snapshot instanceof CounterSnapshot) {
-                    return MetricType.COUNTER;
-                }
-                if (snapshot instanceof InfoSnapshot) {
-                    return MetricType.INFO;
-                }
-                if (snapshot instanceof HistogramSnapshot) {
-                    return MetricType.HISTOGRAM;
-                }
-                if (snapshot instanceof io.prometheus.metrics.model.snapshots.SummarySnapshot) {
-                    return MetricType.SUMMARY;
-                }
-                if (snapshot instanceof GaugeSnapshot) {
-                    return MetricType.GAUGE;
-                }
-                return MetricType.UNKNOWN;
+        for (Descriptor descriptor : registrationDescriptors()) {
+            if (descriptor.getPrometheusName().equals(prometheusName)) {
+                return descriptor.getMetricType();
             }
         }
         return null;
@@ -114,11 +98,9 @@ class MicrometerCollector implements MultiCollector {
     @Override
     public @Nullable Set<String> getLabelNames(String prometheusName) {
         Set<String> names = new HashSet<>();
-        for (MetricSnapshot snapshot : metricSnapshots()) {
-            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
-                for (DataPointSnapshot dataPoint : snapshot.getDataPoints()) {
-                    dataPoint.getLabels().forEach(label -> names.add(label.getName()));
-                }
+        for (Descriptor descriptor : registrationDescriptors()) {
+            if (descriptor.getPrometheusName().equals(prometheusName)) {
+                names.addAll(descriptor.getLabelNames());
             }
         }
         return names.isEmpty() ? null : names;
@@ -126,9 +108,9 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public @Nullable MetricMetadata getMetadata(String prometheusName) {
-        for (MetricSnapshot snapshot : metricSnapshots()) {
-            if (snapshot.getMetadata().getPrometheusName().equals(prometheusName)) {
-                return snapshot.getMetadata();
+        for (Descriptor descriptor : registrationDescriptors()) {
+            if (descriptor.getPrometheusName().equals(prometheusName)) {
+                return descriptor.getMetadata();
             }
         }
         return null;
@@ -153,14 +135,48 @@ class MicrometerCollector implements MultiCollector {
         return new MetricSnapshots(metricSnapshots);
     }
 
-    private List<MetricSnapshot> metricSnapshots() {
-        return collect().stream().collect(toList());
+    private List<Descriptor> registrationDescriptors() {
+        return descriptors.values().stream().flatMap(Collection::stream).collect(toList());
     }
 
     interface Child {
 
         Stream<Family<?>> samples(String conventionName);
 
+    }
+
+    static class Descriptor {
+
+        private final String prometheusName;
+
+        private final MetricType metricType;
+
+        private final MetricMetadata metadata;
+
+        private final Set<String> labelNames;
+
+        Descriptor(MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+            this.prometheusName = metadata.getPrometheusName();
+            this.metricType = metricType;
+            this.metadata = metadata;
+            this.labelNames = new LinkedHashSet<>(labelNames);
+        }
+
+        String getPrometheusName() {
+            return prometheusName;
+        }
+
+        MetricType getMetricType() {
+            return metricType;
+        }
+
+        MetricMetadata getMetadata() {
+            return metadata;
+        }
+
+        Set<String> getLabelNames() {
+            return labelNames;
+        }
     }
 
     static class Family<T extends DataPointSnapshot> {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -219,8 +219,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                     family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                    getMetadata(conventionName, id.getDescription()), new CounterDataPointSnapshot(counter.count(),
-                            Labels.of(tagKeys, tagValues), counter.exemplar(), createdTimestampMillis))));
+                    getCounterMetadata(conventionName, id.getDescription()),
+                    new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
+                            counter.exemplar(), createdTimestampMillis))));
         });
         return counter;
     }
@@ -332,7 +333,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new InfoSnapshot(family.metadata, family.dataPointSnapshots),
-                                getMetadata(conventionName, id.getDescription()),
+                                getInfoMetadata(conventionName, id.getDescription()),
                                 new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))));
             }
             else {
@@ -383,8 +384,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                            getMetadata(conventionName, id.getDescription()), new CounterDataPointSnapshot(fc.count(),
-                                    Labels.of(tagKeys, tagValues), null, createdTimestampMillis))));
+                            getCounterMetadata(conventionName, id.getDescription()),
+                            new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
+                                    createdTimestampMillis))));
         });
         return fc;
     }
@@ -442,7 +444,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         long createdTimestampMillis = clock.wallTime();
         return new MicrometerCollector.Family<>(conventionName + suffix,
                 family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                getMetadata(conventionName + suffix, id.getDescription()),
+                getCounterMetadata(conventionName + suffix, id.getDescription()),
                 new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
     }
 
@@ -579,13 +581,35 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return new MetricMetadata(name, help, null);
     }
 
+    private MetricMetadata getCounterMetadata(String name, @Nullable String description) {
+        String help = prometheusConfig.descriptions() && description != null ? description : " ";
+        if (name.endsWith("_total")) {
+            return new MetricMetadata(name.substring(0, name.length() - "_total".length()), name, name, help, null);
+        }
+        return new MetricMetadata(name, help, null);
+    }
+
+    private MetricMetadata getInfoMetadata(String name, @Nullable String description) {
+        String help = prometheusConfig.descriptions() && description != null ? description : " ";
+        if (name.endsWith("_info")) {
+            return new MetricMetadata(name.substring(0, name.length() - "_info".length()), name, name, help, null);
+        }
+        return new MetricMetadata(name, help, null);
+    }
+
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {
         collectorMap.compute(getConventionName(id), (name, existingCollector) -> {
             if (existingCollector == null) {
                 MicrometerCollector micrometerCollector = new MicrometerCollector(name, id);
                 consumer.accept(micrometerCollector);
-                registry.register(micrometerCollector);
-                return micrometerCollector;
+                try {
+                    registry.register(micrometerCollector);
+                    return micrometerCollector;
+                }
+                catch (IllegalArgumentException e) {
+                    meterRegistrationFailed(id, e.getMessage());
+                    return null;
+                }
             }
 
             if (!existingCollector.getOriginalId().getName().equals(id.getName())) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -226,7 +226,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     metadata,
                     new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
                             counter.exemplar(), createdTimestampMillis))),
-                    descriptor(MetricType.COUNTER, metadata, tagKeys));
+                    descriptor(conventionName(id), MetricType.COUNTER, metadata, tagKeys));
         });
         return counter;
     }
@@ -315,8 +315,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                 return families.build();
             },
-                    descriptor(primaryType, summaryMetadata, tagKeys),
-                    descriptor(MetricType.GAUGE, maxMetadata, tagKeys));
+                    descriptor(conventionName(id), primaryType, summaryMetadata, tagKeys),
+                    descriptor(conventionName(id) + "_max", MetricType.GAUGE, maxMetadata, tagKeys));
         });
 
         return summary;
@@ -346,16 +346,16 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                                 family -> new InfoSnapshot(family.metadata, family.dataPointSnapshots),
                                 infoMetadata,
                                 new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))),
-                        descriptor(MetricType.INFO, infoMetadata, tagKeys));
+                        descriptor(conventionName(id), MetricType.INFO, infoMetadata, tagKeys));
             }
             else {
-                MetricMetadata metadata = getMetadata(conventionName(id), id.getName(), id.getDescription());
+                MetricMetadata metadata = getMetadata(conventionName(id), id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
                                 metadata,
                                 new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))),
-                        descriptor(MetricType.GAUGE, metadata, tagKeys));
+                        descriptor(conventionName(id), MetricType.GAUGE, metadata, tagKeys));
             }
         });
         return gauge;
@@ -378,12 +378,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            MetricMetadata metadata = getMetadata(conventionName(id), id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                            getMetadata(conventionName, id.getDescription()),
+                            metadata,
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
-                                    Quantiles.EMPTY, Labels.of(tagKeys, tagValues), null, createdTimestampMillis))));
+                                    Quantiles.EMPTY, Labels.of(tagKeys, tagValues), null, createdTimestampMillis))),
+                    descriptor(conventionName(id), MetricType.SUMMARY, metadata, tagKeys));
         });
         return ft;
     }
@@ -403,7 +405,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                             metadata,
                             new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
                                     createdTimestampMillis))),
-                    descriptor(MetricType.COUNTER, metadata, tagKeys));
+                    descriptor(conventionName(id), MetricType.COUNTER, metadata, tagKeys));
         });
         return fc;
     }
@@ -438,7 +440,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     private MicrometerCollector.Descriptor customMeterDescriptor(
             Meter.Id id, String conventionName, Statistic statistic, Collection<String> labelNames) {
         CustomMeterMetric metric = customMeterMetric(id, conventionName, statistic);
-        return descriptor(metric.metricType, metric.metadata, labelNames);
+        return descriptor(metric.name, metric.metricType, metric.metadata, labelNames);
     }
 
     private MicrometerCollector.Family<?> customMeterFamily(
@@ -603,8 +605,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
             return families.build();
         },
-                descriptor(primaryType, primaryMetadata, tagKeys),
-                descriptor(MetricType.GAUGE, maxMetadata, tagKeys));
+                descriptor(conventionName(id), primaryType, primaryMetadata, tagKeys),
+                descriptor(conventionName(id) + "_max", MetricType.GAUGE, maxMetadata, tagKeys));
     }
 
     private String conventionName(Meter.Id id) {
@@ -612,8 +614,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MicrometerCollector.Descriptor descriptor(
-            MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
-        return new MicrometerCollector.Descriptor(metricType, metadata, labelNames);
+            String prometheusName, MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+        return new MicrometerCollector.Descriptor(prometheusName, metricType, metadata, labelNames);
     }
 
     private Exemplars createExemplarsWithScaledValues(Exemplars exemplars) {
@@ -643,14 +645,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MetricMetadata getMetadata(String name, @Nullable String description) {
-        return getMetadata(name, name, description);
-    }
-
-    private MetricMetadata getMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return new MetricMetadata(name, name, originalName, help, null);
+        return new MetricMetadata(name, help, null);
     }
 
     private MetricMetadata getCounterMetadata(String name, @Nullable String description) {
@@ -664,13 +662,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         if (baseName.equals(name)) {
             baseName = stripSuffix(name, "_total");
         }
-        return new MetricMetadata(baseName, name, originalName, help, null);
+        return new MetricMetadata(baseName, help, null);
     }
 
     private MetricMetadata getInfoMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
-        return new MetricMetadata(normalizeBaseName(name, originalName, ".info", "_info"), name, originalName, help,
-                null);
+        return new MetricMetadata(normalizeBaseName(name, originalName, ".info", "_info"), help, null);
     }
 
     private static String normalizeBaseName(String name, String originalName, String... suffixMappings) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -29,6 +29,7 @@ import io.micrometer.core.instrument.util.TimeUtils;
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.config.PrometheusPropertiesLoader;
 import io.prometheus.metrics.expositionformats.ExpositionFormats;
+import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import io.prometheus.metrics.model.snapshots.*;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
@@ -44,6 +45,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -217,11 +219,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            MetricMetadata metadata =
+                    getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
             collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                     family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                    getCounterMetadata(conventionName, id.getDescription()),
+                    metadata,
                     new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
-                            counter.exemplar(), createdTimestampMillis))));
+                            counter.exemplar(), createdTimestampMillis))),
+                    descriptor(MetricType.COUNTER, metadata, tagKeys));
         });
         return counter;
     }
@@ -235,6 +240,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            MetricMetadata summaryMetadata = getMetadata(conventionName(id), id.getDescription());
+            MetricMetadata maxMetadata = getMetadata(conventionName(id) + "_max", id.getDescription());
+            MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -256,7 +264,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
                             family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                            getMetadata(conventionName, id.getDescription()), new SummaryDataPointSnapshot(count, sum,
+                            summaryMetadata, new SummaryDataPointSnapshot(count, sum,
                                     quantiles, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
                 }
                 else {
@@ -286,7 +294,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     families.add(new MicrometerCollector.Family<>(conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(family.metadata,
                                     family.dataPointSnapshots),
-                            getMetadata(conventionName, id.getDescription()),
+                            summaryMetadata,
                             new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
                                     Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
 
@@ -302,11 +310,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                 families.add(new MicrometerCollector.Family<>(conventionName + "_max",
                         family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                        getMetadata(conventionName + "_max", id.getDescription()),
+                        maxMetadata,
                         new GaugeDataPointSnapshot(summary.max(), Labels.of(tagKeys, tagValues), null)));
 
                 return families.build();
-            });
+            },
+                    descriptor(primaryType, summaryMetadata, tagKeys),
+                    descriptor(MetricType.GAUGE, maxMetadata, tagKeys));
         });
 
         return summary;
@@ -330,18 +340,22 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
             if (id.getName().endsWith(".info")) {
+                MetricMetadata infoMetadata = getInfoMetadata(conventionName(id), id.getName(), id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new InfoSnapshot(family.metadata, family.dataPointSnapshots),
-                                getInfoMetadata(conventionName, id.getDescription()),
-                                new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))));
+                                infoMetadata,
+                                new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))),
+                        descriptor(MetricType.INFO, infoMetadata, tagKeys));
             }
             else {
+                MetricMetadata metadata = getMetadata(conventionName(id), id.getName(), id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                                getMetadata(conventionName, id.getDescription()),
-                                new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))));
+                                metadata,
+                                new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))),
+                        descriptor(MetricType.GAUGE, metadata, tagKeys));
             }
         });
         return gauge;
@@ -381,12 +395,15 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            MetricMetadata metadata =
+                    getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                            getCounterMetadata(conventionName, id.getDescription()),
+                            metadata,
                             new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
-                                    createdTimestampMillis))));
+                                    createdTimestampMillis))),
+                    descriptor(MetricType.COUNTER, metadata, tagKeys));
         });
         return fc;
     }
@@ -396,10 +413,42 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            List<String> statKeys = new ArrayList<>(tagKeys);
+            statKeys.add("statistic");
+            List<MicrometerCollector.Descriptor> registrationDescriptors = new ArrayList<>();
+            String name = conventionName(id);
+            for (Measurement measurement : measurements) {
+                switch (measurement.getStatistic()) {
+                    case TOTAL:
+                    case TOTAL_TIME:
+                        registrationDescriptors.add(descriptor(MetricType.COUNTER,
+                                getCounterMetadata(name + "_sum", id.getDescription()), statKeys));
+                        break;
+                    case COUNT:
+                        registrationDescriptors.add(descriptor(MetricType.COUNTER,
+                                getCounterMetadata(name, id.getDescription()), statKeys));
+                        break;
+                    case MAX:
+                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
+                                getMetadata(name + "_max", id.getDescription()), statKeys));
+                        break;
+                    case VALUE:
+                    case UNKNOWN:
+                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
+                                getMetadata(name + "_value", id.getDescription()), statKeys));
+                        break;
+                    case ACTIVE_TASKS:
+                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
+                                getMetadata(name + "_active_count", id.getDescription()), statKeys));
+                        break;
+                    case DURATION:
+                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
+                                getMetadata(name + "_duration_sum", id.getDescription()), statKeys));
+                        break;
+                }
+            }
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-                List<String> statKeys = new ArrayList<>(tagKeys);
-                statKeys.add("statistic");
                 for (Measurement measurement : measurements) {
                     List<String> statValues = new ArrayList<>(tagValues);
                     statValues.add(measurement.getStatistic().toString());
@@ -433,7 +482,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
                 }
                 return families.build();
-            });
+            }, registrationDescriptors.toArray(new MicrometerCollector.Descriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
@@ -473,6 +522,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             boolean forLongTaskTimer) {
         long createdTimestampMillis = clock.wallTime();
         List<String> tagKeys = tagKeys(id);
+        MetricMetadata primaryMetadata = getMetadata(conventionName(id), id.getDescription());
+        MetricMetadata maxMetadata = getMetadata(conventionName(id) + "_max", id.getDescription());
+        MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0
+                ? MetricType.SUMMARY : MetricType.HISTOGRAM;
         collector.add(id, (conventionName) -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -495,7 +548,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
                         family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                        getMetadata(conventionName, id.getDescription()), new SummaryDataPointSnapshot(count, sum,
+                        primaryMetadata, new SummaryDataPointSnapshot(count, sum,
                                 quantiles, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
             }
             else {
@@ -525,7 +578,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 families.add(new MicrometerCollector.Family<>(conventionName,
                         family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(forLongTaskTimer,
                                 family.metadata, family.dataPointSnapshots),
-                        getMetadata(conventionName, id.getDescription()),
+                        primaryMetadata,
                         new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
                                 Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
 
@@ -541,11 +594,22 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
             families.add(new MicrometerCollector.Family<>(conventionName + "_max",
                     family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                    getMetadata(conventionName + "_max", id.getDescription()), new GaugeDataPointSnapshot(
+                    maxMetadata, new GaugeDataPointSnapshot(
                             histogramSnapshot.max(getBaseTimeUnit()), Labels.of(tagKeys, tagValues), null)));
 
             return families.build();
-        });
+        },
+                descriptor(primaryType, primaryMetadata, tagKeys),
+                descriptor(MetricType.GAUGE, maxMetadata, tagKeys));
+    }
+
+    private String conventionName(Meter.Id id) {
+        return getConventionName(id);
+    }
+
+    private MicrometerCollector.Descriptor descriptor(
+            MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+        return new MicrometerCollector.Descriptor(metricType, metadata, labelNames);
     }
 
     private Exemplars createExemplarsWithScaledValues(Exemplars exemplars) {
@@ -575,26 +639,48 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MetricMetadata getMetadata(String name, @Nullable String description) {
+        return getMetadata(name, name, description);
+    }
+
+    private MetricMetadata getMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return new MetricMetadata(name, help, null);
+        return new MetricMetadata(name, name, originalName, help, null);
     }
 
     private MetricMetadata getCounterMetadata(String name, @Nullable String description) {
-        String help = prometheusConfig.descriptions() && description != null ? description : " ";
-        if (name.endsWith("_total")) {
-            return new MetricMetadata(name.substring(0, name.length() - "_total".length()), name, name, help, null);
-        }
-        return new MetricMetadata(name, help, null);
+        return getCounterMetadata(name, name, description);
     }
 
-    private MetricMetadata getInfoMetadata(String name, @Nullable String description) {
+    private MetricMetadata getCounterMetadata(String name, String originalName, @Nullable String description) {
+        String help = prometheusConfig.descriptions() && description != null ? description : " ";
+        String baseName = name;
+        if (originalName.endsWith(".bucket")) {
+            baseName = stripSuffix(name, "_bucket");
+        }
+        else if (originalName.endsWith(".created")) {
+            baseName = stripSuffix(name, "_created");
+        }
+        else if (originalName.endsWith(".info")) {
+            baseName = stripSuffix(name, "_info");
+        }
+        else if (name.endsWith("_total")) {
+            baseName = stripSuffix(name, "_total");
+        }
+        return new MetricMetadata(baseName, name, originalName, help, null);
+    }
+
+    private MetricMetadata getInfoMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
         if (name.endsWith("_info")) {
-            return new MetricMetadata(name.substring(0, name.length() - "_info".length()), name, name, help, null);
+            return new MetricMetadata(stripSuffix(name, "_info"), name, originalName, help, null);
         }
-        return new MetricMetadata(name, help, null);
+        return new MetricMetadata(name, name, originalName, help, null);
+    }
+
+    private static String stripSuffix(String name, String suffix) {
+        return name.endsWith(suffix) ? name.substring(0, name.length() - suffix.length()) : name;
     }
 
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -418,68 +418,15 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<MicrometerCollector.Descriptor> registrationDescriptors = new ArrayList<>();
             String name = conventionName(id);
             for (Measurement measurement : measurements) {
-                switch (measurement.getStatistic()) {
-                    case TOTAL:
-                    case TOTAL_TIME:
-                        registrationDescriptors.add(descriptor(MetricType.COUNTER,
-                                getCounterMetadata(name + "_sum", id.getDescription()), statKeys));
-                        break;
-                    case COUNT:
-                        registrationDescriptors.add(descriptor(MetricType.COUNTER,
-                                getCounterMetadata(name, id.getDescription()), statKeys));
-                        break;
-                    case MAX:
-                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
-                                getMetadata(name + "_max", id.getDescription()), statKeys));
-                        break;
-                    case VALUE:
-                    case UNKNOWN:
-                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
-                                getMetadata(name + "_value", id.getDescription()), statKeys));
-                        break;
-                    case ACTIVE_TASKS:
-                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
-                                getMetadata(name + "_active_count", id.getDescription()), statKeys));
-                        break;
-                    case DURATION:
-                        registrationDescriptors.add(descriptor(MetricType.GAUGE,
-                                getMetadata(name + "_duration_sum", id.getDescription()), statKeys));
-                        break;
-                }
+                registrationDescriptors.add(customMeterDescriptor(id, name, measurement.getStatistic(), statKeys));
             }
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
                 for (Measurement measurement : measurements) {
                     List<String> statValues = new ArrayList<>(tagValues);
                     statValues.add(measurement.getStatistic().toString());
-                    switch (measurement.getStatistic()) {
-                        case TOTAL:
-                        case TOTAL_TIME:
-                            families.add(customCounterFamily(id, conventionName, "_sum",
-                                    Labels.of(statKeys, statValues), measurement.getValue()));
-                            break;
-                        case COUNT:
-                            families.add(customCounterFamily(id, conventionName, "", Labels.of(statKeys, statValues),
-                                    measurement.getValue()));
-                            break;
-                        case MAX:
-                            families.add(customGaugeFamily(id, conventionName, "_max", Labels.of(statKeys, statValues),
-                                    measurement.getValue()));
-                            break;
-                        case VALUE:
-                        case UNKNOWN:
-                            families.add(customGaugeFamily(id, conventionName, "_value",
-                                    Labels.of(statKeys, statValues), measurement.getValue()));
-                            break;
-                        case ACTIVE_TASKS:
-                            families.add(customGaugeFamily(id, conventionName, "_active_count",
-                                    Labels.of(statKeys, statValues), measurement.getValue()));
-                            break;
-                        case DURATION:
-                            families.add(customGaugeFamily(id, conventionName, "_duration_sum",
-                                    Labels.of(statKeys, statValues), measurement.getValue()));
-                            break;
-                    }
+                    families.add(customMeterFamily(id, conventionName, measurement.getStatistic(),
+                            Labels.of(statKeys, statValues), measurement.getValue()));
                 }
                 return families.build();
             }, registrationDescriptors.toArray(new MicrometerCollector.Descriptor[0]));
@@ -488,21 +435,78 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id, String conventionName,
-            String suffix, Labels labels, double value) {
+    private MicrometerCollector.Descriptor customMeterDescriptor(
+            Meter.Id id, String conventionName, Statistic statistic, Collection<String> labelNames) {
+        CustomMeterMetric metric = customMeterMetric(id, conventionName, statistic);
+        return descriptor(metric.metricType, metric.metadata, labelNames);
+    }
+
+    private MicrometerCollector.Family<?> customMeterFamily(
+            Meter.Id id, String conventionName, Statistic statistic, Labels labels, double value) {
+        CustomMeterMetric metric = customMeterMetric(id, conventionName, statistic);
+        if (metric.metricType == MetricType.COUNTER) {
+            return customCounterFamily(metric, labels, value);
+        }
+        return customGaugeFamily(metric, labels, value);
+    }
+
+    private CustomMeterMetric customMeterMetric(Meter.Id id, String conventionName, Statistic statistic) {
+        switch (statistic) {
+            case TOTAL:
+            case TOTAL_TIME:
+                return new CustomMeterMetric(conventionName + "_sum", MetricType.COUNTER,
+                        getCounterMetadata(conventionName + "_sum", id.getDescription()));
+            case COUNT:
+                return new CustomMeterMetric(conventionName, MetricType.COUNTER,
+                        getCounterMetadata(conventionName, id.getDescription()));
+            case MAX:
+                return new CustomMeterMetric(conventionName + "_max", MetricType.GAUGE,
+                        getMetadata(conventionName + "_max", id.getDescription()));
+            case VALUE:
+            case UNKNOWN:
+                return new CustomMeterMetric(conventionName + "_value", MetricType.GAUGE,
+                        getMetadata(conventionName + "_value", id.getDescription()));
+            case ACTIVE_TASKS:
+                return new CustomMeterMetric(conventionName + "_active_count", MetricType.GAUGE,
+                        getMetadata(conventionName + "_active_count", id.getDescription()));
+            case DURATION:
+                return new CustomMeterMetric(conventionName + "_duration_sum", MetricType.GAUGE,
+                        getMetadata(conventionName + "_duration_sum", id.getDescription()));
+            default:
+                throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
+        }
+    }
+
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
+            CustomMeterMetric metric, Labels labels, double value) {
         long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(conventionName + suffix,
+        return new MicrometerCollector.Family<>(metric.name,
                 family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                getCounterMetadata(conventionName + suffix, id.getDescription()),
+                metric.metadata,
                 new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, String conventionName,
-            String suffix, Labels labels, double value) {
-        return new MicrometerCollector.Family<>(conventionName + suffix,
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(
+            CustomMeterMetric metric, Labels labels, double value) {
+        return new MicrometerCollector.Family<>(metric.name,
                 family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                getMetadata(conventionName + suffix, id.getDescription()),
+                metric.metadata,
                 new GaugeDataPointSnapshot(value, labels, null));
+    }
+
+    private static class CustomMeterMetric {
+
+        private final String name;
+
+        private final MetricType metricType;
+
+        private final MetricMetadata metadata;
+
+        private CustomMeterMetric(String name, MetricType metricType, MetricMetadata metadata) {
+            this.name = name;
+            this.metricType = metricType;
+            this.metadata = metadata;
+        }
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -219,13 +219,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
-            MetricMetadata metadata =
-                    getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
-            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                    family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                    metadata,
-                    new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
-                            counter.exemplar(), createdTimestampMillis))),
+            MetricMetadata metadata = getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
+            collector.add(id,
+                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                            family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots), metadata,
+                            new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
+                                    counter.exemplar(), createdTimestampMillis))),
                     descriptor(conventionName(id), MetricType.COUNTER, metadata, tagKeys));
         });
         return counter;
@@ -263,9 +262,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                            summaryMetadata, new SummaryDataPointSnapshot(count, sum,
-                                    quantiles, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                            family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots), summaryMetadata,
+                            new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues),
+                                    exemplars, createdTimestampMillis)));
                 }
                 else {
                     List<Double> buckets = new ArrayList<>();
@@ -294,9 +293,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     families.add(new MicrometerCollector.Family<>(conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(family.metadata,
                                     family.dataPointSnapshots),
-                            summaryMetadata,
-                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                    Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                            summaryMetadata, new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts),
+                                    sum, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
 
                     // TODO: Add support back for VictoriaMetrics
                     // Previously we had low-level control so a histogram was just
@@ -309,13 +307,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
 
                 families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                        family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                        maxMetadata,
+                        family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots), maxMetadata,
                         new GaugeDataPointSnapshot(summary.max(), Labels.of(tagKeys, tagValues), null)));
 
                 return families.build();
-            },
-                    descriptor(conventionName(id), primaryType, summaryMetadata, tagKeys),
+            }, descriptor(conventionName(id), primaryType, summaryMetadata, tagKeys),
                     descriptor(conventionName(id) + "_max", MetricType.GAUGE, maxMetadata, tagKeys));
         });
 
@@ -343,8 +339,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 MetricMetadata infoMetadata = getInfoMetadata(conventionName(id), id.getName(), id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new InfoSnapshot(family.metadata, family.dataPointSnapshots),
-                                infoMetadata,
+                                family -> new InfoSnapshot(family.metadata, family.dataPointSnapshots), infoMetadata,
                                 new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))),
                         descriptor(conventionName(id), MetricType.INFO, infoMetadata, tagKeys));
             }
@@ -352,8 +347,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 MetricMetadata metadata = getMetadata(conventionName(id), id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                                metadata,
+                                family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots), metadata,
                                 new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))),
                         descriptor(conventionName(id), MetricType.GAUGE, metadata, tagKeys));
             }
@@ -381,8 +375,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricMetadata metadata = getMetadata(conventionName(id), id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                            metadata,
+                            family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots), metadata,
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
                                     Quantiles.EMPTY, Labels.of(tagKeys, tagValues), null, createdTimestampMillis))),
                     descriptor(conventionName(id), MetricType.SUMMARY, metadata, tagKeys));
@@ -397,12 +390,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
-            MetricMetadata metadata =
-                    getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
+            MetricMetadata metadata = getCounterMetadata(conventionName(id), id.getName(), id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                            metadata,
+                            family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots), metadata,
                             new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
                                     createdTimestampMillis))),
                     descriptor(conventionName(id), MetricType.COUNTER, metadata, tagKeys));
@@ -437,14 +428,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MicrometerCollector.Descriptor customMeterDescriptor(
-            Meter.Id id, String conventionName, Statistic statistic, Collection<String> labelNames) {
+    private MicrometerCollector.Descriptor customMeterDescriptor(Meter.Id id, String conventionName,
+            Statistic statistic, Collection<String> labelNames) {
         CustomMeterMetric metric = customMeterMetric(id, conventionName, statistic);
         return descriptor(metric.name, metric.metricType, metric.metadata, labelNames);
     }
 
-    private MicrometerCollector.Family<?> customMeterFamily(
-            Meter.Id id, String conventionName, Statistic statistic, Labels labels, double value) {
+    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
+            Labels labels, double value) {
         CustomMeterMetric metric = customMeterMetric(id, conventionName, statistic);
         if (metric.metricType == MetricType.COUNTER) {
             return customCounterFamily(metric, labels, value);
@@ -479,20 +470,18 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
-            CustomMeterMetric metric, Labels labels, double value) {
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(CustomMeterMetric metric,
+            Labels labels, double value) {
         long createdTimestampMillis = clock.wallTime();
         return new MicrometerCollector.Family<>(metric.name,
-                family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
-                metric.metadata,
+                family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots), metric.metadata,
                 new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(
-            CustomMeterMetric metric, Labels labels, double value) {
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(CustomMeterMetric metric,
+            Labels labels, double value) {
         return new MicrometerCollector.Family<>(metric.name,
-                family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                metric.metadata,
+                family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots), metric.metadata,
                 new GaugeDataPointSnapshot(value, labels, null));
     }
 
@@ -509,6 +498,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             this.metricType = metricType;
             this.metadata = metadata;
         }
+
     }
 
     @Override
@@ -530,8 +520,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         List<String> tagKeys = tagKeys(id);
         MetricMetadata primaryMetadata = getMetadata(conventionName(id), id.getDescription());
         MetricMetadata maxMetadata = getMetadata(conventionName(id) + "_max", id.getDescription());
-        MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0
-                ? MetricType.SUMMARY : MetricType.HISTOGRAM;
+        MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
+                : MetricType.HISTOGRAM;
         collector.add(id, (conventionName) -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -553,9 +543,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
-                        family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots),
-                        primaryMetadata, new SummaryDataPointSnapshot(count, sum,
-                                quantiles, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                        family -> new SummarySnapshot(family.metadata, family.dataPointSnapshots), primaryMetadata,
+                        new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues), exemplars,
+                                createdTimestampMillis)));
             }
             else {
                 List<Double> buckets = new ArrayList<>();
@@ -584,9 +574,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 families.add(new MicrometerCollector.Family<>(conventionName,
                         family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(forLongTaskTimer,
                                 family.metadata, family.dataPointSnapshots),
-                        primaryMetadata,
-                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                        primaryMetadata, new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts),
+                                sum, Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
 
                 // TODO: Add support back for VictoriaMetrics
                 // Previously we had low-level control so a histogram was just
@@ -599,13 +588,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                    family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots),
-                    maxMetadata, new GaugeDataPointSnapshot(
-                            histogramSnapshot.max(getBaseTimeUnit()), Labels.of(tagKeys, tagValues), null)));
+                    family -> new GaugeSnapshot(family.metadata, family.dataPointSnapshots), maxMetadata,
+                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), Labels.of(tagKeys, tagValues),
+                            null)));
 
             return families.build();
-        },
-                descriptor(conventionName(id), primaryType, primaryMetadata, tagKeys),
+        }, descriptor(conventionName(id), primaryType, primaryMetadata, tagKeys),
                 descriptor(conventionName(id) + "_max", MetricType.GAUGE, maxMetadata, tagKeys));
     }
 
@@ -613,8 +601,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return getConventionName(id);
     }
 
-    private MicrometerCollector.Descriptor descriptor(
-            String prometheusName, MetricType metricType, MetricMetadata metadata, Collection<String> labelNames) {
+    private MicrometerCollector.Descriptor descriptor(String prometheusName, MetricType metricType,
+            MetricMetadata metadata, Collection<String> labelNames) {
         return new MicrometerCollector.Descriptor(prometheusName, metricType, metadata, labelNames);
     }
 
@@ -657,8 +645,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricMetadata getCounterMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
-        String baseName = normalizeBaseName(name, originalName, ".bucket", "_bucket", ".created", "_created",
-                ".info", "_info");
+        String baseName = normalizeBaseName(name, originalName, ".bucket", "_bucket", ".created", "_created", ".info",
+                "_info");
         if (baseName.equals(name)) {
             baseName = stripSuffix(name, "_total");
         }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -659,17 +659,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricMetadata getCounterMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
-        String baseName = name;
-        if (originalName.endsWith(".bucket")) {
-            baseName = stripSuffix(name, "_bucket");
-        }
-        else if (originalName.endsWith(".created")) {
-            baseName = stripSuffix(name, "_created");
-        }
-        else if (originalName.endsWith(".info")) {
-            baseName = stripSuffix(name, "_info");
-        }
-        else if (name.endsWith("_total")) {
+        String baseName = normalizeBaseName(name, originalName, ".bucket", "_bucket", ".created", "_created",
+                ".info", "_info");
+        if (baseName.equals(name)) {
             baseName = stripSuffix(name, "_total");
         }
         return new MetricMetadata(baseName, name, originalName, help, null);
@@ -677,10 +669,17 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricMetadata getInfoMetadata(String name, String originalName, @Nullable String description) {
         String help = prometheusConfig.descriptions() && description != null ? description : " ";
-        if (name.endsWith("_info")) {
-            return new MetricMetadata(stripSuffix(name, "_info"), name, originalName, help, null);
+        return new MetricMetadata(normalizeBaseName(name, originalName, ".info", "_info"), name, originalName, help,
+                null);
+    }
+
+    private static String normalizeBaseName(String name, String originalName, String... suffixMappings) {
+        for (int i = 0; i < suffixMappings.length; i += 2) {
+            if (originalName.endsWith(suffixMappings[i])) {
+                return stripSuffix(name, suffixMappings[i + 1]);
+            }
         }
-        return new MetricMetadata(name, name, originalName, help, null);
+        return name;
     }
 
     private static String stripSuffix(String name, String suffix) {

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -21,11 +21,13 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.NamingConvention;
+import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import org.junit.jupiter.api.Test;
 
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -150,6 +152,26 @@ class MicrometerCollectorTest {
                         new MetricMetadata(conventionName), sample2)));
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
+    }
+
+    @Test
+    void registrationDescriptorUsesPrometheusFamilyName() {
+        Meter.Id id = Metrics.counter("my.counter").getId();
+        MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+
+        CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
+                Labels.of("k", "v"), null, 0);
+        MetricMetadata metadata = new MetricMetadata("my_counter", "help");
+
+        collector.add(id,
+                (conventionName) -> Stream.of(new MicrometerCollector.Family<>("my_counter_total",
+                        family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots), metadata, sample)),
+                new MicrometerCollector.Descriptor("my_counter_total", MetricType.COUNTER, metadata, asList("k")));
+
+        assertThat(collector.getPrometheusNames()).containsExactly("my_counter_total");
+        assertThat(collector.getMetricType("my_counter_total")).isEqualTo(MetricType.COUNTER);
+        assertThat(collector.getLabelNames("my_counter_total")).containsExactly("k");
+        assertThat(Objects.requireNonNull(collector.getMetadata("my_counter_total")).getName()).isEqualTo("my_counter");
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -91,6 +91,19 @@ class PrometheusMeterRegistryTest {
     }
 
     @Test
+    void functionTimerCollisionUsesPrometheusRegistrationMetadata() {
+        registry.throwExceptionOnRegistrationFailure();
+
+        registry.more().timer("test", Tags.empty(), this, o -> 1, o -> 2, TimeUnit.SECONDS);
+
+        assertThatThrownBy(
+                () -> Gauge.builder("test.seconds", new AtomicInteger(42), AtomicInteger::get).register(registry))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("same Prometheus name (test_seconds)")
+            .hasMessageContaining("would fail with an exception on scrape");
+    }
+
+    @Test
     @Disabled("We don't detect this situation yet; scrape will fail")
     void differentTypesThatProduceSamePrometheusMetricFamilyFailsToRegister() {
         AtomicBoolean failed = new AtomicBoolean(false);


### PR DESCRIPTION
## Summary

Tests added on the Prometheus side to support repeated `prom-client-java`
upgrade work exposed this issue in Micrometer.

In this case, the compatibility testing did not only show a prom-side problem.
It also showed a necessary Micrometer-side change in the `prometheusmetrics`
adapter.

This draft contains the change we currently believe Micrometer will need when
moving to the newer `prom-client-java` release line.

## What this changes

- expose the actual Prometheus family metadata from `MicrometerCollector`
- align registration-time metadata in `PrometheusMeterRegistry` with the
  `MetricSnapshot` metadata used at scrape time
- make collision validation use the same names, types, and labels that the
  scrape path will actually emit

## Why this is draft

We'd like feedback from Micrometer maintainers on whether this is the right
Micrometer-side fix.

## Context

- Prometheus-side compatibility workflow:
  https://github.com/zeitlinger/client_java/pull/1
- related prom-client-java fix:
  https://github.com/prometheus/client_java/pull/2100
- we also noticed that the downstream-adapter implication was not explicit in
  the Prometheus-side release notes/docs, so that is being clarified here:
  https://github.com/prometheus/client_java/pull/2101
