### PR TITLE
GH-4621: Clarify Spring Boot auto-configuration scope for @Timed and @Counted

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -50,6 +50,9 @@ Counter counter = Counter
 
 The `micrometer-core` module contains a `@Counted` annotation that frameworks can use to add counting support to either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
 
+NOTE: **Spring Boot auto-configuration** does not process `@Counted` on arbitrary Spring beans.
+To use `@Counted` on services, repositories, or other non-web components, register the `CountedAspect` bean described below.
+
 Also, an incubating AspectJ aspect is included in `micrometer-core`. You can use it in your application either through compile/load time AspectJ weaving or through framework facilities that interpret AspectJ aspects and proxy targeted methods in some other way, such as Spring AOP. Here is a sample Spring AOP configuration:
 
 [source,java]

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -73,6 +73,10 @@ Note how we do not decide the timer to which to accumulate the sample until it i
 
 The `micrometer-core` module contains a `@Timed` annotation that frameworks can use to add timing support to either specific types of methods such as those serving web request endpoints or, more generally, to all methods.
 
+NOTE: **Spring Boot auto-configuration** processes `@Timed` on web endpoint handlers automatically (Spring MVC `@Controller`/`@RestController`, Spring WebFlux handlers, and Jersey resource classes/methods).
+It does **not** process `@Timed` on arbitrary Spring beans (services, repositories, and so on).
+To use `@Timed` on arbitrary methods, register the `TimedAspect` bean described below.
+
 Also, an incubating AspectJ aspect is included in `micrometer-core`. You can use it in your application either through compile/load time AspectJ weaving or through framework facilities that interpret AspectJ aspects and proxy targeted methods in some other way, such as Spring AOP. Here is a sample Spring AOP configuration:
 
 [source,java]


### PR DESCRIPTION
## What

Partially addresses #4621 (adds the clarification the issue asks for; adding more exhaustive examples would be a follow-up).

Adds a NOTE to the `@Timed` section in `timers.adoc` and the `@Counted` section in `counters.adoc` explaining that Spring Boot's autoconfiguration only applies these annotations to **web endpoint handlers** (Spring MVC `@Controller`/`@RestController`, Spring WebFlux handlers, Jersey resources).  For arbitrary Spring beans (services, repositories, and so on), the corresponding `TimedAspect` / `CountedAspect` bean must be explicitly registered.

## Why

A common confusion reported in #4621 and on Stack Overflow is that developers annotate a `@Service` method with `@Timed` or `@Counted`, observe no metrics, and can't find a clear explanation in the docs. The current wording — "frameworks can use to add timing support to … web request endpoints or, more generally, to all methods" — is accurate but passive and doesn't help Spring Boot users understand what they need to do for arbitrary methods.

The NOTE makes the Spring Boot scope explicit up front, immediately before the `TimedAspect`/`CountedAspect` configuration examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)