### PR TITLE
Fix NullPointerException in StatsdMeterRegistryPublishTest

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/StatsdMeterRegistryPublishTest.java
@@ -401,7 +401,8 @@ class StatsdMeterRegistryPublishTest {
     }
 
     private boolean clientIsDisposed(StatsdMeterRegistry meterRegistry) {
-        return meterRegistry.statsdConnection.get().isDisposed();
+        Disposable connection = meterRegistry.statsdConnection.get();
+        return connection == null || connection.isDisposed();
     }
 
     private DisposableChannel startServer(StatsdProtocol protocol, int port, CountDownLatch serverLatch) {


### PR DESCRIPTION
Flakiness noticed in the docker tests for https://github.com/micrometer-metrics/micrometer/pull/7678

* Fixes a transient `NullPointerException` in `StatsdMeterRegistryPublishTest` (and the `clientIsDisposed` helper) by checking if the connection is `null` before invoking `.isDisposed()`.
* Under CI load, the asynchronous connection setup might not have completed when the status check runs, resulting in a `null` connection reference.

When merging forward, the same fix needs to be applied to `TelegrafStatsdLineBuilderIntegrationTest` from `1.17.x`