### PR TITLE
Cache baseline JARs in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,7 @@ commands:
           paths:
             - ~/.gradle/caches/modules-2
             - ~/.gradle/wrapper
+            - ~/micrometer/build/baselineLibs
           when: always
       - run:
           name: collect test reports

--- a/build.gradle
+++ b/build.gradle
@@ -456,11 +456,11 @@ subprojects {
                     }
 
                     src "${rootUrl}io/micrometer/${project.name}/${compatibleVersion}/${project.name}-${compatibleVersion}.jar"
-                    dest layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar")
+                    dest rootProject.layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar")
                 }
 
                 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
-                    oldClasspath.from(layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar"))
+                    oldClasspath.from(rootProject.layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar"))
                     newClasspath.from(files(jar.archiveFile, project(":${project.name}").jar))
                     onlyBinaryIncompatibleModified = true
                     failOnModification = true


### PR DESCRIPTION
Fixes #7102

This moves downloaded baseline JARs into the root project's `build/baselineLibs` directory and adds that directory to the CircleCI Gradle cache. That lets CI reuse the same baseline artifacts across jobs and reruns instead of downloading them into each module's build directory every time.

Verification:
- `./gradlew :micrometer-core:downloadBaseline --dry-run`
- `./gradlew :micrometer-core:downloadBaseline`
- `./gradlew :micrometer-core:japicmp`
