### PR TITLE
Remove downloadDependencies task and optimize CI dependency caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,14 @@ commands:
             echo "=== Gradle cache size (after restore) ==="
             du -sh ~/.gradle 2>/dev/null || echo "N/A"
       - run:
-          name: downloadDependencies
-          command: ./gradlew downloadDependencies --console=plain
+          name: run gradle command
+          command: ./gradlew << parameters.command >>
       - save_cache:
           key: gradle-dependencies-{{ .Branch }}-{{ checksum "build.gradle" }}-{{ checksum ".circleci/config.yml" }}
           paths:
-            - ~/.gradle
-      - run:
-          name: run gradle command
-          command: ./gradlew << parameters.command >>
+            - ~/.gradle/caches/modules-2
+            - ~/.gradle/wrapper
+          when: always
       - run:
           name: collect test reports
           when: always

--- a/build.gradle
+++ b/build.gradle
@@ -366,13 +366,6 @@ subprojects {
         kotlinSourcesJar.enabled = false
     }
 
-    tasks.register('downloadDependencies') {
-        outputs.upToDateWhen { false }
-        doLast {
-            project.configurations.findAll { it.canBeResolved }*.files
-        }
-    }
-
     // Do not publish some modules
     if (!['samples', 'benchmarks', 'micrometer-osgi-test', 'micrometer-osgi-test-slf4j2', 'concurrency-tests', 'micrometer-test-aspectj-ctw', 'micrometer-test-aspectj-ltw'].find { project.name.contains(it) }) {
         apply plugin: 'com.netflix.nebula.maven-publish'


### PR DESCRIPTION
- Removed the custom `downloadDependencies` task from `build.gradle`. This task eagerly resolved all configurations, which is fragile and can pull in unused optional dependencies (such as R8 in newer shadow plugin versions - see #7706).
- Updated `.circleci/config.yml` to remove the up-front execution of `downloadDependencies`.
- Configured CircleCI's `save_cache` step to run `when: always` after the main build command, ensuring dependencies are successfully cached even if the build fails.
- Optimized cached paths to selectively target `~/.gradle/caches/modules-2` and `~/.gradle/wrapper` to prevent cache bloat and keep the cache size minimal.
