### PR TITLE
Cache baseline JARs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -466,8 +466,6 @@ subprojects {
 
                     fieldExcludes = []
                     methodExcludes = []
-
-                    onlyIf { compatibleVersion != 'SKIP' }
                 }
 
                 tasks.check.dependsOn(japicmp)

--- a/build.gradle
+++ b/build.gradle
@@ -429,6 +429,7 @@ subprojects {
                 apply plugin: 'me.champeau.gradle.japicmp'
 
                 tasks.register('downloadBaseline') {
+                    onlyIf { !project.gradle.startParameter.isOffline() }
                     doLast {
                         String originalGroup = project.group
                         project.group = 'downloadBaseline' // hack, see: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455132296

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ buildscript {
         classpath libs.plugin.nexusPublish
         classpath libs.plugin.javaformat
         classpath libs.plugin.japicmp
-        classpath libs.plugin.downloadTask
         classpath libs.plugin.spotless
         classpath libs.plugin.bnd
 
@@ -428,38 +427,29 @@ subprojects {
 
             if (!(project.name in [])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
-                apply plugin: 'de.undercouch.download'
 
-                tasks.register("downloadBaseline", Download) {
-                    onlyIf {
-                        if (project.gradle.startParameter.isOffline()) {
-                            println 'Offline: skipping downloading of baseline and JAPICMP'
-                            return false
-                        } else if (compatibleVersion == 'SKIP') {
-                            println 'SKIP: Instructed to skip the baseline comparison'
-                            return false
-                        } else {
-                            println "Will download and perform baseline comparison with ${compatibleVersion}"
-                            return true
+                tasks.register('downloadBaseline') {
+                    doLast {
+                        String originalGroup = project.group
+                        project.group = 'downloadBaseline' // hack, see: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455132296
+                        try {
+                            Set<File> baselineFiles = configurations.detachedConfiguration(dependencies.create("${originalGroup}:${project.name}:${compatibleVersion}@jar")).files
+                            logger.info("Downloaded for baseline comparison: $baselineFiles")
+                            assert baselineFiles.size() == 1
+                            assert baselineFiles.first().name.endsWith("${project.name}-${compatibleVersion}.jar")
+                            copy {
+                                from baselineFiles.first()
+                                into layout.buildDirectory.dir('baselineLibs')
+                            }
+                        }
+                        finally {
+                            project.group = originalGroup
                         }
                     }
-
-                    onlyIfNewer true
-                    compress true
-                    String rootUrl
-                    if (compatibleVersion.contains('-M') || compatibleVersion.contains('-RC')) {
-                        rootUrl = 'https://repo.spring.io/milestone/'
-                    } else if (compatibleVersion.contains('-SNAPSHOT') ) {
-                        rootUrl = 'https://repo.spring.io/snapshot/'
-                    } else {
-                        rootUrl = repositories.mavenCentral().url
-                    }
-
-                    src "${rootUrl}io/micrometer/${project.name}/${compatibleVersion}/${project.name}-${compatibleVersion}.jar"
-                    dest layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar")
                 }
 
                 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
+                    dependsOn downloadBaseline, jar
                     oldClasspath.from(layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar"))
                     newClasspath.from(files(jar.archiveFile, project(":${project.name}").jar))
                     onlyBinaryIncompatibleModified = true
@@ -480,8 +470,6 @@ subprojects {
                     onlyIf { compatibleVersion != 'SKIP' }
                 }
 
-                tasks.japicmp.dependsOn(downloadBaseline)
-                tasks.japicmp.dependsOn(jar)
                 tasks.check.dependsOn(japicmp)
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -430,13 +430,7 @@ subprojects {
 
                 tasks.register('downloadBaseline') {
                     doLast {
-                        // Gradle 8 and earlier do not allow cycles between the current project and the root of the dependency graph
-                        // (a project cannot depend on itself, which is what we are doing here).
-                        // Since we don't use this task for the root project, we can work this limitation around by
-                        // resolving dependencies using a detached configuration of the root project instead of the current subproject.
-                        // Doing this ensures that the dependency coordinates don't collide since the root project's coordinates never match a subproject's coordinates.
-                        // See: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455135698
-                        Set<File> baselineFiles = rootProject.configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")).files
+                        Set<File> baselineFiles = configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")).files
                         logger.info("Downloaded for baseline comparison: $baselineFiles")
                         assert baselineFiles.size() == 1
                         assert baselineFiles.first().name.endsWith("${project.name}-${compatibleVersion}.jar")
@@ -503,10 +497,6 @@ subprojects {
 
     def check = tasks.findByName('check')
     if (check) project.rootProject.tasks.releaseCheck.dependsOn check
-}
-
-repositories { // for the downloadBaseline task
-    mavenCentral()
 }
 
 nexusPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -429,7 +429,6 @@ subprojects {
                 apply plugin: 'me.champeau.gradle.japicmp'
 
                 tasks.register('downloadBaseline') {
-                    onlyIf { !project.gradle.startParameter.isOffline() }
                     doLast {
                         String originalGroup = project.group
                         project.group = 'downloadBaseline' // hack, see: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455132296

--- a/build.gradle
+++ b/build.gradle
@@ -430,20 +430,19 @@ subprojects {
 
                 tasks.register('downloadBaseline') {
                     doLast {
-                        String originalGroup = project.group
-                        project.group = 'downloadBaseline' // hack, see: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455132296
-                        try {
-                            Set<File> baselineFiles = configurations.detachedConfiguration(dependencies.create("${originalGroup}:${project.name}:${compatibleVersion}@jar")).files
-                            logger.info("Downloaded for baseline comparison: $baselineFiles")
-                            assert baselineFiles.size() == 1
-                            assert baselineFiles.first().name.endsWith("${project.name}-${compatibleVersion}.jar")
-                            copy {
-                                from baselineFiles.first()
-                                into layout.buildDirectory.dir('baselineLibs')
-                            }
-                        }
-                        finally {
-                            project.group = originalGroup
+                        // Gradle 8 and earlier do not allow cycles between the current project and the root of the dependency graph
+                        // (a project cannot depend on itself, which is what we are doing here).
+                        // Since we don't use this task for the root project, we can work this limitation around by
+                        // resolving dependencies using a detached configuration of the root project instead of the current subproject.
+                        // Doing this ensures that the dependency coordinates don't collide since the root project's coordinates never match a subproject's coordinates.
+                        // See: https://github.com/melix/japicmp-gradle-plugin/issues/16#issuecomment-455135698
+                        Set<File> baselineFiles = rootProject.configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")).files
+                        logger.info("Downloaded for baseline comparison: $baselineFiles")
+                        assert baselineFiles.size() == 1
+                        assert baselineFiles.first().name.endsWith("${project.name}-${compatibleVersion}.jar")
+                        copy {
+                            from baselineFiles.first()
+                            into layout.buildDirectory.dir('baselineLibs')
                         }
                     }
                 }
@@ -504,6 +503,10 @@ subprojects {
 
     def check = tasks.findByName('check')
     if (check) project.rootProject.tasks.releaseCheck.dependsOn check
+}
+
+repositories { // for the downloadBaseline task
+    mavenCentral()
 }
 
 nexusPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -212,7 +212,6 @@ plugin-noHttp = { module = "io.spring.nohttp:nohttp-gradle", version = "0.0.11" 
 plugin-nexusPublish = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 plugin-javaformat = { module = "io.spring.javaformat:spring-javaformat-gradle-plugin", version.ref = "spring-javaformat" }
 plugin-japicmp = { module = "me.champeau.gradle:japicmp-gradle-plugin", version = "0.4.6" }
-plugin-downloadTask = { module = "de.undercouch:gradle-download-task", version = "5.7.0" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.25.0" }
 plugin-bnd = "biz.aQute.bnd:biz.aQute.bnd.gradle:7.3.0"
 


### PR DESCRIPTION
Remove the `de.undercouch.download` plugin and use
Gradle's dependency resolution mechanism to download and cache the jars

Closes gh-7102