### PR TITLE
Swap StepFunctionTimer's last values atomically to avoid double-counting

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.ToDoubleFunction;
@@ -50,9 +51,9 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
 
     private volatile long lastUpdateTime = (long) -2e6;
 
-    private volatile long lastCount;
+    private final AtomicLong lastCount = new AtomicLong();
 
-    private volatile double lastTime;
+    private final AtomicLong lastTime = new AtomicLong();
 
     private final LongAdder count = new LongAdder();
 
@@ -93,14 +94,17 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
     private void accumulateCountAndTotal() {
         T obj2 = ref.get();
         if (obj2 != null && clock.monotonicTime() - lastUpdateTime > 1e6) {
-            long prevLastCount = lastCount;
-            lastCount = Math.max(countFunction.applyAsLong(obj2), 0);
-            count.add(lastCount - prevLastCount);
+            // Swap the last observed values atomically so concurrent callers telescope
+            // the deltas
+            // instead of both applying the same increase (double-counting).
+            long newLastCount = Math.max(countFunction.applyAsLong(obj2), 0);
+            long prevLastCount = lastCount.getAndSet(newLastCount);
+            count.add(newLastCount - prevLastCount);
 
-            double prevLastTime = lastTime;
-            lastTime = Math.max(
+            double newLastTime = Math.max(
                     TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnit, baseTimeUnit()), 0);
-            total.add(lastTime - prevLastTime);
+            double prevLastTime = Double.longBitsToDouble(lastTime.getAndSet(Double.doubleToLongBits(newLastTime)));
+            total.add(newLastTime - prevLastTime);
 
             lastUpdateTime = clock.monotonicTime();
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.step;
 
 import io.micrometer.core.Issue;
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MockClock;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -104,6 +106,56 @@ class StepFunctionTimerTest {
 
         assertThat(timer.count()).isEqualTo(2);
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);
+    }
+
+    @Test
+    void concurrentAccumulateDoesNotOverCount() throws InterruptedException {
+        AtomicLong wall = new AtomicLong();
+        AtomicLong mono = new AtomicLong();
+        // monotonicTime advances past the 1ms accumulate throttle on every call, so the
+        // read-modify-write is exercised on each call; wallTime stays within one step so
+        // the value does not roll over mid-test.
+        Clock stressClock = new Clock() {
+            @Override
+            public long wallTime() {
+                return wall.get();
+            }
+
+            @Override
+            public long monotonicTime() {
+                return mono.addAndGet((long) 2e6);
+            }
+        };
+
+        AtomicLong n = new AtomicLong();
+        Duration step = Duration.ofMillis(10);
+        StepFunctionTimer<Object> timer = new StepFunctionTimer<>(mock(Meter.Id.class), stressClock, step.toMillis(),
+                new Object(), t -> n.get(), t -> n.get(), TimeUnit.NANOSECONDS, TimeUnit.NANOSECONDS);
+
+        int threads = 4;
+        int incrementsPerThread = 10_000;
+        Thread[] workers = new Thread[threads];
+        for (int i = 0; i < threads; i++) {
+            workers[i] = new Thread(() -> {
+                for (int j = 0; j < incrementsPerThread; j++) {
+                    n.incrementAndGet();
+                    timer.count();
+                    timer.totalTime(TimeUnit.NANOSECONDS);
+                }
+            });
+            workers[i].start();
+        }
+        for (Thread worker : workers) {
+            worker.join();
+        }
+
+        // Flush the final delta into the current step, then roll it over.
+        timer.count();
+        wall.set(step.toMillis());
+        // Deltas must telescope to the total increments; a lost update would
+        // double-count.
+        assertThat(timer.count()).isEqualTo((double) (threads * incrementsPerThread));
+        assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isEqualTo((double) (threads * incrementsPerThread));
     }
 
 }


### PR DESCRIPTION
`StepFunctionTimer.accumulateCountAndTotal()` reads the previous `lastCount`/`lastTime`, recomputes the function, and adds the delta to the step — a non-atomic read-modify-write on plain `volatile` fields.

A `StepMeterRegistry` touches the same meter from two threads: the rollover poller (`pollMetersToRollover` → `FunctionTimer::count`) and the publisher (`publish` → `count()`/`totalTime()`). Both call `accumulateCountAndTotal()`, and if both pass the 1 ms throttle in the same window they can read the same previous value and each add the full increase, so the step reports up to 2× the true count/total. The 1 ms guard only throttles how often the user function is called; it does not make the update atomic.

Fix: store the last observed values in `AtomicLong` and swap them with `getAndSet`, so concurrent callers telescope the deltas — the same fix as #7758 for `StepFunctionCounter`, applied to the sibling timer.

Added `concurrentAccumulateDoesNotOverCount` (4 threads × 10k increments); it fails on the current code (observed ~42k for a true 40k) and passes with the swap. `spotless`/`checkFormat` clean.