### PR TITLE
GH-5461: Document thread-safety expectations for MeterBinder.bindTo()

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterBinder.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/MeterBinder.java
@@ -26,6 +26,16 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 public interface MeterBinder {
 
+    /**
+     * Bind meters to the given registry.
+     * <p>
+     * This method is typically called once per registry at application configuration
+     * time. The framework does not provide any thread-safety guarantee for concurrent
+     * calls to this method on the same {@code MeterBinder} instance. Implementations
+     * that must support concurrent binding to multiple registries should ensure their
+     * own thread safety.
+     * @param registry the registry to bind metrics to
+     */
     void bindTo(MeterRegistry registry);
 
 }


### PR DESCRIPTION
## Summary

Addresses #5461.

`MeterBinder.bindTo()` had no Javadoc at all, leaving implementors uncertain about whether their implementations need to be thread-safe. Based on [the maintainer's guidance in that issue](https://github.com/micrometer-metrics/micrometer/issues/5461#issuecomment-1829014870), this PR adds Javadoc to `bindTo()` that clarifies:

- It is typically called once per registry at application configuration time.
- The Micrometer framework does not provide any thread-safety guarantee for concurrent calls to `bindTo()` on the same instance.
- Implementations that need to support concurrent binding to multiple registries must ensure their own thread safety.

## Test plan

- [ ] No behaviour change (Javadoc only); existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)