### PR TITLE
Skip registering Hazelcast meters when statistics are not enabled

### DIFF
--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -52,6 +52,7 @@ jar {
         Import-Package: \
             org.aspectj.*;resolution:=dynamic,\
             com.github.benmanes.caffeine.*;resolution:=dynamic;version="${@}",\
+            com.hazelcast.*;resolution:=dynamic;version="${@}",\
             net.sf.ehcache.*;resolution:=dynamic;version="${@}",\
             javax.cache.*;resolution:=dynamic;version="${@}",\
             org.hibernate.*;resolution:=dynamic;version="${@}",\

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.cache.HazelcastIMapAdapter.LocalMapStats;
@@ -33,6 +35,8 @@ import java.util.function.ToLongFunction;
  */
 public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
 
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(HazelcastCacheMetrics.class);
+
     private static final String DESCRIPTION_CACHE_ENTRIES = "The number of entries held by this member";
 
     private static final String DESCRIPTION_CACHE_ENTRY_MEMORY = "Memory cost of entries held by this member";
@@ -40,6 +44,8 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
     private static final String DESCRIPTION_CACHE_NEAR_REQUESTS = "The number of requests (hits or misses) of near cache entries owned by this member";
 
     private final HazelcastIMapAdapter cache;
+
+    private final boolean statisticsEnabled;
 
     /**
      * Record metrics on a Hazelcast cache.
@@ -75,10 +81,20 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
     public HazelcastCacheMetrics(Object cache, Iterable<Tag> tags) {
         super(cache, HazelcastIMapAdapter.nameOf(cache), tags);
         this.cache = new HazelcastIMapAdapter(cache);
+        String name = HazelcastIMapAdapter.nameOf(cache);
+        this.statisticsEnabled = this.cache.isStatisticsEnabled(name);
+        if (!statisticsEnabled) {
+            log.warn(
+                    "The cache '{}' is not recording statistics. No meters that require statistics will be registered. Enable statistics for this cache (for example by calling 'MapConfig#setStatisticsEnabled(true)' when building the cache) before binding metrics.",
+                    name);
+        }
     }
 
     @Override
     protected @Nullable Long size() {
+        if (!statisticsEnabled) {
+            return null;
+        }
         LocalMapStats localMapStats = cache.getLocalMapStats();
         if (localMapStats != null) {
             return localMapStats.getOwnedEntryCount();
@@ -96,6 +112,9 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
      */
     @Override
     protected long hitCount() {
+        if (!statisticsEnabled) {
+            return UNSUPPORTED;
+        }
         LocalMapStats localMapStats = cache.getLocalMapStats();
         if (localMapStats != null) {
             return localMapStats.getHits();
@@ -119,6 +138,9 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
 
     @Override
     protected long putCount() {
+        if (!statisticsEnabled) {
+            return UNSUPPORTED;
+        }
         LocalMapStats localMapStats = cache.getLocalMapStats();
         if (localMapStats != null) {
             return localMapStats.getPutOperationCount() + localMapStats.getSetOperationCount();
@@ -129,6 +151,9 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
 
     @Override
     protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
+        if (!statisticsEnabled) {
+            return;
+        }
         Gauge
             .builder("cache.entries", cache,
                     cache -> getDouble(cache.getLocalMapStats(), LocalMapStats::getBackupEntryCount))

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetrics.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import com.hazelcast.config.Config;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.*;
@@ -30,8 +31,14 @@ import java.util.function.ToLongFunction;
 /**
  * Collect metrics on Hazelcast caches, including detailed metrics on storage space, near
  * cache usage, and timings.
+ * <p>
+ * To detect whether statistics are enabled, use an overload that accepts the Hazelcast
+ * {@link Config}. If no configuration is provided, statistics are assumed to be enabled.
+ * The statistics-enabled state is captured when this binder is created. If statistics are
+ * enabled later, create and bind a new {@code HazelcastCacheMetrics} instance.
  *
  * @author Jon Schneider
+ * @author Jewoo Shin
  */
 public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
 
@@ -74,19 +81,50 @@ public class HazelcastCacheMetrics extends CacheMeterBinder<Object> {
     }
 
     /**
+     * Record metrics on a Hazelcast cache.
+     * @param registry registry to bind metrics to
+     * @param cache Hazelcast IMap cache to instrument
+     * @param tags Tags to apply to all recorded metrics.
+     * @param config Hazelcast configuration used to determine whether statistics are
+     * enabled for the cache
+     * @return The instrumented cache, unchanged. The original cache is not wrapped or
+     * proxied in any way.
+     * @since 1.18.0
+     */
+    public static Object monitor(MeterRegistry registry, Object cache, Iterable<Tag> tags, Config config) {
+        new HazelcastCacheMetrics(cache, tags, config).bindTo(registry);
+        return cache;
+    }
+
+    /**
      * Binder for Hazelcast cache metrics.
      * @param cache Hazelcast IMap cache to instrument
      * @param tags Tags to apply to all recorded metrics.
      */
     public HazelcastCacheMetrics(Object cache, Iterable<Tag> tags) {
+        this(cache, tags, true);
+    }
+
+    /**
+     * Binder for Hazelcast cache metrics.
+     * @param cache Hazelcast IMap cache to instrument
+     * @param tags Tags to apply to all recorded metrics.
+     * @param config Hazelcast configuration used to determine whether statistics are
+     * enabled for the cache
+     * @since 1.18.0
+     */
+    public HazelcastCacheMetrics(Object cache, Iterable<Tag> tags, Config config) {
+        this(cache, tags, config.findMapConfig(HazelcastIMapAdapter.nameOf(cache)).isStatisticsEnabled());
+    }
+
+    private HazelcastCacheMetrics(Object cache, Iterable<Tag> tags, boolean statisticsEnabled) {
         super(cache, HazelcastIMapAdapter.nameOf(cache), tags);
         this.cache = new HazelcastIMapAdapter(cache);
-        String name = HazelcastIMapAdapter.nameOf(cache);
-        this.statisticsEnabled = this.cache.isStatisticsEnabled(name);
+        this.statisticsEnabled = statisticsEnabled;
         if (!statisticsEnabled) {
             log.warn(
                     "The cache '{}' is not recording statistics. No meters that require statistics will be registered. Enable statistics for this cache (for example by calling 'MapConfig#setStatisticsEnabled(true)' when building the cache) before binding metrics.",
-                    name);
+                    HazelcastIMapAdapter.nameOf(cache));
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastIMapAdapter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastIMapAdapter.java
@@ -48,13 +48,38 @@ class HazelcastIMapAdapter {
     private static final Class<?> CLASS_NEAR_CACHE_STATS = resolveOneOf("com.hazelcast.nearcache.NearCacheStats",
             "com.hazelcast.monitor.NearCacheStats");
 
+    // Internal Hazelcast classes used only to read MapConfig#isStatisticsEnabled. The
+    // package moved from com.hazelcast.spi (3.x) to com.hazelcast.spi.impl (4.x+). Any
+    // resolution failure falls back to assuming statistics are enabled.
+    private static final @Nullable Class<?> CLASS_ABSTRACT_DISTRIBUTED_OBJECT = resolveOneOfOrNull(
+            "com.hazelcast.spi.impl.AbstractDistributedObject", "com.hazelcast.spi.AbstractDistributedObject");
+
+    private static final @Nullable Class<?> CLASS_NODE_ENGINE = resolveOneOfOrNull("com.hazelcast.spi.impl.NodeEngine",
+            "com.hazelcast.spi.NodeEngine");
+
+    private static final @Nullable Class<?> CLASS_CONFIG = resolveClassOrNull("com.hazelcast.config.Config");
+
+    private static final @Nullable Class<?> CLASS_MAP_CONFIG = resolveClassOrNull("com.hazelcast.config.MapConfig");
+
     private static final MethodHandle GET_NAME;
 
     private static final MethodHandle GET_LOCAL_MAP_STATS;
 
+    private static final @Nullable MethodHandle GET_NODE_ENGINE;
+
+    private static final @Nullable MethodHandle NODE_ENGINE_GET_CONFIG;
+
+    private static final @Nullable MethodHandle CONFIG_GET_MAP_CONFIG;
+
+    private static final @Nullable MethodHandle MAP_CONFIG_IS_STATISTICS_ENABLED;
+
     static {
         GET_NAME = resolveMethod(CLASS_DISTRIBUTED_OBJECT, "getName", methodType(String.class));
         GET_LOCAL_MAP_STATS = resolveMethod(CLASS_I_MAP, "getLocalMapStats", methodType(CLASS_LOCAL_MAP));
+        GET_NODE_ENGINE = resolveMethodOrNull(CLASS_ABSTRACT_DISTRIBUTED_OBJECT, "getNodeEngine", CLASS_NODE_ENGINE);
+        NODE_ENGINE_GET_CONFIG = resolveMethodOrNull(CLASS_NODE_ENGINE, "getConfig", CLASS_CONFIG);
+        CONFIG_GET_MAP_CONFIG = resolveMethodOrNull(CLASS_CONFIG, "getMapConfig", CLASS_MAP_CONFIG, String.class);
+        MAP_CONFIG_IS_STATISTICS_ENABLED = resolveMethodOrNull(CLASS_MAP_CONFIG, "isStatisticsEnabled", boolean.class);
     }
 
     private final WeakReference<Object> cache;
@@ -80,6 +105,37 @@ class HazelcastIMapAdapter {
 
         Object result = invoke(GET_LOCAL_MAP_STATS, ref);
         return result == null ? null : new LocalMapStats(result);
+    }
+
+    // Captured once by HazelcastCacheMetrics at construction; runtime toggles
+    // via MapConfig#setStatisticsEnabled(...) are not tracked.
+    // Rebind the metrics if statistics are enabled later.
+    boolean isStatisticsEnabled(String name) {
+        Object ref = cache.get();
+        if (ref == null || GET_NODE_ENGINE == null || NODE_ENGINE_GET_CONFIG == null || CONFIG_GET_MAP_CONFIG == null
+                || MAP_CONFIG_IS_STATISTICS_ENABLED == null) {
+            return true;
+        }
+
+        try {
+            Object nodeEngine = GET_NODE_ENGINE.invoke(ref);
+            if (nodeEngine == null) {
+                return true;
+            }
+            Object config = NODE_ENGINE_GET_CONFIG.invoke(nodeEngine);
+            if (config == null) {
+                return true;
+            }
+            Object mapConfig = CONFIG_GET_MAP_CONFIG.invoke(config, name);
+            if (mapConfig == null) {
+                return true;
+            }
+            return (boolean) MAP_CONFIG_IS_STATISTICS_ENABLED.invoke(mapConfig);
+        }
+        catch (Throwable t) {
+            log.debug("Failed to detect Hazelcast statistics-enabled state, assuming enabled", t);
+            return true;
+        }
     }
 
     static class LocalMapStats {
@@ -308,6 +364,34 @@ class HazelcastIMapAdapter {
         }
         catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    private static @Nullable Class<?> resolveClassOrNull(String clazz) {
+        try {
+            return Class.forName(clazz);
+        }
+        catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    private static @Nullable Class<?> resolveOneOfOrNull(String class1, String class2) {
+        Class<?> resolved = resolveClassOrNull(class1);
+        return resolved != null ? resolved : resolveClassOrNull(class2);
+    }
+
+    private static @Nullable MethodHandle resolveMethodOrNull(@Nullable Class<?> clazz, String name,
+            @Nullable Class<?> returnType, Class<?>... parameterTypes) {
+        if (clazz == null || returnType == null) {
+            return null;
+        }
+        try {
+            return MethodHandles.publicLookup().findVirtual(clazz, name, methodType(returnType, parameterTypes));
+        }
+        catch (NoSuchMethodException | IllegalAccessException e) {
+            log.debug("Failed to resolve method: " + name, e);
+            return null;
         }
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastIMapAdapter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/HazelcastIMapAdapter.java
@@ -48,38 +48,13 @@ class HazelcastIMapAdapter {
     private static final Class<?> CLASS_NEAR_CACHE_STATS = resolveOneOf("com.hazelcast.nearcache.NearCacheStats",
             "com.hazelcast.monitor.NearCacheStats");
 
-    // Internal Hazelcast classes used only to read MapConfig#isStatisticsEnabled. The
-    // package moved from com.hazelcast.spi (3.x) to com.hazelcast.spi.impl (4.x+). Any
-    // resolution failure falls back to assuming statistics are enabled.
-    private static final @Nullable Class<?> CLASS_ABSTRACT_DISTRIBUTED_OBJECT = resolveOneOfOrNull(
-            "com.hazelcast.spi.impl.AbstractDistributedObject", "com.hazelcast.spi.AbstractDistributedObject");
-
-    private static final @Nullable Class<?> CLASS_NODE_ENGINE = resolveOneOfOrNull("com.hazelcast.spi.impl.NodeEngine",
-            "com.hazelcast.spi.NodeEngine");
-
-    private static final @Nullable Class<?> CLASS_CONFIG = resolveClassOrNull("com.hazelcast.config.Config");
-
-    private static final @Nullable Class<?> CLASS_MAP_CONFIG = resolveClassOrNull("com.hazelcast.config.MapConfig");
-
     private static final MethodHandle GET_NAME;
 
     private static final MethodHandle GET_LOCAL_MAP_STATS;
 
-    private static final @Nullable MethodHandle GET_NODE_ENGINE;
-
-    private static final @Nullable MethodHandle NODE_ENGINE_GET_CONFIG;
-
-    private static final @Nullable MethodHandle CONFIG_GET_MAP_CONFIG;
-
-    private static final @Nullable MethodHandle MAP_CONFIG_IS_STATISTICS_ENABLED;
-
     static {
         GET_NAME = resolveMethod(CLASS_DISTRIBUTED_OBJECT, "getName", methodType(String.class));
         GET_LOCAL_MAP_STATS = resolveMethod(CLASS_I_MAP, "getLocalMapStats", methodType(CLASS_LOCAL_MAP));
-        GET_NODE_ENGINE = resolveMethodOrNull(CLASS_ABSTRACT_DISTRIBUTED_OBJECT, "getNodeEngine", CLASS_NODE_ENGINE);
-        NODE_ENGINE_GET_CONFIG = resolveMethodOrNull(CLASS_NODE_ENGINE, "getConfig", CLASS_CONFIG);
-        CONFIG_GET_MAP_CONFIG = resolveMethodOrNull(CLASS_CONFIG, "getMapConfig", CLASS_MAP_CONFIG, String.class);
-        MAP_CONFIG_IS_STATISTICS_ENABLED = resolveMethodOrNull(CLASS_MAP_CONFIG, "isStatisticsEnabled", boolean.class);
     }
 
     private final WeakReference<Object> cache;
@@ -105,37 +80,6 @@ class HazelcastIMapAdapter {
 
         Object result = invoke(GET_LOCAL_MAP_STATS, ref);
         return result == null ? null : new LocalMapStats(result);
-    }
-
-    // Captured once by HazelcastCacheMetrics at construction; runtime toggles
-    // via MapConfig#setStatisticsEnabled(...) are not tracked.
-    // Rebind the metrics if statistics are enabled later.
-    boolean isStatisticsEnabled(String name) {
-        Object ref = cache.get();
-        if (ref == null || GET_NODE_ENGINE == null || NODE_ENGINE_GET_CONFIG == null || CONFIG_GET_MAP_CONFIG == null
-                || MAP_CONFIG_IS_STATISTICS_ENABLED == null) {
-            return true;
-        }
-
-        try {
-            Object nodeEngine = GET_NODE_ENGINE.invoke(ref);
-            if (nodeEngine == null) {
-                return true;
-            }
-            Object config = NODE_ENGINE_GET_CONFIG.invoke(nodeEngine);
-            if (config == null) {
-                return true;
-            }
-            Object mapConfig = CONFIG_GET_MAP_CONFIG.invoke(config, name);
-            if (mapConfig == null) {
-                return true;
-            }
-            return (boolean) MAP_CONFIG_IS_STATISTICS_ENABLED.invoke(mapConfig);
-        }
-        catch (Throwable t) {
-            log.debug("Failed to detect Hazelcast statistics-enabled state, assuming enabled", t);
-            return true;
-        }
     }
 
     static class LocalMapStats {
@@ -364,34 +308,6 @@ class HazelcastIMapAdapter {
         }
         catch (ClassNotFoundException e) {
             throw new IllegalStateException(e);
-        }
-    }
-
-    private static @Nullable Class<?> resolveClassOrNull(String clazz) {
-        try {
-            return Class.forName(clazz);
-        }
-        catch (ClassNotFoundException e) {
-            return null;
-        }
-    }
-
-    private static @Nullable Class<?> resolveOneOfOrNull(String class1, String class2) {
-        Class<?> resolved = resolveClassOrNull(class1);
-        return resolved != null ? resolved : resolveClassOrNull(class2);
-    }
-
-    private static @Nullable MethodHandle resolveMethodOrNull(@Nullable Class<?> clazz, String name,
-            @Nullable Class<?> returnType, Class<?>... parameterTypes) {
-        if (clazz == null || returnType == null) {
-            return null;
-        }
-        try {
-            return MethodHandles.publicLookup().findVirtual(clazz, name, methodType(returnType, parameterTypes));
-        }
-        catch (NoSuchMethodException | IllegalAccessException e) {
-            log.debug("Failed to resolve method: " + name, e);
-            return null;
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -15,7 +15,10 @@
  */
 package io.micrometer.core.instrument.binder.cache;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.internal.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.map.IMap;
@@ -23,9 +26,12 @@ import com.hazelcast.map.LocalMapStats;
 import com.hazelcast.nearcache.NearCacheStats;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.core.testsupport.system.CapturedOutput;
+import io.micrometer.core.testsupport.system.OutputCaptureExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.Random;
@@ -41,11 +47,17 @@ import static org.mockito.Mockito.when;
  *
  * @author Oleksii Bondar
  */
+@ExtendWith(OutputCaptureExtension.class)
 class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
+
+    private static final String STATS_DISABLED_MAP_NAME = "statsDisabledCache";
 
     @SuppressWarnings("NullAway.Init")
     // tag::setup[]
     static IMap<String, String> cache;
+
+    @SuppressWarnings("NullAway.Init")
+    static IMap<String, String> statsDisabledCache;
 
     HazelcastCacheMetrics metrics = new HazelcastCacheMetrics(cache, expectedTag);
 
@@ -164,9 +176,30 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
             .isThrownBy(() -> new HazelcastCacheMetrics(new HashMap<String, String>(), Tags.empty()));
     }
 
+    @Test
+    void doNotReportMetricsWhenStatisticsAreDisabled(CapturedOutput output) {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        new HazelcastCacheMetrics(statsDisabledCache, expectedTag).bindTo(registry);
+
+        assertThat(output).contains("'" + STATS_DISABLED_MAP_NAME + "' is not recording statistics");
+        assertThat(registry.find("cache.size").gauge()).isNull();
+        assertThat(registry.find("cache.gets").functionCounter()).isNull();
+        assertThat(registry.find("cache.puts").functionCounter()).isNull();
+        assertThat(registry.find("cache.entries").gauges()).isEmpty();
+        assertThat(registry.find("cache.entry.memory").gauges()).isEmpty();
+        assertThat(registry.find("cache.partition.gets").functionCounter()).isNull();
+        assertThat(registry.find("cache.gets.latency").functionTimer()).isNull();
+        assertThat(registry.find("cache.puts.latency").functionTimer()).isNull();
+        assertThat(registry.find("cache.removals.latency").functionTimer()).isNull();
+    }
+
     @BeforeAll
     static void setup() {
-        cache = Hazelcast.newHazelcastInstance().getMap("mycache");
+        Config config = new Config();
+        config.addMapConfig(new MapConfig(STATS_DISABLED_MAP_NAME).setStatisticsEnabled(false));
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        cache = instance.getMap("mycache");
+        statsDisabledCache = instance.getMap(STATS_DISABLED_MAP_NAME);
         NearCacheStats nearCacheStats = mock(NearCacheStatsImpl.class);
         // generate non-negative random value to address false-positives
         int valueBound = 100000;

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/HazelcastCacheMetricsTest.java
@@ -46,11 +46,14 @@ import static org.mockito.Mockito.when;
  * Tests for {@link HazelcastCacheMetrics}.
  *
  * @author Oleksii Bondar
+ * @author Jewoo Shin
  */
 @ExtendWith(OutputCaptureExtension.class)
 class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
 
     private static final String STATS_DISABLED_MAP_NAME = "statsDisabledCache";
+
+    private static final Config CONFIG = new Config();
 
     @SuppressWarnings("NullAway.Init")
     // tag::setup[]
@@ -179,7 +182,7 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
     @Test
     void doNotReportMetricsWhenStatisticsAreDisabled(CapturedOutput output) {
         MeterRegistry registry = new SimpleMeterRegistry();
-        new HazelcastCacheMetrics(statsDisabledCache, expectedTag).bindTo(registry);
+        HazelcastCacheMetrics.monitor(registry, statsDisabledCache, expectedTag, CONFIG);
 
         assertThat(output).contains("'" + STATS_DISABLED_MAP_NAME + "' is not recording statistics");
         assertThat(registry.find("cache.size").gauge()).isNull();
@@ -193,11 +196,18 @@ class HazelcastCacheMetricsTest extends AbstractCacheMetricsTest {
         assertThat(registry.find("cache.removals.latency").functionTimer()).isNull();
     }
 
+    @Test
+    void assumeStatisticsAreEnabledWhenConfigIsNotProvided() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        new HazelcastCacheMetrics(statsDisabledCache, expectedTag).bindTo(registry);
+
+        assertThat(registry.find("cache.size").gauge()).isNotNull();
+    }
+
     @BeforeAll
     static void setup() {
-        Config config = new Config();
-        config.addMapConfig(new MapConfig(STATS_DISABLED_MAP_NAME).setStatisticsEnabled(false));
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        CONFIG.addMapConfig(new MapConfig(STATS_DISABLED_MAP_NAME).setStatisticsEnabled(false));
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(CONFIG);
         cache = instance.getMap("mycache");
         statsDisabledCache = instance.getMap(STATS_DISABLED_MAP_NAME);
         NearCacheStats nearCacheStats = mock(NearCacheStatsImpl.class);


### PR DESCRIPTION
**Summary**

Follow-up to gh-5402, gh-5409, and gh-7562 for `HazelcastCacheMetrics`. See gh-5066.

When a Hazelcast `IMap` is bound without statistics enabled, its meters silently report zero, which can be misleading. This change adds `Config`-aware constructor and `monitor` overloads that resolve the effective map configuration through the public `Config#findMapConfig(name)` API and inspect `MapConfig#isStatisticsEnabled()`.

When statistics are disabled, `HazelcastCacheMetrics` logs a warning and skips the statistics-dependent meters: `cache.size`, `cache.gets`, `cache.puts`, `cache.entries`, `cache.entry.memory`, `cache.partition.gets`, the near-cache gauges, and the `cache.gets.latency`, `cache.puts.latency`, and `cache.removals.latency` timers. `cache.size` is included because it reads `LocalMapStats#getOwnedEntryCount()`, which is not meaningful when statistics are disabled.

The existing constructor and `monitor` overloads remain unchanged and assume statistics are enabled because they do not receive a `Config`. This preserves existing behavior and the Hazelcast 3/4 compatibility surface in `HazelcastIMapAdapter` without relying on Hazelcast internal SPI. The statistics-enabled state is captured when the binder is created; if statistics are enabled later, a new `HazelcastCacheMetrics` instance must be created and bound.

**Status of other cache binders**

- **Caffeine** — handled in gh-5402 and gh-5409.
- **JCache** — handled in gh-7562.
- **Hazelcast** — covered by this change.
- **EhCache 2** — EhCache 2.5+ has statistics always enabled, so no check is necessary.
- **Guava** — Guava does not expose a public API to detect whether `recordStats()` was called. The upstream request (google/guava#7381) was closed with no plans to add further cache features.

**Testing**

- `HazelcastCacheMetricsTest#doNotReportMetricsWhenStatisticsAreDisabled` verifies that the `Config`-aware API logs a warning and does not register statistics-dependent meters when map statistics are disabled.
- `HazelcastCacheMetricsTest#assumeStatisticsAreEnabledWhenConfigIsNotProvided` verifies that the existing API continues to register meters when no `Config` is provided.
- The `micrometer-core` checks and the latest-Hazelcast compatibility test pass.
