### PR TITLE
Swap StepFunctionCounter's last value atomically to avoid double-counting

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.FunctionCounter;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ToDoubleFunction;
 
 public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCounter, StepMeter {
@@ -28,7 +29,9 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
 
     private final ToDoubleFunction<T> f;
 
-    private volatile double last;
+    // Holds the last observed function value as double bits so it can be swapped
+    // atomically.
+    private final AtomicLong last = new AtomicLong();
 
     private StepDouble count;
 
@@ -43,9 +46,11 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
     public double count() {
         T obj2 = ref.get();
         if (obj2 != null) {
-            double prevLast = last;
-            last = f.applyAsDouble(obj2);
-            count.getCurrent().add(last - prevLast);
+            double newLast = f.applyAsDouble(obj2);
+            // Atomic swap so concurrent callers telescope deltas instead of
+            // double-counting.
+            double prevLast = Double.longBitsToDouble(last.getAndSet(Double.doubleToLongBits(newLast)));
+            count.getCurrent().add(newLast - prevLast);
         }
         return count.poll();
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -22,6 +22,9 @@ import io.micrometer.core.instrument.Tags;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -81,6 +84,42 @@ class StepFunctionCounterTest {
         clock.add(config.step());
 
         assertThat(counter.count()).isEqualTo(3);
+    }
+
+    @Test
+    void concurrentCountDoesNotOverCount() throws InterruptedException {
+        AtomicInteger n = new AtomicInteger(0);
+        FunctionCounter counter = registry.more().counter("my.counter", Tags.empty(), n);
+
+        int threads = 4;
+        int incrementsPerThread = 10_000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        for (int t = 0; t < threads; t++) {
+            pool.execute(() -> {
+                try {
+                    start.await();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int i = 0; i < incrementsPerThread; i++) {
+                    n.incrementAndGet();
+                    counter.count();
+                }
+            });
+        }
+        start.countDown();
+        pool.shutdown();
+        assertThat(pool.awaitTermination(30, TimeUnit.SECONDS)).isTrue();
+
+        // Flush the final delta into the current step, then roll it over.
+        counter.count();
+        clock.add(config.step());
+        // Deltas must telescope to the total increments; a lost update would
+        // double-count.
+        assertThat(counter.count()).isEqualTo((double) (threads * incrementsPerThread));
     }
 
 }


### PR DESCRIPTION
## Problem

`StepFunctionCounter.count()` did a non-atomic read-modify-write on the `last` value:

```java
double prevLast = last;                 // volatile read
last = f.applyAsDouble(obj2);           // volatile write
count.getCurrent().add(last - prevLast); // add the delta
```

`count()` is called from several threads: the step-rollover poller
(`StepMeterRegistry.pollMetersToRollover`), the publish thread of a push registry, `close()`
(`StepMeterRegistry.stop()` shuts the poller down without `awaitTermination`, then closing
rollover calls `count()`), and any actuator/`/metrics` scrape. When two of them run
concurrently they can read the same `prevLast`, each compute the same new value, and each add
the full delta to the current step's `DoubleAdder` — so the same increment of the underlying
function is counted twice and the published rate for that step is inflated (up to ~2x).

## Fix

Store `last` as an `AtomicLong` of the double bits and swap it with `getAndSet`, so concurrent
callers telescope their deltas (caller *k*'s `prevLast` is exactly caller *k-1*'s new value)
instead of each adding the full delta from a shared previous value:

```java
double newLast = f.applyAsDouble(obj2);
double prevLast = Double.longBitsToDouble(last.getAndSet(Double.doubleToLongBits(newLast)));
count.getCurrent().add(newLast - prevLast);
```

Single-threaded behaviour is unchanged. `_closingRollover()` still flushes the residual delta
correctly.

## Tests

`StepFunctionCounterTest.concurrentCountDoesNotOverCount` — 4 threads increment a source and
call `count()` concurrently; after a step rollover the polled total must equal the number of
increments. With the fix it telescopes exactly; against the current code it over-counts
(measured 18–68% over across runs). All existing `StepFunctionCounterTest` tests, `spotlessCheck`,
and `checkstyle` pass.

`StepFunctionTimer.accumulateCountAndTotal()` has the same class of race on its
`lastCount`/`lastTime` fields (plus a `lastUpdateTime` check-then-act); that needs a larger
change and is left as a follow-up.
