### PR TITLE
Document MeterBinders that need to be closed

### DIFF
--- a/docs/modules/ROOT/pages/reference/commons-pool.adoc
+++ b/docs/modules/ROOT/pages/reference/commons-pool.adoc
@@ -16,3 +16,8 @@ include::{include-core-test-java}/io/micrometer/core/instrument/binder/commonspo
 // Generic Keyed Pool instrumentation (with examples of created meters)
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2MetricsTest.java[tags=generic_keyed_pool, indent=0]
 -----
+
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `CommonsObjectPool2Metrics` implements `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.

--- a/docs/modules/ROOT/pages/reference/jetty.adoc
+++ b/docs/modules/ROOT/pages/reference/jetty.adoc
@@ -52,6 +52,11 @@ resourceConfig.register(new MetricsApplicationEventListener(
 ServletContainer servletContainer = new ServletContainer(resourceConfig);
 ----
 
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `JettyServerThreadPoolMetrics` implements `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.
+
 [[overview-observation]]
 == Eclipse Observation Jersey Instrumentation
 

--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -104,3 +104,8 @@ If you are running your application with Java 24 or later on a JVM that has `jdk
 |===
 
 Note that aggregating the values of `jvm.threads.virtual.live` across the different tags gives the total number of virtual threads started but not ended.
+
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `JvmGcMetrics` and `JvmHeapPressureMetrics` implement `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.

--- a/docs/modules/ROOT/pages/reference/kafka.adoc
+++ b/docs/modules/ROOT/pages/reference/kafka.adoc
@@ -29,3 +29,7 @@ Setting up instrumentation with Apache Kafka using Kafka Streams.
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetricsTest.java[tags=example, indent=0]
 -----
 
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `KafkaClientMetrics` and `KafkaStreamsMetrics` implement `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.

--- a/docs/modules/ROOT/pages/reference/logging.adoc
+++ b/docs/modules/ROOT/pages/reference/logging.adoc
@@ -29,3 +29,8 @@ include::{include-core-test-java}/io/micrometer/core/instrument/binder/logging/L
 // Usage example
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/logging/LogbackMetricsTest.java[tags=example, indent=0]
 -----
+
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `Log4j2Metrics` and `LogbackMetrics` implement `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.

--- a/docs/modules/ROOT/pages/reference/tomcat.adoc
+++ b/docs/modules/ROOT/pages/reference/tomcat.adoc
@@ -13,3 +13,8 @@ include::{include-core-test-java}/io/micrometer/core/instrument/binder/tomcat/To
 // Example of Tomcat metrics
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java[tags=example, indent=0]
 -----
+
+[[lifecycle]]
+== Lifecycle
+
+NOTE: `TomcatMetrics` implements `AutoCloseable`. When used outside a lifecycle-aware container, call `close()` on application shutdown so the binder can clean up the resources it registered or started, such as listeners, schedulers, or meters.

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -40,6 +40,10 @@ import static java.util.Collections.emptyList;
 /**
  * Apache Commons Pool 2.x metrics collected from metrics exposed via the MBeanServer.
  * Metrics are exposed for each object pool.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the {@code MBeanServer} notification listeners and to shut down the internal
+ * metrics-updater executor this binder starts.
  *
  * @author Chao Chang
  * @since 1.6.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
@@ -39,6 +39,9 @@ import java.util.concurrent.ConcurrentHashMap;
  *     new JettyServerThreadPoolMetrics(threadPool, tags).bindTo(registry);
  *     }
  * </pre>
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * remove the meters this binder registered from the {@link MeterRegistry}.
  *
  * @author Manabu Matsuzaki
  * @author Andy Wilkinson

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -60,6 +60,10 @@ import static java.util.Collections.emptyList;
  * notes</a> and <a href="https://bugs.openjdk.org/browse/JDK-8265136">JDK-8265136</a>. If
  * you want better accuracy, please make sure that you use a newer version and the new
  * metrics are enabled.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the GC notification listeners this binder registers on the JVM's
+ * {@link GarbageCollectorMXBean}s.
  *
  * @author Jon Schneider
  * @author Tommy Ludwig

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmHeapPressureMetrics.java
@@ -47,6 +47,10 @@ import static java.util.Collections.emptyList;
  * described in <a href=
  * "https://www.jetbrains.com/help/teamcity/teamcity-memory-monitor.html">TeamCity's
  * Memory Monitor</a>.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the GC notification listeners this binder registers on the JVM's
+ * {@link java.lang.management.GarbageCollectorMXBean}s.
  *
  * @author Jon Schneider
  * @since 1.4.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaClientMetrics.java
@@ -27,13 +27,16 @@ import org.apache.kafka.common.Metric;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * Kafka Client metrics binder. This should be closed on application shutdown to clean up
- * resources.
+ * Kafka Client metrics binder.
  * <p>
  * It is based on the Kafka client's {@code metrics()} method returning a {@link Metric}
  * map.
  * <p>
  * Meter names have the following convention: {@code kafka.(metric_group).(metric_name)}
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * shut down the internal metrics-refresh scheduler (when not externally managed) and to
+ * remove the meters this binder registered.
  *
  * @author Jorge Quilcate
  * @see <a href="https://docs.confluent.io/current/kafka/monitoring.html">Kakfa monitoring

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -43,6 +43,9 @@ import static java.util.Collections.emptyList;
  * <p>
  * Metric names here are based on the naming scheme as it was last changed in Kafka
  * version 0.11.0. Metrics for earlier versions of Kafka will not report correctly.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the {@code MBeanServer} notification listeners this binder registers.
  *
  * @author Wardha Perinkadakattu
  * @author Jon Schneider

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -45,8 +45,11 @@ import static io.micrometer.core.instrument.Meter.Type.OTHER;
 import static java.util.Collections.emptyList;
 
 /**
- * Kafka metrics binder. This should be closed on application shutdown to clean up
- * resources.
+ * Kafka metrics binder.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * shut down the internal metrics-refresh scheduler (when not externally managed) and to
+ * remove the meters this binder registered.
  *
  * @author Jorge Quilcate
  * @see <a href="https://docs.confluent.io/current/kafka/monitoring.html">Kakfa monitoring

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetrics.java
@@ -25,13 +25,16 @@ import org.apache.kafka.streams.KafkaStreams;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
- * Kafka Streams metrics binder. This should be closed on application shutdown to clean up
- * resources.
+ * Kafka Streams metrics binder.
  * <p>
  * It is based on the Kafka client's {@code metrics()} method returning a {@link Metric}
  * map.
  * <p>
  * Meter names have the following convention: {@code kafka.(metric_group).(metric_name)}
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * shut down the internal metrics-refresh scheduler (when not externally managed) and to
+ * remove the meters this binder registered.
  *
  * @author Jorge Quilcate
  * @see <a href="https://docs.confluent.io/current/kafka/monitoring.html">Kakfa monitoring

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -45,6 +45,10 @@ import static java.util.Collections.emptyList;
 /**
  * {@link MeterBinder} for Apache Log4j 2. Please use at least 2.21.0 since there was a
  * bug in earlier versions that prevented Micrometer to increment its counters correctly.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the {@code LoggerContext} property change listener and the metrics filters
+ * this binder registers.
  *
  * @see <a href=
  * "https://github.com/apache/logging-log4j2/issues/1550">logging-log4j2#1550</a>

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/LogbackMetrics.java
@@ -40,6 +40,9 @@ import static java.util.Collections.emptyList;
  * Metrics instrumentation of Logback log events. Counts the log events with a log level
  * equal to or higher than the corresponding logger's effective log level. A filter added
  * to an appender will not affect the metrics.
+ * <p>
+ * Note: the {@link #close()} method should be called when the application shuts down to
+ * clean up the {@code LoggerContext} listener and turbo filters this binder registers.
  *
  * @author Jon Schneider
  */


### PR DESCRIPTION
## Summary

For `MeterBinder`s that implement `AutoCloseable`, add a Javadoc note explaining that `close()` should be invoked on application shutdown when the binder is used outside a lifecycle-aware container, and add the same lifecycle requirement to the relevant reference docs.

Updated binders: `JvmGcMetrics`, `JvmHeapPressureMetrics`, `Log4j2Metrics`, `LogbackMetrics`, `KafkaClientMetrics`, `KafkaConsumerMetrics` (deprecated), `KafkaStreamsMetrics`, `JettyServerThreadPoolMetrics`, `CommonsObjectPool2Metrics`. `TomcatMetrics` already had a comparable note in its Javadoc.

Updated reference pages: `jvm.adoc`, `logging.adoc`, `tomcat.adoc`, `kafka.adoc`, `jetty.adoc`, `commons-pool.adoc`. Each gets a short `Lifecycle` NOTE scoped to the public, non-deprecated binders documented on that page. `KafkaConsumerMetrics` is intentionally left out of `kafka.adoc` (the page only covers `KafkaClientMetrics` and `KafkaStreamsMetrics`) but its Javadoc still carries the lifecycle note for existing users.

This stays in Javadoc + reference-doc scope per the direction in gh-1492.

Closes #4624.

## Testing

- `./gradlew :micrometer-core:format` — no changes
- `./gradlew :micrometer-core:checkFormatMain` — passes
- `./gradlew :micrometer-core:javadoc` — builds; no new warnings on the modified files
