### PR TITLE
Add Kotlin tagsOf for pairs

### DIFF
--- a/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/Tags.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/Tags.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Tags
+
+/**
+ * Creates [Tags] from Kotlin [Pair] instances.
+ *
+ * @since 1.18.0
+ */
+fun tagsOf(vararg tags: Pair<String, String>): Tags {
+    return Tags.of(tags.map { Tag.of(it.first, it.second) })
+}

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/TagsKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/TagsKtTests.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.micrometer.core.instrument.kotlin
+
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Tags
+import org.assertj.core.api.BDDAssertions.then
+import org.junit.jupiter.api.Test
+
+internal class TagsKtTests {
+
+    @Test
+    fun `should create tags from pairs`() {
+        val tags = tagsOf("method" to "GET", "status" to "200")
+
+        then(tags).containsExactly(Tag.of("method", "GET"), Tag.of("status", "200"))
+    }
+
+    @Test
+    fun `should return empty tags when pairs are empty`() {
+        val tags = tagsOf()
+
+        then(tags).isSameAs(Tags.empty())
+    }
+
+    @Test
+    fun `should retain last pair when keys are duplicated`() {
+        val tags = tagsOf("status" to "200", "status" to "201")
+
+        then(tags).containsExactly(Tag.of("status", "201"))
+    }
+}


### PR DESCRIPTION
Fixes gh-4960

This adds a Kotlin `tagsOf` utility for creating `Tags` from `Pair<String, String>` values:

```kotlin
tagsOf("method" to "GET", "status" to "200")
```

This keeps the convenience API in Kotlin source so Java users do not see a Kotlin-specific `Pair` API on `Tags`.

Verification:
- `./gradlew :micrometer-core:spotlessKotlinCheck :micrometer-core:compileKotlin :micrometer-core:compileTestKotlin`

Note:
- `./gradlew :micrometer-core:test --tests io.micrometer.core.instrument.kotlin.TagsKtTests` currently fails before running the test due to existing NullAway errors in unrelated Java tests (`StepMeterRegistryTest` and `MeterTest`).
