### PR TITLE
Add Caffeine cache utilization metric

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetrics.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.binder.BaseUnits;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
@@ -61,7 +62,7 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
 
         if (!cache.policy().isRecordingStats()) {
             log.warn(
-                    "The cache '{}' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.",
+                    "The cache '{}' is not recording statistics. Only meters that do not require cache statistics will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.",
                     cacheName);
         }
     }
@@ -172,7 +173,23 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
     @Override
     protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
         C cache = getCache();
-        if (cache == null || !cache.policy().isRecordingStats()) {
+        if (cache == null) {
+            return;
+        }
+
+        if (utilization() != null) {
+            Gauge.builder("cache.utilization", cache, c -> {
+                Double utilization = utilization();
+                return utilization == null ? 0 : utilization;
+            })
+                .tags(getTagsWithCacheName())
+                .description(
+                        "The utilization of this cache as a percentage. This may be an approximation, depending on the type of cache.")
+                .baseUnit(BaseUnits.PERCENT)
+                .register(registry);
+        }
+
+        if (!cache.policy().isRecordingStats()) {
             return;
         }
 
@@ -200,6 +217,22 @@ public class CaffeineCacheMetrics<K, V extends @Nullable Object, C extends Cache
                 .description(DESCRIPTION_CACHE_LOAD)
                 .register(registry);
         }
+    }
+
+    private @Nullable Double utilization() {
+        C cache = getCache();
+        if (cache == null) {
+            return null;
+        }
+
+        return cache.policy().eviction().map((eviction) -> {
+            long maximum = eviction.getMaximum();
+            if (maximum == 0) {
+                return null;
+            }
+            long size = eviction.weightedSize().orElseGet(cache::estimatedSize);
+            return 100.0 * size / maximum;
+        }).orElse(null);
     }
 
     private @Nullable Long getOrDefault(Function<C, Long> function, @Nullable Long defaultValue) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/cache/CaffeineCacheMetricsTest.java
@@ -20,9 +20,11 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.testsupport.system.CapturedOutput;
@@ -102,7 +104,7 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
 
         assertThat(meterRegistry.find("cache.load.duration").timeGauge()).isNull();
         assertThat(output).doesNotContain(
-                "The cache 'testCache' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
+                "The cache 'testCache' is not recording statistics. Only meters that do not require cache statistics will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
     }
 
     @Test
@@ -123,7 +125,58 @@ class CaffeineCacheMetricsTest extends AbstractCacheMetricsTest {
         assertThat(metrics.size()).isOne();
         assertThat(meterRegistry.get("cache.size").gauge().value()).isOne();
         assertThat(output).contains(
-                "The cache 'testCache' is not recording statistics. No meters except 'cache.size' will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
+                "The cache 'testCache' is not recording statistics. Only meters that do not require cache statistics will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
+    }
+
+    @Test
+    void reportUtilizationForBoundedCache() {
+        Cache<String, String> cache = Caffeine.newBuilder().maximumSize(10).recordStats().build();
+        cache.put("a", "1");
+        cache.put("b", "2");
+
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        Gauge utilization = meterRegistry.get("cache.utilization").tags(expectedTag).gauge();
+        assertThat(utilization.value()).isEqualTo(20.0);
+        assertThat(utilization.getId().getBaseUnit()).isEqualTo(BaseUnits.PERCENT);
+    }
+
+    @Test
+    void reportUtilizationForWeightedCache() {
+        Cache<String, String> cache = Caffeine.newBuilder()
+            .maximumWeight(10)
+            .weigher((String key, String value) -> value.length())
+            .recordStats()
+            .build();
+        cache.put("a", "123");
+        cache.put("b", "12");
+
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        assertThat(meterRegistry.get("cache.utilization").tags(expectedTag).gauge().value()).isEqualTo(50.0);
+    }
+
+    @Test
+    void doesNotReportUtilizationForUnboundedCache() {
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        assertThat(meterRegistry.find("cache.utilization").tags(expectedTag).gauge()).isNull();
+    }
+
+    @Test
+    void reportUtilizationWithoutRecordStats(CapturedOutput output) {
+        Cache<String, String> cache = Caffeine.newBuilder().maximumSize(10).build();
+        cache.put("a", "1");
+
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        CaffeineCacheMetrics.monitor(meterRegistry, cache, "testCache", expectedTag);
+
+        assertThat(meterRegistry.get("cache.utilization").tags(expectedTag).gauge().value()).isEqualTo(10.0);
+        assertThat(output).contains(
+                "The cache 'testCache' is not recording statistics. Only meters that do not require cache statistics will be registered. Call 'Caffeine#recordStats()' prior to building the cache for metrics to be recorded.");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds a Caffeine-specific `cache.utilization` gauge for bounded caches.

The gauge reports the current cache utilization as a percentage using the eviction policy maximum and either the weighted size or estimated entry count.

## Details

- Registers `cache.utilization` for Caffeine caches with an eviction policy.
- Uses `BaseUnits.PERCENT` for the metric base unit.
- Keeps unbounded Caffeine caches from registering the utilization meter.
- Allows utilization to be registered even when `recordStats()` is not enabled, since the value does not depend on Caffeine statistics.

Closes #4321.

## Verification

- `./gradlew :micrometer-core:compileJava`
- `./gradlew :micrometer-core:checkFormatMain :micrometer-core:checkFormatTest`
- `./gradlew -I /private/tmp/disable-errorprone.gradle :micrometer-core:test --tests io.micrometer.core.instrument.binder.cache.CaffeineCacheMetricsTest`
- `./gradlew -I /private/tmp/disable-errorprone.gradle :micrometer-core:checkstyleMain :micrometer-core:checkstyleTest`

The targeted test and checkstyle commands used a temporary init script to disable ErrorProne because the current test compilation fails on unrelated NullAway errors in `StepMeterRegistryTest` and `MeterTest`.

AI assistance was used to draft and validate this change.
