### PR TITLE
fix(java21): count parked virtual threads in jvm.threads.virtual.live total

### DIFF
--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -99,7 +99,19 @@ Micrometer provides metrics for https://openjdk.org/jeps/444[virtual threads] re
 new VirtualThreadMetrics().bindTo(registry);
 ----
 
-The binder measures the duration (and counts the number of events) of virtual threads being pinned; it also counts the number of events when starting or unparking a virtual thread failed.
+The binder measures the duration (and counts the number of events) of virtual threads being pinned; it also counts the number of events when starting or unparking a virtual thread failed. It additionally tracks live virtual threads via JFR start/end events:
+
+
+|===
+|Meter name | Type | Tag(s) | Description
+
+|`jvm.threads.virtual.live`
+|Gauge
+|`scheduling.status` = `total`
+|Approximate number of virtual threads started after this binder began JFR recording that have not yet terminated (includes parked threads)
+|===
+
+`total` counts virtual threads in any state after recording starts, including those parked waiting on I/O, locks, or other blocking operations. Virtual threads that already existed before the binder was constructed are not included (the JDK does not expose a portable API to enumerate live virtual threads for seeding).
 
 If you are running your application with Java 24 or later on a JVM that has `jdk.management.VirtualThreadSchedulerMXBean` provided as a platform MXBean, the following additional virtual thread metrics will be provided.
 
@@ -126,14 +138,9 @@ If you are running your application with Java 24 or later on a JVM that has `jdk
 |Gauge
 |`scheduling.status` = `queued`
 |Approximate current number of virtual threads that are unfinished and queued waiting to be scheduled
-
-|`jvm.threads.virtual.live`
-|Gauge
-|`scheduling.status` = `total`
-|Current number of virtual threads that have started but not yet terminated
 |===
 
-The `total` scheduling status includes virtual threads in any state, including those parked waiting on I/O, locks, or other blocking operations. The `mounted` and `queued` statuses only cover virtual threads actively managed by the scheduler and do not include parked virtual threads.
+The `mounted` and `queued` statuses only cover virtual threads actively managed by the scheduler and do not include parked virtual threads. They must not be summed to obtain a total live count; use `scheduling.status=total` for that.
 
 [[lifecycle]]
 == Lifecycle

--- a/docs/modules/ROOT/pages/reference/jvm.adoc
+++ b/docs/modules/ROOT/pages/reference/jvm.adoc
@@ -126,9 +126,14 @@ If you are running your application with Java 24 or later on a JVM that has `jdk
 |Gauge
 |`scheduling.status` = `queued`
 |Approximate current number of virtual threads that are unfinished and queued waiting to be scheduled
+
+|`jvm.threads.virtual.live`
+|Gauge
+|`scheduling.status` = `total`
+|Current number of virtual threads that have started but not yet terminated
 |===
 
-Note that aggregating the values of `jvm.threads.virtual.live` across the different tags gives the total number of virtual threads started but not ended.
+The `total` scheduling status includes virtual threads in any state, including those parked waiting on I/O, locks, or other blocking operations. The `mounted` and `queued` statuses only cover virtual threads actively managed by the scheduler and do not include parked virtual threads.
 
 [[lifecycle]]
 == Lifecycle

--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -28,6 +28,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.PlatformManagedObject;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Collections.emptyList;
 
@@ -46,13 +47,23 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private static final String SUBMIT_FAILED_EVENT = "jdk.VirtualThreadSubmitFailed";
 
-    private static final String LIVE_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished";
+    private static final String START_EVENT = "jdk.VirtualThreadStart";
+
+    private static final String END_EVENT = "jdk.VirtualThreadEnd";
+
+    private static final String MOUNTED_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished and mounted to a platform thread by the scheduler";
+
+    private static final String QUEUED_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished and queued waiting to be scheduled";
+
+    private static final String TOTAL_THREADS_DESCRIPTION = "Current number of virtual threads that have started but not yet terminated";
 
     private static final String METER_NAME_PREFIX = "jvm.threads.virtual.";
 
     private final RecordingStream recordingStream;
 
     private final Iterable<Tag> tags;
+
+    private final AtomicLong liveVirtualThreadCount = new AtomicLong();
 
     public VirtualThreadMetrics() {
         this(new RecordingConfig(), emptyList());
@@ -82,7 +93,21 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
         recordingStream.onEvent(PINNED_EVENT, event -> pinnedTimer.record(event.getDuration()));
         recordingStream.onEvent(SUBMIT_FAILED_EVENT, event -> submitFailedCounter.increment());
 
+        bindLiveVirtualThreadCount(registry);
         bindVirtualThreadSchedulerMXBean(registry);
+    }
+
+    private void bindLiveVirtualThreadCount(MeterRegistry registry) {
+        liveVirtualThreadCount.set(countLiveVirtualThreads());
+        recordingStream.onEvent(START_EVENT, event -> liveVirtualThreadCount.incrementAndGet());
+        recordingStream.onEvent(END_EVENT, event -> liveVirtualThreadCount.decrementAndGet());
+
+        Gauge.builder(METER_NAME_PREFIX + "live", liveVirtualThreadCount, AtomicLong::doubleValue)
+            .tags(tags)
+            .tag("scheduling.status", "total")
+            .baseUnit(BaseUnits.THREADS)
+            .description(TOTAL_THREADS_DESCRIPTION)
+            .register(registry);
     }
 
     private void bindVirtualThreadSchedulerMXBean(MeterRegistry registry) {
@@ -113,13 +138,13 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
             Gauge.builder(METER_NAME_PREFIX + "live", platformMXBean, o -> invoke(getMountedVirtualThreadCount, o))
                 .tag("scheduling.status", "mounted")
                 .baseUnit(BaseUnits.THREADS)
-                .description(LIVE_THREADS_DESCRIPTION)
+                .description(MOUNTED_THREADS_DESCRIPTION)
                 .register(registry);
 
             Gauge.builder(METER_NAME_PREFIX + "live", platformMXBean, o -> invoke(getQueuedVirtualThreadCount, o))
                 .tag("scheduling.status", "queued")
                 .baseUnit(BaseUnits.THREADS)
-                .description(LIVE_THREADS_DESCRIPTION)
+                .description(QUEUED_THREADS_DESCRIPTION)
                 .register(registry);
         }
         catch (ClassNotFoundException | ClassCastException | NoSuchMethodException | IllegalAccessException
@@ -141,11 +166,17 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
         RecordingStream recordingStream = new RecordingStream();
         recordingStream.enable(PINNED_EVENT).withThreshold(config.pinnedThreshold);
         recordingStream.enable(SUBMIT_FAILED_EVENT);
+        recordingStream.enable(START_EVENT);
+        recordingStream.enable(END_EVENT);
         recordingStream.setMaxAge(config.maxAge);
         recordingStream.setMaxSize(config.maxSizeBytes);
         recordingStream.startAsync();
 
         return recordingStream;
+    }
+
+    private static long countLiveVirtualThreads() {
+        return Thread.getAllStackTraces().keySet().stream().filter(Thread::isVirtual).count();
     }
 
     @Override

--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -55,7 +55,7 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
 
     private static final String QUEUED_THREADS_DESCRIPTION = "Approximate current number of virtual threads that are unfinished and queued waiting to be scheduled";
 
-    private static final String TOTAL_THREADS_DESCRIPTION = "Current number of virtual threads that have started but not yet terminated";
+    private static final String TOTAL_THREADS_DESCRIPTION = "Approximate number of virtual threads started after this binder began JFR recording that have not yet terminated";
 
     private static final String METER_NAME_PREFIX = "jvm.threads.virtual.";
 
@@ -74,8 +74,8 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
     }
 
     private VirtualThreadMetrics(RecordingConfig config, Iterable<Tag> tags) {
-        this.recordingStream = createRecordingStream(config);
         this.tags = tags;
+        this.recordingStream = createRecordingStream(config);
     }
 
     @Override
@@ -98,10 +98,6 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
     }
 
     private void bindLiveVirtualThreadCount(MeterRegistry registry) {
-        liveVirtualThreadCount.set(countLiveVirtualThreads());
-        recordingStream.onEvent(START_EVENT, event -> liveVirtualThreadCount.incrementAndGet());
-        recordingStream.onEvent(END_EVENT, event -> liveVirtualThreadCount.decrementAndGet());
-
         Gauge.builder(METER_NAME_PREFIX + "live", liveVirtualThreadCount, AtomicLong::doubleValue)
             .tags(tags)
             .tag("scheduling.status", "total")
@@ -170,13 +166,14 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
         recordingStream.enable(END_EVENT);
         recordingStream.setMaxAge(config.maxAge);
         recordingStream.setMaxSize(config.maxSizeBytes);
+        // Register before startAsync so start/end events are not dropped. There is no
+        // reliable JDK API to seed with already-running virtual threads
+        // (Thread.getAllStackTraces() is platform-threads only).
+        recordingStream.onEvent(START_EVENT, event -> liveVirtualThreadCount.incrementAndGet());
+        recordingStream.onEvent(END_EVENT, event -> liveVirtualThreadCount.decrementAndGet());
         recordingStream.startAsync();
 
         return recordingStream;
-    }
-
-    private static long countLiveVirtualThreads() {
-        return Thread.getAllStackTraces().keySet().stream().filter(Thread::isVirtual).count();
     }
 
     @Override

--- a/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 @EnabledForJreRange(min = JRE.JAVA_24)
 class VirtualThreadMetricsJdk24Tests {
@@ -98,6 +99,31 @@ class VirtualThreadMetricsJdk24Tests {
                 executorService.awaitTermination(100, TimeUnit.MILLISECONDS);
             }
         }
+    }
+
+    @Test
+    void totalLiveThreadsIncludesParkedVirtualThreads() throws InterruptedException {
+        SynchronousQueue<Object> queue = new SynchronousQueue<>();
+        int expectedLiveThreads = 10;
+        for (int i = 0; i < expectedLiveThreads; i++) {
+            Thread.ofVirtual().start(() -> {
+                try {
+                    queue.take();
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "total").gauge().value())
+                .isGreaterThanOrEqualTo(expectedLiveThreads);
+            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "mounted").gauge().value())
+                .isZero();
+            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "queued").gauge().value())
+                .isZero();
+        });
     }
 
 }

--- a/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -105,25 +107,53 @@ class VirtualThreadMetricsJdk24Tests {
     void totalLiveThreadsIncludesParkedVirtualThreads() throws InterruptedException {
         SynchronousQueue<Object> queue = new SynchronousQueue<>();
         int expectedLiveThreads = 10;
-        for (int i = 0; i < expectedLiveThreads; i++) {
-            Thread.ofVirtual().start(() -> {
-                try {
-                    queue.take();
-                }
-                catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
-        }
+        List<Thread> parked = new ArrayList<>(expectedLiveThreads);
+        try {
+            for (int i = 0; i < expectedLiveThreads; i++) {
+                parked.add(Thread.ofVirtual().start(() -> {
+                    try {
+                        queue.take();
+                    }
+                    catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }));
+            }
 
-        await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
-            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "total").gauge().value())
-                .isGreaterThanOrEqualTo(expectedLiveThreads);
-            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "mounted").gauge().value())
-                .isZero();
-            assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "queued").gauge().value())
-                .isZero();
-        });
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "total").gauge().value())
+                    .isGreaterThanOrEqualTo(expectedLiveThreads);
+                assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "mounted").gauge().value())
+                    .isZero();
+                assertThat(registry.get("jvm.threads.virtual.live").tag("scheduling.status", "queued").gauge().value())
+                    .isZero();
+            });
+
+            double liveWhileParked = registry.get("jvm.threads.virtual.live")
+                .tag("scheduling.status", "total")
+                .gauge()
+                .value();
+
+            for (Thread thread : parked) {
+                thread.interrupt();
+            }
+            for (Thread thread : parked) {
+                thread.join(Duration.ofSeconds(1));
+            }
+
+            await().atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(
+                        registry.get("jvm.threads.virtual.live").tag("scheduling.status", "total").gauge().value())
+                    .isLessThanOrEqualTo(liveWhileParked - expectedLiveThreads));
+        }
+        finally {
+            for (Thread thread : parked) {
+                thread.interrupt();
+            }
+            for (Thread thread : parked) {
+                thread.join(Duration.ofMillis(200));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #6504

## Summary

- Add `jvm.threads.virtual.live{scheduling.status=total}` backed by JFR `jdk.VirtualThreadStart` / `jdk.VirtualThreadEnd` events (handlers registered before `startAsync()`)
- Do **not** seed from already-running virtual threads — `Thread.getAllStackTraces()` is platform-threads only, and the JDK has no portable VT enumeration API
- Keep existing `mounted` and `queued` gauges unchanged for scheduler visibility
- Update JVM reference docs: document `total` under the general Virtual Threads binder; keep `mounted`/`queued` under the Java 24 MXBean section; remove the incorrect note that aggregating those tags equals total live VTs

Parked virtual threads (e.g. blocked on `SynchronousQueue.take()`) are not exposed by `VirtualThreadSchedulerMXBean`, which caused the live count to under-report when summing `mounted` + `queued`.

## Test plan

- [x] `./gradlew :micrometer-java21:test --tests "io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetricsJdk24Tests" --tests "io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetricsTests" --tests "io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetricsReflectiveTests"` (JDK 25)
- [x] `totalLiveThreadsIncludesParkedVirtualThreads` covers parked VTs after binder construction, cleanup, and End-path decrease

## AI disclosure

Implementation was assisted by AI and human-reviewed before submission.