### PR TITLE
Add milestones and grouping to isolated Dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,17 +31,23 @@ updates:
     schedule:
       interval: daily
     target-branch: "1.16.x"
+    milestone: 296
     ignore:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      jersey:
+        patterns:
+          - "org.glassfish.jersey.*"
     open-pull-requests-limit: 10
   - package-ecosystem: gradle
     directory: "/samples/micrometer-samples-jooq"
     schedule:
       interval: daily
     target-branch: "1.16.x"
+    milestone: 296
     ignore:
       - dependency-name: "*"
         update-types:
@@ -74,17 +80,23 @@ updates:
     schedule:
       interval: daily
     target-branch: "1.17.x"
+    milestone: 317
     ignore:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
           - version-update:semver-minor
+    groups:
+      jersey:
+        patterns:
+          - "org.glassfish.jersey.*"
     open-pull-requests-limit: 10
   - package-ecosystem: gradle
     directory: "/samples/micrometer-samples-jooq"
     schedule:
       interval: daily
     target-branch: "1.17.x"
+    milestone: 317
     ignore:
       - dependency-name: "*"
         update-types:
@@ -96,6 +108,7 @@ updates:
     schedule:
       interval: daily
     target-branch: "1.17.x"
+    milestone: 317
     ignore:
       - dependency-name: "*"
         update-types:
@@ -123,16 +136,22 @@ updates:
     schedule:
       interval: daily
     target-branch: "main"
+    milestone: 337
     ignore:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+    groups:
+      jersey:
+        patterns:
+          - "org.glassfish.jersey.*"
     open-pull-requests-limit: 10
   - package-ecosystem: gradle
     directory: "/samples/micrometer-samples-jooq"
     schedule:
       interval: daily
     target-branch: "main"
+    milestone: 337
     ignore:
       - dependency-name: "*"
         update-types:
@@ -143,6 +162,7 @@ updates:
     schedule:
       interval: daily
     target-branch: "main"
+    milestone: 337
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
This configures milestones for all isolated subdirectory package-ecosystems to match the milestones of their respective branches (1.16.x, 1.17.x, main). It also adds grouping rules for Jersey 3 dependencies in the micrometer-samples-jersey3 subdirectory to ensure they are updated together in a single pull request instead of multiple individual ones.

Follow-up for #7632 