### PR TITLE
Fix flakiness in JvmGcMetricsTest.gcMetricsAvailableAfterGc

### DIFF
--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetricsTest.java
@@ -78,12 +78,14 @@ class JvmGcMetricsTest {
     @Test
     void gcMetricsAvailableAfterGc() {
         binder.bindTo(registry);
-        System.gc();
         // GC notifications are posted and processed asynchronously. We must assert all
         // metrics inside the await block to avoid race conditions where some metrics are
         // not yet updated when the await block exits early (e.g. if a different GC
         // notification triggers it).
+        // We also trigger System.gc() inside the await block because generational GCs
+        // require multiple cycles to promote objects to the long-lived pool.
         await().atMost(5, TimeUnit.SECONDS).alias("NotificationListener takes time after GC").untilAsserted(() -> {
+            System.gc();
             assertThat(registry.get("jvm.gc.live.data.size").gauge().value()).isPositive();
             assertThat(registry.get("jvm.gc.memory.allocated").counter().count()).isPositive();
             assertThat(registry.get("jvm.gc.max.data.size").gauge().value()).isPositive();


### PR DESCRIPTION
## Summary
- Triggers `System.gc()` inside the `await().untilAsserted(...)` block during the `gcMetricsAvailableAfterGc` test.
- This ensures that generational GCs (like G1, Generational ZGC, and Generational Shenandoah) run multiple GC cycles as needed.
- Surviving multiple cycles allows the JVM to naturally promote existing/internal objects to the long-lived heap memory pool (e.g., Old Gen), making the `jvm.gc.live.data.size` metric positive.
- This resolves the intermittent test timeout/failure on clean JVM environments where no other tests have run yet to promote objects to the old generation, without requiring any custom memory allocation.

## Test plan
- Verified that on Generational Shenandoah (Java 25) the Old Gen is empty on the first 2 GC cycles, but naturally populates on the 3rd cycle, allowing the test to pass successfully and stably.