### PR TITLE
Prevent concurrent over-counting in StepFunctionCounter and StepFunctionTimer

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionCounter.java
@@ -20,6 +20,7 @@ import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.FunctionCounter;
 
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.ToDoubleFunction;
 
 public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCounter, StepMeter {
@@ -28,7 +29,7 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
 
     private final ToDoubleFunction<T> f;
 
-    private volatile double last;
+    private final AtomicLong last = new AtomicLong();
 
     private StepDouble count;
 
@@ -43,9 +44,9 @@ public class StepFunctionCounter<T> extends AbstractMeter implements FunctionCou
     public double count() {
         T obj2 = ref.get();
         if (obj2 != null) {
-            double prevLast = last;
-            last = f.applyAsDouble(obj2);
-            count.getCurrent().add(last - prevLast);
+            double newLast = f.applyAsDouble(obj2);
+            double prevLast = Double.longBitsToDouble(last.getAndSet(Double.doubleToLongBits(newLast)));
+            count.getCurrent().add(newLast - prevLast);
         }
         return count.poll();
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepFunctionTimer.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.util.TimeUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.ToDoubleFunction;
@@ -50,9 +51,9 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
 
     private volatile long lastUpdateTime = (long) -2e6;
 
-    private volatile long lastCount;
+    private final AtomicLong lastCount = new AtomicLong();
 
-    private volatile double lastTime;
+    private final AtomicLong lastTime = new AtomicLong();
 
     private final LongAdder count = new LongAdder();
 
@@ -93,14 +94,14 @@ public class StepFunctionTimer<T> implements FunctionTimer, StepMeter {
     private void accumulateCountAndTotal() {
         T obj2 = ref.get();
         if (obj2 != null && clock.monotonicTime() - lastUpdateTime > 1e6) {
-            long prevLastCount = lastCount;
-            lastCount = Math.max(countFunction.applyAsLong(obj2), 0);
-            count.add(lastCount - prevLastCount);
+            long newLastCount = Math.max(countFunction.applyAsLong(obj2), 0);
+            long prevLastCount = lastCount.getAndSet(newLastCount);
+            count.add(newLastCount - prevLastCount);
 
-            double prevLastTime = lastTime;
-            lastTime = Math.max(
+            double newLastTime = Math.max(
                     TimeUtils.convert(totalTimeFunction.applyAsDouble(obj2), totalTimeFunctionUnit, baseTimeUnit()), 0);
-            total.add(lastTime - prevLastTime);
+            double prevLastTime = Double.longBitsToDouble(lastTime.getAndSet(Double.doubleToLongBits(newLastTime)));
+            total.add(newLastTime - prevLastTime);
 
             lastUpdateTime = clock.monotonicTime();
         }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionCounterTest.java
@@ -83,4 +83,33 @@ class StepFunctionCounterTest {
         assertThat(counter.count()).isEqualTo(3);
     }
 
+    @Test
+    void concurrentCountDoesNotOverCount() throws InterruptedException {
+        AtomicInteger n = new AtomicInteger(0);
+        FunctionCounter counter = registry.more().counter("my.counter", Tags.empty(), n);
+
+        int threads = 4;
+        int incrementsPerThread = 10_000;
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(threads);
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(threads);
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                for (int j = 0; j < incrementsPerThread; j++) {
+                    n.incrementAndGet();
+                    counter.count();
+                }
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        @SuppressWarnings("rawtypes")
+        StepFunctionCounter stepCounter = (StepFunctionCounter) counter;
+        stepCounter._closingRollover();
+        assertThat(counter.count()).isEqualTo(threads * incrementsPerThread);
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -106,4 +106,50 @@ class StepFunctionTimerTest {
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(150);
     }
 
+    @Test
+    void concurrentAccumulateDoesNotOverCount() throws InterruptedException {
+        java.util.concurrent.atomic.AtomicLong count = new java.util.concurrent.atomic.AtomicLong();
+        java.util.concurrent.atomic.AtomicLong totalTime = new java.util.concurrent.atomic.AtomicLong();
+
+        io.micrometer.core.instrument.Clock concurrentClock = new io.micrometer.core.instrument.Clock() {
+            private final java.util.concurrent.atomic.AtomicLong time = new java.util.concurrent.atomic.AtomicLong(0);
+
+            @Override
+            public long wallTime() {
+                return time.get();
+            }
+
+            @Override
+            public long monotonicTime() {
+                return time.getAndAdd(2_000_000);
+            }
+        };
+
+        StepFunctionTimer<Object> timer = new StepFunctionTimer<>(mock(Meter.Id.class), concurrentClock, 1000L,
+                new Object(), (o) -> count.get(), (o) -> (double) totalTime.get(), TimeUnit.SECONDS, TimeUnit.SECONDS);
+
+        int threads = 4;
+        int incrementsPerThread = 10_000;
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(threads);
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(threads);
+
+        for (int i = 0; i < threads; i++) {
+            executor.submit(() -> {
+                for (int j = 0; j < incrementsPerThread; j++) {
+                    count.incrementAndGet();
+                    totalTime.addAndGet(2);
+                    timer.count();
+                }
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        timer._closingRollover();
+        assertThat(timer.count()).isEqualTo(threads * incrementsPerThread);
+        assertThat(timer.totalTime(TimeUnit.SECONDS)).isEqualTo(threads * incrementsPerThread * 2);
+    }
+
 }


### PR DESCRIPTION
## Summary

This PR fixes a race condition in `StepFunctionCounter` and `StepFunctionTimer` where concurrent scrapes can over-count step metrics.

Previously, the last observed values were tracked using `volatile` fields with a non-atomic read-modify-write sequence. Under concurrent access, multiple threads could observe the same baseline value and add duplicate deltas to the underlying adders, resulting in inflated metrics.

This change replaces the baseline tracking fields with `AtomicLong` and uses `getAndSet()` to atomically swap the observed value before computing the delta.

## Changes

- Replace `volatile` baseline fields with `AtomicLong`
- Use `AtomicLong.getAndSet()` for atomic delta calculation
- Add regression tests covering concurrent access for:
  - `StepFunctionCounter`
  - `StepFunctionTimer`

## Regression Validation

The newly added concurrency tests were executed against the original implementation and consistently reproduced the reported over-counting behavior.

After applying this change, the same tests pass, demonstrating that the race condition has been eliminated.

## Verification

- Ran formatting
- Ran `:micrometer-core:check`
- Ran `:micrometer-core:test`

Fixes #7785
Fixes #7758