### PR TITLE
docs: rename SpelValueExpressionResolver to CustomValueExpressionResolver and add clarification

### DIFF
--- a/docs/modules/ROOT/pages/concepts/counters.adoc
+++ b/docs/modules/ROOT/pages/concepts/counters.adoc
@@ -90,6 +90,10 @@ public class ExampleService {
 
 To support using the `@MeterTag` annotation on method parameters, you need to configure the `@CountedAspect` to add the `CountedMeterTagAnnotationHandler`.
 
+NOTE: Micrometer does not provide a `ValueExpressionResolver` implementation out of the box.
+You need to supply your own (for example, one backed by Spring Expression Language) or use one provided by your framework.
+`CustomValueExpressionResolver` in the examples below is a sample SpEL-based implementation — it is **not** part of the Micrometer API.
+
 [source,java,subs=+attributes]
 -----
 include::{include-java}/metrics/CountedAspectTest.java[tags=resolvers,indent=0]

--- a/docs/modules/ROOT/pages/concepts/timers.adoc
+++ b/docs/modules/ROOT/pages/concepts/timers.adoc
@@ -118,6 +118,10 @@ NOTE: `TimedAspect` doesn't support meta-annotations with `@Timed`.
 
 To support using the `@MeterTag` annotation on method parameters, you need to configure the `@TimedAspect` to add the `MeterTagAnnotationHandler`.
 
+NOTE: Micrometer does not provide a `ValueExpressionResolver` implementation out of the box.
+You need to supply your own (for example, one backed by Spring Expression Language) or use one provided by your framework.
+`CustomValueExpressionResolver` in the examples below is a sample SpEL-based implementation — it is **not** part of the Micrometer API.
+
 [source,java,subs=+attributes]
 -----
 include::{include-java}/metrics/TimedAspectTest.java[tags=resolvers,indent=0]

--- a/docs/src/test/java/io/micrometer/docs/CustomValueExpressionResolver.java
+++ b/docs/src/test/java/io/micrometer/docs/CustomValueExpressionResolver.java
@@ -25,9 +25,13 @@ import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 
-public class SpelValueExpressionResolver implements ValueExpressionResolver {
+// tag::class[]
+// NOTE: Micrometer does not provide a ValueExpressionResolver out of the box.
+// You need to implement one yourself (or use one provided by your framework).
+// Below is an example implementation using Spring Expression Language (SpEL).
+public class CustomValueExpressionResolver implements ValueExpressionResolver {
 
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(SpelValueExpressionResolver.class);
+    private static final InternalLogger log = InternalLoggerFactory.getInstance(CustomValueExpressionResolver.class);
 
     @Override
     public @NonNull String resolve(@NonNull String expression, @Nullable Object parameter) {
@@ -44,3 +48,4 @@ public class SpelValueExpressionResolver implements ValueExpressionResolver {
     }
 
 }
+// end::class[]

--- a/docs/src/test/java/io/micrometer/docs/metrics/CountedAspectTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/CountedAspectTest.java
@@ -23,7 +23,7 @@ import io.micrometer.core.aop.CountedMeterTagAnnotationHandler;
 import io.micrometer.core.aop.MeterTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -36,8 +36,8 @@ class CountedAspectTest {
     // tag::resolvers[]
     ValueResolver valueResolver = parameter -> "Value from myCustomTagValueResolver [" + parameter + "]";
 
-    // Example of a ValueExpressionResolver that uses Spring Expression Language
-    ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+    // Example of a custom ValueExpressionResolver; see CustomValueExpressionResolver for an implementation using SpEL
+    ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
 
     // end::resolvers[]
 

--- a/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
+++ b/docs/src/test/java/io/micrometer/docs/metrics/TimedAspectTest.java
@@ -23,7 +23,7 @@ import io.micrometer.core.aop.MeterTag;
 import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -36,8 +36,8 @@ class TimedAspectTest {
     // tag::resolvers[]
     ValueResolver valueResolver = parameter -> "Value from myCustomTagValueResolver [" + parameter + "]";
 
-    // Example of a ValueExpressionResolver that uses Spring Expression Language
-    ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+    // Example of a custom ValueExpressionResolver; see CustomValueExpressionResolver for an implementation using SpEL
+    ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
 
     // end::resolvers[]
 

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import io.micrometer.docs.SpelValueExpressionResolver;
+import io.micrometer.docs.CustomValueExpressionResolver;
 import io.micrometer.observation.*;
 import io.micrometer.observation.annotation.Observed;
 import io.micrometer.observation.annotation.ObservationKeyValue;
@@ -237,7 +237,7 @@ class ObservationHandlerTests {
         AspectJProxyFactory pf = new AspectJProxyFactory(new ObservedServiceWithParameter());
         ObservedAspect observedAspect = new ObservedAspect(registry);
         ValueResolver valueResolver = parameter -> "Value from myCustomValueResolver [" + parameter + "]";
-        ValueExpressionResolver valueExpressionResolver = new SpelValueExpressionResolver();
+        ValueExpressionResolver valueExpressionResolver = new CustomValueExpressionResolver();
         observedAspect.setObservationKeyValueAnnotationHandler(
             new ObservationKeyValueAnnotationHandler(
                 aClass -> valueResolver, aClass -> valueExpressionResolver)


### PR DESCRIPTION
## Summary

Closes #6465

The documentation showed `new SpelValueExpressionResolver()` in the `@MeterTag` examples, implying it was a built-in Micrometer class. However, it only existed as a private helper in the docs test package (`io.micrometer.docs`). Users who followed the docs got a compilation error.

The maintainer suggested renaming it to `CustomValueExpressionResolver` to make it clear that it is a custom (user-provided) implementation, and adding a note explaining that `ValueExpressionResolver` is not shipped with Micrometer.

### Changes

- Renamed `SpelValueExpressionResolver` → `CustomValueExpressionResolver` (the "Spel" prefix implied framework-provided)
- Added a comment block in the class explaining it is an example SpEL-based implementation, not part of the Micrometer API
- Updated imports in `TimedAspectTest`, `CountedAspectTest`, `ObservationHandlerTests`
- Added a `NOTE` callout in `timers.adoc` and `counters.adoc` (the `@MeterTag on Method Parameters` section) explaining:
  - `ValueExpressionResolver` must be implemented by the user or provided by the framework
  - `CustomValueExpressionResolver` is a sample implementation — it is **not** part of the Micrometer API

## Test plan

- [ ] Docs build with Antora renders the NOTE callout correctly
- [ ] Tests compile and pass with the renamed class
- [ ] The included Java snippets (via `include::` tags) still render correctly