### PR TITLE
GH-3108: Document that NamingConvention only processes dot-separated names

### DIFF
--- a/docs/modules/ROOT/pages/concepts/naming.adoc
+++ b/docs/modules/ROOT/pages/concepts/naming.adoc
@@ -30,6 +30,18 @@ By adhering to Micrometer's lowercase dot notation convention, you guarantee the
 
 TIP: We recommend that you follow the same lowercase dot notation described for meter names when naming tags. Using this consistent naming convention for tags allows for better translation into the respective monitoring system's idiomatic naming schemes.
 
+[NOTE]
+====
+The naming convention that each registry applies transforms *dot-separated* names to the backend's idiomatic format.
+Characters other than dots — such as hyphens (`-`), underscores (`_`), or spaces — are *not* converted by the generic naming conventions and are passed through verbatim (after removing any characters the backend disallows).
+
+For example, `NamingConvention.snakeCase` converts `my.tag.name` to `my_tag_name`, but `my-tag-name` remains `my-tag-name` (a hyphen is not a dot, so it is not replaced).
+
+Each registry ships with a backend-specific naming convention (for example, `PrometheusNamingConvention`) that replaces all disallowed characters with `_`.
+Replacing the default with a generic one like `NamingConvention.snakeCase` may therefore produce unexpected results for names and tags that use non-dot separators.
+If you use Prometheus, keep the default `PrometheusNamingConvention` and use dot notation for your names and tags.
+====
+
 Suppose we are trying to measure the number of http requests and the number of database calls.
 
 *Recommended Approach*


### PR DESCRIPTION
## Summary

Closes #3108

The root confusion in this issue is that users expect `NamingConvention.snakeCase` to convert all separators (including hyphens) to underscores, but it only processes dot-separated names — which is Micrometer's canonical form.

The issue thread clarifies (from @shakuzen):
> _In general, we don't want to change things any more than we have to for a backend's requirements... `NamingConvention.snakeCase` is a general implementation not specific to any backend, and therefore it only handles converting from canonical form (dot case) to snake case._
> _`PrometheusNamingConvention` can be more specific... Prometheus doesn't allow many characters - so it is by chance that kebab case also gets converted, because `-` is not an allowed character._
> _The problem here is that `NamingConvention.snakeCase` should not be used with `PrometheusMeterRegistry`._

This PR adds a NOTE callout in the `naming.adoc` Tag Naming section that:
- Explains that generic naming conventions only translate dot separators, not hyphens or other chars
- Shows a concrete example (`my-tag-name` stays as `my-tag-name`, but `my.tag.name` → `my_tag_name`)
- Notes that each registry ships with a backend-specific naming convention, and replacing it (e.g., Prometheus' default) with `NamingConvention.snakeCase` produces unexpected results

## Test plan

- [ ] `./gradlew antora` generates the site and the Tag Naming section includes the new NOTE
- [ ] Example text renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)