### PR TITLE
GH-5461: Document lifecycle and thread-safety contract for MeterBinder

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterBinder.java
@@ -23,6 +23,20 @@ import io.micrometer.core.instrument.MeterRegistry;
  * <p>
  * Binders are enabled by default if they source data for an alert that is recommended for
  * a production ready app.
+ *
+ * <h2>Lifecycle</h2>
+ * {@link #bindTo(MeterRegistry)} is typically called once per registry during application
+ * startup (configuration time). The same {@code MeterBinder} instance may be bound to
+ * multiple registries, for example when a composite registry and an individual registry
+ * are both present in a Spring Boot application. Each such call registers fresh meters on
+ * the supplied registry.
+ *
+ * <h2>Thread Safety</h2>
+ * Implementations are <strong>not</strong> required to make {@link #bindTo} thread-safe.
+ * Concurrent invocations of {@link #bindTo} on the same instance, or invocations that
+ * overlap with ongoing meter observations from a previous call, are not a supported use
+ * case. In normal usage, all {@code bindTo} calls for a given instance happen serially
+ * during the single-threaded application context initialization phase.
  */
 public interface MeterBinder {
 


### PR DESCRIPTION
## What

Closes #5461.

Adds Javadoc to the `MeterBinder` interface documenting:

1. **Lifecycle** — `bindTo()` is typically called once per registry at application startup (configuration time). The same `MeterBinder` instance may be bound to multiple registries (e.g. a composite registry plus an individual registry in Spring Boot), with each call registering fresh meters on the supplied registry.

2. **Thread safety** — implementations are **not** required to make `bindTo` thread-safe. Concurrent invocations of `bindTo` on the same instance are not a supported use case. In normal usage all `bindTo` calls for a given instance happen serially during the single-threaded application context initialization phase.

## Why

The `MeterBinder` contract had no documentation about when `bindTo` is expected to be called or what thread-safety guarantees implementors must provide. Users implementing custom binders were left guessing — some used `synchronized` or `ReentrantLock` unnecessarily, while others had questions (as raised in #5461) about whether that was required.

The maintainer comment on #5461 confirmed: _"We will update documentation on this."_

🤖 Generated with [Claude Code](https://claude.com/claude-code)