### PR TITLE
Filter null Humio meter events

### DIFF
--- a/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
+++ b/implementations/micrometer-registry-humio/src/main/java/io/micrometer/humio/HumioMeterRegistry.java
@@ -114,6 +114,7 @@ public class HumioMeterRegistry extends StepMeterRegistry {
                             batch::writeFunctionCounter,
                             batch::writeFunctionTimer,
                             batch::writeMeter))
+                    .filter(java.util.Objects::nonNull)
                     .collect(joining(",", "[{" + tags + "\"events\": [", "]}]")))
                     .send()
                     .onSuccess(response -> logger.debug("successfully sent {} metrics to humio.", meters.size()))

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -60,6 +60,18 @@ class HumioMeterRegistryTest {
     }
 
     @Test
+    void publishDropsNullMeterEvents(@WiremockResolver.Wiremock WireMockServer server) {
+        HumioMeterRegistry registry = humioMeterRegistry(server);
+        registry.timer("my.timer", "status", "success");
+        registry.gauge("my.gauge", Double.NaN);
+
+        server.stubFor(any(anyUrl()));
+        registry.publish();
+        server.verify(postRequestedFor(urlMatching("/api/v1/ingest/humio-structured")).withRequestBody(equalTo(
+                "[{\"events\": [{\"timestamp\":\"1970-01-01T00:00:00.001Z\",\"attributes\":{\"name\":\"my_timer\",\"count\":0,\"sum\":0,\"avg\":0,\"max\":0,\"status\":\"success\"}}]}]")));
+    }
+
+    @Test
     void datasourceTags(@WiremockResolver.Wiremock WireMockServer server) {
         HumioMeterRegistry registry = humioMeterRegistry(server, "name", "micrometer");
         registry.counter("my.counter").increment();

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -62,13 +62,15 @@ class HumioMeterRegistryTest {
     @Test
     void publishDropsNullMeterEvents(@WiremockResolver.Wiremock WireMockServer server) {
         HumioMeterRegistry registry = humioMeterRegistry(server);
-        registry.timer("my.timer", "status", "success");
-        registry.gauge("my.gauge", Double.NaN);
+        registry.counter("my.counter").increment();
+        clock.add(config.step());
+        Measurement measurement = new Measurement(() -> Double.NaN, Statistic.VALUE);
+        Meter.builder("my.meter", Meter.Type.GAUGE, List.of(measurement)).register(registry);
 
         server.stubFor(any(anyUrl()));
         registry.publish();
         server.verify(postRequestedFor(urlMatching("/api/v1/ingest/humio-structured")).withRequestBody(equalTo(
-                "[{\"events\": [{\"timestamp\":\"1970-01-01T00:00:00.001Z\",\"attributes\":{\"name\":\"my_timer\",\"count\":0,\"sum\":0,\"avg\":0,\"max\":0,\"status\":\"success\"}}]}]")));
+                "[{\"events\": [{\"timestamp\":\"1970-01-01T00:01:00.001Z\",\"attributes\":{\"name\":\"my_counter\",\"count\":1}}]}]")));
     }
 
     @Test

--- a/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
+++ b/implementations/micrometer-registry-humio/src/test/java/io/micrometer/humio/HumioMeterRegistryTest.java
@@ -64,8 +64,7 @@ class HumioMeterRegistryTest {
         HumioMeterRegistry registry = humioMeterRegistry(server);
         registry.counter("my.counter").increment();
         clock.add(config.step());
-        Measurement measurement = new Measurement(() -> Double.NaN, Statistic.VALUE);
-        Meter.builder("my.meter", Meter.Type.GAUGE, List.of(measurement)).register(registry);
+        Meter.builder("my.empty", Meter.Type.OTHER, List.<Measurement>of()).register(registry);
 
         server.stubFor(any(anyUrl()));
         registry.publish();


### PR DESCRIPTION
Fixes #7579.

## Summary
- filter out null Humio event payloads before joining the publish batch
- add a regression test covering a mixed batch where one meter produces a valid event and another produces `null`

## Verification
- `./gradlew :micrometer-registry-humio:test --tests io.micrometer.humio.HumioMeterRegistryTest.publishDropsNullMeterEvents --no-daemon`
- `./gradlew :micrometer-registry-humio:test --no-daemon`
- `git diff --check origin/main..HEAD`
