### PR TITLE
Preserve shared child meters in CompositeMeterRegistry

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/CompositeMeterRemovalBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/CompositeMeterRemovalBenchmark.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.core;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@Fork(1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+public class CompositeMeterRemovalBenchmark {
+
+    @Param({ "10", "10000" })
+    int sharedMeterCount;
+
+    CompositeMeterRegistry composite;
+
+    Meter meterToReplace;
+
+    int nextTagValue;
+
+    @Setup
+    public void setup() {
+        SimpleMeterRegistry child = new SimpleMeterRegistry();
+        child.config().meterFilter(MeterFilter.ignoreTags("key"));
+        composite = new CompositeMeterRegistry();
+        composite.add(child);
+        for (int i = 0; i < sharedMeterCount; i++) {
+            meterToReplace = composite.counter("counter", "key", String.valueOf(i));
+        }
+        nextTagValue = sharedMeterCount;
+    }
+
+    @Benchmark
+    public Meter removeAndReplaceSharedChildOwner() {
+        Meter removed = composite.remove(meterToReplace);
+        meterToReplace = composite.counter("counter", "key", String.valueOf(nextTagValue++));
+        return removed;
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(CompositeMeterRemovalBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build()).run();
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/AbstractCompositeMeter.java
@@ -66,19 +66,19 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
     }
 
     @Override
-    public final void add(MeterRegistry registry) {
+    public final @Nullable T add(MeterRegistry registry) {
         final T newMeter = registerNewMeter(registry);
         if (newMeter == null) {
-            return;
+            return null;
         }
 
         for (;;) {
             if (childrenGuard.compareAndSet(false, true)) {
                 try {
                     IdentityHashMap<MeterRegistry, T> newChildren = new IdentityHashMap<>(children);
-                    newChildren.put(registry, newMeter);
+                    T previous = newChildren.put(registry, newMeter);
                     this.children = newChildren;
-                    break;
+                    return previous == null ? newMeter : null;
                 }
                 finally {
                     childrenGuard.set(false);
@@ -94,14 +94,14 @@ abstract class AbstractCompositeMeter<T extends Meter> extends AbstractMeter imp
      */
     @Override
     @Deprecated
-    public final void remove(MeterRegistry registry) {
+    public final @Nullable T remove(MeterRegistry registry) {
         for (;;) {
             if (childrenGuard.compareAndSet(false, true)) {
                 try {
                     IdentityHashMap<MeterRegistry, T> newChildren = new IdentityHashMap<>(children);
-                    newChildren.remove(registry);
+                    T removed = newChildren.remove(registry);
                     this.children = newChildren;
-                    break;
+                    return removed;
                 }
                 finally {
                     childrenGuard.set(false);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCustomMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeCustomMeter.java
@@ -19,25 +19,59 @@ import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.internal.DefaultMeter;
+import org.jspecify.annotations.Nullable;
+
+import java.util.IdentityHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class CompositeCustomMeter extends DefaultMeter implements CompositeMeter {
+
+    private final AtomicBoolean childrenGuard = new AtomicBoolean();
+
+    private IdentityHashMap<MeterRegistry, Meter> children = new IdentityHashMap<>();
 
     CompositeCustomMeter(Id id, Type type, Iterable<Measurement> measurements) {
         super(id, type, measurements);
     }
 
     @Override
-    public void add(MeterRegistry registry) {
-        Meter.builder(getId().getName(), getType(), measure())
+    public @Nullable Meter add(MeterRegistry registry) {
+        Meter newMeter = Meter.builder(getId().getName(), getType(), measure())
             .tags(getId().getTagsAsIterable())
             .description(getId().getDescription())
             .baseUnit(getId().getBaseUnit())
             .register(registry);
+
+        for (;;) {
+            if (childrenGuard.compareAndSet(false, true)) {
+                try {
+                    IdentityHashMap<MeterRegistry, Meter> newChildren = new IdentityHashMap<>(children);
+                    Meter previous = newChildren.put(registry, newMeter);
+                    this.children = newChildren;
+                    return previous == null ? newMeter : null;
+                }
+                finally {
+                    childrenGuard.set(false);
+                }
+            }
+        }
     }
 
     @Override
-    public void remove(MeterRegistry registry) {
-        // do nothing
+    public @Nullable Meter remove(MeterRegistry registry) {
+        for (;;) {
+            if (childrenGuard.compareAndSet(false, true)) {
+                try {
+                    IdentityHashMap<MeterRegistry, Meter> newChildren = new IdentityHashMap<>(children);
+                    Meter removed = newChildren.remove(registry);
+                    this.children = newChildren;
+                    return removed;
+                }
+                finally {
+                    childrenGuard.set(false);
+                }
+            }
+        }
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeter.java
@@ -17,11 +17,12 @@ package io.micrometer.core.instrument.composite;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.jspecify.annotations.Nullable;
 
 interface CompositeMeter extends Meter {
 
-    void add(MeterRegistry registry);
+    @Nullable Meter add(MeterRegistry registry);
 
-    void remove(MeterRegistry registry);
+    @Nullable Meter remove(MeterRegistry registry);
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -49,6 +49,8 @@ public class CompositeMeterRegistry extends MeterRegistry {
 
     private final Set<MeterRegistry> unmodifiableRegistries = Collections.unmodifiableSet(registries);
 
+    private final IdentityHashMap<MeterRegistry, IdentityHashMap<Meter, Integer>> childMeterReferences = new IdentityHashMap<>();
+
     // VisibleForTesting
     volatile Set<MeterRegistry> nonCompositeDescendants = Collections.emptySet();
 
@@ -68,15 +70,59 @@ public class CompositeMeterRegistry extends MeterRegistry {
         super(clock);
         config().namingConvention(NamingConvention.identity).onMeterAdded(m -> {
             if (m instanceof CompositeMeter) { // should always be
-                lock(registriesLock, () -> nonCompositeDescendants.forEach(((CompositeMeter) m)::add));
+                lock(registriesLock, () -> nonCompositeDescendants.forEach(r -> addChildMeter((CompositeMeter) m, r)));
             }
         }).onMeterRemoved(m -> {
             if (m instanceof CompositeMeter) { // should always be
-                lock(registriesLock, () -> nonCompositeDescendants.forEach(r -> r.removeByPreFilterId(m.getId())));
+                lock(registriesLock,
+                        () -> nonCompositeDescendants.forEach(r -> removeChildMeter((CompositeMeter) m, r, true)));
             }
         });
 
         registries.forEach(this::add);
+    }
+
+    private void addChildMeter(CompositeMeter compositeMeter, MeterRegistry registry) {
+        Meter childMeter = compositeMeter.add(registry);
+        if (childMeter == null) {
+            return;
+        }
+
+        IdentityHashMap<Meter, Integer> references = childMeterReferences.get(registry);
+        if (references == null) {
+            references = new IdentityHashMap<>();
+            childMeterReferences.put(registry, references);
+        }
+        Integer count = references.get(childMeter);
+        references.put(childMeter, count == null ? 1 : count + 1);
+    }
+
+    private void removeChildMeter(CompositeMeter compositeMeter, MeterRegistry registry, boolean removeFromRegistry) {
+        Meter childMeter = compositeMeter.remove(registry);
+        if (childMeter == null) {
+            return;
+        }
+
+        IdentityHashMap<Meter, Integer> references = childMeterReferences.get(registry);
+        if (references == null) {
+            return;
+        }
+        Integer count = references.get(childMeter);
+        if (count == null) {
+            return;
+        }
+        if (count > 1) {
+            references.put(childMeter, count - 1);
+            return;
+        }
+
+        references.remove(childMeter);
+        if (references.isEmpty()) {
+            childMeterReferences.remove(registry);
+        }
+        if (removeFromRegistry) {
+            registry.remove(childMeter);
+        }
     }
 
     @Override
@@ -229,8 +275,8 @@ public class CompositeMeterRegistry extends MeterRegistry {
             for (Meter meter : getMeters()) {
                 if (meter instanceof CompositeMeter) { // should always be
                     CompositeMeter composite = (CompositeMeter) meter;
-                    removes.forEach(composite::remove);
-                    adds.forEach(composite::add);
+                    removes.forEach(r -> removeChildMeter(composite, r, false));
+                    adds.forEach(r -> addChildMeter(composite, r));
                 }
             }
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/composite/CompositeMeterRegistryTest.java
@@ -495,4 +495,71 @@ class CompositeMeterRegistryTest {
         assertThat(this.simple.getMeters()).isEmpty();
     }
 
+    @Test
+    @Issue("#5607")
+    void meterRemovalPreservesChildMeterReferencedByAnotherCompositeMeter() {
+        this.simple.config().meterFilter(MeterFilter.ignoreTags("tableId"));
+        this.composite.add(this.simple);
+
+        DistributionSummary summary1 = this.composite.summary("scan.results", "address", "localhost:1234", "tableId",
+                "1");
+        DistributionSummary summary2 = this.composite.summary("scan.results", "address", "localhost:1234", "tableId",
+                "2");
+        DistributionSummary childSummary = this.simple.get("scan.results").tag("address", "localhost:1234").summary();
+
+        summary1.record(1);
+        summary2.record(2);
+        assertThat(childSummary.count()).isEqualTo(2);
+
+        this.composite.remove(summary2);
+
+        assertThat(this.simple.find("scan.results").summary()).isSameAs(childSummary);
+        summary1.record(3);
+        assertThat(childSummary.count()).isEqualTo(3);
+
+        this.composite.remove(summary1);
+        assertThat(this.simple.find("scan.results").summary()).isNull();
+    }
+
+    @Test
+    @Issue("#5607")
+    void sharedChildMeterReferencesRemainConsistentWhenRegistryIsReadded() {
+        this.simple.config().meterFilter(MeterFilter.ignoreTags("tableId"));
+        this.composite.add(this.simple);
+
+        Counter counter1 = this.composite.counter("requests", "tableId", "1");
+        Counter counter2 = this.composite.counter("requests", "tableId", "2");
+
+        this.composite.remove(this.simple);
+        this.composite.add(this.simple);
+        this.composite.remove(counter2);
+
+        assertThat(this.simple.find("requests").counter()).isNotNull();
+
+        this.composite.remove(counter1);
+        assertThat(this.simple.find("requests").counter()).isNull();
+    }
+
+    @Test
+    @Issue("#5607")
+    void customMeterRemovalPreservesSharedChildMeter() {
+        this.simple.config().meterFilter(MeterFilter.ignoreTags("tableId"));
+        this.composite.add(this.simple);
+
+        Meter meter1 = Meter
+            .builder("custom", Meter.Type.OTHER, singletonList(new Measurement(() -> 1.0, Statistic.UNKNOWN)))
+            .tag("tableId", "1")
+            .register(this.composite);
+        Meter meter2 = Meter
+            .builder("custom", Meter.Type.OTHER, singletonList(new Measurement(() -> 2.0, Statistic.UNKNOWN)))
+            .tag("tableId", "2")
+            .register(this.composite);
+
+        this.composite.remove(meter2);
+        assertThat(this.simple.find("custom").meter()).isNotNull();
+
+        this.composite.remove(meter1);
+        assertThat(this.simple.find("custom").meter()).isNull();
+    }
+
 }


### PR DESCRIPTION
## Summary

- Track descendant meter references by identity when meter filters map multiple composite meters to the same child meter.
- Remove a child meter only after its final composite meter reference is removed.
- Keep reference tracking consistent when descendant registries are removed and re-added, including custom meters.

## Performance

Reference counts are updated only during meter registration, removal, and registry attachment changes. Removal uses identity map lookups and does not scan the composite registry's meters. A JMH benchmark covers removal with 10 and 10,000 composite meters sharing one child meter.

## Tests

- `./gradlew -PtoolchainVersion=11 --no-build-cache --rerun-tasks :micrometer-core:test --tests io.micrometer.core.instrument.composite.CompositeMeterRegistryTest :micrometer-core:checkFormat :micrometer-core:checkstyleMain :micrometer-core:checkstyleTest :micrometer-core:licenseMain :micrometer-core:licenseTest`
- `./gradlew -PtoolchainVersion=17 :micrometer-benchmarks-core:jmhClasses`

Fixes #5607