### PR TITLE
docs: warn against combining TimedAspect with Spring Boot's built-in @Timed support

### DIFF
--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -114,6 +114,18 @@ public class ExampleService {
 
 NOTE: `TimedAspect` doesn't support meta-annotations with `@Timed`.
 
+[WARNING]
+====
+*Avoid combining `TimedAspect` with Spring Boot's built-in `@Timed` support.*
+
+Spring Boot auto-configures `@Timed` processing for `@Controller` and `@RestController` beans (web request mappings).
+Registering a `TimedAspect` bean in the same application causes those controller methods to be instrumented *twice* — once by the aspect and once by the framework — producing duplicate meters with the same name but potentially different tags.
+This is especially problematic with the Prometheus registry, which rejects duplicate metric names as a registration error.
+
+Use `TimedAspect` only for methods on non-web beans (services, repositories, and so on) that Spring Boot does not instrument automatically.
+If you only need timing for web endpoints, rely on Spring Boot's built-in support and do *not* register a `TimedAspect` bean.
+====
+
 === @MeterTag on Method Parameters
 
 To support using the `@MeterTag` annotation on method parameters, you need to configure the `@TimedAspect` to add the `MeterTagAnnotationHandler`.


### PR DESCRIPTION
## Summary

Closes #4621

Registering a `TimedAspect` bean when Spring Boot's built-in `@Timed` processing is active for `@Controller`/`@RestController` methods leads to double instrumentation of web endpoints. Both mechanisms time the same method, creating duplicate meters — often with the same name but different tags. This is particularly painful with the Prometheus registry, which rejects duplicate metric names at registration time.

Added a `WARNING` callout in the `@Timed` section of `timers.adoc` clarifying:

- Spring Boot auto-instruments web endpoints (`@Controller` / `@RestController`) — no `TimedAspect` needed for those
- `TimedAspect` should only be used for **non-web beans** (services, repositories, etc.) that Spring Boot does not instrument automatically
- Combining both on the same method produces duplicate meters, with Prometheus being the most affected

## Test plan

- [ ] Docs build with Antora renders the WARNING callout correctly
- [ ] Wording is consistent with guidance from the team (comment by @jonatan-ivanov in the issue)