### PR TITLE
docs: clarify SpelValueExpressionResolver is not in Micrometer's public API

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -97,6 +97,10 @@ include::{include-java}/metrics/CountedAspectTest.java[tags=resolvers,indent=0]
 include::{include-java}/metrics/CountedAspectTest.java[tags=meter_tag_annotation_handler,indent=0]
 -----
 
+NOTE: `SpelValueExpressionResolver` is not part of Micrometer's public API — it is a utility used in the documentation examples only.
+You need to provide your own `ValueExpressionResolver` implementation.
+See the xref:concepts/timers.adoc#_metertag_on_method_parameters[`@Timed` section] for an example implementation.
+
 Let's assume that we have the following interface.
 
 [source,java,subs=+attributes]

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -125,6 +125,35 @@ include::{include-java}/metrics/TimedAspectTest.java[tags=resolvers,indent=0]
 include::{include-java}/metrics/TimedAspectTest.java[tags=meter_tag_annotation_handler,indent=0]
 -----
 
+NOTE: `SpelValueExpressionResolver` is not part of Micrometer's public API — it is a utility used in the documentation examples only.
+You need to provide your own `ValueExpressionResolver` implementation.
+If you are using Spring, you can implement one backed by Spring Expression Language (SpEL):
+
+[source,java]
+----
+class SpelValueExpressionResolver implements ValueExpressionResolver {
+
+    @Override
+    public String resolve(String expression, Object parameter) {
+        try {
+            SimpleEvaluationContext context = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+            ExpressionParser parser = new SpelExpressionParser();
+            return String.valueOf(parser.parseExpression(expression).getValue(context, parameter, String.class));
+        }
+        catch (Exception ex) {
+            return String.valueOf(parameter);
+        }
+    }
+}
+----
+
+If your application does not need SpEL, you can use a simpler implementation that falls back to `toString()`:
+
+[source,java]
+----
+ValueExpressionResolver valueExpressionResolver = (expression, parameter) -> String.valueOf(parameter);
+----
+
 Let's assume that we have the following interface.
 
 [source,java,subs=+attributes]


### PR DESCRIPTION
## Problem

The `@MeterTag` sections in `timers.adoc` and `counters.adoc` reference `new SpelValueExpressionResolver()`, but `SpelValueExpressionResolver` only exists in the documentation test module (`io.micrometer.docs`) and is not part of Micrometer's public API. Users who copy the snippet get a compile error.

## Changes

- **`timers.adoc`**: Add a NOTE after the resolver setup block explaining that `SpelValueExpressionResolver` is docs-only, followed by:
  - A SpEL-backed implementation example for Spring users
  - A simple `toString()` fallback for applications that don't need SpEL evaluation
- **`counters.adoc`**: Add a shorter NOTE with a cross-reference to the `@Timed` section where the full implementation is shown

Closes #6465

🤖 Generated with [Claude Code](https://claude.com/claude-code)