### PR TITLE
Fix ineffective ExemplarSampler cache in DefaultExemplarSamplerFactory

### DIFF
--- a/implementations/micrometer-registry-prometheus/build.gradle
+++ b/implementations/micrometer-registry-prometheus/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation libs.restAssured
     testImplementation libs.testcontainers.junitJupiter
     testImplementation libs.awaitility
+    testImplementation libs.mockitoCore5
 }
 
 dockerTest {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -20,6 +20,7 @@ import io.prometheus.metrics.core.exemplars.ExemplarSampler;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfig;
 import io.prometheus.metrics.tracer.common.SpanContext;
 
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -34,8 +35,7 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
 
     private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
 
-    @SuppressWarnings("ArrayAsKeyOfSetOrMap")
-    private final ConcurrentMap<double[], ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
+    private final ConcurrentMap<DoubleArrayKey, ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
 
     private final SpanContext spanContext;
 
@@ -54,8 +54,38 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
     @Override
     public ExemplarSampler createExemplarSampler(double[] histogramUpperBounds) {
         ExemplarSamplerConfig config = exemplarSamplerConfigsByHistogramUpperBounds.computeIfAbsent(
-                histogramUpperBounds, key -> new ExemplarSamplerConfig(exemplarsProperties, histogramUpperBounds));
+                new DoubleArrayKey(histogramUpperBounds), key -> new ExemplarSamplerConfig(exemplarsProperties, histogramUpperBounds));
         return new ExemplarSampler(config, spanContext);
+    }
+
+    private static final class DoubleArrayKey {
+
+        private final double[] array;
+
+        private final int hashCode;
+
+        private DoubleArrayKey(double[] array) {
+            this.array = array;
+            this.hashCode = Arrays.hashCode(array);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            DoubleArrayKey that = (DoubleArrayKey) o;
+            return Arrays.equals(array, that.array);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -35,7 +35,8 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
 
     private final ConcurrentMap<Integer, ExemplarSamplerConfig> exemplarSamplerConfigsByNumberOfExemplars = new ConcurrentHashMap<>();
 
-    private final ConcurrentMap<DoubleArrayKey, ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
+    // VisibleForTesting
+    final ConcurrentMap<DoubleArrayKey, ExemplarSamplerConfig> exemplarSamplerConfigsByHistogramUpperBounds = new ConcurrentHashMap<>();
 
     private final SpanContext spanContext;
 
@@ -54,7 +55,8 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
     @Override
     public ExemplarSampler createExemplarSampler(double[] histogramUpperBounds) {
         ExemplarSamplerConfig config = exemplarSamplerConfigsByHistogramUpperBounds.computeIfAbsent(
-                new DoubleArrayKey(histogramUpperBounds), key -> new ExemplarSamplerConfig(exemplarsProperties, histogramUpperBounds));
+                new DoubleArrayKey(histogramUpperBounds),
+                key -> new ExemplarSamplerConfig(exemplarsProperties, histogramUpperBounds));
         return new ExemplarSampler(config, spanContext);
     }
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactoryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheusmetrics;
+
+import io.prometheus.metrics.config.ExemplarsProperties;
+import io.prometheus.metrics.config.PrometheusPropertiesLoader;
+import io.prometheus.metrics.tracer.common.SpanContext;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultExemplarSamplerFactoryTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void exemplarSamplerConfigsByHistogramUpperBoundsCacheIsEffective() throws Exception {
+        SpanContext spanContext = (SpanContext) Proxy.newProxyInstance(
+                SpanContext.class.getClassLoader(),
+                new Class<?>[]{SpanContext.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("equals")) {
+                        return proxy == args[0];
+                    }
+                    if (method.getName().equals("hashCode")) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if (method.getReturnType().equals(String.class)) {
+                        return "";
+                    }
+                    if (method.getReturnType().equals(boolean.class)) {
+                        return false;
+                    }
+                    return null;
+                }
+        );
+
+        ExemplarsProperties properties = PrometheusPropertiesLoader.load().getExemplarProperties();
+        DefaultExemplarSamplerFactory factory = new DefaultExemplarSamplerFactory(spanContext, properties);
+
+        double[] bounds1 = new double[]{1.0, 2.0, 5.0, Double.POSITIVE_INFINITY};
+        double[] bounds2 = new double[]{1.0, 2.0, 5.0, Double.POSITIVE_INFINITY};
+
+        // Create exemplar samplers with two different array instances having the same values
+        factory.createExemplarSampler(bounds1);
+        factory.createExemplarSampler(bounds2);
+
+        Field field = DefaultExemplarSamplerFactory.class.getDeclaredField("exemplarSamplerConfigsByHistogramUpperBounds");
+        field.setAccessible(true);
+        Map<?, ?> map = (Map<?, ?>) field.get(factory);
+
+        // If the cache is effective, there should only be 1 entry in the map
+        assertThat(map).hasSize(1);
+    }
+}

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactoryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactoryTest.java
@@ -20,52 +20,25 @@ import io.prometheus.metrics.config.PrometheusPropertiesLoader;
 import io.prometheus.metrics.tracer.common.SpanContext;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Proxy;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DefaultExemplarSamplerFactoryTest {
 
     @Test
-    @SuppressWarnings("unchecked")
-    void exemplarSamplerConfigsByHistogramUpperBoundsCacheIsEffective() throws Exception {
-        SpanContext spanContext = (SpanContext) Proxy.newProxyInstance(
-                SpanContext.class.getClassLoader(),
-                new Class<?>[]{SpanContext.class},
-                (proxy, method, args) -> {
-                    if (method.getName().equals("equals")) {
-                        return proxy == args[0];
-                    }
-                    if (method.getName().equals("hashCode")) {
-                        return System.identityHashCode(proxy);
-                    }
-                    if (method.getReturnType().equals(String.class)) {
-                        return "";
-                    }
-                    if (method.getReturnType().equals(boolean.class)) {
-                        return false;
-                    }
-                    return null;
-                }
-        );
-
+    void exemplarSamplerConfigsByHistogramUpperBoundsCacheIsEffective() {
         ExemplarsProperties properties = PrometheusPropertiesLoader.load().getExemplarProperties();
-        DefaultExemplarSamplerFactory factory = new DefaultExemplarSamplerFactory(spanContext, properties);
+        DefaultExemplarSamplerFactory factory = new DefaultExemplarSamplerFactory(mock(SpanContext.class), properties);
 
-        double[] bounds1 = new double[]{1.0, 2.0, 5.0, Double.POSITIVE_INFINITY};
-        double[] bounds2 = new double[]{1.0, 2.0, 5.0, Double.POSITIVE_INFINITY};
+        double[] bounds1 = new double[] { 1.0, 2.0, 5.0, Double.POSITIVE_INFINITY };
+        double[] bounds2 = new double[] { 1.0, 2.0, 5.0, Double.POSITIVE_INFINITY };
 
-        // Create exemplar samplers with two different array instances having the same values
+        // Create samplers with two different array instances having the same values
         factory.createExemplarSampler(bounds1);
         factory.createExemplarSampler(bounds2);
 
-        Field field = DefaultExemplarSamplerFactory.class.getDeclaredField("exemplarSamplerConfigsByHistogramUpperBounds");
-        field.setAccessible(true);
-        Map<?, ?> map = (Map<?, ?>) field.get(factory);
-
         // If the cache is effective, there should only be 1 entry in the map
-        assertThat(map).hasSize(1);
+        assertThat(factory.exemplarSamplerConfigsByHistogramUpperBounds).hasSize(1);
     }
+
 }


### PR DESCRIPTION
Fix ineffective `ExemplarSampler` cache in `DefaultExemplarSamplerFactory`.

Wrap `double[]` in a value-based `DoubleArrayKey` to ensure that `equals()` and `hashCode()` compare array elements rather than array identities.