### PR TITLE
Guard Step function meters against negative counts on count function reset

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -45,7 +45,13 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
         if (obj2 != null) {
             double prevLast = last;
             last = f.applyAsDouble(obj2);
-            count.getCurrent().add(last - prevLast);
+            double delta = last - prevLast;
+            // The count function is expected to be monotonically increasing. Guard
+            // against a finite decrease (a reset), which would otherwise record a
+            // negative count for the step interval. A non-finite delta is left as-is
+            // so each registry's own infinite/NaN-value handling still applies.
+            // See gh-2489.
+            count.getCurrent().add(Double.isFinite(delta) ? Math.max(delta, 0) : delta);
         }
         return count.poll();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -95,12 +95,18 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
         if (obj2 != null && clock.monotonicTime() - lastUpdateTime > 1e6) {
             long prevLastCount = lastCount;
             lastCount = Math.max(countFunction.applyAsLong(obj2), 0);
-            count.add(lastCount - prevLastCount);
+            // The count and totalTime functions are expected to be monotonically
+            // increasing. Guard against a finite decrease (a reset), which would
+            // otherwise record a negative count/total for the step interval. A
+            // non-finite total delta (e.g. NaN/Inf totalTime) is left as-is so each
+            // registry's own infinite/NaN-value handling still applies. See gh-2489.
+            count.add(Math.max(lastCount - prevLastCount, 0));
 
             double prevLastTime = lastTime;
             lastTime = Math.max(
                     TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnit, baseTimeUnit()), 0);
-            total.add(lastTime - prevLastTime);
+            double timeDelta = lastTime - prevLastTime;
+            total.add(Double.isFinite(timeDelta) ? Math.max(timeDelta, 0) : timeDelta);
 
             lastUpdateTime = clock.monotonicTime();
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.step;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.MockClock;
@@ -81,6 +82,24 @@ class StepFunctionCounterTest {
         clock.add(config.step());
 
         assertThat(counter.count()).isEqualTo(3);
+    }
+
+    @Issue("#2489")
+    @Test
+    void countShouldNotGoNegativeWhenCountFunctionResets() {
+        AtomicInteger n = new AtomicInteger(100);
+        FunctionCounter counter = registry.more().counter("my.counter", Tags.empty(), n);
+
+        counter.count(); // read the initial value into the current step
+        clock.add(config.step());
+        assertThat(counter.count()).isEqualTo(100);
+
+        // The count function is expected to be monotonically increasing, but it can
+        // decrease when the monitored object is reset/replaced or a guarded function
+        // returns 0 after an exception. This must not record a negative count.
+        n.set(0);
+        clock.add(config.step());
+        assertThat(counter.count()).isEqualTo(0);
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -104,6 +105,29 @@ class StepFunctionTimerTest {
 
         assertThat(timer.count()).isEqualTo(2);
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);
+    }
+
+    @Issue("#2489")
+    @Test
+    void countAndTotalTimeShouldNotGoNegativeWhenFunctionsReset() {
+        AtomicLong count = new AtomicLong(100);
+        AtomicLong totalTimeNanos = new AtomicLong(TimeUnit.SECONDS.toNanos(50));
+        Duration stepDuration = Duration.ofSeconds(60);
+        StepFunctionTimer<Object> timer = new StepFunctionTimer<>(mock(Meter.Id.class), clock, stepDuration.toMillis(),
+                new Object(), (o) -> count.get(), (o) -> totalTimeNanos.get(), TimeUnit.NANOSECONDS, TimeUnit.SECONDS);
+
+        clock.add(stepDuration);
+        assertThat(timer.count()).isEqualTo(100);
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(50);
+
+        // The count and totalTime functions are expected to be monotonically
+        // increasing, but they can decrease on a reset. This must not record a
+        // negative count/total for the interval.
+        count.set(0);
+        totalTimeNanos.set(0);
+        clock.add(stepDuration);
+        assertThat(timer.count()).isEqualTo(0);
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(0);
     }
 
 }


### PR DESCRIPTION
Fixes #2489

## Root cause
`StepFunctionCounter` and `StepFunctionTimer` record the amount for a step interval as the delta between the current and previous reading of the count/totalTime functions. Those functions are expected to be monotonically increasing, but they can decrease — e.g. when the monitored object is reset/replaced, or a guarded function such as [`safeLong` in `TomcatMetrics`](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java) returns `0` after an exception. The negative delta was added as-is, so `count()`/`totalTime()` reported a negative value for that interval (as noted in the issue, originally surfaced via spring-projects/spring-boot#25444).

## Change
Clamp only a **finite** negative per-interval delta at zero, in both `StepFunctionCounter` and `StepFunctionTimer` (count and totalTime), so a reset is treated as no activity for that step rather than producing a negative count/rate:

```java
double delta = last - prevLast;
count.getCurrent().add(Double.isFinite(delta) ? Math.max(delta, 0) : delta);
```

A **non-finite** delta (`NaN`/`±Infinity`) is deliberately passed through unchanged. Registries already have their own handling for non-finite function-counter/timer values (e.g. the various `writeFunctionCounterShouldDropInfiniteValues` / clamp tests across cloudwatch2, opentsdb, influx, humio, kairos, appoptics, new-relic). Clamping the delta unconditionally with `Math.max(delta, 0)` would turn a `NEGATIVE_INFINITY` function counter into `0` at the step level, so those values would never reach the registries' drop/clamp logic — silently changing behavior well beyond the reset fix. Guarding on `Double.isFinite` keeps the reset fix while leaving non-finite handling to each registry.

## Test evidence
Added regression tests that reproduce the issue from the report:
- `StepFunctionCounterTest.countShouldNotGoNegativeWhenCountFunctionResets` (mirrors the failing test in the issue)
- `StepFunctionTimerTest.countAndTotalTimeShouldNotGoNegativeWhenFunctionsReset`

Both fail before the change (`expected: 0.0 but was: -100.0`) and pass after. Also ran the step-based registry test suites that inject `NEGATIVE_INFINITY`/`NaN` into function counters/timers (cloudwatch2, opentsdb, influx, humio, kairos, appoptics, new-relic) plus `:micrometer-core:spotlessCheck` — all green, confirming the finite guard doesn't disturb existing non-finite handling.

## Scope note
This addresses the Step variants, where `count()`/`totalTime()` return the per-step delta and therefore go negative on a reset. The Dropwizard variants (`DropwizardFunctionCounter`/`DropwizardFunctionTimer`) mentioned in the issue return the absolute cumulative value from `count()`, so they don't exhibit a negative `count()`; they do feed a negative increment into their `DropwizardRate` EWMA on reset, which is a related but distinct symptom. Happy to extend this PR to cover that too if you'd prefer it in one change.

---
_Recreated from #7736, which was inadvertently closed by a force-push on my fork branch._
