### PR TITLE
Add MdcToKeyValuesObservationFilter to copy MDC entries into KeyValues

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -21,6 +21,7 @@
 	<suppress id="SLF4JIllegalImportCheck" files="benchmarks[\\/].+" />
 	<suppress id="SLF4JIllegalImportCheck" files="micrometer-osgi-test" />
 	<suppress id="SLF4JIllegalImportCheck" files="MeterRegistryLoggingTest" />
+	<suppress id="SLF4JIllegalImportCheck" files="MdcToKeyValuesObservationFilter" />
 
 	<suppress id="sysout" files="ClearCustomMetricDescriptors.java"/>
 	<suppress id="sysout" files="HttpSender.java"/>

--- a/micrometer-observation/build.gradle
+++ b/micrometer-observation/build.gradle
@@ -31,6 +31,7 @@ jar {
             javax.servlet.*;resolution:=optional,\
             io.micrometer.context.*;resolution:=optional,\
             org.aspectj.*;resolution:=optional,\
+            org.slf4j.*;resolution:=optional,\
             *
         '''.stripIndent()
     }
@@ -47,6 +48,10 @@ dependencies {
     // Aspects
     optionalApi libs.aspectjrt
 
+    // MDC source for MdcToKeyValuesObservationFilter
+    optionalApi libs.slf4jApi
+
+    testImplementation libs.slf4jApi
     testRuntimeOnly libs.logback12
 
     testImplementation(libs.archunitJunit5) {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/MdcToKeyValuesObservationFilter.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/MdcToKeyValuesObservationFilter.java
@@ -1,0 +1,1075 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.common.KeyValue;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * An {@link ObservationFilter} that copies entries from the SLF4J {@link MDC Mapped
+ * Diagnostic Context} into the {@link Observation.Context} as low or high cardinality
+ * {@link KeyValue key values}.
+ * <p>
+ * Which MDC keys are copied, the cardinality level at which they are added, and whether
+ * they are renamed is controlled by an ordered set of rules configured through the
+ * {@link Builder}. For each MDC entry, the rules are consulted and the <em>first</em>
+ * matching rule decides the outcome; an entry that matches no rule is dropped. Rules are
+ * added in three phases that must be declared in order:
+ * <ol>
+ * <li>exact key rules ({@code includeKey}/{@code excludeKey})</li>
+ * <li>matching rules, by regular expression or predicate
+ * ({@code includeKeysMatching}/{@code excludeKeysMatching})</li>
+ * <li>a single optional catch-all
+ * ({@code includeByDefault}/{@code excludeByDefault})</li>
+ * </ol>
+ * <p>
+ * At least one include rule must be defined; otherwise {@link Builder#build()} throws an
+ * {@link IllegalStateException} since the filter would not copy any MDC entry.
+ * <p>
+ * Example: <pre>{@code
+ * MdcToKeyValuesObservationFilter filter = MdcToKeyValuesObservationFilter.builder()
+ *     // include a specific high-cardinality key, without renaming it
+ *     .includeKey("order.id")
+ *
+ *     // include a specific high-cardinality key and rename it
+ *     .includeKey("accountId", spec -> spec.renameTo("account.id"))
+ *
+ *     // include a specific low-cardinality key, without renaming it
+ *     .includeKey("tenant", spec -> spec.lowCardinality())
+ *
+ *     // exclude a specific key that would otherwise be included by later rules
+ *     .excludeKey("foobar")
+ *
+ *     // exclude a set of keys that would otherwise be included by later rules
+ *     .excludeKeysMatching("foobarbaz.*")
+ *
+ *     // include a set of high-cardinality keys by regex,
+ *     // and use back references to rename
+ *     .includeKeysMatching("foo(.*)", spec -> spec.renameTo("Foo$1"))
+ *
+ *     // include a set of high-cardinality keys that start with a specific prefix
+ *     .includeKeysMatching(key -> key.startsWith("order"))
+ *
+ *     // include the remaining keys as high-cardinality and rename them
+ *     .includeByDefault(spec -> spec.renameUsing(key -> "mdc." + key))
+ *
+ *     .build();
+ *
+ * registry.observationConfig().observationFilter(filter);
+ * }</pre>
+ * <p>
+ * Notes:
+ * <ul>
+ * <li>The MDC is thread local and is read on the thread that {@link Observation#stop()
+ * stops} the observation. The configured rules, including any
+ * {@link AbstractMdcKeySpec#renameUsing(UnaryOperator) rename functions}, run on that
+ * same thread as part of stopping the observation, so they should be cheap and must not
+ * throw.</li>
+ * <li>Because the filter runs when the observation is stopped, only MDC entries that are
+ * present at that moment can be copied. If the observation wraps code that populates the
+ * MDC and then removes those entries before the observation stops (for example a key set
+ * and cleared inside the observed scope), those values are no longer visible to the
+ * filter and cannot be copied.</li>
+ * <li>Included keys are added as high cardinality key values by default; use
+ * {@link AbstractMdcKeySpec#lowCardinality()} to add them as low cardinality key values
+ * instead.</li>
+ * <li>Renaming is configured per rule. Exact-key and regular-expression rules accept
+ * {@code renameTo} (a literal name for exact keys, a {@code $}-back-reference replacement
+ * template for regular expressions) as well as {@code renameUsing}. Predicate and
+ * catch-all default rules accept only {@code renameUsing}, since they can match many keys
+ * and renaming them all to one literal name is rarely intended. {@code renameTo} and
+ * {@code renameUsing} are mutually exclusive; the last one called wins.</li>
+ * <li>If two MDC entries are renamed to the same key, the later one overwrites the
+ * earlier one. However, the order of MDC entries is non-deterministic.</li>
+ * <li>The resolution of regular-expression and default rules for a given MDC key is
+ * cached so a recurring key does not repeatedly re-scan those rules. This cache is
+ * enabled by default and bounded; it can be tuned or disabled through
+ * {@link Builder#keyResolutionCache(Consumer) keyResolutionCache}.</li>
+ * </ul>
+ *
+ * @author Phil Clay
+ * @since 1.18.0
+ */
+public final class MdcToKeyValuesObservationFilter implements ObservationFilter {
+
+    /**
+     * Precomputed outcomes for exact key rules, keyed by MDC key name. Consulted first
+     * and resolved with an O(1) lookup. Unmodifiable.
+     */
+    private final Map<String, Outcome> exactRules;
+
+    /**
+     * Regular-expression and predicate rules, in declared order. Consulted after the
+     * exact rules for keys that no exact rule matched; the first matching rule wins.
+     * Unmodifiable.
+     */
+    private final List<Rule> matchingRules;
+
+    /**
+     * The catch-all rule applied to keys matched by neither an exact nor a matching rule.
+     * Defaults to {@link Rule#EXCLUDE_BY_DEFAULT}.
+     */
+    private final Rule defaultRule;
+
+    /**
+     * True when the only rules are exact key rules and unmatched keys are excluded. In
+     * that case the output depends solely on the configured keys, so they can be looked
+     * up directly instead of copying the whole MDC.
+     */
+    private final boolean exactKeysOnly;
+
+    /**
+     * Caches the resolved outcome for keys handled by the regex/predicate/default rules
+     * (exact keys are already an O(1) lookup and stay out of the cache). {@code null}
+     * when caching is disabled or unnecessary. Bounded to
+     * {@link #keyResolutionCacheMaxSize} entries: once full, already-cached keys are
+     * still served from the cache, but other keys are resolved on each lookup rather than
+     * being added. Configure via {@link Builder#keyResolutionCache(Consumer)}.
+     */
+    private final @Nullable Map<String, Outcome> keyResolutionCache;
+
+    /**
+     * Soft maximum number of entries kept in {@link #keyResolutionCache}. It is a soft
+     * bound because the size is checked before adding without locking, so under
+     * concurrent stops the cache may exceed this by roughly the number of racing threads
+     * before settling.
+     */
+    private final int keyResolutionCacheMaxSize;
+
+    /**
+     * Creates a filter from the rules and cache settings collected by the given builder.
+     * @param builder the builder holding the configured rules and cache settings
+     */
+    private MdcToKeyValuesObservationFilter(Builder builder) {
+        this.exactRules = Collections.unmodifiableMap(new HashMap<>(builder.exactRules));
+        this.matchingRules = Collections.unmodifiableList(new ArrayList<>(builder.matchingRules));
+        this.defaultRule = builder.defaultRule;
+        this.exactKeysOnly = this.matchingRules.stream().noneMatch(rule -> rule.include) && !this.defaultRule.include;
+        this.keyResolutionCache = (builder.keyResolutionCacheEnabled && !this.exactKeysOnly) ? new ConcurrentHashMap<>()
+                : null;
+        this.keyResolutionCacheMaxSize = builder.keyResolutionCacheMaxSize;
+    }
+
+    /**
+     * Creates a new {@link Builder}.
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Observation.Context map(Observation.Context context) {
+        if (this.exactKeysOnly) {
+            // Fast path: the output depends only on the configured exact keys, so look
+            // each one up directly instead of copying the whole MDC.
+            for (Map.Entry<String, Outcome> entry : this.exactRules.entrySet()) {
+                Outcome outcome = entry.getValue();
+                // Skip the MDC lookup for keys an exclude rule would drop anyway.
+                if (outcome.include) {
+                    addIfIncluded(context, outcome, MDC.get(entry.getKey()));
+                }
+            }
+            return context;
+        }
+
+        // Slow path: copy the MDC and resolve every entry through the rules.
+        Map<String, String> mdc = MDC.getCopyOfContextMap();
+        if (mdc == null || mdc.isEmpty()) {
+            return context;
+        }
+        for (Map.Entry<String, String> entry : mdc.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (value == null) {
+                continue;
+            }
+
+            // Exact key rules always precede regex/predicate/default rules (enforced by
+            // the builder), so an exact match can be resolved with an O(1) lookup. Other
+            // keys fall through to the regex/predicate/default rules, whose resolution is
+            // cached by key when caching is enabled.
+            @Nullable Outcome outcome = this.exactRules.get(key);
+            if (outcome == null) {
+                outcome = resolveWithCache(key);
+            }
+
+            addIfIncluded(context, outcome, value);
+        }
+        return context;
+    }
+
+    /**
+     * Resolves the outcome for {@code key} via the cache when enabled. On a miss, the key
+     * is resolved and, while the cache is below its {@link #keyResolutionCacheMaxSize max
+     * size}, added. Once the cache is full, uncached keys are resolved on every call.
+     */
+    private @Nullable Outcome resolveWithCache(String key) {
+        Map<String, Outcome> cache = this.keyResolutionCache;
+        if (cache == null) {
+            return resolve(key);
+        }
+        Outcome cached = cache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        Outcome resolved = resolve(key);
+        if (resolved != null && cache.size() < this.keyResolutionCacheMaxSize) {
+            cache.putIfAbsent(key, resolved);
+        }
+        return resolved;
+    }
+
+    /**
+     * Resolves the outcome for a key not handled by an exact rule: the first matching
+     * regex rule, otherwise the default rule. This is a pure function of the key, so its
+     * result can be cached.
+     */
+    private @Nullable Outcome resolve(String key) {
+        for (Rule rule : this.matchingRules) {
+            Outcome outcome = rule.evaluate(key);
+            if (outcome != null) {
+                return outcome;
+            }
+        }
+        return this.defaultRule.evaluate(key);
+    }
+
+    /**
+     * Adds the MDC value to the context as a key value when the resolved outcome includes
+     * it, at the cardinality the outcome dictates. This is the single place both the fast
+     * and slow paths in {@link #map(Observation.Context)} funnel through, so the
+     * include/cardinality decision cannot diverge between them.
+     * @param context the context to add the key value to
+     * @param outcome the resolved outcome, or {@code null} when no rule matched the key
+     * @param value the MDC value, or {@code null} when the key has no value
+     */
+    private static void addIfIncluded(Observation.Context context, @Nullable Outcome outcome, @Nullable String value) {
+        if (outcome == null || !outcome.include || value == null) {
+            return;
+        }
+        KeyValue keyValue = KeyValue.of(outcome.newKey, value);
+        if (outcome.lowCardinality) {
+            context.addLowCardinalityKeyValue(keyValue);
+        }
+        else {
+            context.addHighCardinalityKeyValue(keyValue);
+        }
+    }
+
+    /**
+     * Applies a rename operator to a key, returning the key unchanged when no operator is
+     * configured.
+     * @param renameOperator the rename operator, or {@code null} to keep the original key
+     * @param key the original MDC key
+     * @return the renamed key, or the original key when no operator is configured
+     * @throws NullPointerException if the operator returns {@code null}
+     */
+    private static String applyRenameOperator(@Nullable UnaryOperator<String> renameOperator, String key) {
+        if (renameOperator == null) {
+            return key;
+        }
+        return Objects.requireNonNull(renameOperator.apply(key), "renameOperator must not return null");
+    }
+
+    /**
+     * Builder for {@link MdcToKeyValuesObservationFilter}.
+     * <p>
+     * Rules must be declared in phases: all exact key rules first, then all matching
+     * rules (regular expressions or predicates), then at most one catch-all default rule.
+     * Declaring a rule out of order throws an {@link IllegalStateException}.
+     */
+    public static final class Builder {
+
+        /**
+         * The phases in which rules must be declared, in order. Used to enforce the exact
+         * then matching then default ordering.
+         */
+        private enum Phase {
+
+            /** Exact key rules ({@code includeKey}/{@code excludeKey}). */
+            KEY,
+            /** Matching rules by regular expression or predicate. */
+            MATCHING,
+            /** The single optional catch-all default rule. */
+            DEFAULT
+
+        }
+
+        /**
+         * Accumulates exact key outcomes, keyed by MDC key name; first declaration of a
+         * key wins.
+         */
+        private final Map<String, Outcome> exactRules = new HashMap<>();
+
+        /**
+         * Accumulates regular-expression and predicate rules in declared order.
+         */
+        private final List<Rule> matchingRules = new ArrayList<>();
+
+        /**
+         * The catch-all default rule; excludes unmatched keys until configured otherwise.
+         */
+        private Rule defaultRule = Rule.EXCLUDE_BY_DEFAULT;
+
+        /**
+         * The current declaration phase, advanced as matching and default rules are
+         * declared to enforce ordering.
+         */
+        private Phase phase = Phase.KEY;
+
+        /**
+         * Whether the key resolution cache is enabled on the built filter.
+         */
+        private boolean keyResolutionCacheEnabled = KeyResolutionCacheSpec.DEFAULT_ENABLED;
+
+        /**
+         * The soft maximum size of the key resolution cache on the built filter.
+         */
+        private int keyResolutionCacheMaxSize = KeyResolutionCacheSpec.DEFAULT_MAX_SIZE;
+
+        /**
+         * Creates an empty builder; obtain one via
+         * {@link MdcToKeyValuesObservationFilter#builder()}.
+         */
+        private Builder() {
+        }
+
+        /**
+         * Configures the cache that memoizes the resolution of regex/predicate/default
+         * rules for a given MDC key, so a recurring key does not repeatedly re-scan those
+         * rules. The cache is enabled by default with a maximum size of
+         * {@value KeyResolutionCacheSpec#DEFAULT_MAX_SIZE}, which suits the typical case
+         * of low MDC-key cardinality. Has no effect on exact key rules, which are always
+         * an O(1) lookup. May be called at any point.
+         * @param spec configures whether the cache is enabled and its maximum size
+         * @return this builder
+         * @see KeyResolutionCacheSpec
+         */
+        public Builder keyResolutionCache(Consumer<KeyResolutionCacheSpec> spec) {
+            Objects.requireNonNull(spec, "spec must not be null");
+            KeyResolutionCacheSpec cacheSpec = new KeyResolutionCacheSpec();
+            spec.accept(cacheSpec);
+            this.keyResolutionCacheEnabled = cacheSpec.enabled;
+            this.keyResolutionCacheMaxSize = cacheSpec.maxSize;
+            return this;
+        }
+
+        /**
+         * Includes the given exact MDC key as a high cardinality key value, keeping its
+         * name.
+         * @param key the exact MDC key name to include
+         * @return this builder
+         */
+        public Builder includeKey(String key) {
+            return includeKey(key, spec -> {
+            });
+        }
+
+        /**
+         * Includes the given exact MDC key, configured by the given spec. An
+         * {@link ExactKeySpec#renameTo(String) renameTo} value, if any, is a literal
+         * name.
+         * @param key the exact MDC key name to include
+         * @param spec configures the cardinality and optional rename
+         * @return this builder
+         */
+        public Builder includeKey(String key, Consumer<ExactKeySpec> spec) {
+            Objects.requireNonNull(key, "key must not be null");
+            Objects.requireNonNull(spec, "spec must not be null");
+            checkKeyPhase("includeKey");
+            ExactKeySpec keySpec = applySpec(new ExactKeySpec(), spec);
+            // Exact rule: the key is known now, so a renameTo template is its literal
+            // value.
+            String newKey = (keySpec.renameTemplate != null) ? keySpec.renameTemplate
+                    : applyRenameOperator(keySpec.renameOperator, key);
+            this.exactRules.putIfAbsent(key, new Outcome(true, keySpec.lowCardinality, newKey));
+            return this;
+        }
+
+        /**
+         * Excludes the given exact MDC key.
+         * @param key the exact MDC key name to exclude
+         * @return this builder
+         */
+        public Builder excludeKey(String key) {
+            Objects.requireNonNull(key, "key must not be null");
+            checkKeyPhase("excludeKey");
+            this.exactRules.putIfAbsent(key, Outcome.EXCLUDED);
+            return this;
+        }
+
+        /**
+         * Includes MDC keys fully matching the given regular expression as high
+         * cardinality key values, keeping their names.
+         * @param regex the regular expression that an MDC key must fully match
+         * @return this builder
+         */
+        public Builder includeKeysMatching(String regex) {
+            return includeKeysMatching(regex, spec -> {
+            });
+        }
+
+        /**
+         * Includes MDC keys fully matching the given regular expression, configured by
+         * the given spec. The rename, if any, may contain back-references (e.g.
+         * {@code $1}) to groups captured by the regular expression.
+         * @param regex the regular expression that an MDC key must fully match
+         * @param spec configures the cardinality and optional rename
+         * @return this builder
+         */
+        public Builder includeKeysMatching(String regex, Consumer<RegexKeySpec> spec) {
+            Objects.requireNonNull(regex, "regex must not be null");
+            Objects.requireNonNull(spec, "spec must not be null");
+            checkMatchingPhase("includeKeysMatching");
+            RegexKeySpec keySpec = applySpec(new RegexKeySpec(), spec);
+            this.matchingRules.add(Rule.regex(Pattern.compile(regex), true, keySpec.lowCardinality,
+                    keySpec.renameTemplate, keySpec.renameOperator));
+            return this;
+        }
+
+        /**
+         * Excludes MDC keys fully matching the given regular expression.
+         * @param regex the regular expression that an MDC key must fully match
+         * @return this builder
+         */
+        public Builder excludeKeysMatching(String regex) {
+            Objects.requireNonNull(regex, "regex must not be null");
+            checkMatchingPhase("excludeKeysMatching");
+            this.matchingRules.add(Rule.regex(Pattern.compile(regex), false, false, null, null));
+            return this;
+        }
+
+        /**
+         * Includes MDC keys matching the given predicate as high cardinality key values,
+         * keeping their names.
+         * @param predicate tests whether an MDC key should be included
+         * @return this builder
+         */
+        public Builder includeKeysMatching(Predicate<String> predicate) {
+            return includeKeysMatching(predicate, spec -> {
+            });
+        }
+
+        /**
+         * Includes MDC keys matching the given predicate, configured by the given spec.
+         * The spec offers no {@code renameTo}, since a predicate can match many keys and
+         * renaming them all to one literal name is rarely intended; derive a name from
+         * the key with {@link PredicateKeySpec#renameUsing(UnaryOperator) renameUsing}
+         * instead.
+         * <p>
+         * The predicate is invoked on the thread that {@link Observation#stop() stops}
+         * the observation, so it should be cheap and must not throw. It must also be a
+         * pure function of the key, since its result may be memoized per distinct key by
+         * the {@link #keyResolutionCache(Consumer) key resolution cache}.
+         * @param predicate tests whether an MDC key should be included
+         * @param spec configures the cardinality and optional rename
+         * @return this builder
+         */
+        public Builder includeKeysMatching(Predicate<String> predicate, Consumer<PredicateKeySpec> spec) {
+            Objects.requireNonNull(predicate, "predicate must not be null");
+            Objects.requireNonNull(spec, "spec must not be null");
+            checkMatchingPhase("includeKeysMatching");
+            PredicateKeySpec keySpec = applySpec(new PredicateKeySpec(), spec);
+            this.matchingRules.add(Rule.predicate(predicate, true, keySpec.lowCardinality, keySpec.renameOperator));
+            return this;
+        }
+
+        /**
+         * Excludes MDC keys matching the given predicate.
+         * @param predicate tests whether an MDC key should be excluded
+         * @return this builder
+         */
+        public Builder excludeKeysMatching(Predicate<String> predicate) {
+            Objects.requireNonNull(predicate, "predicate must not be null");
+            checkMatchingPhase("excludeKeysMatching");
+            this.matchingRules.add(Rule.predicate(predicate, false, false, null));
+            return this;
+        }
+
+        /**
+         * Sets the default policy to include every MDC key not matched by an earlier
+         * rule, as high cardinality key values keeping their names. Must be the last rule
+         * declared.
+         * @return this builder
+         */
+        public Builder includeByDefault() {
+            return includeByDefault(spec -> {
+            });
+        }
+
+        /**
+         * Sets the default policy to include every MDC key not matched by an earlier
+         * rule, configured by the given spec. The spec offers no {@code renameTo}, since
+         * the default rule matches many keys and renaming them all to one literal name is
+         * rarely intended; derive a name from the key with
+         * {@link DefaultKeySpec#renameUsing(UnaryOperator) renameUsing} instead. Must be
+         * the last rule declared.
+         * @param spec configures the cardinality and optional rename
+         * @return this builder
+         */
+        public Builder includeByDefault(Consumer<DefaultKeySpec> spec) {
+            Objects.requireNonNull(spec, "spec must not be null");
+            checkDefaultPhase();
+            DefaultKeySpec keySpec = applySpec(new DefaultKeySpec(), spec);
+            this.defaultRule = Rule.includeByDefault(keySpec.lowCardinality, keySpec.renameOperator);
+            return this;
+        }
+
+        /**
+         * Sets the default policy to exclude every MDC key not matched by an earlier
+         * rule. This is already the implicit default of dropping unmatched keys but
+         * states the intent explicitly. Must be the last rule declared.
+         * @return this builder
+         */
+        public Builder excludeByDefault() {
+            checkDefaultPhase();
+            this.defaultRule = Rule.EXCLUDE_BY_DEFAULT;
+            return this;
+        }
+
+        /**
+         * Builds the {@link MdcToKeyValuesObservationFilter}.
+         * @return a new filter
+         * @throws IllegalStateException if no include rule was defined, since such a
+         * filter could never copy any MDC entry
+         */
+        public MdcToKeyValuesObservationFilter build() {
+            boolean includesNothing = this.exactRules.values().stream().noneMatch(outcome -> outcome.include)
+                    && this.matchingRules.stream().noneMatch(rule -> rule.include) && !this.defaultRule.include;
+            if (includesNothing) {
+                throw new IllegalStateException("no include rules defined; add at least one of includeKey, "
+                        + "includeKeysMatching, or includeByDefault");
+            }
+            return new MdcToKeyValuesObservationFilter(this);
+        }
+
+        /**
+         * Applies the caller's configuration to the given spec and returns it.
+         * @param keySpec the spec to configure
+         * @param spec the caller-provided configuration
+         * @param <S> the concrete spec type
+         * @return the configured spec
+         */
+        private static <S extends AbstractMdcKeySpec<?>> S applySpec(S keySpec, Consumer<? super S> spec) {
+            spec.accept(keySpec);
+            return keySpec;
+        }
+
+        /**
+         * Verifies an exact key rule is declared while still in the {@link Phase#KEY}
+         * phase.
+         * @param method the calling builder method, used in the error message
+         * @throws IllegalStateException if a matching or default rule was already
+         * declared
+         */
+        private void checkKeyPhase(String method) {
+            if (this.phase != Phase.KEY) {
+                throw new IllegalStateException(method
+                        + " must be called before includeKeysMatching/excludeKeysMatching and includeByDefault/excludeByDefault");
+            }
+        }
+
+        /**
+         * Verifies a matching rule is declared before the default rule and advances the
+         * phase to {@link Phase#MATCHING}.
+         * @param method the calling builder method, used in the error message
+         * @throws IllegalStateException if a default rule was already declared
+         */
+        private void checkMatchingPhase(String method) {
+            if (this.phase == Phase.DEFAULT) {
+                throw new IllegalStateException(method + " must be called before includeByDefault/excludeByDefault");
+            }
+            this.phase = Phase.MATCHING;
+        }
+
+        /**
+         * Verifies the default rule has not already been declared and advances the phase
+         * to {@link Phase#DEFAULT}.
+         * @throws IllegalStateException if a default rule was already declared
+         */
+        private void checkDefaultPhase() {
+            if (this.phase == Phase.DEFAULT) {
+                throw new IllegalStateException("includeByDefault/excludeByDefault may only be called once");
+            }
+            this.phase = Phase.DEFAULT;
+        }
+
+    }
+
+    /**
+     * Base type for the per-rule key specs created by the {@link Builder}. Holds the
+     * shared cardinality and {@link #renameUsing(UnaryOperator) rename-by-operator}
+     * configuration. Each kind of rule has its own concrete subtype
+     * ({@link ExactKeySpec}, {@link RegexKeySpec}, {@link PredicateKeySpec},
+     * {@link DefaultKeySpec}); the two whose rules match a single nameable key, exact and
+     * regex, additionally offer {@code renameTo}.
+     *
+     * @param <S> the concrete spec type, returned by the fluent methods so chained calls
+     * keep the subtype
+     */
+    public abstract static class AbstractMdcKeySpec<S extends AbstractMdcKeySpec<S>> {
+
+        /**
+         * Whether the key is added as a low cardinality key value.
+         * <ul>
+         * <li>true = low cardinality</li>
+         * <li>false = high cardinality (the default)</li>
+         * </ul>
+         *
+         * Protected so the builder and subtypes can read and set it.
+         */
+        protected boolean lowCardinality;
+
+        /**
+         * The rename template set by {@link ExactKeySpec#renameTo(String)} (a literal
+         * name) or {@link RegexKeySpec#renameTo(String)} (a replacement template), or
+         * {@code null}. Always {@code null} for {@link PredicateKeySpec} and
+         * {@link DefaultKeySpec}, which have no {@code renameTo}. Mutually exclusive with
+         * {@link #renameOperator}.
+         */
+        protected @Nullable String renameTemplate;
+
+        /**
+         * The rename operator, or {@code null} to keep the original key. Mutually
+         * exclusive with {@link #renameTemplate}.
+         */
+        protected @Nullable UnaryOperator<String> renameOperator;
+
+        /**
+         * Package private so the spec types cannot be subclassed or instantiated outside
+         * this class.
+         */
+        AbstractMdcKeySpec() {
+        }
+
+        /**
+         * Returns {@code this} as the concrete subtype, so the fluent methods keep the
+         * subtype for chaining.
+         * @return this spec as its concrete type
+         */
+        @SuppressWarnings("unchecked")
+        private S self() {
+            return (S) this;
+        }
+
+        /**
+         * Adds the matched key as a high cardinality key value. This is the default.
+         * @return this spec
+         */
+        public S highCardinality() {
+            this.lowCardinality = false;
+            return self();
+        }
+
+        /**
+         * Adds the matched key as a low cardinality key value.
+         * @return this spec
+         */
+        public S lowCardinality() {
+            this.lowCardinality = true;
+            return self();
+        }
+
+        /**
+         * Renames the matched key using the given operator, applied to the original MDC
+         * key, before it is added to the context. The operator must return a non-null key
+         * and has no access to regex capture groups. Mutually exclusive with
+         * {@link ExactKeySpec#renameTo(String)} and {@link RegexKeySpec#renameTo(String)}
+         * (where available); the last of the two called wins.
+         * <p>
+         * The operator must be a pure function of the key: for matching and default rules
+         * its result may be memoized per distinct key by the
+         * {@link Builder#keyResolutionCache(Consumer) key resolution cache}, so it may be
+         * invoked only once for a recurring key rather than on every observation. Like
+         * the rest of the filter it runs on the thread that {@link Observation#stop()
+         * stops} the observation, so it should be cheap and must not throw.
+         * @param renamer maps the original MDC key to the new key name
+         * @return this spec
+         */
+        public S renameUsing(UnaryOperator<String> renamer) {
+            this.renameOperator = Objects.requireNonNull(renamer, "renamer must not be null");
+            this.renameTemplate = null;
+            return self();
+        }
+
+    }
+
+    /**
+     * Spec for an exact-key rule, configured via
+     * {@link Builder#includeKey(String, Consumer) includeKey}.
+     */
+    public static final class ExactKeySpec extends AbstractMdcKeySpec<ExactKeySpec> {
+
+        /**
+         * Package private so it cannot be instantiated outside this class.
+         */
+        ExactKeySpec() {
+        }
+
+        /**
+         * Renames the matched key to the given literal name before it is added to the
+         * context. The name is used verbatim (no template substitution). To derive a name
+         * from the key, use {@link #renameUsing(UnaryOperator)} instead. Mutually
+         * exclusive with {@link #renameUsing(UnaryOperator)}; the last of the two called
+         * wins.
+         * @param name the literal new key name
+         * @return this spec
+         */
+        public ExactKeySpec renameTo(String name) {
+            this.renameTemplate = Objects.requireNonNull(name, "name must not be null");
+            this.renameOperator = null;
+            return this;
+        }
+
+    }
+
+    /**
+     * Spec for a regular-expression rule, configured via
+     * {@link Builder#includeKeysMatching(String, Consumer) includeKeysMatching}.
+     */
+    public static final class RegexKeySpec extends AbstractMdcKeySpec<RegexKeySpec> {
+
+        /**
+         * Package private so it cannot be instantiated outside this class.
+         */
+        RegexKeySpec() {
+        }
+
+        /**
+         * Renames the matched key using the given replacement template before it is added
+         * to the context. The template may contain back-references to groups captured by
+         * the regular expression ({@code $0} = whole key, {@code $1} = group 1,
+         * &hellip;), so distinct keys can yield distinct names. To derive a name from the
+         * key without using capture groups, use {@link #renameUsing(UnaryOperator)}
+         * instead. Mutually exclusive with {@link #renameUsing(UnaryOperator)}; the last
+         * of the two called wins.
+         * @param replacementTemplate the regex replacement template
+         * @return this spec
+         */
+        public RegexKeySpec renameTo(String replacementTemplate) {
+            this.renameTemplate = Objects.requireNonNull(replacementTemplate, "replacementTemplate must not be null");
+            this.renameOperator = null;
+            return this;
+        }
+
+    }
+
+    /**
+     * Spec for a predicate rule, configured via
+     * {@link Builder#includeKeysMatching(Predicate, Consumer) includeKeysMatching}. A
+     * predicate can match many keys, so there is no {@code renameTo}; derive a name from
+     * each key with {@link #renameUsing(UnaryOperator)}.
+     */
+    public static final class PredicateKeySpec extends AbstractMdcKeySpec<PredicateKeySpec> {
+
+        /**
+         * Package private so it cannot be instantiated outside this class.
+         */
+        PredicateKeySpec() {
+        }
+
+    }
+
+    /**
+     * Spec for the catch-all default rule, configured via
+     * {@link Builder#includeByDefault(Consumer) includeByDefault}. The default rule
+     * matches many keys, so there is no {@code renameTo}; derive a name from each key
+     * with {@link #renameUsing(UnaryOperator)}.
+     */
+    public static final class DefaultKeySpec extends AbstractMdcKeySpec<DefaultKeySpec> {
+
+        /**
+         * Package private so it cannot be instantiated outside this class.
+         */
+        DefaultKeySpec() {
+        }
+
+    }
+
+    /**
+     * Configures the cache that memoizes regex/predicate/default rule resolution by MDC
+     * key.
+     */
+    public static final class KeyResolutionCacheSpec {
+
+        /**
+         * Whether the key resolution cache is enabled by default.
+         */
+        public static final boolean DEFAULT_ENABLED = true;
+
+        /**
+         * Default {@link #maxSize(int) maximum number of keys} held in the cache.
+         */
+        public static final int DEFAULT_MAX_SIZE = 100;
+
+        /**
+         * Whether the cache is enabled.
+         */
+        private boolean enabled = DEFAULT_ENABLED;
+
+        /**
+         * The soft maximum number of keys held in the cache.
+         */
+        private int maxSize = DEFAULT_MAX_SIZE;
+
+        /**
+         * Creates a spec with the default settings ({@link #DEFAULT_ENABLED},
+         * {@link #DEFAULT_MAX_SIZE}).
+         */
+        private KeyResolutionCacheSpec() {
+        }
+
+        /**
+         * Sets whether the key resolution cache is enabled. Enabled by default.
+         * @param enabled whether to cache rule resolution by key
+         * @return this spec
+         */
+        public KeyResolutionCacheSpec enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of keys held in the cache. Defaults to
+         * {@value #DEFAULT_MAX_SIZE}. Once the cache is full, already-cached keys
+         * continue to be served from the cache, but other keys are resolved on each
+         * lookup rather than being added, bounding memory use when MDC-key cardinality is
+         * unexpectedly high.
+         * @param maxSize the maximum number of cached keys; must be at least {@code 1}
+         * @return this spec
+         */
+        public KeyResolutionCacheSpec maxSize(int maxSize) {
+            if (maxSize < 1) {
+                throw new IllegalArgumentException("maxSize must be at least 1");
+            }
+            this.maxSize = maxSize;
+            return this;
+        }
+
+    }
+
+    /**
+     * The resolved decision for an MDC key.
+     */
+    private static final class Outcome {
+
+        /**
+         * Shared outcome for keys that an exclude rule drops.
+         */
+        private static final Outcome EXCLUDED = new Outcome(false, false, "");
+
+        /**
+         * Whether the key is added to the context ({@code false} means dropped).
+         */
+        private final boolean include;
+
+        /**
+         * Whether to add the key as a low cardinality key value; high cardinality when
+         * {@code false}. Unused when {@link #include} is {@code false}.
+         */
+        private final boolean lowCardinality;
+
+        /**
+         * The (possibly renamed) key to record. Empty when {@link #include} is
+         * {@code false}.
+         */
+        private final String newKey;
+
+        /**
+         * Creates an outcome.
+         * @param include whether the key is added to the context
+         * @param lowCardinality whether to add it as a low cardinality key value
+         * @param newKey the (possibly renamed) key to record
+         */
+        private Outcome(boolean include, boolean lowCardinality, String newKey) {
+            this.include = include;
+            this.lowCardinality = lowCardinality;
+            this.newKey = newKey;
+        }
+
+    }
+
+    /**
+     * A matching rule, either regular-expression ({@code pattern != null}) or predicate
+     * ({@code predicate != null}), or the catch-all default rule (both {@code null}).
+     * Exact key rules are precomputed into a map and need no {@link Rule}.
+     */
+    private static final class Rule {
+
+        /**
+         * The default rule that drops every key not matched by an earlier rule.
+         */
+        private static final Rule EXCLUDE_BY_DEFAULT = new Rule(null, null, false, false, null, null);
+
+        /**
+         * The regular expression a key must fully match, or {@code null} for predicate
+         * and default rules.
+         */
+        private final @Nullable Pattern pattern;
+
+        /**
+         * The predicate a key must satisfy, or {@code null} for regex and default rules.
+         */
+        private final @Nullable Predicate<String> predicate;
+
+        /**
+         * Whether a matched key is included ({@code false} excludes it).
+         */
+        private final boolean include;
+
+        /**
+         * Whether an included key is added as a low cardinality key value.
+         */
+        private final boolean lowCardinality;
+
+        /**
+         * The {@code $}-back-reference replacement template for a regex rule, or
+         * {@code null}. Only regex rules carry a template (predicate and default rules
+         * rename only via {@link #renameOperator}, since their specs have no
+         * {@code renameTo}). Mutually exclusive with {@link #renameOperator}.
+         */
+        private final @Nullable String renameTemplate;
+
+        /**
+         * The rename operator applied to the original key, or {@code null}. Mutually
+         * exclusive with {@link #renameTemplate}.
+         */
+        private final @Nullable UnaryOperator<String> renameOperator;
+
+        /**
+         * Creates a rule. Use the {@link #regex}, {@link #predicate} and
+         * {@link #includeByDefault} factories rather than calling this directly.
+         * @param pattern the regular expression, or {@code null}
+         * @param predicate the predicate, or {@code null}
+         * @param include whether a matched key is included
+         * @param lowCardinality whether an included key is low cardinality
+         * @param renameTemplate the rename template, or {@code null}
+         * @param renameOperator the rename operator, or {@code null}
+         */
+        private Rule(@Nullable Pattern pattern, @Nullable Predicate<String> predicate, boolean include,
+                boolean lowCardinality, @Nullable String renameTemplate,
+                @Nullable UnaryOperator<String> renameOperator) {
+            this.pattern = pattern;
+            this.predicate = predicate;
+            this.include = include;
+            this.lowCardinality = lowCardinality;
+            this.renameTemplate = renameTemplate;
+            this.renameOperator = renameOperator;
+        }
+
+        /**
+         * Creates a regular-expression rule.
+         * @param pattern the regular expression a key must fully match
+         * @param include whether a matched key is included
+         * @param lowCardinality whether an included key is low cardinality
+         * @param renameTemplate the rename template, or {@code null}
+         * @param renameOperator the rename operator, or {@code null}
+         * @return the rule
+         */
+        private static Rule regex(Pattern pattern, boolean include, boolean lowCardinality,
+                @Nullable String renameTemplate, @Nullable UnaryOperator<String> renameOperator) {
+            return new Rule(pattern, null, include, lowCardinality, renameTemplate, renameOperator);
+        }
+
+        /**
+         * Creates a predicate rule. Predicate rules carry no rename template; any rename
+         * is via {@code renameOperator}.
+         * @param predicate the predicate a key must satisfy
+         * @param include whether a matched key is included
+         * @param lowCardinality whether an included key is low cardinality
+         * @param renameOperator the rename operator, or {@code null}
+         * @return the rule
+         */
+        private static Rule predicate(Predicate<String> predicate, boolean include, boolean lowCardinality,
+                @Nullable UnaryOperator<String> renameOperator) {
+            return new Rule(null, predicate, include, lowCardinality, null, renameOperator);
+        }
+
+        /**
+         * Creates a catch-all default rule that includes every otherwise-unmatched key.
+         * Carries no rename template; any rename is via {@code renameOperator}.
+         * @param lowCardinality whether included keys are low cardinality
+         * @param renameOperator the rename operator, or {@code null}
+         * @return the rule
+         */
+        private static Rule includeByDefault(boolean lowCardinality, @Nullable UnaryOperator<String> renameOperator) {
+            return new Rule(null, null, true, lowCardinality, null, renameOperator);
+        }
+
+        /**
+         * Evaluates this rule against the given MDC key.
+         * @param key the MDC key to evaluate
+         * @return the {@link Outcome} when this rule matches the key (an include outcome
+         * carrying the renamed key and cardinality, or {@link Outcome#EXCLUDED} for an
+         * exclude rule), or {@code null} when the key does not match and the next rule
+         * should be tried
+         */
+        private @Nullable Outcome evaluate(String key) {
+            String newKey;
+            if (this.pattern != null) {
+                Matcher matcher = this.pattern.matcher(key);
+                if (!matcher.matches()) {
+                    return null;
+                }
+                if (!this.include) {
+                    return Outcome.EXCLUDED;
+                }
+                if (this.renameTemplate != null) {
+                    // Build the renamed key from the match captured by matches() via
+                    // appendReplacement/appendTail, so the input is processed only once.
+                    // (replaceFirst would reset the matcher and re-scan the input.)
+                    StringBuffer renamed = new StringBuffer();
+                    matcher.appendReplacement(renamed, this.renameTemplate);
+                    matcher.appendTail(renamed);
+                    newKey = renamed.toString();
+                }
+                else {
+                    newKey = applyRenameOperator(this.renameOperator, key);
+                }
+            }
+            else {
+                // Predicate rule (predicate != null), or the catch-all default rule
+                // (predicate == null) which always matches. Neither carries a rename
+                // template, so any rename comes from the operator.
+                if (this.predicate != null && !this.predicate.test(key)) {
+                    return null;
+                }
+                if (!this.include) {
+                    return Outcome.EXCLUDED;
+                }
+                newKey = applyRenameOperator(this.renameOperator, key);
+            }
+            return new Outcome(true, this.lowCardinality, newKey);
+        }
+
+    }
+
+}

--- a/micrometer-observation/src/test/java/io/micrometer/observation/MdcToKeyValuesObservationFilterTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/MdcToKeyValuesObservationFilterTests.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.observation;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.Observation.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link MdcToKeyValuesObservationFilter}.
+ *
+ * @author Phil Clay
+ */
+class MdcToKeyValuesObservationFilterTests {
+
+    private ObservationRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        this.registry = ObservationRegistry.create();
+        this.registry.observationConfig().observationHandler(context -> true);
+        MDC.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear();
+    }
+
+    private Context runWith(MdcToKeyValuesObservationFilter filter) {
+        this.registry.observationConfig().observationFilter(filter);
+        Context context = new Context();
+        Observation.start("foo", () -> context, this.registry).stop();
+        return context;
+    }
+
+    @Test
+    void buildWithoutIncludeRulesThrows() {
+        // A filter that can never include anything is a misconfiguration, so it is
+        // rejected at build time rather than silently copying nothing.
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().build())
+            .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().excludeKey("a").build())
+            .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(
+                () -> MdcToKeyValuesObservationFilter.builder().excludeKeysMatching("a.*").excludeByDefault().build())
+            .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void includeKeyWithRenameAsLowCardinality() {
+        MDC.put("accountId", "123");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("accountId", spec -> spec.lowCardinality().renameTo("account.id"))
+            .build());
+
+        assertThat(context.getLowCardinalityKeyValue("account.id")).isEqualTo(KeyValue.of("account.id", "123"));
+        assertThat(context.getHighCardinalityKeyValues()).isEmpty();
+    }
+
+    @Test
+    void includeKeyNoSpecDefaultsToHighCardinalityAndOriginalName() {
+        MDC.put("accountId", "123");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder().includeKey("accountId").build());
+
+        assertThat(context.getHighCardinalityKeyValue("accountId")).isEqualTo(KeyValue.of("accountId", "123"));
+        assertThat(context.getLowCardinalityKeyValues()).isEmpty();
+    }
+
+    @Test
+    void exactRuleWinsOverRegexRuleThatWouldAlsoMatch() {
+        MDC.put("foobar", "1");
+        MDC.put("fooX", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .excludeKey("foobar")
+            .includeKeysMatching("foo(.*)", spec -> spec.renameTo("Foo$1"))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("FooX")).isEqualTo(KeyValue.of("FooX", "2"));
+        // "foobar" is excluded by the exact rule even though it matches "foo(.*)"
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getValue).doesNotContain("1");
+    }
+
+    @Test
+    void duplicateExactKeyFirstRuleWins() {
+        MDC.put("k", "v");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("k", MdcToKeyValuesObservationFilter.ExactKeySpec::lowCardinality)
+            .excludeKey("k")
+            .build());
+
+        assertThat(context.getLowCardinalityKeyValue("k")).isEqualTo(KeyValue.of("k", "v"));
+        assertThat(context.getHighCardinalityKeyValues()).isEmpty();
+    }
+
+    @Test
+    void excludeKeysMatchingDropsMatchingKeys() {
+        MDC.put("foobarbaz1", "a");
+        MDC.put("other", "b");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .excludeKeysMatching("foobarbaz.*")
+            .includeByDefault()
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("other")).isEqualTo(KeyValue.of("other", "b"));
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getKey).doesNotContain("foobarbaz1");
+    }
+
+    @Test
+    void regexRenameBackReferenceAndFullMatchAnchoring() {
+        MDC.put("fooXYZ", "1");
+        MDC.put("xfooXYZ", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKeysMatching("foo(.*)", spec -> spec.renameTo("Foo$1"))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("FooXYZ")).isEqualTo(KeyValue.of("FooXYZ", "1"));
+        // "xfooXYZ" does not fully match "foo(.*)"
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getValue).doesNotContain("2");
+    }
+
+    @Test
+    void includeByDefaultWithRenameUsing() {
+        MDC.put("tenant", "t");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeByDefault(spec -> spec.renameUsing(key -> "other." + key))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("other.tenant")).isEqualTo(KeyValue.of("other.tenant", "t"));
+    }
+
+    @Test
+    void excludeByDefaultDropsUnmatchedKeys() {
+        MDC.put("a", "1");
+        MDC.put("b", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder().includeKey("a").excludeByDefault().build());
+
+        assertThat(context.getHighCardinalityKeyValue("a")).isEqualTo(KeyValue.of("a", "1"));
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getKey).doesNotContain("b");
+    }
+
+    @Test
+    void keyMatchingNoRuleIsDropped() {
+        MDC.put("a", "1");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder().includeKey("b").build());
+
+        assertThat(context.getAllKeyValues()).isEmpty();
+    }
+
+    @Test
+    void exactKeysOnlyFastPathSkipsExcludedAndUnconfiguredKeys() {
+        MDC.put("a", "1");
+        MDC.put("b", "2");
+        MDC.put("c", "3");
+
+        // Only exact rules + (default) exclude-by-default -> the per-key lookup
+        // fast-path.
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder().includeKey("a").excludeKey("b").build());
+
+        assertThat(context.getHighCardinalityKeyValue("a")).isEqualTo(KeyValue.of("a", "1"));
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getKey).doesNotContain("b", "c");
+    }
+
+    @Test
+    void emptyMdcLeavesContextUnchanged() {
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder().includeByDefault().build());
+
+        assertThat(context.getAllKeyValues()).isEmpty();
+    }
+
+    @Test
+    void lowCardinalityRouting() {
+        MDC.put("a", "1");
+        MDC.put("b", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("a", MdcToKeyValuesObservationFilter.ExactKeySpec::lowCardinality)
+            .includeByDefault()
+            .build());
+
+        assertThat(context.getLowCardinalityKeyValue("a")).isEqualTo(KeyValue.of("a", "1"));
+        assertThat(context.getHighCardinalityKeyValue("b")).isEqualTo(KeyValue.of("b", "2"));
+    }
+
+    @Test
+    void renameCollisionKeepsSingleEntry() {
+        MDC.put("a", "1");
+        MDC.put("b", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("a", spec -> spec.renameTo("same"))
+            .includeKey("b", spec -> spec.renameTo("same"))
+            .build());
+
+        KeyValue keyValue = context.getHighCardinalityKeyValue("same");
+        assertThat(keyValue).isNotNull();
+        // iteration order of the MDC map is not guaranteed, so either value may win
+        assertThat(keyValue.getValue()).isIn("1", "2");
+        assertThat(context.getHighCardinalityKeyValues()).hasSize(1);
+    }
+
+    @Test
+    void builderEnforcesPhaseOrdering() {
+        // key rules cannot follow keysMatching rules
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().includeKeysMatching("a.*").includeKey("b"))
+            .isInstanceOf(IllegalStateException.class);
+
+        // keysMatching rules cannot follow the default rule
+        assertThatThrownBy(
+                () -> MdcToKeyValuesObservationFilter.builder().includeByDefault().includeKeysMatching("a.*"))
+            .isInstanceOf(IllegalStateException.class);
+
+        // key rules cannot follow the default rule
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().excludeByDefault().excludeKey("b"))
+            .isInstanceOf(IllegalStateException.class);
+
+        // the default rule may only be declared once
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().includeByDefault().excludeByDefault())
+            .isInstanceOf(IllegalStateException.class);
+
+        // a valid in-order chain builds successfully
+        MdcToKeyValuesObservationFilter.builder()
+            .includeKey("a")
+            .excludeKey("b")
+            .includeKeysMatching("c.*")
+            .excludeKeysMatching("d.*")
+            .includeByDefault()
+            .build();
+    }
+
+    @Test
+    void renameUsingOnExactKey() {
+        MDC.put("accountId", "123");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("accountId", spec -> spec.renameUsing(String::toUpperCase))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("ACCOUNTID")).isEqualTo(KeyValue.of("ACCOUNTID", "123"));
+    }
+
+    @Test
+    void renameUsingOnKeysMatching() {
+        MDC.put("fooBar", "1");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKeysMatching("foo.*", spec -> spec.renameUsing(key -> "mdc." + key))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("mdc.fooBar")).isEqualTo(KeyValue.of("mdc.fooBar", "1"));
+    }
+
+    @Test
+    void renameUsingOnDefault() {
+        MDC.put("tenant", "t");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeByDefault(spec -> spec.renameUsing(key -> key + ".value"))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("tenant.value")).isEqualTo(KeyValue.of("tenant.value", "t"));
+    }
+
+    @Test
+    void renameUsingWinsWhenCalledAfterRenameTo() {
+        MDC.put("accountId", "123");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("accountId", spec -> spec.renameTo("ignored").renameUsing(String::toUpperCase))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("ACCOUNTID")).isEqualTo(KeyValue.of("ACCOUNTID", "123"));
+        assertThat(context.getHighCardinalityKeyValue("ignored")).isNull();
+    }
+
+    @Test
+    void renameToWinsWhenCalledAfterRenameUsing() {
+        MDC.put("accountId", "123");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKey("accountId", spec -> spec.renameUsing(String::toUpperCase).renameTo("account.id"))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("account.id")).isEqualTo(KeyValue.of("account.id", "123"));
+        assertThat(context.getHighCardinalityKeyValue("ACCOUNTID")).isNull();
+    }
+
+    @Test
+    @SuppressWarnings("NullAway")
+    void renameUsingNullThrows() {
+        assertThatThrownBy(
+                () -> MdcToKeyValuesObservationFilter.builder().includeKey("a", spec -> spec.renameUsing(null)).build())
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void includeKeysMatchingPredicate() {
+        MDC.put("fooBar", "1");
+        MDC.put("baz", "2");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKeysMatching(key -> key.startsWith("foo"),
+                    spec -> spec.lowCardinality().renameUsing(key -> "mdc." + key))
+            .build());
+
+        assertThat(context.getLowCardinalityKeyValue("mdc.fooBar")).isEqualTo(KeyValue.of("mdc.fooBar", "1"));
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getValue).doesNotContain("2");
+    }
+
+    @Test
+    void excludeKeysMatchingPredicateThenIncludeByDefault() {
+        MDC.put("secret.token", "x");
+        MDC.put("tenant", "t");
+
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .excludeKeysMatching(key -> key.startsWith("secret."))
+            .includeByDefault()
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("tenant")).isEqualTo(KeyValue.of("tenant", "t"));
+        assertThat(context.getAllKeyValues()).extracting(KeyValue::getKey).doesNotContain("secret.token");
+    }
+
+    @Test
+    void regexAndPredicateMatchingRulesEvaluateInOrder() {
+        MDC.put("fooBar", "1");
+
+        // The regex rule is declared first, so it wins over the later predicate rule.
+        Context context = runWith(MdcToKeyValuesObservationFilter.builder()
+            .includeKeysMatching("foo(.*)", spec -> spec.renameTo("regex.$1"))
+            .includeKeysMatching(key -> key.startsWith("foo"), spec -> spec.renameUsing(key -> "predicate." + key))
+            .build());
+
+        assertThat(context.getHighCardinalityKeyValue("regex.Bar")).isEqualTo(KeyValue.of("regex.Bar", "1"));
+        assertThat(context.getHighCardinalityKeyValue("predicate.fooBar")).isNull();
+    }
+
+    @Test
+    void cachedKeyResolutionResolvesOncePerKey() {
+        // A deliberately non-deterministic renamer lets us observe whether the regex rule
+        // is re-resolved for a recurring key. With the cache on it should resolve once.
+        AtomicInteger invocations = new AtomicInteger();
+        MdcToKeyValuesObservationFilter filter = MdcToKeyValuesObservationFilter.builder()
+            .includeKeysMatching("foo.*", spec -> spec.renameUsing(key -> key + "-" + invocations.incrementAndGet()))
+            .build();
+        this.registry.observationConfig().observationFilter(filter);
+        MDC.put("fooX", "v");
+
+        Context first = new Context();
+        Observation.start("a", () -> first, this.registry).stop();
+        Context second = new Context();
+        Observation.start("b", () -> second, this.registry).stop();
+
+        assertThat(invocations.get()).isEqualTo(1);
+        assertThat(first.getHighCardinalityKeyValue("fooX-1")).isEqualTo(KeyValue.of("fooX-1", "v"));
+        assertThat(second.getHighCardinalityKeyValue("fooX-1")).isEqualTo(KeyValue.of("fooX-1", "v"));
+    }
+
+    @Test
+    void disabledKeyResolutionCacheReResolvesEachTime() {
+        AtomicInteger invocations = new AtomicInteger();
+        MdcToKeyValuesObservationFilter filter = MdcToKeyValuesObservationFilter.builder()
+            .keyResolutionCache(spec -> spec.enabled(false))
+            .includeKeysMatching("foo.*", spec -> spec.renameUsing(key -> key + "-" + invocations.incrementAndGet()))
+            .build();
+        this.registry.observationConfig().observationFilter(filter);
+        MDC.put("fooX", "v");
+
+        Context first = new Context();
+        Observation.start("a", () -> first, this.registry).stop();
+        Context second = new Context();
+        Observation.start("b", () -> second, this.registry).stop();
+
+        assertThat(invocations.get()).isEqualTo(2);
+        assertThat(first.getHighCardinalityKeyValue("fooX-1")).isEqualTo(KeyValue.of("fooX-1", "v"));
+        assertThat(second.getHighCardinalityKeyValue("fooX-2")).isEqualTo(KeyValue.of("fooX-2", "v"));
+    }
+
+    @Test
+    void boundedCacheResolvesUncachedKeysEachTimeWhenFull() {
+        AtomicInteger invocations = new AtomicInteger();
+        MdcToKeyValuesObservationFilter filter = MdcToKeyValuesObservationFilter.builder()
+            .keyResolutionCache(spec -> spec.maxSize(1))
+            .includeKeysMatching("foo.*", spec -> spec.renameUsing(key -> key + "-" + invocations.incrementAndGet()))
+            .build();
+        this.registry.observationConfig().observationFilter(filter);
+
+        // The single cache slot is filled by "fooA".
+        MDC.put("fooA", "a");
+        Context c1 = new Context();
+        Observation.start("o1", () -> c1, this.registry).stop();
+        assertThat(invocations.get()).isEqualTo(1);
+        assertThat(c1.getHighCardinalityKeyValue("fooA-1")).isEqualTo(KeyValue.of("fooA-1", "a"));
+
+        // "fooB" cannot be cached (cache full) and is resolved on every observation,
+        // while
+        // "fooA" is still served from the cache.
+        MDC.put("fooB", "b");
+        Context c2 = new Context();
+        Observation.start("o2", () -> c2, this.registry).stop();
+        Context c3 = new Context();
+        Observation.start("o3", () -> c3, this.registry).stop();
+
+        assertThat(c2.getHighCardinalityKeyValue("fooA-1")).isEqualTo(KeyValue.of("fooA-1", "a"));
+        assertThat(c3.getHighCardinalityKeyValue("fooA-1")).isEqualTo(KeyValue.of("fooA-1", "a"));
+        assertThat(c2.getHighCardinalityKeyValue("fooB-2")).isEqualTo(KeyValue.of("fooB-2", "b"));
+        assertThat(c3.getHighCardinalityKeyValue("fooB-3")).isEqualTo(KeyValue.of("fooB-3", "b"));
+        assertThat(invocations.get()).isEqualTo(3);
+    }
+
+    @Test
+    void keyResolutionCacheMaxSizeMustBePositive() {
+        assertThatThrownBy(() -> MdcToKeyValuesObservationFilter.builder().keyResolutionCache(spec -> spec.maxSize(0)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds a reusable [`ObservationFilter`](https://github.com/micrometer-metrics/micrometer/blob/64e9a2697e16d0bb77cdc06a6859c0fceddabfab/micrometer-observation/src/main/java/io/micrometer/observation/ObservationFilter.java) that copies entries from the [slf4j **MDC** (Mapped Diagnostic Context)](https://www.slf4j.org/api/org/slf4j/MDC.html) into the [`Observation.Context`](https://github.com/micrometer-metrics/micrometer/blob/64e9a2697e16d0bb77cdc06a6859c0fceddabfab/micrometer-observation/src/main/java/io/micrometer/observation/Observation.java#L1004-L1345) as low or high cardinality [`KeyValue`](https://github.com/micrometer-metrics/micrometer/blob/64e9a2697e16d0bb77cdc06a6859c0fceddabfab/micrometer-commons/src/main/java/io/micrometer/common/KeyValue.java)s. This lets contextual logging data (request id, tenant, account, …) flow into metrics and traces without custom Observation instrumentation.

I find this helpful when adding observations to existing applications where the MDC is already well-instrumented for logging. For example, say that an application does not generate log messages for certain requests, but does generate metrics and spans. In this case, it is helpful to include certain MDC values in Spans, since no log messages containing the MDC values exist. Additionally, even if there were log messages, it is sometimes helpful to include the additional context in Spans so that they can be queried directly in the tracing backend.

Micrometer ships no production `ObservationFilter` implementation today, so users have to roll their own. This provides a configurable, well-tested one for a common use case.

## What it does

Which MDC keys are copied, the cardinality at which they are added, and whether they are renamed is configured through a fluent `Builder` using an **ordered, first-match-wins** set of rules. Rules are declared in three phases, enforced at runtime:

1. **exact key** rules: `includeKey` / `excludeKey`
2. **matching** rules: `includeKeysMatching` / `excludeKeysMatching`, by regular expression or `Predicate<String>`
3. a single optional **catch-all default**: `includeByDefault` / `excludeByDefault`

`build()` throws `IllegalStateException` unless at least one include rule is declared (otherwise the filter would copy nothing).

Per-rule you can control:

- **cardinality**: high by default, `lowCardinality()` to opt in to low
- **renaming**:
  - `renameTo(...)`: a literal name for exact keys, a `$`-group back-reference replacement template for regular expressions
  - `renameUsing(UnaryOperator<String>)`: custom logic applied to the original key (the only rename option for predicate and default rules, which can match many keys)
  - `renameTo` and `renameUsing` are mutually exclusive, last call wins

### Example

```java
MdcToKeyValuesObservationFilter filter = MdcToKeyValuesObservationFilter.builder()
    // include a specific high-cardinality key, without renaming it
    .includeKey("order.id")
    // include a specific high-cardinality key and rename it
    .includeKey("accountId", spec -> spec.renameTo("account.id"))
    // include a specific low-cardinality key
    .includeKey("tenant", spec -> spec.lowCardinality())
    // exclude keys that would otherwise be included by later rules
    .excludeKey("foobar")
    .excludeKeysMatching("foobarbaz.*")
    // include by regex, renaming with back-references
    .includeKeysMatching("foo(.*)", spec -> spec.renameTo("Foo$1"))
    // include by predicate
    .includeKeysMatching(key -> key.startsWith("order"))
    // include everything else, renamed
    .includeByDefault(spec -> spec.renameUsing(key -> "mdc." + key))
    .build();

registry.observationConfig().observationFilter(filter);
```

## Design decisions

- **Ordered, first-match-wins rules**: precedence between overlapping rules (e.g. an exclude vs a broad include) needs to be obvious. An explicit order with first-match-wins makes the outcome for any key easy to reason about, rather than implicit priorities between rule kinds.
- **Three enforced phases (exact → matching → default), checked at runtime**: a fixed phase order keeps configurations readable and, crucially, lets an exact-key match short-circuit the regex/predicate scan (see the fast path below). The order is enforced with runtime `IllegalStateException`s from a single `Builder` type rather than a compile-time staged-builder interface chain, which would multiply the API surface for little gain; a unit test covers the enforcement.
- **High cardinality is the default**: MDC values are frequently unbounded (request id, account id), so high cardinality is the safe default; `lowCardinality()` is an explicit opt-in. Internally this is a `lowCardinality` boolean so the safe default coincides with the Java default (`false`).
- **`Consumer<…Spec>` arguments instead of parameter-heavy overloads**: each rule has several optional facets (cardinality, rename-to-literal, rename-via-template, rename-via-function). Expressing those as method parameters would mean either a combinatorial set of overloads or long positional argument lists (e.g. `includeKey(key, lowCardinality, renameTemplate, renamer)`) that are easy to misread and brittle as options grow. A single `Consumer<…Spec>` lets callers set only what they need fluently, keeps the method signatures stable when new options are added, and avoids ambiguous positional booleans. It also lets each rule kind expose its own spec type, so the compiler only offers the options that are valid for that kind (e.g. a predicate rule's spec has no `renameTo`).
- **Per-rule-kind rename specs**: exact keys accept a literal `renameTo`, regex keys accept a `$`-back-reference `renameTo`, while predicate and default rules accept only `renameUsing`. A predicate/default rule can match many keys, so a literal `renameTo` would collapse them all onto one name (last-write-wins), almost never the intent, whereas `renameUsing` renames each key individually. `renameTo`/`renameUsing` are mutually exclusive (last call wins) to avoid an ambiguous combined state.
- **At least one include rule is required**: a filter with only excludes (or no rules) copies nothing, which is almost certainly a misconfiguration, so `build()` fails fast instead of silently producing a no-op filter.
- **Read MDC directly via `org.slf4j.MDC`, slf4j optional**: rather than a pluggable value supplier. This keeps the common case simple and matches how the module already declares optional integrations; the dependency stays optional so non-MDC users pay nothing.
- **Caching assumes pure rule functions**: the key-resolution cache and the renamed-key memoization rely on predicates and rename functions being pure functions of the key. This is documented on the relevant methods; it is what makes per-key memoization correct.
- **Cache is bounded and on by default**: MDC-key cardinality is assumed low, so caching helps and a small bound protects memory if that assumption is wrong; it can be resized or disabled for genuinely high-cardinality keys.

## Performance

- **O(1) exact-key fast path**: when no rule could include any key other than the configured exact keys, the filter reads only those keys via `MDC.get(...)` instead of copying the whole MDC map.
- **Bounded key-resolution cache**: resolution of regex/predicate/default rules for a given MDC key is a pure function of the key, so it is memoized (on by default, size-bounded). Tunable or disablable via `keyResolutionCache(spec -> spec.enabled(...).maxSize(...))` for high MDC-key cardinality.

## Caveats

- **Only the MDC visible at stop time is copied**: the filter runs when the observation is stopped, so it sees only the MDC entries present at that moment. If the observed code populates the MDC and then removes those entries before the observation stops (e.g. a key set and cleared inside the observed scope), those values are no longer visible and cannot be copied.
- **Runs synchronously on the stopping thread**: rules, predicates, and rename functions execute on the thread that stops the observation, so they must be cheap and must not throw.
- **Rule functions should be pure**: predicates and rename functions may be memoized by the key-resolution cache, so a non-pure function (one that depends on changing state) can yield stale or surprising results for a recurring key. Disable the cache if you truly need per-observation evaluation.
- **Rename collisions are order-dependent**: if two MDC entries rename to the same key, the later one overwrites the earlier, but MDC iteration order is non-deterministic, so which one wins is unspecified.

## Build / packaging

- `slf4j-api` is added as an **optional** dependency (and an optional OSGi `Import-Package`), matching how `contextPropagation`, `javax.servletApi`, and `aspectjrt` are declared. The filter reads MDC directly via `org.slf4j.MDC`.
- A checkstyle suppression is added for the new file, since the project bans `org.slf4j.*` imports by default (same mechanism already used for `MeterRegistryLoggingTest`).

## Testing

`MdcToKeyValuesObservationFilterTests` drives the filter through a real `ObservationRegistry` / `Observation.start(...).stop()` flow and covers: rule ordering and first-match-wins, exact/regex/predicate/default include & exclude, cardinality routing, `renameTo` (literal + back-reference) and `renameUsing` (including last-call-wins and null handling), the exact-key fast path, the key-resolution cache (hit, disabled, and bounded/full behavior), builder phase enforcement, and the "no include rule" build failure.

`./gradlew check` passes (tests, NullAway, checkstyle, license, formatting, and a clean japicmp, since the change is purely additive).
