### PR TITLE
Mark nullability on Meter.match

### DIFF
--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -1004,8 +1004,8 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
         @Override
         protected void publish() {
             publishCount.incrementAndGet();
-            forEachMeter(meter -> meter.match(null, this::publishCounter, this::publishTimer, this::publishSummary,
-                    null, null, this::publishFunctionCounter, this::publishFunctionTimer, null));
+            forEachMeter(meter -> meter.match(g -> null, this::publishCounter, this::publishTimer, this::publishSummary,
+                    ltt -> null, tg -> null, this::publishFunctionCounter, this::publishFunctionTimer, m -> null));
         }
 
         private void scheduledPublish() {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Meter.java
@@ -18,7 +18,6 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.HistogramGauges;
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -86,16 +85,15 @@ public interface Meter {
      * @param visitFunctionCounter function to apply for {@link FunctionCounter}
      * @param visitFunctionTimer function to apply for {@link FunctionTimer}
      * @param visitMeter function to apply as a fallback
-     * @param <T> return type of function to apply
+     * @param <T> return type of function to apply, possibly nullable
      * @return return value from the applied function
      * @since 1.1.0
      */
-    @NullUnmarked // I can't figure out the magical combination that makes NullAway happy
-                  // here
-    default <T> T match(Function<Gauge, T> visitGauge, Function<Counter, T> visitCounter, Function<Timer, T> visitTimer,
-            Function<DistributionSummary, T> visitSummary, Function<LongTaskTimer, T> visitLongTaskTimer,
-            Function<TimeGauge, T> visitTimeGauge, Function<FunctionCounter, T> visitFunctionCounter,
-            Function<FunctionTimer, T> visitFunctionTimer, Function<Meter, T> visitMeter) {
+    default <T extends @Nullable Object> T match(Function<Gauge, T> visitGauge, Function<Counter, T> visitCounter,
+            Function<Timer, T> visitTimer, Function<DistributionSummary, T> visitSummary,
+            Function<LongTaskTimer, T> visitLongTaskTimer, Function<TimeGauge, T> visitTimeGauge,
+            Function<FunctionCounter, T> visitFunctionCounter, Function<FunctionTimer, T> visitFunctionTimer,
+            Function<Meter, T> visitMeter) {
         if (this instanceof TimeGauge) {
             return visitTimeGauge.apply((TimeGauge) this);
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,6 +40,15 @@ class MeterTest {
                 (timeGauge) -> "timeGauge", (functionCounter) -> "functionCounter", (functionTimer) -> "functionTimer",
                 (meter) -> "meter");
         assertThat(matched).isEqualTo("timeGauge");
+    }
+
+    @Test
+    void matchWhenFunctionReturnsNullShouldReturnNull() {
+        @Nullable String matched = gauge.match((gauge) -> "gauge", (counter) -> "counter", (timer) -> "timer",
+                (distributionSummary) -> "distributionSummary", (longTaskTimer) -> "longTaskTimer", (timeGauge) -> null,
+                (functionCounter) -> "functionCounter", (functionTimer) -> "functionTimer", (meter) -> "meter");
+
+        assertThat(matched).isNull();
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -657,7 +657,7 @@ class StepMeterRegistryTest {
             publishCount.incrementAndGet();
             List<Meter> ignored = getMeters().stream()
                 .map(meter -> meter.match(g -> null, this::publishCounter, this::publishTimer, this::publishSummary,
-                        null, tg -> null, this::publishFunctionCounter, this::publishFunctionTimer, m -> null))
+                        ltt -> null, tg -> null, this::publishFunctionCounter, this::publishFunctionTimer, m -> null))
                 .collect(Collectors.toList());
         }
 


### PR DESCRIPTION
Removes the `@NullUnmarked` workaround on `Meter.match` and expresses the nullability contract with JSpecify.

`match` returns whatever the selected visitor returns, so the result type has to allow `null` when a visitor returns `null`. Switched the type parameter to `<T extends @Nullable Object>`; the visitor functions themselves stay non-null.

Updated test call sites that passed `null` for unused visitors to pass `x -> null` instead, since `Function` params are no longer nullable. Added a test for the `match`-returns-`null` case.

Closes gh-6408