### PR TITLE
Add separate Dependabot configurations for sample dependency versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,6 +113,17 @@ updates:
           - version-update:semver-minor
     open-pull-requests-limit: 10
   - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-caffeine3"
+    schedule:
+      interval: daily
+    target-branch: "1.17.x"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: daily
@@ -140,6 +151,16 @@ updates:
     open-pull-requests-limit: 10
   - package-ecosystem: gradle
     directory: "/samples/micrometer-samples-jooq"
+    schedule:
+      interval: daily
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-caffeine3"
     schedule:
       interval: daily
     target-branch: "main"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,28 @@ updates:
           - version-update:semver-minor
     open-pull-requests-limit: 30
   - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jersey3"
+    schedule:
+      interval: daily
+    target-branch: "1.16.x"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jooq"
+    schedule:
+      interval: daily
+    target-branch: "1.16.x"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: daily
@@ -69,6 +91,28 @@ updates:
           - version-update:semver-minor
     open-pull-requests-limit: 30
   - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jersey3"
+    schedule:
+      interval: daily
+    target-branch: "1.17.x"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jooq"
+    schedule:
+      interval: daily
+    target-branch: "1.17.x"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
     directory: "/"
     schedule:
       interval: daily
@@ -84,3 +128,23 @@ updates:
         update-types:
           - version-update:semver-major
     open-pull-requests-limit: 50
+  - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jersey3"
+    schedule:
+      interval: daily
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    open-pull-requests-limit: 10
+  - package-ecosystem: gradle
+    directory: "/samples/micrometer-samples-jooq"
+    schedule:
+      interval: daily
+    target-branch: "main"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR adds separate, isolated Dependabot configuration blocks to `.github/dependabot.yml` for the subdirectories containing secondary/newer versions of dependencies (such as **Jersey 3** and **jOOQ Latest**). 

This is part of a two-PR solution to prevent Dependabot from clobbering multiple versions of the same dependency:
1. **PR #7621 (targeting `1.16.x`)**: Removes secondary versions from the root `gradle/libs.versions.toml` catalog and hardcodes them as string literals in their respective subproject `build.gradle` files.
2. **This PR (targeting `main`)**: Configures Dependabot to scan those subdirectories in isolated, separate jobs so they receive automatic updates without clobbering the root catalog.

### Why this is split into two PRs:
Dependabot's configuration (`.github/dependabot.yml`) is only active when read from the repository's default branch (`main`). Changes to `dependabot.yml` on maintenance branches like `1.16.x` are completely ignored by GitHub. Therefore, the configuration changes must be merged into `main` to take effect for all branches (including `1.16.x`, `1.17.x`, and `main`).