### PR TITLE
Match HTTP/2 GlobalRequestProcessor MBean in TomcatMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -53,6 +53,16 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
 
     private static final String OBJECT_NAME_SERVER_STANDALONE = JMX_DOMAIN_STANDALONE + OBJECT_NAME_SERVER_SUFFIX;
 
+    // The :type=GlobalRequestProcessor,name=*,Upgrade=* ObjectName shape is shared by
+    // RequestGroupInfo (HTTP/1.1 + HTTP/2 per-connector aggregator) and UpgradeGroupInfo
+    // (servlet upgrades such as WebSocket). They expose different attribute sets, so we
+    // only register meters for the former. Tomcat wraps RequestGroupInfo in a
+    // BaseModelMBean, so MBeanServer.isInstanceOf and className comparison both fail;
+    // we discriminate on the presence of "requestCount" (defining attribute of
+    // RequestGroupInfo, absent from UpgradeGroupInfo which exposes
+    // msgsReceived/msgsSent).
+    private static final String REQUEST_GROUP_INFO_ATTRIBUTE = "requestCount";
+
     private final @Nullable Manager manager;
 
     private final MBeanServer mBeanServer;
@@ -222,38 +232,93 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     }
 
     private void registerGlobalRequestMetrics(MeterRegistry registry) {
-        registerMetricsEventually(":type=GlobalRequestProcessor,name=*", (name, allTags) -> {
+        // The trailing ",*" lets the pattern also match the per-upgrade MBean that
+        // Tomcat registers for HTTP/2 (an extra Upgrade="h2c" key). Without it, HTTP/2
+        // traffic is silently dropped from the tomcat.global.* meters.
+        registerMetricsEventually(":type=GlobalRequestProcessor,name=*,*", (name, allTags) -> {
+            // Skip UpgradeGroupInfo (e.g., the WebSocket servlet-upgrade aggregator)
+            // which shares this ObjectName shape but exposes a different attribute set;
+            // registering meters against it would produce NaN/0 series.
+            if (!isRequestGroupInfo(name)) {
+                return;
+            }
+            // The Upgrade key disambiguates the HTTP/2 RequestGroupInfo from the
+            // HTTP/1.1 one that shares the same connector name; surface it as a tag so
+            // both series can register and stay distinguishable.
+            Iterable<Tag> tagsWithUpgrade = Tags.concat(allTags, "upgrade", upgradeTagValue(name));
+
             FunctionCounter
                 .builder("tomcat.global.sent", mBeanServer, s -> safeDouble(() -> s.getAttribute(name, "bytesSent")))
-                .tags(allTags)
+                .tags(tagsWithUpgrade)
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
 
             FunctionCounter
                 .builder("tomcat.global.received", mBeanServer,
                         s -> safeDouble(() -> s.getAttribute(name, "bytesReceived")))
-                .tags(allTags)
+                .tags(tagsWithUpgrade)
                 .baseUnit(BaseUnits.BYTES)
                 .register(registry);
 
             FunctionCounter
                 .builder("tomcat.global.error", mBeanServer, s -> safeDouble(() -> s.getAttribute(name, "errorCount")))
-                .tags(allTags)
+                .tags(tagsWithUpgrade)
                 .register(registry);
 
             FunctionTimer
                 .builder("tomcat.global.request", mBeanServer,
                         s -> safeLong(() -> s.getAttribute(name, "requestCount")),
                         s -> safeDouble(() -> s.getAttribute(name, "processingTime")), TimeUnit.MILLISECONDS)
-                .tags(allTags)
+                .tags(tagsWithUpgrade)
                 .register(registry);
 
             TimeGauge
                 .builder("tomcat.global.request.max", mBeanServer, TimeUnit.MILLISECONDS,
                         s -> safeDouble(() -> s.getAttribute(name, "maxTime")))
-                .tags(allTags)
+                .tags(tagsWithUpgrade)
                 .register(registry);
         });
+    }
+
+    private static String upgradeTagValue(ObjectName name) {
+        String upgrade = name.getKeyProperty("Upgrade");
+        if (upgrade == null) {
+            return "none";
+        }
+        return unquoteKeyProperty(upgrade);
+    }
+
+    /**
+     * Strip the optional surrounding quotes from an {@link ObjectName} key-property
+     * value. JMX only quotes values that contain reserved characters, so unquoted values
+     * are returned as-is; quoted values are unescaped through {@link ObjectName#unquote}
+     * so backslash escapes survive the round-trip.
+     */
+    private static String unquoteKeyProperty(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            return ObjectName.unquote(value);
+        }
+        return value;
+    }
+
+    private boolean isRequestGroupInfo(ObjectName name) {
+        try {
+            // Tomcat's modeler exposes the attribute as "requestCount" (lowercase, per
+            // its mbean-descriptors), whereas a Standard MBean derived from a getter
+            // exposes it as "RequestCount" (capitalized JavaBean convention). Accept
+            // either casing so both forms are recognized.
+            for (MBeanAttributeInfo attribute : mBeanServer.getMBeanInfo(name).getAttributes()) {
+                if (REQUEST_GROUP_INFO_ATTRIBUTE.equalsIgnoreCase(attribute.getName())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        catch (InstanceNotFoundException | IntrospectionException | ReflectionException ex) {
+            // The MBean was unregistered or its metadata is unavailable; treat it as a
+            // non-match so the callback skips it.
+            return false;
+        }
     }
 
     /**
@@ -381,7 +446,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
     private Iterable<Tag> nameTag(ObjectName name) {
         String nameTagValue = name.getKeyProperty("name");
         if (nameTagValue != null) {
-            return Tags.of("name", nameTagValue.replace("\"", ""));
+            return Tags.of("name", unquoteKeyProperty(nameTagValue));
         }
         return Collections.emptyList();
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.tomcat;
 
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
@@ -30,6 +31,7 @@ import org.apache.catalina.session.ManagerBase;
 import org.apache.catalina.session.StandardSession;
 import org.apache.catalina.session.TooManyActiveSessionsException;
 import org.apache.catalina.startup.Tomcat;
+import org.apache.coyote.RequestGroupInfo;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -38,12 +40,15 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,6 +56,7 @@ import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -67,12 +73,18 @@ class TomcatMetricsTest {
 
     private static final int PROCESSING_TIME_IN_MILLIS = 10;
 
+    private static final AtomicInteger TEST_DOMAIN_COUNTER = new AtomicInteger();
+
     // tag::setup[]
     SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new MockClock());
 
     // end::setup[]
 
     private int port;
+
+    private static String nextTestDomain() {
+        return "TomcatMetricsTest-" + TEST_DOMAIN_COUNTER.incrementAndGet();
+    }
 
     @Test
     void managerBasedMetrics() {
@@ -387,6 +399,247 @@ class TomcatMetricsTest {
         assertThat(registry.get("tomcat.cache.access").functionCounter().count()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.cache.hit").functionCounter().count()).isEqualTo(0.0);
         assertThat(registry.get("tomcat.servlet.error").functionCounter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @Issue("#7535")
+    void globalRequestMetrics_areRegisteredForBothHttp11AndHttp2UpgradeMBeans() throws Exception {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        String domain = nextTestDomain();
+
+        ObjectName http11 = new ObjectName(domain + ":type=GlobalRequestProcessor,name=\"http-nio-0\"");
+        ObjectName http2 = new ObjectName(domain + ":type=GlobalRequestProcessor,name=\"http-nio-0\",Upgrade=\"h2c\"");
+
+        try {
+            mBeanServer.registerMBean(new FakeGlobalRequestProcessor(1, 2, 3, 4, 5, 6), http11);
+            mBeanServer.registerMBean(new FakeGlobalRequestProcessor(7, 8, 9, 10, 11, 12), http2);
+
+            try (TomcatMetrics binder = new TomcatMetrics(null, Tags.empty(), mBeanServer)) {
+                binder.setJmxDomain(domain);
+                binder.bindTo(registry);
+
+                Collection<Meter> received = registry.find("tomcat.global.received").meters();
+                assertThat(received)
+                    .as("both the HTTP/1.1 and the HTTP/2 GlobalRequestProcessor MBeans must be exposed")
+                    .hasSize(2);
+                assertThat(received).extracting(m -> m.getId().getTag("name")).containsOnly("http-nio-0");
+                assertThat(received).extracting(m -> m.getId().getTag("upgrade"))
+                    .as("the upgrade tag distinguishes HTTP/2 from HTTP/1.1; HTTP/1.1 uses the 'none' placeholder so the label set stays consistent")
+                    .containsExactlyInAnyOrder("none", "h2c");
+            }
+        }
+        finally {
+            safeUnregister(mBeanServer, http11);
+            safeUnregister(mBeanServer, http2);
+        }
+    }
+
+    @Test
+    @Issue("#7535")
+    void globalRequestMetrics_skipNonRequestGroupInfoMBeans() throws Exception {
+        // Tomcat registers UpgradeGroupInfo (servlet upgrades such as WebSocket) under
+        // the
+        // same :type=GlobalRequestProcessor,name=...,Upgrade=... ObjectName shape used by
+        // HTTP/2's RequestGroupInfo. The binder must skip the former — its attribute set
+        // is incompatible and would produce NaN/0 series.
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        String domain = nextTestDomain();
+
+        ObjectName websocket = new ObjectName(
+                domain + ":type=GlobalRequestProcessor,name=\"http-nio-0\",Upgrade=\"websocket\"");
+
+        try {
+            mBeanServer.registerMBean(new FakeUpgradeGroupInfo(), websocket);
+
+            try (TomcatMetrics binder = new TomcatMetrics(null, Tags.empty(), mBeanServer)) {
+                binder.setJmxDomain(domain);
+                binder.bindTo(registry);
+
+                assertThat(registry.find("tomcat.global.received").meters())
+                    .as("MBeans matching the ObjectName pattern but not RequestGroupInfo must be skipped")
+                    .isEmpty();
+                assertThat(registry.find("tomcat.global.request").meters()).isEmpty();
+                assertThat(registry.find("tomcat.global.error").meters()).isEmpty();
+            }
+        }
+        finally {
+            safeUnregister(mBeanServer, websocket);
+        }
+    }
+
+    @Test
+    @Issue("#7535")
+    void globalRequestMetrics_areRegisteredEventuallyForLateMBeans() throws Exception {
+        // Exercises the MBeanServer notification-listener path: bindTo runs before any
+        // matching MBean is present, so the registration must happen via the listener
+        // when the per-protocol MBeans appear later.
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        String domain = nextTestDomain();
+
+        ObjectName http11 = new ObjectName(domain + ":type=GlobalRequestProcessor,name=\"http-nio-0\"");
+        ObjectName http2 = new ObjectName(domain + ":type=GlobalRequestProcessor,name=\"http-nio-0\",Upgrade=\"h2c\"");
+
+        CountDownLatch latch = new CountDownLatch(2);
+        registry.config().onMeterAdded(m -> {
+            if ("tomcat.global.received".equals(m.getId().getName())) {
+                latch.countDown();
+            }
+        });
+
+        try (TomcatMetrics binder = new TomcatMetrics(null, Tags.empty(), mBeanServer)) {
+            // setJmxDomain bypasses the embedded/standalone autodetect that would
+            // otherwise fail without a real Tomcat MBean present
+            binder.setJmxDomain(domain);
+            binder.bindTo(registry);
+
+            try {
+                mBeanServer.registerMBean(new FakeGlobalRequestProcessor(1, 2, 3, 4, 5, 6), http11);
+                mBeanServer.registerMBean(new FakeGlobalRequestProcessor(7, 8, 9, 10, 11, 12), http2);
+
+                assertThat(latch.await(5, TimeUnit.SECONDS))
+                    .as("the registration-notification path must register meters for both protocols")
+                    .isTrue();
+
+                Collection<Meter> received = registry.find("tomcat.global.received").meters();
+                assertThat(received).hasSize(2);
+                assertThat(received).extracting(m -> m.getId().getTag("upgrade"))
+                    .containsExactlyInAnyOrder("none", "h2c");
+            }
+            finally {
+                safeUnregister(mBeanServer, http11);
+                safeUnregister(mBeanServer, http2);
+            }
+        }
+    }
+
+    private static void safeUnregister(MBeanServer mBeanServer, ObjectName name) throws Exception {
+        if (mBeanServer.isRegistered(name)) {
+            mBeanServer.unregisterMBean(name);
+        }
+    }
+
+    public interface FakeGlobalRequestProcessorMBean {
+
+        long getBytesSent();
+
+        long getBytesReceived();
+
+        int getRequestCount();
+
+        int getErrorCount();
+
+        long getProcessingTime();
+
+        long getMaxTime();
+
+    }
+
+    /**
+     * Registered as a Standard MBean via {@link FakeGlobalRequestProcessorMBean} so the
+     * fixture lives in the platform server without a running Tomcat. The Standard MBean
+     * convention exposes the attribute as {@code RequestCount} (capitalized); the
+     * production {@code isRequestGroupInfo} guard uses
+     * {@code equalsIgnoreCase("requestCount")}, which matches both this naming and
+     * Tomcat's {@code BaseModelMBean} wrapping (lowercase {@code requestCount}).
+     * Extending {@link RequestGroupInfo} is only to align getter return types with the
+     * parent so the overrides compile ({@code int} for request/error counts).
+     */
+    public static class FakeGlobalRequestProcessor extends RequestGroupInfo implements FakeGlobalRequestProcessorMBean {
+
+        private final long bytesSent;
+
+        private final long bytesReceived;
+
+        private final int requestCount;
+
+        private final int errorCount;
+
+        private final long processingTime;
+
+        private final long maxTime;
+
+        public FakeGlobalRequestProcessor(long bytesSent, long bytesReceived, int requestCount, int errorCount,
+                long processingTime, long maxTime) {
+            this.bytesSent = bytesSent;
+            this.bytesReceived = bytesReceived;
+            this.requestCount = requestCount;
+            this.errorCount = errorCount;
+            this.processingTime = processingTime;
+            this.maxTime = maxTime;
+        }
+
+        @Override
+        public long getBytesSent() {
+            return bytesSent;
+        }
+
+        @Override
+        public long getBytesReceived() {
+            return bytesReceived;
+        }
+
+        @Override
+        public int getRequestCount() {
+            return requestCount;
+        }
+
+        @Override
+        public int getErrorCount() {
+            return errorCount;
+        }
+
+        @Override
+        public long getProcessingTime() {
+            return processingTime;
+        }
+
+        @Override
+        public long getMaxTime() {
+            return maxTime;
+        }
+
+    }
+
+    public interface FakeUpgradeGroupInfoMBean {
+
+        long getBytesSent();
+
+        long getBytesReceived();
+
+        long getMsgsSent();
+
+        long getMsgsReceived();
+
+    }
+
+    /**
+     * Mirrors the shape of Tomcat's {@code UpgradeGroupInfo} (used by WebSocket and other
+     * servlet upgrades): same ObjectName pattern as the per-connector aggregator, but a
+     * different attribute set. Intentionally does NOT extend {@link RequestGroupInfo} so
+     * the binder's guard skips it.
+     */
+    public static class FakeUpgradeGroupInfo implements FakeUpgradeGroupInfoMBean {
+
+        @Override
+        public long getBytesSent() {
+            return 0;
+        }
+
+        @Override
+        public long getBytesReceived() {
+            return 0;
+        }
+
+        @Override
+        public long getMsgsSent() {
+            return 0;
+        }
+
+        @Override
+        public long getMsgsReceived() {
+            return 0;
+        }
+
     }
 
 }


### PR DESCRIPTION
## Summary

When `server.http2.enabled` is set, Tomcat registers a second `GlobalRequestProcessor` MBean per connector with an extra `Upgrade` key (e.g. `Upgrade="h2c"`) for HTTP/2 traffic:

- `Catalina:type=GlobalRequestProcessor,name="http-nio-XXXX"` (HTTP/1.1)
- `Catalina:type=GlobalRequestProcessor,name="http-nio-XXXX",Upgrade="h2c"` (HTTP/2)

The previous `:type=GlobalRequestProcessor,name=*` pattern only matches MBeans whose key set is exactly `{name}` (per `javax.management.ObjectName` matching rules), so the HTTP/2 aggregator was silently ignored and `tomcat.global.*` reflected HTTP/1.1 only.

This change:

1. Broadens the pattern with a trailing `,*` so MBeans with extra keys are matched (mirrors the Servlet pattern already used in `registerServletMetrics`).
2. Surfaces the `Upgrade` key as an `upgrade` tag on the registered meters so the two per-connector series register with distinct label values instead of being rejected as duplicates.
3. Filters out `UpgradeGroupInfo` MBeans (WebSocket and other servlet upgrades), which share the ObjectName shape but expose a different attribute set.

> **Compatibility:** this adds an `upgrade` tag to every `tomcat.global.*` meter. Existing HTTP/1.1 series get `upgrade=none`; the HTTP/2 series gets `upgrade=h2c` (or `h2`). The label set stays consistent across protocols so dimensional registries like Prometheus accept both as separate series, but downstream queries/dashboards that depend on the exact label set will see one additional key.

> **UpgradeGroupInfo exclusion:** the `Upgrade` key on `:type=GlobalRequestProcessor` is shared between `RequestGroupInfo` (HTTP/2 per-connector aggregator) and `UpgradeGroupInfo` (servlet upgrades such as WebSocket). `UpgradeGroupInfo` exposes `msgsSent` / `msgsReceived` instead of `requestCount` / `processingTime` / ..., so registering meters against it would produce silently broken NaN/0 series. The binder discriminates on the presence of the `requestCount` attribute. (Tomcat wraps `RequestGroupInfo` in a `BaseModelMBean`, which makes `MBeanServer.isInstanceOf` and className-based discrimination both return false.)

> **Defect-class sweep:** the other `registerMetricsEventually` call sites in `TomcatMetrics` (`ThreadPool`, `StringCache`) and the `GlobalRequestProcessor` / `UpgradeGroupInfo` namespace itself were verified — no other ObjectName patterns in this binder collide with multi-key MBeans that Tomcat registers under the same shape.

## Testing

Added to `TomcatMetricsTest`:

- `globalRequestMetrics_areRegisteredForBothHttp11AndHttp2UpgradeMBeans` — registers two fake `GlobalRequestProcessor` MBeans (with and without an `Upgrade` key) against the platform MBean server and asserts that both produce `tomcat.global.received` meters tagged with `upgrade=none` and `upgrade=h2c` respectively. Fails on `main`, passes with this change.
- `globalRequestMetrics_skipNonRequestGroupInfoMBeans` — registers an MBean that matches the ObjectName pattern but lacks `requestCount` (mirrors `UpgradeGroupInfo`) and asserts no `tomcat.global.*` meters are registered.
- `globalRequestMetrics_areRegisteredEventuallyForLateMBeans` — registers the MBeans *after* `bindTo`, exercising the `MBeanServer` notification-listener path.

Local verification on Tomcat 8.5.100 (test classpath):

```bash
./gradlew :micrometer-core:test --tests TomcatMetricsTest
./gradlew :micrometer-core:checkFormat :micrometer-core:checkstyleMain :micrometer-core:checkstyleTest
```

`TomcatMetricsTest` (existing and new cases) and the style checks above all pass.

Closes gh-7535