### PR TITLE
Make virtual thread pinned event threshold configurable

### DIFF
--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -50,6 +50,8 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private static final long DEFAULT_MAX_SIZE_BYTES = 10L * 1024 * 1024;
 
+    private static final Duration DEFAULT_PINNED_THRESHOLD = Duration.ofMillis(20);
+
     private static final String LIVE_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished";
 
     private static final String METER_NAME_PREFIX = "jvm.threads.virtual.";
@@ -182,7 +184,7 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private record RecordingConfig(Duration maxAge, long maxSizeBytes, Duration pinnedThreshold) {
         private RecordingConfig() {
-            this(DEFAULT_MAX_AGE, DEFAULT_MAX_SIZE_BYTES, Duration.ofMillis(20));
+            this(DEFAULT_MAX_AGE, DEFAULT_MAX_SIZE_BYTES, DEFAULT_PINNED_THRESHOLD);
         }
 
         private RecordingConfig {

--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -46,6 +46,10 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private static final String SUBMIT_FAILED_EVENT = "jdk.VirtualThreadSubmitFailed";
 
+    private static final Duration DEFAULT_MAX_AGE = Duration.ofSeconds(5);
+
+    private static final long DEFAULT_MAX_SIZE_BYTES = 10L * 1024 * 1024;
+
     private static final String LIVE_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished";
 
     private static final String METER_NAME_PREFIX = "jvm.threads.virtual.";
@@ -60,6 +64,29 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     public VirtualThreadMetrics(Iterable<Tag> tags) {
         this(new RecordingConfig(), tags);
+    }
+
+    /**
+     * Creates a new {@code VirtualThreadMetrics} with the specified JFR pinned-event
+     * threshold. Events shorter than the threshold will not be recorded by JFR.
+     * @param pinnedThreshold minimum duration a virtual thread must be pinned before the
+     * JFR event is emitted; must not be {@code null} or negative
+     * @since 1.18.0
+     */
+    public VirtualThreadMetrics(Duration pinnedThreshold) {
+        this(new RecordingConfig(DEFAULT_MAX_AGE, DEFAULT_MAX_SIZE_BYTES, pinnedThreshold), emptyList());
+    }
+
+    /**
+     * Creates a new {@code VirtualThreadMetrics} with the specified JFR pinned-event
+     * threshold and tags. Events shorter than the threshold will not be recorded by JFR.
+     * @param pinnedThreshold minimum duration a virtual thread must be pinned before the
+     * JFR event is emitted; must not be {@code null} or negative
+     * @param tags tags to apply to all meters registered by this binder
+     * @since 1.18.0
+     */
+    public VirtualThreadMetrics(Duration pinnedThreshold, Iterable<Tag> tags) {
+        this(new RecordingConfig(DEFAULT_MAX_AGE, DEFAULT_MAX_SIZE_BYTES, pinnedThreshold), tags);
     }
 
     private VirtualThreadMetrics(RecordingConfig config, Iterable<Tag> tags) {
@@ -155,7 +182,7 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private record RecordingConfig(Duration maxAge, long maxSizeBytes, Duration pinnedThreshold) {
         private RecordingConfig() {
-            this(Duration.ofSeconds(5), 10L * 1024 * 1024, Duration.ofMillis(20));
+            this(DEFAULT_MAX_AGE, DEFAULT_MAX_SIZE_BYTES, Duration.ofMillis(20));
         }
 
         private RecordingConfig {
@@ -163,6 +190,9 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
             Objects.requireNonNull(pinnedThreshold, "pinnedThreshold must not be null");
             if (maxSizeBytes < 0) {
                 throw new IllegalArgumentException("maxSizeBytes must be positive");
+            }
+            if (pinnedThreshold.isNegative()) {
+                throw new IllegalArgumentException("pinnedThreshold must not be negative");
             }
         }
     }

--- a/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsTests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.*;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 /**
@@ -114,6 +115,45 @@ class VirtualThreadMetricsTests {
         finally {
             future.cancel(true);
         }
+    }
+
+    @Test
+    void defaultConstructorIsUnchanged() {
+        try (VirtualThreadMetrics metrics = new VirtualThreadMetrics()) {
+            // no exception expected — regression guard for default ctor
+        }
+    }
+
+    @Test
+    void customPinnedThresholdConstructorAcceptsValidDuration() {
+        try (VirtualThreadMetrics metrics = new VirtualThreadMetrics(Duration.ofMillis(50))) {
+            // no exception expected
+        }
+    }
+
+    @Test
+    void customPinnedThresholdWithTagsConstructorAcceptsValidDuration() {
+        try (VirtualThreadMetrics metrics = new VirtualThreadMetrics(Duration.ofMillis(50), Tags.of("k", "v"))) {
+            // no exception expected
+        }
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void customPinnedThresholdConstructorRejectsNullThreshold() {
+        assertThatThrownBy(() -> new VirtualThreadMetrics((Duration) null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void customPinnedThresholdWithTagsConstructorRejectsNullThreshold() {
+        assertThatThrownBy(() -> new VirtualThreadMetrics(null, Tags.empty())).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void customPinnedThresholdConstructorRejectsNegativeThreshold() {
+        assertThatThrownBy(() -> new VirtualThreadMetrics(Duration.ofMillis(-1)))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
 }


### PR DESCRIPTION
I ran into the same thing — the 20ms pinned-event threshold in `VirtualThreadMetrics` is hardcoded, so any `jdk.VirtualThreadPinned` event shorter than 20ms is dropped and never shows up in the `jvm.threads.virtual.pinned` timer. In our apps a lot of pins are well under 20ms, so we were effectively blind to them. Opening this PR to make the threshold configurable.

The threshold was already plumbed through `RecordingConfig.pinnedThreshold` and applied via `withThreshold(...)`; it just wasn't reachable from the public API. This adds two constructors:

```java
new VirtualThreadMetrics(Duration pinnedThreshold)
new VirtualThreadMetrics(Duration pinnedThreshold, Iterable<Tag> tags)
```

The existing constructors and the 20ms default are unchanged, so this is backward compatible. A null threshold is rejected with `NullPointerException` and a negative one with `IllegalArgumentException`, mirroring the existing `maxSizeBytes` guard.

Tests pass on JDK 24:

```
VirtualThreadMetricsTests > tests=7, skipped=1, failures=0, errors=0
  customPinnedThresholdConstructorAcceptsValidDuration         PASSED
  customPinnedThresholdWithTagsConstructorAcceptsValidDuration PASSED
  customPinnedThresholdConstructorRejectsNullThreshold         PASSED
  customPinnedThresholdWithTagsConstructorRejectsNullThreshold PASSED
  customPinnedThresholdConstructorRejectsNegativeThreshold     PASSED
  defaultConstructorIsUnchanged                                PASSED
  pinnedEventsShouldBeRecorded                                 SKIPPED (@DisabledForJreRange min JAVA_24)
```

Resolves #7563
