### PR TITLE
Apply MeterFilters when building Kafka meter id for comparison

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -659,7 +659,7 @@ public abstract class MeterRegistry {
         return meterClass.cast(m);
     }
 
-    Meter.Id getMappedId(Meter.Id id) {
+    public Meter.Id getMappedId(Meter.Id id) {
         Meter m = preFilterIdToMeterMap.get(id);
         if (m != null && !isStaleId(id)) {
             return m.getId();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -100,8 +100,6 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
 
     private final Duration refreshInterval;
 
-    private @Nullable Iterable<Tag> commonTags;
-
     /**
      * Keeps track of current set of metrics.
      */
@@ -144,18 +142,10 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
     public void bindTo(MeterRegistry registry) {
         this.registry = registry;
 
-        commonTags = getCommonTags(registry);
         prepareToBindMetrics(registry);
         checkAndBindMetrics(registry);
         scheduler.scheduleAtFixedRate(() -> checkAndBindMetrics(registry), refreshInterval.toMillis(),
                 refreshInterval.toMillis(), TimeUnit.MILLISECONDS);
-    }
-
-    private Iterable<Tag> getCommonTags(MeterRegistry registry) {
-        // FIXME hack until we have proper API to retrieve common tags
-        Meter.Id dummyId = Meter.builder("delete.this", OTHER, Collections.emptyList()).register(registry).getId();
-        registry.remove(dummyId);
-        return dummyId.getTagsAsIterable();
     }
 
     /**
@@ -205,7 +195,7 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                 .collect(Collectors.toSet());
 
             for (MetricName metricName : metricsToRemove) {
-                Meter.Id id = meterIdForComparison(metricName);
+                Meter.Id id = meterIdForComparison(registry, metricName);
                 registry.remove(id);
                 registeredMeterIds.remove(id);
             }
@@ -230,18 +220,18 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
                 // topic or partition tag)
                 // Remove meters with lower number of tags
                 boolean hasLessTags = false;
+                List<Tag> mappedTags = meterIdForComparison(registry, name).getTags();
                 for (Meter other : registryMetersByNames.getOrDefault(meterName, emptyList())) {
                     Meter.Id otherId = other.getId();
                     List<Tag> otherTags = otherId.getTags();
-                    List<Tag> meterTagsWithCommonTags = meterTags(name, true);
-                    if (otherTags.size() < meterTagsWithCommonTags.size()) {
+                    if (otherTags.size() < mappedTags.size()) {
                         registry.remove(otherId);
                         registeredMeterIds.remove(otherId);
                     }
                     // Check if already exists
-                    else if (otherTags.size() == meterTagsWithCommonTags.size()) {
+                    else if (otherTags.size() == mappedTags.size()) {
                         // https://www.jetbrains.com/help/inspectopedia/SlowListContainsAll.html
-                        if (new HashSet<>(otherTags).containsAll(meterTagsWithCommonTags))
+                        if (new HashSet<>(otherTags).containsAll(mappedTags))
                             return;
                     }
                     else
@@ -337,19 +327,12 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         return ((Number) metricValue).doubleValue();
     }
 
-    private List<Tag> meterTags(MetricName metricName, boolean includeCommonTags) {
+    private List<Tag> meterTags(MetricName metricName) {
         List<Tag> tags = new ArrayList<>();
         metricName.tags().forEach((key, value) -> tags.add(Tag.of(key.replace('-', '.'), value)));
         tags.add(Tag.of(KAFKA_VERSION_TAG_NAME, kafkaVersion));
         extraTags.forEach(tags::add);
-        if (includeCommonTags && commonTags != null) {
-            commonTags.forEach(tags::add);
-        }
         return tags;
-    }
-
-    private List<Tag> meterTags(MetricName metricName) {
-        return meterTags(metricName, false);
     }
 
     private String meterName(MetricName metricName) {
@@ -357,8 +340,9 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         return name.replaceAll("-metrics", "").replace('-', '.');
     }
 
-    private Meter.Id meterIdForComparison(MetricName metricName) {
-        return new Meter.Id(meterName(metricName), Tags.of(meterTags(metricName, true)), null, null, OTHER);
+    private Meter.Id meterIdForComparison(MeterRegistry registry, MetricName metricName) {
+        Meter.Id preFilteredId = new Meter.Id(meterName(metricName), Tags.of(meterTags(metricName)), null, null, OTHER);
+        return registry.getMappedId(preFilteredId);
     }
 
     @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -17,6 +17,7 @@ package io.micrometer.core.instrument.binder.kafka;
 
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.testsupport.system.CapturedOutput;
 import io.micrometer.core.testsupport.system.OutputCaptureExtension;
@@ -615,6 +616,29 @@ class KafkaMetricsTest {
         kafkaMetrics.checkAndBindMetrics(registry);
         assertThat(registry.get("kafka.test.a").gauge().value()).isNaN();
         assertThat(output).isEmpty();
+    }
+
+    @Issue("#7541")
+    @Test
+    void shouldRemoveMeterWhenAMeterFilterTransformsTags() {
+        Map<MetricName, Metric> kafkaMetricMap = new HashMap<>();
+        Supplier<Map<MetricName, ? extends Metric>> supplier = () -> kafkaMetricMap;
+        kafkaMetrics = new KafkaMetrics(supplier);
+        MeterRegistry registry = new SimpleMeterRegistry();
+        registry.config().meterFilter(MeterFilter.replaceTagValues("topic", value -> value.replace('_', '.')));
+        kafkaMetrics.bindTo(registry);
+        assertThat(registry.getMeters()).hasSize(0);
+
+        MetricName aMetric = createMetricName("a", "topic", "my_topic");
+        kafkaMetricMap.put(aMetric, createKafkaMetric(aMetric));
+        kafkaMetrics.checkAndBindMetrics(registry);
+        assertThat(registry.getMeters()).hasSize(1);
+        assertThat(registry.getMeters().get(0).getId().getTags()).containsExactlyInAnyOrder(Tag.of("topic", "my.topic"),
+                Tag.of("kafka.version", "unknown"));
+
+        kafkaMetricMap.clear();
+        kafkaMetrics.checkAndBindMetrics(registry);
+        assertThat(registry.getMeters()).hasSize(0);
     }
 
     private MetricName createMetricName(String name) {


### PR DESCRIPTION
Fixes gh-7541.

`KafkaMetrics` built the id used to compare against and remove already-registered meters from raw tags (plus a common-tags workaround), so configured `MeterFilter`s that transform tags (`replaceTagValues`, `renameTag`, ...) made the comparison id diverge from the id the registry actually stores. As a result, stale meters were never removed.

This change routes the comparison id through `MeterRegistry#getMappedId` so all configured `MeterFilter`s are applied, and drops the common-tags workaround. A regression test reproduces the issue with a `replaceTagValues` filter.