### PR TITLE
Skip registering JCache meters when statistics are not enabled

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -195,6 +195,9 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
         }
     }
 
+    // Captured once at construction; runtime toggles via
+    // CacheManager#enableStatistics(...) are not tracked.
+    // Rebind the metrics if statistics are enabled later.
     private static boolean isStatisticsEnabled(Cache<?, ?> cache) {
         try {
             CompleteConfiguration<?, ?> config = cache.getConfiguration(CompleteConfiguration.class);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/JCacheMetrics.java
@@ -15,12 +15,15 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.InvalidConfigurationException;
 import org.jspecify.annotations.Nullable;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.configuration.CompleteConfiguration;
 import javax.management.*;
 import java.util.List;
 
@@ -36,10 +39,14 @@ import java.util.List;
  */
 public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder<C> {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(JCacheMetrics.class);
+
     // VisibleForTesting
     @Nullable ObjectName objectName;
 
     private final boolean registerCacheRemovalsAsFunctionCounter;
+
+    private final boolean statisticsEnabled;
 
     /**
      * Record metrics on a JCache cache.
@@ -107,6 +114,12 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
     public JCacheMetrics(C cache, Iterable<Tag> tags, boolean registerCacheRemovalsAsFunctionCounter) {
         super(cache, cache.getName(), tags);
         this.registerCacheRemovalsAsFunctionCounter = registerCacheRemovalsAsFunctionCounter;
+        this.statisticsEnabled = isStatisticsEnabled(cache);
+        if (!statisticsEnabled) {
+            log.warn(
+                    "The cache '{}' is not recording statistics. No meters that require statistics will be registered. Enable statistics for this cache (for example by calling 'MutableConfiguration#setStatisticsEnabled(true)' when building the cache) before binding metrics.",
+                    cache.getName());
+        }
         try {
             CacheManager cacheManager = cache.getCacheManager();
             if (cacheManager != null) {
@@ -131,26 +144,41 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
 
     @Override
     protected long hitCount() {
+        if (!statisticsEnabled) {
+            return UNSUPPORTED;
+        }
         return lookupStatistic("CacheHits");
     }
 
     @Override
-    protected Long missCount() {
+    protected @Nullable Long missCount() {
+        if (!statisticsEnabled) {
+            return null;
+        }
         return lookupStatistic("CacheMisses");
     }
 
     @Override
-    protected Long evictionCount() {
+    protected @Nullable Long evictionCount() {
+        if (!statisticsEnabled) {
+            return null;
+        }
         return lookupStatistic("CacheEvictions");
     }
 
     @Override
     protected long putCount() {
+        if (!statisticsEnabled) {
+            return UNSUPPORTED;
+        }
         return lookupStatistic("CachePuts");
     }
 
     @Override
     protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
+        if (!statisticsEnabled) {
+            return;
+        }
         if (objectName != null) {
             if (registerCacheRemovalsAsFunctionCounter) {
                 FunctionCounter.builder("cache.removals", objectName, objectName -> lookupStatistic("CacheRemovals"))
@@ -164,6 +192,19 @@ public class JCacheMetrics<K, V, C extends Cache<K, V>> extends CacheMeterBinder
                     .description("Cache removals")
                     .register(registry);
             }
+        }
+    }
+
+    private static boolean isStatisticsEnabled(Cache<?, ?> cache) {
+        try {
+            CompleteConfiguration<?, ?> config = cache.getConfiguration(CompleteConfiguration.class);
+            // When the provider does not expose CompleteConfiguration (or the
+            // configuration cannot be resolved), assume statistics are enabled
+            // to avoid a false positive warning and avoid skipping meters.
+            return config == null || config.isStatisticsEnabled();
+        }
+        catch (IllegalArgumentException ignored) {
+            return true;
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/JCacheMetricsTest.java
@@ -21,12 +21,16 @@ import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.testsupport.system.CapturedOutput;
+import io.micrometer.core.testsupport.system.OutputCaptureExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.configuration.CompleteConfiguration;
 import javax.management.*;
 import java.net.URI;
 import java.util.Random;
@@ -40,6 +44,7 @@ import static org.mockito.Mockito.when;
  *
  * @author Oleksii Bondar
  */
+@ExtendWith(OutputCaptureExtension.class)
 class JCacheMetricsTest extends AbstractCacheMetricsTest {
 
     @SuppressWarnings("unchecked")
@@ -174,6 +179,35 @@ class JCacheMetricsTest extends AbstractCacheMetricsTest {
         metrics.bindTo(meterRegistry);
 
         assertThat(meterRegistry.get("cache.removals").tags(expectedTag).meter()).isNotNull().isInstanceOf(Gauge.class);
+    }
+
+    @Test
+    @Issue("#5066")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void doNotReportMetricsWhenStatisticsAreDisabled(CapturedOutput output) throws Exception {
+        Cache<String, String> disabledCache = mock(Cache.class);
+        CacheManager disabledCacheManager = mock(CacheManager.class);
+        when(disabledCache.getCacheManager()).thenReturn(disabledCacheManager);
+        when(disabledCache.getName()).thenReturn("disabledCache");
+        when(disabledCacheManager.getURI()).thenReturn(new URI("http://localhost"));
+
+        CompleteConfiguration config = mock(CompleteConfiguration.class);
+        when(config.isStatisticsEnabled()).thenReturn(false);
+        when(disabledCache.getConfiguration(CompleteConfiguration.class)).thenReturn(config);
+
+        JCacheMetrics<String, String, Cache<String, String>> disabledMetrics = new JCacheMetrics<>(disabledCache,
+                expectedTag);
+
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        disabledMetrics.bindTo(meterRegistry);
+
+        assertThat(output).contains(
+                "The cache 'disabledCache' is not recording statistics. No meters that require statistics will be registered.");
+        assertThat(meterRegistry.find("cache.gets").tag("result", "hit").functionCounter()).isNull();
+        assertThat(meterRegistry.find("cache.gets").tag("result", "miss").functionCounter()).isNull();
+        assertThat(meterRegistry.find("cache.puts").functionCounter()).isNull();
+        assertThat(meterRegistry.find("cache.evictions").functionCounter()).isNull();
+        assertThat(meterRegistry.find("cache.removals").meter()).isNull();
     }
 
     private static class CacheMBeanStub implements DynamicMBean {


### PR DESCRIPTION
**Summary**

Follow-up to gh-5402 and gh-5409 for `JCacheMetrics`. See gh-5066.

When a JCache cache is bound without statistics enabled, the registered meters silently report zero, which is hard to diagnose. This change mirrors the Caffeine pattern: detect the stats-disabled state via `CompleteConfiguration#isStatisticsEnabled()`, log a warning explaining how to enable statistics, and skip registering the stats-dependent meters (`cache.gets`, `cache.puts`, `cache.evictions`, `cache.removals`).

If the JCache provider does not expose `CompleteConfiguration` (the configuration is `null` or `getConfiguration(CompleteConfiguration.class)` throws `IllegalArgumentException`), this assumes statistics are enabled to avoid a false-positive warning.

**Status of other cache binders**

- **Caffeine** — already handled in gh-5402 and gh-5409.
- **Hazelcast** — `MapConfig#isStatisticsEnabled()` makes the same detection possible, but `HazelcastCacheMetrics` accesses the cache through reflection via `HazelcastIMapAdapter`, so adding this check requires extending the adapter surface. Hazelcast remains applicable but is left out to keep this PR focused.
- **EhCache 2** — EhCache 2.5+ has statistics always on, so the check is unnecessary.
- **Guava** — Guava does not expose a public API to detect whether `recordStats()` was called. The upstream request (google/guava#7381) was closed in 2024 with no plans to add cache features.

**Testing**

- New test `JCacheMetricsTest#doNotReportMetricsWhenStatisticsAreDisabled` asserts the warning is emitted and that `cache.gets`, `cache.puts`, `cache.evictions`, and `cache.removals` are not registered when statistics are disabled.
- Existing tests remain unchanged: their mock `Cache` does not stub `getConfiguration`, so the helper falls into the `null → assume enabled` branch and they continue to register meters as before.
- `./gradlew :micrometer-core:check` passes locally.
