### PR TITLE
Remove Gradle Wrapper configuration block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -544,8 +544,4 @@ tasks.register('build') {
     dependsOn check
 }
 
-wrapper {
-    gradleVersion = '9.5.0'
-}
-
 defaultTasks 'build'


### PR DESCRIPTION
This PR removes the Gradle Wrapper configuration block as it's not used by Dependabot.

See https://github.com/micrometer-metrics/micrometer/pull/7485