### PR TITLE
Allow filtering specific loggers in Log4j2Metrics (#6233)

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+import org.jspecify.annotations.Nullable;
 
 import static java.util.Collections.emptyList;
 
@@ -72,6 +74,8 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private final List<PropertyChangeListener> changeListeners = new CopyOnWriteArrayList<>();
 
+    private final @Nullable Predicate<LogEvent> ignoreEventPredicate;
+
     public Log4j2Metrics() {
         this(emptyList());
     }
@@ -81,8 +85,35 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
     }
 
     public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext) {
+        this(tags, loggerContext, null);
+    }
+
+    /**
+     * Create a {@code Log4j2Metrics} instance with the given tags and a predicate to
+     * selectively ignore log events from metrics collection.
+     * @param tags extra tags to add to all metrics
+     * @param ignoreEventPredicate a predicate that, when it returns {@code true} for a
+     * given {@link LogEvent}, causes that event to be excluded from metrics collection.
+     * The event is still logged normally. May be {@code null}.
+     */
+    public Log4j2Metrics(Iterable<Tag> tags, @Nullable Predicate<LogEvent> ignoreEventPredicate) {
+        this(tags, (LoggerContext) LogManager.getContext(false), ignoreEventPredicate);
+    }
+
+    /**
+     * Create a {@code Log4j2Metrics} instance with the given tags, logger context, and a
+     * predicate to selectively ignore log events from metrics collection.
+     * @param tags extra tags to add to all metrics
+     * @param loggerContext the Log4j2 {@link LoggerContext}
+     * @param ignoreEventPredicate a predicate that, when it returns {@code true} for a
+     * given {@link LogEvent}, causes that event to be excluded from metrics collection.
+     * The event is still logged normally. May be {@code null}.
+     */
+    public Log4j2Metrics(Iterable<Tag> tags, LoggerContext loggerContext,
+            @Nullable Predicate<LogEvent> ignoreEventPredicate) {
         this.tags = tags;
         this.loggerContext = loggerContext;
+        this.ignoreEventPredicate = ignoreEventPredicate;
     }
 
     @Override
@@ -139,7 +170,7 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
     private MetricsFilter getOrCreateMetricsFilterAndStart(MeterRegistry registry) {
         return metricsFilters.computeIfAbsent(registry, r -> {
-            MetricsFilter metricsFilter = new MetricsFilter(r, tags);
+            MetricsFilter metricsFilter = new MetricsFilter(r, tags, ignoreEventPredicate);
             metricsFilter.start();
             return metricsFilter;
         });
@@ -189,7 +220,11 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         private final Counter traceCounter;
 
-        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags) {
+        private final @Nullable Predicate<LogEvent> ignoreEventPredicate;
+
+        MetricsFilter(MeterRegistry registry, Iterable<Tag> tags, @Nullable Predicate<LogEvent> ignoreEventPredicate) {
+            this.ignoreEventPredicate = ignoreEventPredicate;
+
             fatalCounter = Counter.builder(METER_NAME)
                 .tags(tags)
                 .tags("level", "fatal")
@@ -235,6 +270,17 @@ public class Log4j2Metrics implements MeterBinder, AutoCloseable {
 
         @Override
         public Result filter(LogEvent event) {
+            if (ignoreEventPredicate != null) {
+                try {
+                    if (ignoreEventPredicate.test(event)) {
+                        return Result.NEUTRAL;
+                    }
+                }
+                catch (Exception e) {
+                    // Don't let a faulty predicate break logging.
+                    // Fall through to count the event normally.
+                }
+            }
             incrementCounter(event);
             return Result.NEUTRAL;
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/logging/Log4j2MetricsTest.java
@@ -90,6 +90,89 @@ class Log4j2MetricsTest {
     }
 
     @Test
+    void log4j2MetricsCanIgnoreSpecificLoggers() {
+        new Log4j2Metrics(emptyList(), (LoggerContext) LogManager.getContext(false),
+                event -> event.getLoggerName().startsWith("ignored.logger")).bindTo(registry);
+
+        Logger logger = LogManager.getLogger("regular.logger");
+        Logger ignoredLogger = LogManager.getLogger("ignored.logger.test");
+
+        Configurator.setLevel("regular.logger", Level.INFO);
+        Configurator.setLevel("ignored.logger.test", Level.INFO);
+
+        logger.info("info");
+        ignoredLogger.info("ignored info");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void log4j2MetricsCountsAllEventsWhenPredicateIsNull() {
+        new Log4j2Metrics(emptyList(), (LoggerContext) LogManager.getContext(false), null).bindTo(registry);
+
+        Logger logger = LogManager.getLogger("null.predicate.logger");
+        Configurator.setLevel("null.predicate.logger", Level.INFO);
+
+        logger.info("info");
+        logger.warn("warn");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+        assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void log4j2MetricsCountsEventWhenPredicateThrows() {
+        new Log4j2Metrics(emptyList(), (LoggerContext) LogManager.getContext(false), event -> {
+            throw new RuntimeException("boom");
+        }).bindTo(registry);
+
+        Logger logger = LogManager.getLogger("throwing.predicate.logger");
+        Configurator.setLevel("throwing.predicate.logger", Level.INFO);
+
+        logger.info("info");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
+    void log4j2MetricsIgnoresAllLevelsForIgnoredLogger() {
+        new Log4j2Metrics(emptyList(), (LoggerContext) LogManager.getContext(false),
+                event -> event.getLoggerName().equals("noisy.logger")).bindTo(registry);
+
+        Logger noisyLogger = LogManager.getLogger("noisy.logger");
+        Configurator.setLevel("noisy.logger", Level.TRACE);
+
+        noisyLogger.trace("trace");
+        noisyLogger.debug("debug");
+        noisyLogger.info("info");
+        noisyLogger.warn("warn");
+        noisyLogger.error("error");
+        noisyLogger.fatal("fatal");
+
+        assertThat(registry.get("log4j2.events").tags("level", "trace").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "debug").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "warn").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "error").counter().count()).isEqualTo(0.0);
+        assertThat(registry.get("log4j2.events").tags("level", "fatal").counter().count()).isEqualTo(0.0);
+    }
+
+    @Test
+    void log4j2MetricsConvenienceConstructorWithPredicate() {
+        new Log4j2Metrics(emptyList(), event -> event.getLoggerName().equals("skip.me")).bindTo(registry);
+
+        Logger regular = LogManager.getLogger("count.me");
+        Logger skipped = LogManager.getLogger("skip.me");
+        Configurator.setLevel("count.me", Level.INFO);
+        Configurator.setLevel("skip.me", Level.INFO);
+
+        regular.info("counted");
+        skipped.info("skipped");
+
+        assertThat(registry.get("log4j2.events").tags("level", "info").counter().count()).isEqualTo(1.0);
+    }
+
+    @Test
     void filterWhenLoggerAdditivityIsFalseShouldWork() {
         Logger additivityDisabledLogger = LogManager.getLogger("additivityDisabledLogger");
         Configurator.setLevel("additivityDisabledLogger", Level.INFO);


### PR DESCRIPTION
Resolves #6233.

Provides the ability to selectively exclude noisy or specific loggers (e.g. `com.a.b.c`) from being collected by `Log4j2Metrics`.

 Changes
* Added an overloaded constructor to `Log4j2Metrics` accepting an optional `Predicate<LogEvent> ignoreEventPredicate`. 
* Added a convenience constructor `Log4j2Metrics(Iterable<Tag>, Predicate<LogEvent>)` so users aren't forced to pass a `LoggerContext` manually just to use the predicate.
* The `MetricsFilter.filter(LogEvent event)` method now returns `Result.NEUTRAL` early if the predicate evaluates to `true`, bypassing the counter increment.
* Wrapped the predicate evaluation in a `try-catch` block to ensure that a faulty user-supplied predicate will never break the Log4j2 logging filter chain.
* Fully annotated the new fields and parameters with `org.jspecify.annotations.Nullable` to align with Micrometer's existing conventions.

 Testing
* Added comprehensive unit test coverage (`Log4j2MetricsTest.java`), including tests for null predicates, throwing predicates, and level-specific ignores.
* All tests pass cleanly (`./gradlew :micrometer-core:test`).

