### PR TITLE
Make `DefaultLongTaskTimer.takeSnapshot` handle multiple percentiles per active task duration

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java
@@ -197,22 +197,24 @@ public class DefaultLongTaskTimer extends AbstractMeter implements LongTaskTimer
                 }
                 count++;
 
-                if (percentile != null) {
+                // We are looping here as multiple percentiles ranks might be rank-mapped
+                // between this and the prior active task duration.
+                while (percentile != null) {
                     double rank = percentile * (activeTasks.size() + 1);
-
-                    if (count >= rank) {
-                        double percentileValue = activeTaskDuration;
-                        if (count != rank && priorActiveTaskDuration != null) {
-                            // interpolate the percentile value when the active task rank
-                            // is non-integral
-                            double priorPercentileValue = priorActiveTaskDuration;
-                            percentileValue = priorPercentileValue
-                                    + ((percentileValue - priorPercentileValue) * (rank - (int) rank));
-                        }
-
-                        valueAtPercentiles.add(new ValueAtPercentile(percentile, percentileValue));
-                        percentile = percentilesRequested.poll();
+                    if (count < rank) {
+                        break;
                     }
+                    double percentileValue = activeTaskDuration;
+                    if (count != rank && priorActiveTaskDuration != null) {
+                        // interpolate the percentile value when the active task rank
+                        // is non-integral
+                        double priorPercentileValue = priorActiveTaskDuration;
+                        percentileValue = priorPercentileValue
+                                + ((percentileValue - priorPercentileValue) * (rank - (int) rank));
+                    }
+
+                    valueAtPercentiles.add(new ValueAtPercentile(percentile, percentileValue));
+                    percentile = percentilesRequested.poll();
                 }
 
                 priorActiveTaskDuration = activeTaskDuration;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimerTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.internal;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer.SampleImpl;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer.SampleImplCounted;
 import io.micrometer.core.instrument.simple.SimpleConfig;
@@ -25,6 +26,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -112,6 +114,25 @@ class DefaultLongTaskTimerTest {
         ((DefaultLongTaskTimer) ltt).setCounter(-2);
         assertInternalCounterValue(ltt.start(), -1);
         assertInternalCounterValue(ltt.start(), 1);
+    }
+
+    @Test
+    void snapshotWithMorePercentilesThanValuesContainsAllConfiguredPercentilesInSortedOrder() {
+        // N=1, percentiles [0.1, 0.25, 0.5, 0.75, 0.9]
+        // The above-line condition is p*2>1, so {0.75, 0.9} go directly to max and
+        // {0.1, 0.25, 0.5} enter the interpolation loop.
+        // Prior to #7507, we process one percentile per value, which would be wrong here.
+        // We would process 0.1 with the first and only duration and leave both 0.25 and
+        // 0.5 uncomputed.
+        final LongTaskTimer ltt2 = LongTaskTimer.builder("my.ltt.2")
+            .publishPercentiles(0.1, 0.25, 0.5, 0.75, 0.9)
+            .register(registry);
+        ltt2.start();
+        clock.add(Duration.ofSeconds(5));
+        final ValueAtPercentile[] snap2 = ltt2.takeSnapshot().percentileValues();
+        // Prior to #7507, this would be [0.1, 0.75, 0.9] only
+        assertThat(snap2).extracting(ValueAtPercentile::percentile).containsExactly(0.1, 0.25, 0.5, 0.75, 0.9);
+        assertThat(snap2).extracting(v -> v.value(TimeUnit.SECONDS)).containsOnly(5.0);
     }
 
     private void assertInternalCounterIsZero(LongTaskTimer.Sample sample) {


### PR DESCRIPTION
Fixes #3877.

The percentile interpolation loop in `DefaultLongTaskTimer.takeSnapshot()` advances at most one percentile per active-task duration:

https://github.com/micrometer-metrics/micrometer/blob/3c6fe3d9dd994b5ebe3f136e858078393927b37e/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultLongTaskTimer.java#L193-L219

However, multiple configured percentiles can map to the same active-task duration. For example, with one active task and percentiles `[0.1, 0.25, 0.5]`, all three percentile ranks (`0.2`, `0.5`, `1.0`) are satisfied once `count = 1`.

The existing loop recorded only `0.1` and omitted the remaining percentiles because there was no next duration to advance to. As a result, the snapshot contains fewer percentile values than the percentiles configured for the `DefaultLongTaskTimer`. This can trip an `ArrayIndexOutOfBoundsException` in `HistogramGauges`, which expects the snapshot percentiles to match the configured percentiles:

  https://github.com/micrometer-metrics/micrometer/blob/3c6fe3d9dd994b5ebe3f136e858078393927b37e/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java#L113-L120

**Fix:** change the `if` to a `while` so every percentile satisfied by the current `count` is recorded before advancing to the next duration.