### PR TITLE
Fast-forward time-window rotation after a long idle gap

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/AbstractTimeWindowHistogram.java
@@ -201,7 +201,8 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
     }
 
     private void rotate() {
-        long timeSinceLastRotateMillis = clock.wallTime() - lastRotateTimestampMillis;
+        long wallTime = clock.wallTime();
+        long timeSinceLastRotateMillis = wallTime - lastRotateTimestampMillis;
         if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
             // Need to wait more for next rotation.
             return;
@@ -215,6 +216,20 @@ abstract class AbstractTimeWindowHistogram<T, U> implements Histogram {
         try {
             int iterations = 0;
             synchronized (this) {
+                if (timeSinceLastRotateMillis >= durationBetweenRotatesMillis * ringBuffer.length) {
+                    // Time since the last rotation is enough to clear the whole ring buffer.
+                    // Reset every bucket once and fast-forward, otherwise a later rotation would
+                    // still lag behind and wipe freshly recorded samples on the next call.
+                    for (T bucket : ringBuffer) {
+                        resetBucket(bucket);
+                    }
+                    currentBucket = 0;
+                    lastRotateTimestampMillis = wallTime - timeSinceLastRotateMillis % durationBetweenRotatesMillis;
+                    resetAccumulatedHistogram();
+                    accumulatedHistogramStale = true;
+                    return;
+                }
+
                 do {
                     resetBucket(ringBuffer[currentBucket]);
                     if (++currentBucket >= ringBuffer.length) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowSum.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowSum.java
@@ -74,7 +74,8 @@ public class TimeWindowSum {
     }
 
     private void rotate() {
-        long timeSinceLastRotateMillis = System.currentTimeMillis() - lastRotateTimestampMillis;
+        long currentTimeMillis = System.currentTimeMillis();
+        long timeSinceLastRotateMillis = currentTimeMillis - lastRotateTimestampMillis;
         if (timeSinceLastRotateMillis < durationBetweenRotatesMillis) {
             // Need to wait more for next rotation.
             return;
@@ -88,6 +89,18 @@ public class TimeWindowSum {
         try {
             int iterations = 0;
             synchronized (this) {
+                if (timeSinceLastRotateMillis >= durationBetweenRotatesMillis * ringBuffer.length) {
+                    // Time since the last rotation is enough to clear the whole ring buffer.
+                    // Reset every bucket once and fast-forward, otherwise a later rotation would
+                    // still lag behind and wipe freshly recorded samples on the next call.
+                    for (AtomicLong bufferItem : ringBuffer) {
+                        bufferItem.set(0);
+                    }
+                    currentBucket = 0;
+                    lastRotateTimestampMillis = currentTimeMillis - timeSinceLastRotateMillis % durationBetweenRotatesMillis;
+                    return;
+                }
+
                 do {
                     ringBuffer[currentBucket].set(0);
                     if (++currentBucket >= ringBuffer.length) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowRotationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/TimeWindowRotationTest.java
@@ -57,4 +57,32 @@ class TimeWindowRotationTest {
                 DistributionStatisticConfig.builder().expiry(Duration.ofMillis(9)).bufferLength(10).build());
     }
 
+    @ParameterizedTest
+    @MethodSource("histogramTypes")
+    void samplesRecordedAfterLongIdleGapAreNotDiscarded(
+            Class<? extends AbstractTimeWindowHistogram<?, ?>> histogramType) throws Exception {
+        MockClock clock = new MockClock();
+        try (AbstractTimeWindowHistogram<?, ?> histogram = newHistogram(histogramType, clock,
+                DistributionStatisticConfig.builder()
+                    .serviceLevelObjectives(10.0)
+                    .expiry(Duration.ofMinutes(1))
+                    .bufferLength(3)
+                    .build()
+                    .merge(DistributionStatisticConfig.DEFAULT))) {
+
+            // Record once, then stay idle far longer than the whole ring buffer spans. A single
+            // rotation must clear the buffer and fast-forward; if it only lags one buffer-length
+            // per call it re-wipes the buffer on every subsequent record and destroys the burst.
+            histogram.recordDouble(1);
+            clock.add(Duration.ofMinutes(10));
+
+            // A burst that all falls within the same window after the gap.
+            for (int i = 0; i < 5; i++) {
+                histogram.recordDouble(1);
+            }
+
+            assertThat(histogram.takeSnapshot(0, 0, 0).histogramCounts()).containsExactly(new CountAtBucket(10.0, 5));
+        }
+    }
+
 }


### PR DESCRIPTION
## Problem

`AbstractTimeWindowHistogram.rotate()` (used by `TimeWindowPercentileHistogram` and
`TimeWindowFixedBoundaryHistogram`) and `TimeWindowSum.rotate()` cap the catch-up loop at
`ringBuffer.length` iterations but never fast-forward `lastRotateTimestampMillis` when the
cap is reached:

```java
do {
    resetBucket(ringBuffer[currentBucket]);
    ...
    timeSinceLastRotateMillis -= durationBetweenRotatesMillis;
    lastRotateTimestampMillis += durationBetweenRotatesMillis;
}
while (timeSinceLastRotateMillis >= durationBetweenRotatesMillis && ++iterations < ringBuffer.length);
```

After the meter is idle (no records, no snapshot) for longer than the whole ring buffer
spans (`bufferLength × durationBetweenRotates`, e.g. 3 × 40s = 2 min at defaults), each
`rotate()` advances the timestamp by at most one buffer-length worth of time and then exits,
leaving `lastRotateTimestampMillis` still in the past. Since `rotate()` runs at the top of
**every** `recordLong`/`recordDouble`/`takeSnapshot`, each following call wipes the **entire**
ring buffer again — destroying the samples recorded since the previous call — until the
timestamp finally catches up.

**Effect:** a burst of traffic that arrives after a quiet period (the classic "cold endpoint
hit after an idle night", an infrequently-scraped meter, or a publish interval longer than
the expiry) silently loses most of its samples. For a `Timer` with `publishPercentiles`, p50
of `{100,200,300,400,500}` recorded 1 ms apart after a 10-minute gap comes back as the last
value instead of the median; for `serviceLevelObjectives`, the SLO bucket counts are wiped.
`TimeWindowSum` is likewise reachable via `JvmHeapPressureMetrics`, under-reporting
`jvm.gc.overhead` after a scrape gap.

The sibling `TimeWindowMax.rotate()` already handles exactly this (issue #2647) with a
dedicated fast-forward branch; that fix was never applied to the other two implementations.

## Fix

Mirror `TimeWindowMax.rotate()`: when `timeSinceLastRotateMillis` covers the whole buffer,
clear every bucket once, reset `currentBucket`, and fast-forward
`lastRotateTimestampMillis = now - timeSinceLastRotateMillis % durationBetweenRotatesMillis`.

## Tests

`TimeWindowRotationTest.samplesRecordedAfterLongIdleGapAreNotDiscarded`, parameterized over
both histogram implementations: record once, advance a `MockClock` 10 minutes, record a
5-value burst, and assert the SLO bucket count is 5. It fails against the current code (the
burst is wiped, count 0) and passes with the fix. Existing `TimeWindow*Test` suites,
`spotlessCheck`, and `checkstyleMain` all pass.

`TimeWindowSum` gets the identical fix; it reads `System.currentTimeMillis()` directly (no
injectable clock and no existing unit test), so it can't be exercised deterministically
without an API change — happy to follow up if you'd like it made testable.
