### PR TITLE
Clarify custom MeterTag value expression resolver docs

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -97,6 +97,8 @@ include::{include-java}/metrics/CountedAspectTest.java[tags=resolvers,indent=0]
 include::{include-java}/metrics/CountedAspectTest.java[tags=meter_tag_annotation_handler,indent=0]
 -----
 
+NOTE: `CustomValueExpressionResolver` is an application-provided `ValueExpressionResolver` example. Micrometer does not provide this class. You need to provide an implementation that matches your application framework if you use `@MeterTag` expressions.
+
 Let's assume that we have the following interface.
 
 [source,java,subs=+attributes]

--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -97,7 +97,7 @@ include::{include-java}/metrics/CountedAspectTest.java[tags=resolvers,indent=0]
 include::{include-java}/metrics/CountedAspectTest.java[tags=meter_tag_annotation_handler,indent=0]
 -----
 
-NOTE: `CustomValueExpressionResolver` is an application-provided `ValueExpressionResolver` example. Micrometer does not provide this class. You need to provide an implementation that matches your application framework if you use `@MeterTag` expressions.
+NOTE: `CustomValueExpressionResolver` is a sample implementation of `ValueExpressionResolver` for documentation purposes. Micrometer does not provide this class. An implementation is required to use `@MeterTag` expressions.
 
 Let's assume that we have the following interface.
 

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -125,6 +125,8 @@ include::{include-java}/metrics/TimedAspectTest.java[tags=resolvers,indent=0]
 include::{include-java}/metrics/TimedAspectTest.java[tags=meter_tag_annotation_handler,indent=0]
 -----
 
+NOTE: `CustomValueExpressionResolver` is an application-provided `ValueExpressionResolver` example. Micrometer does not provide this class. You need to provide an implementation that matches your application framework if you use `@MeterTag` expressions.
+
 Let's assume that we have the following interface.
 
 [source,java,subs=+attributes]

--- a/docs/src/test/java/io/micrometer/docs/CustomValueExpressionResolver.java
+++ b/docs/src/test/java/io/micrometer/docs/CustomValueExpressionResolver.java
@@ -25,9 +25,9 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 
-public class SpelValueExpressionResolver implements ValueExpressionResolver {
+public class CustomValueExpressionResolver implements ValueExpressionResolver {
 
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(SpelValueExpressionResolver.class);
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(CustomValueExpressionResolver.class);
 
     @Override
     public @NonNull String resolve(@NonNull String expression, @Nullable Object parameter) {

--- a/docs/src/test/java/io/micrometer/docs/metrics/CountedAspectTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/CountedAspectTest.java
@@ -23,7 +23,7 @@ import io.micrometer.core.aop.CountedMeterTagAnnotationHandler;
 import io.micrometer.core.aop.MeterTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -36,8 +36,8 @@ class CountedAspectTest {
     // tag::resolvers[]
     ValueResolver valueResolver = parameter -> "Value from myCustomTagValueResolver [" + parameter + "]";
 
-    // Example of a ValueExpressionResolver that uses Spring Expression Language
-    ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+    // Example of a custom ValueExpressionResolver
+    ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
 
     // end::resolvers[]
 

--- a/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
@@ -23,7 +23,7 @@ import io.micrometer.core.aop.MeterTag;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -36,8 +36,8 @@ class TimedAspectTest {
     // tag::resolvers[]
     ValueResolver valueResolver = parameter -> "Value from myCustomTagValueResolver [" + parameter + "]";
 
-    // Example of a ValueExpressionResolver that uses Spring Expression Language
-    ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+    // Example of a custom ValueExpressionResolver
+    ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
 
     // end::resolvers[]
 

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 import io.micrometer.observation.*;
 import io.micrometer.observation.annotation.Observed;
 import io.micrometer.observation.annotation.ObservationKeyValue;
@@ -237,7 +237,7 @@ class ObservationHandlerTests {
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedServiceWithParameter());
         ObservedAspect observedAspect = new ObservedAspect(registry);
         ValueResolver valueResolver = parameter -> "Value from myCustomValueResolver [" + parameter + "]";
-        ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+        ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
         observedAspect.setObservationKeyValueAnnotationHandler(
             new ObservationKeyValueAnnotationHandler(
                 aClass -> valueResolver, aClass -> valueExpressionResolver)


### PR DESCRIPTION
## Summary
Renames the docs-only example resolver to `CustomValueExpressionResolver` and updates the `@MeterTag` docs to make clear that this resolver is application-provided, not a Micrometer class.

Updates the Timed, Counted, and Observation docs tests to use the renamed resolver.

Fixes #6465

## Testing
- `./gradlew :docs:test --tests io.micrometer.docs.metrics.TimedAspectTest --tests io.micrometer.docs.metrics.CountedAspectTest --tests io.micrometer.docs.observation.ObservationHandlerTests --console=plain --max-workers=2`
- `rg -n "SpelValueExpressionResolver|CustomValueExpressionResolver" docs/src/test/java docs/modules/ROOT/pages`
- `git diff --cached --check`
