### PR TITLE
  Fix Kotlin nullable value support in CaffeineCacheMetrics

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -80,8 +80,8 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
      * @return The instrumented cache, unchanged. The original cache is not wrapped or
      * proxied in any way.
      */
-    public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, String cacheName,
-            String... tags) {
+    public static <K, V extends @Nullable Object, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache,
+            String cacheName, String... tags) {
         return monitor(registry, cache, cacheName, Tags.of(tags));
     }
 
@@ -99,8 +99,8 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
      * proxied in any way.
      * @see CacheStats
      */
-    public static <K, V, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache, String cacheName,
-            Iterable<Tag> tags) {
+    public static <K, V extends @Nullable Object, C extends Cache<K, V>> C monitor(MeterRegistry registry, C cache,
+            String cacheName, Iterable<Tag> tags) {
         new CaffeineCacheMetrics<>(cache, cacheName, tags).bindTo(registry);
         return cache;
     }
@@ -119,8 +119,8 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
      * @return The instrumented cache, unchanged. The original cache is not wrapped or
      * proxied in any way.
      */
-    public static <K, V, C extends AsyncCache<K, V>> C monitor(MeterRegistry registry, C cache, String cacheName,
-            String... tags) {
+    public static <K, V extends @Nullable Object, C extends AsyncCache<K, V>> C monitor(MeterRegistry registry, C cache,
+            String cacheName, String... tags) {
         return monitor(registry, cache, cacheName, Tags.of(tags));
     }
 
@@ -138,8 +138,8 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
      * proxied in any way.
      * @see CacheStats
      */
-    public static <K, V, C extends AsyncCache<K, V>> C monitor(MeterRegistry registry, C cache, String cacheName,
-            Iterable<Tag> tags) {
+    public static <K, V extends @Nullable Object, C extends AsyncCache<K, V>> C monitor(MeterRegistry registry, C cache,
+            String cacheName, Iterable<Tag> tags) {
         monitor(registry, cache.synchronous(), cacheName, tags);
         return cache;
     }

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsKtTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.binder.cache
+
+import com.github.benmanes.caffeine.cache.AsyncCache
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+
+class CaffeineCacheMetricsKtTests {
+
+    @Test
+    fun shouldAcceptKotlinNullableCacheValueType() {
+        val cache: Cache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().build()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache")
+    }
+
+    @Test
+    fun shouldAcceptKotlinNullableAsyncCacheValueType() {
+        val cache: AsyncCache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().buildAsync()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache")
+    }
+
+    private class FSCacheValue
+}

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsKtTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.binder.cache
+
+import com.github.benmanes.caffeine.cache.AsyncCache
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+
+class CaffeineCacheMetricsKtTests {
+
+    @Test
+    fun shouldAcceptKotlinNullableCacheValueType() {
+        val cache: Cache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().build()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache")
+    }
+
+    @Test
+    fun shouldAcceptKotlinNullableCacheValueTypeWithIterableTags() {
+        val cache: Cache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().build()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache", Tags.empty())
+    }
+
+    @Test
+    fun shouldAcceptKotlinNullableAsyncCacheValueType() {
+        val cache: AsyncCache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().buildAsync()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache")
+    }
+
+    @Test
+    fun shouldAcceptKotlinNullableAsyncCacheValueTypeWithIterableTags() {
+        val cache: AsyncCache<String, FSCacheValue?> = Caffeine.newBuilder().recordStats().buildAsync()
+
+        CaffeineCacheMetrics.monitor(SimpleMeterRegistry(), cache, "cache", Tags.empty())
+    }
+
+    private class FSCacheValue
+}


### PR DESCRIPTION
Fixes #7582.

The CaffeineCacheMetrics class allows nullable cache value types through its
`V extends @Nullable Object` bound, but its four static monitor overloads
still declared an unbounded `V`.

Because the cache binder package is `@NullMarked`, Kotlin treats those
method-level value types as non-null. As a result, `Cache<K, V?>` and
`AsyncCache<K, V?>` could not be passed to CaffeineCacheMetrics.monitor(...)
without an unchecked cast.

This change aligns the generic bounds of all `Cache` and `AsyncCache`
monitor overloads with the class-level declaration. It does not change the
method bodies, return types, or meter registration behavior.

A Kotlin regression test verifies compile compatibility for nullable value
types in both synchronous and asynchronous Caffeine caches.

Tests:

* ./gradlew :micrometer-core:compileTestKotlin
* ./gradlew :micrometer-core:test --tests '*CaffeineCacheMetrics*'
* ./gradlew :micrometer-core:test
* ./gradlew :micrometer-core:spotlessCheck