### PR TITLE
fix exception message with `MeterNotFoundException` in concurrent case

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/MeterNotFoundException.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/MeterNotFoundException.java
@@ -42,8 +42,9 @@ public class MeterNotFoundException extends RuntimeException {
                 + (tagDetail == null ? "" : "\n   " + tagDetail.stream().collect(joining("\n   "))));
     }
 
-    static MeterNotFoundException forSearch(RequiredSearch search, Class<? extends Meter> requiredType) {
-        return new FromRequiredSearch(search, requiredType).build();
+    static MeterNotFoundException forSearch(RequiredSearch search, Class<? extends Meter> requiredType,
+            Collection<Meter> meters) {
+        return new FromRequiredSearch(search, requiredType, meters).build();
     }
 
     private static class FromRequiredSearch {
@@ -52,20 +53,22 @@ public class MeterNotFoundException extends RuntimeException {
 
         private final Class<? extends Meter> requiredMeterType;
 
-        private FromRequiredSearch(RequiredSearch search, Class<? extends Meter> requiredMeterType) {
+        private final Collection<Meter> meters;
+
+        private FromRequiredSearch(RequiredSearch search, Class<? extends Meter> requiredMeterType,
+                Collection<Meter> meters) {
             this.search = search;
             this.requiredMeterType = requiredMeterType;
+            this.meters = meters;
         }
 
         private @Nullable String nameDetail() {
             if (search.nameMatches == null)
                 return null;
 
-            Collection<String> matchingName = Search.in(search.registry)
-                .name(search.nameMatches)
-                .meters()
-                .stream()
+            Collection<String> matchingName = meters.stream()
                 .map(m -> m.getId().getName())
+                .filter(search.nameMatches)
                 .distinct()
                 .sorted()
                 .collect(toList());
@@ -94,11 +97,9 @@ public class MeterNotFoundException extends RuntimeException {
             List<String> details = new ArrayList<>();
 
             for (String requiredKey : search.requiredTagKeys) {
-                Collection<String> matchingRequiredKey = Search.in(search.registry)
-                    .name(search.nameMatches)
-                    .tagKeys(requiredKey)
-                    .meters()
-                    .stream()
+                Collection<String> matchingRequiredKey = meters.stream()
+                    .filter(m -> search.nameMatches == null || search.nameMatches.test(m.getId().getName()))
+                    .filter(m -> hasTagKey(m, requiredKey))
                     .filter(requiredMeterType::isInstance)
                     .map(m -> m.getId().getName())
                     .distinct()
@@ -121,11 +122,9 @@ public class MeterNotFoundException extends RuntimeException {
             }
 
             for (Tag requiredTag : search.requiredTags) {
-                Collection<String> matchingRequiredTag = Search.in(search.registry)
-                    .name(search.nameMatches)
-                    .tag(requiredTag.getKey(), requiredTag.getValue())
-                    .meters()
-                    .stream()
+                Collection<String> matchingRequiredTag = meters.stream()
+                    .filter(m -> search.nameMatches == null || search.nameMatches.test(m.getId().getName()))
+                    .filter(m -> m.getId().getTags().contains(requiredTag))
                     .filter(requiredMeterType::isInstance)
                     .map(m -> m.getId().getName())
                     .distinct()
@@ -135,11 +134,9 @@ public class MeterNotFoundException extends RuntimeException {
                 String requiredTagDetail = "a tag '" + requiredTag.getKey() + "' with value '" + requiredTag.getValue()
                         + "'.";
                 if (matchingRequiredTag.isEmpty()) {
-                    Collection<String> nonMatchingValues = Search.in(search.registry)
-                        .name(search.nameMatches)
-                        .tagKeys(requiredTag.getKey())
-                        .meters()
-                        .stream()
+                    Collection<String> nonMatchingValues = meters.stream()
+                        .filter(m -> search.nameMatches == null || search.nameMatches.test(m.getId().getName()))
+                        .filter(m -> hasTagKey(m, requiredTag.getKey()))
                         .filter(requiredMeterType::isInstance)
                         .map(m -> m.getId().getTag(requiredTag.getKey()))
                         .distinct()
@@ -172,6 +169,10 @@ public class MeterNotFoundException extends RuntimeException {
             return details;
         }
 
+        private boolean hasTagKey(Meter meter, String key) {
+            return meter.getId().getTag(key) != null;
+        }
+
         /**
          * This makes the (I think fairly safe) assumption that there aren't meters of two
          * or more types that vary only by tag such that none of the types match the
@@ -183,7 +184,9 @@ public class MeterNotFoundException extends RuntimeException {
                 return null;
 
             if (search.nameMatches != null) {
-                Collection<Meter> matchesName = Search.in(search.registry).name(search.nameMatches).meters();
+                Collection<Meter> matchesName = meters.stream()
+                    .filter(m -> search.nameMatches.test(m.getId().getName()))
+                    .collect(toList());
 
                 if (!matchesName.isEmpty()) {
                     Collection<String> nonMatchingTypes = matchesName.stream()
@@ -204,7 +207,7 @@ public class MeterNotFoundException extends RuntimeException {
                 }
             }
 
-            long count = Search.in(search.registry).meters().stream().filter(requiredMeterType::isInstance).count();
+            long count = meters.stream().filter(requiredMeterType::isInstance).count();
 
             if (count == 0) {
                 return NOT_OK + " No meters with type " + meterTypeName(requiredMeterType) + " were found.";

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/search/RequiredSearch.java
@@ -191,17 +191,19 @@ public final class RequiredSearch {
     }
 
     private <M extends Meter> M getOne(Class<M> clazz) {
-        return meterStream().filter(clazz::isInstance)
+        Collection<Meter> registryMeters = registry.getMeters();
+        return meterStream(registryMeters).filter(clazz::isInstance)
             .findAny()
             .map(clazz::cast)
-            .orElseThrow(() -> MeterNotFoundException.forSearch(this, clazz));
+            .orElseThrow(() -> MeterNotFoundException.forSearch(this, clazz, registryMeters));
     }
 
     private <M extends Meter> Collection<M> findAll(Class<M> clazz) {
-        List<M> meters = meterStream().filter(clazz::isInstance).map(clazz::cast).collect(toList());
+        Collection<Meter> registryMeters = registry.getMeters();
+        List<M> meters = meterStream(registryMeters).filter(clazz::isInstance).map(clazz::cast).collect(toList());
 
         if (meters.isEmpty()) {
-            throw MeterNotFoundException.forSearch(this, clazz);
+            throw MeterNotFoundException.forSearch(this, clazz, registryMeters);
         }
 
         return meters;
@@ -212,18 +214,18 @@ public final class RequiredSearch {
      * @throws MeterNotFoundException if there is no match.
      */
     public Collection<Meter> meters() {
-        List<Meter> meters = meterStream().collect(Collectors.toList());
+        Collection<Meter> registryMeters = registry.getMeters();
+        List<Meter> meters = meterStream(registryMeters).collect(Collectors.toList());
 
         if (meters.isEmpty()) {
-            throw MeterNotFoundException.forSearch(this, Meter.class);
+            throw MeterNotFoundException.forSearch(this, Meter.class, registryMeters);
         }
 
         return meters;
     }
 
-    private Stream<Meter> meterStream() {
-        Stream<Meter> meterStream = registry.getMeters()
-            .stream()
+    private Stream<Meter> meterStream(Collection<Meter> meters) {
+        Stream<Meter> meterStream = meters.stream()
             .filter(m -> nameMatches == null || nameMatches.test(m.getId().getName()));
 
         if (!requiredTags.isEmpty() || !requiredTagKeys.isEmpty()) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/search/RequiredSearchTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/search/RequiredSearchTest.java
@@ -15,10 +15,14 @@
  */
 package io.micrometer.core.instrument.search;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -153,6 +157,35 @@ class RequiredSearchTest {
     @Test
     void allMetersWithTagKey() {
         assertThat(RequiredSearch.in(registry).tagKeys("k", "k2").counter()).isNotNull();
+    }
+
+    @Test
+    void meterNotFoundExceptionDoesNotReportMetersThatAppearedAfterSearch() {
+        MeterAppearingAfterSearchRegistry registry = new MeterAppearingAfterSearchRegistry();
+        registry.timer("name");
+        registry.hideMetersOnce();
+
+        assertThatThrownBy(() -> registry.get("name").timer()).isInstanceOf(MeterNotFoundException.class)
+            .hasMessageNotContaining("OK:");
+    }
+
+    private static class MeterAppearingAfterSearchRegistry extends SimpleMeterRegistry {
+
+        private boolean hideMetersOnce;
+
+        void hideMetersOnce() {
+            hideMetersOnce = true;
+        }
+
+        @Override
+        public List<Meter> getMeters() {
+            if (hideMetersOnce) {
+                hideMetersOnce = false;
+                return Collections.emptyList();
+            }
+            return super.getMeters();
+        }
+
     }
 
 }


### PR DESCRIPTION
fixes #2307 

Use the same meter snapshot for failed RequiredSearch lookups and MeterNotFoundException diagnostics so concurrent registrations cannot make the failure message report meters that were not visible to the failed search.