### PR TITLE
Move fixed dependency versions to gradle.properties to hide them from Dependabot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,17 +61,6 @@ apply plugin: 'io.github.gradle-nexus.publish-plugin'
 allprojects {
     group = 'io.micrometer'
     ext.'release.stage' = releaseStage ?: 'SNAPSHOT'
-    // Legacy/older versions of dependencies are defined as ext properties here instead of
-    // the Version Catalog to prevent Dependabot from clobbering them when it upgrades
-    // the primary/newer versions in the catalog.
-    // Because Dependabot's static parser cannot resolve these dynamic Gradle variables,
-    // these versions will never be automatically upgraded. This is acceptable because
-    // these legacy versions/maintenance lines are rarely updated and can be managed manually.
-    ext.logback12Version = '1.2.13'
-    ext.jetty9Version = '9.4.58.v20250814'
-    ext.jetty11Version = '11.0.16'
-    ext.nettyBomDocsVersion = '4.2.15.Final'
-    ext.slf4j2Version = '2.0.17'
 
     afterEvaluate { project -> println "I'm configuring $project.name with version $project.version" }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,13 @@ compatibleVersion=1.15.0
 kotlin.stdlib.default.dependency=false
 
 nebula.dependencyLockPluginEnabled=false
+
+# Legacy/older versions of dependencies are defined here to hide them from Dependabot.
+# Because Dependabot's static parser does not resolve properties from gradle.properties,
+# these versions will never be automatically upgraded or clobbered.
+logback12Version=1.2.13
+jetty9Version=9.4.58.v20250814
+jetty11Version=11.0.16
+nettyBomDocsVersion=4.2.15.Final
+slf4j2Version=2.0.17
+


### PR DESCRIPTION
This moves the legacy/older dependency versions (such as logback12Version, jetty9Version, jetty11Version, nettyBomDocsVersion, and slf4j2Version) from build.gradle's ext properties block to gradle.properties.

Since Dependabot's static parser does not resolve properties defined in gradle.properties, it will completely ignore these dependencies and will never attempt to upgrade or clobber them. Gradle, on the other hand, natively resolves these properties at build time, ensuring the build remains fully functional.

See https://github.com/micrometer-metrics/micrometer/pull/7661 which proves the previous fix does not work. Hopefully this does...