### PR TITLE
Optimize PrometheusMeterRegistry and MicrometerCollector snapshot collection

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -32,11 +32,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * JMH Benchmarks for quantifying performance and allocations in {@link PrometheusMeterRegistry}.
+ * JMH Benchmarks for quantifying performance and allocations in
+ * {@link PrometheusMeterRegistry}.
  * <p>
- * Specifically benchmarks:
- * 1. Meter Creation: Batch registration of new meters into a fresh registry.
- * 2. Meter Scrape / Collection: Scraping pre-registered metrics.
+ * Specifically benchmarks: 1. Meter Creation: Batch registration of new meters into a
+ * fresh registry. 2. Meter Scrape / Collection: Scraping pre-registered metrics.
  */
 @Fork(1)
 @Warmup(iterations = 3, time = 1)
@@ -48,10 +48,11 @@ public class PrometheusRegistryBenchmark {
 
     public static final int CREATION_BATCH_SIZE = 500;
 
-    @Param({"500"})
+    @Param({ "500" })
     private int scrapeMeterCount;
 
     private PrometheusMeterRegistry scrapeRegistry;
+
     private AtomicInteger gaugeValue;
 
     @Setup(Level.Trial)
@@ -62,28 +63,29 @@ public class PrometheusRegistryBenchmark {
         // Pre-register meters for the scrape benchmark (500 meter families with tags)
         for (int i = 0; i < scrapeMeterCount; i++) {
             String idSuffix = String.valueOf(i);
-            Counter counter = scrapeRegistry.counter("benchmark_counter_" + idSuffix,
-                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            Counter counter = scrapeRegistry.counter("benchmark_counter_" + idSuffix, "region", "us-east-1", "env",
+                    "production", "service", "payment-service", "instance", idSuffix);
             counter.increment(i + 1);
 
             Gauge.builder("benchmark_gauge_" + idSuffix, gaugeValue, AtomicInteger::get)
                 .tags("region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix)
                 .register(scrapeRegistry);
 
-            Timer timer = scrapeRegistry.timer("benchmark_timer_" + idSuffix,
-                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            Timer timer = scrapeRegistry.timer("benchmark_timer_" + idSuffix, "region", "us-east-1", "env",
+                    "production", "service", "payment-service", "instance", idSuffix);
             timer.record(i + 10, TimeUnit.MILLISECONDS);
 
-            DistributionSummary summary = scrapeRegistry.summary("benchmark_summary_" + idSuffix,
-                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            DistributionSummary summary = scrapeRegistry.summary("benchmark_summary_" + idSuffix, "region", "us-east-1",
+                    "env", "production", "service", "payment-service", "instance", idSuffix);
             summary.record(i * 1.5);
         }
     }
 
     /**
-     * Benchmark scenario 1: Meter creation and registration.
-     * Uses batching (@OperationsPerInvocation) with 500 fresh meters per invocation to accurately
-     * quantify per-meter creation latency and heap allocations while amortizing registry setup overhead.
+     * Benchmark scenario 1: Meter creation and registration. Uses batching
+     * (@OperationsPerInvocation) with 500 fresh meters per invocation to accurately
+     * quantify per-meter creation latency and heap allocations while amortizing registry
+     * setup overhead.
      */
     @Benchmark
     @OperationsPerInvocation(CREATION_BATCH_SIZE)
@@ -93,8 +95,8 @@ public class PrometheusRegistryBenchmark {
 
         for (int i = 0; i < CREATION_BATCH_SIZE; i++) {
             String idSuffix = String.valueOf(i);
-            Counter counter = registry.counter("created_counter_" + idSuffix,
-                    "region", "us-east-1", "env", "production", "service", "auth-service", "instance", idSuffix);
+            Counter counter = registry.counter("created_counter_" + idSuffix, "region", "us-east-1", "env",
+                    "production", "service", "auth-service", "instance", idSuffix);
             counter.increment();
             bh.consume(counter);
         }
@@ -110,8 +112,8 @@ public class PrometheusRegistryBenchmark {
     }
 
     /**
-     * Benchmark scenario 3: Full meter scrape (snapshot collection + text format serialization).
-     * Evaluates scrape latency and allocations across registered meters.
+     * Benchmark scenario 3: Full meter scrape (snapshot collection + text format
+     * serialization). Evaluates scrape latency and allocations across registered meters.
      */
     @Benchmark
     @OutputTimeUnit(TimeUnit.MICROSECONDS)
@@ -136,8 +138,7 @@ public class PrometheusRegistryBenchmark {
     }
 
     public static void main(String[] args) throws RunnerException {
-        new Runner(new OptionsBuilder()
-            .include(PrometheusRegistryBenchmark.class.getSimpleName())
+        new Runner(new OptionsBuilder().include(PrometheusRegistryBenchmark.class.getSimpleName())
             .addProfiler(GCProfiler.class)
             .build()).run();
     }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -48,6 +48,28 @@ public class PrometheusRegistryBenchmark {
 
     public static final int CREATION_BATCH_SIZE = 500;
 
+    private static final String[] COUNTER_NAMES = {
+            "cache.gets", "executor.completed", "logback.events"
+    };
+
+    private static final String[] GAUGE_NAMES = {
+            "jvm.memory.used", "system.cpu.usage"
+    };
+
+    private static final String[] TIMER_NAMES = {
+            "http.server.requests", "http.client.requests", "db.statement"
+    };
+
+    private static final String[] SUMMARY_NAMES = {
+            "http.server.response.size", "kafka.producer.record.size"
+    };
+
+    private static final String[] METHODS = { "GET", "POST", "PUT", "DELETE" };
+
+    private static final String[] STATUSES = { "200", "201", "400", "404", "500" };
+
+    private static final String[] OUTCOMES = { "SUCCESS", "CLIENT_ERROR", "SERVER_ERROR" };
+
     @Param({ "500" })
     private int scrapeMeterCount;
 
@@ -60,32 +82,39 @@ public class PrometheusRegistryBenchmark {
         scrapeRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         gaugeValue = new AtomicInteger(42);
 
-        // Pre-register meters for the scrape benchmark (500 meter families with tags)
+        // Pre-register realistic meters for scrape benchmarks across 10 metric families with distinct types
         for (int i = 0; i < scrapeMeterCount; i++) {
-            String idSuffix = String.valueOf(i);
-            Counter counter = scrapeRegistry.counter("benchmark_counter_" + idSuffix, "region", "us-east-1", "env",
-                    "production", "service", "payment-service", "instance", idSuffix);
-            counter.increment(i + 1);
+            String uri = "/api/v1/endpoint_" + (i / 10);
+            String method = METHODS[i % METHODS.length];
+            String status = STATUSES[i % STATUSES.length];
+            String outcome = OUTCOMES[i % OUTCOMES.length];
 
-            Gauge.builder("benchmark_gauge_" + idSuffix, gaugeValue, AtomicInteger::get)
-                .tags("region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix)
-                .register(scrapeRegistry);
-
-            Timer timer = scrapeRegistry.timer("benchmark_timer_" + idSuffix, "region", "us-east-1", "env",
-                    "production", "service", "payment-service", "instance", idSuffix);
-            timer.record(i + 10, TimeUnit.MILLISECONDS);
-
-            DistributionSummary summary = scrapeRegistry.summary("benchmark_summary_" + idSuffix, "region", "us-east-1",
-                    "env", "production", "service", "payment-service", "instance", idSuffix);
-            summary.record(i * 1.5);
+            if (i % 4 == 0) {
+                String name = COUNTER_NAMES[(i / 4) % COUNTER_NAMES.length];
+                Counter counter = scrapeRegistry.counter(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                counter.increment(i + 1);
+            } else if (i % 4 == 1) {
+                String name = GAUGE_NAMES[(i / 4) % GAUGE_NAMES.length];
+                Gauge.builder(name, gaugeValue, AtomicInteger::get)
+                        .tags("uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service")
+                        .register(scrapeRegistry);
+            } else if (i % 4 == 2) {
+                String name = TIMER_NAMES[(i / 4) % TIMER_NAMES.length];
+                Timer timer = scrapeRegistry.timer(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                timer.record(i + 10, TimeUnit.MILLISECONDS);
+            } else {
+                String name = SUMMARY_NAMES[(i / 4) % SUMMARY_NAMES.length];
+                DistributionSummary summary = scrapeRegistry.summary(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                summary.record(i * 1.5);
+            }
         }
     }
 
     /**
      * Benchmark scenario 1: Meter creation and registration. Uses batching
-     * (@OperationsPerInvocation) with 500 fresh meters per invocation to accurately
-     * quantify per-meter creation latency and heap allocations while amortizing registry
-     * setup overhead.
+     * (@OperationsPerInvocation) with 500 fresh meters per invocation across 10
+     * realistic metric family names to accurately quantify per-meter creation
+     * latency and heap allocations under realistic metric distributions.
      */
     @Benchmark
     @OperationsPerInvocation(CREATION_BATCH_SIZE)
@@ -94,11 +123,31 @@ public class PrometheusRegistryBenchmark {
         PrometheusMeterRegistry registry = state.getRegistry();
 
         for (int i = 0; i < CREATION_BATCH_SIZE; i++) {
-            String idSuffix = String.valueOf(i);
-            Counter counter = registry.counter("created_counter_" + idSuffix, "region", "us-east-1", "env",
-                    "production", "service", "auth-service", "instance", idSuffix);
-            counter.increment();
-            bh.consume(counter);
+            String uri = "/api/v1/endpoint_" + (i / 10);
+            String method = METHODS[i % METHODS.length];
+            String status = STATUSES[i % STATUSES.length];
+            String outcome = OUTCOMES[i % OUTCOMES.length];
+
+            if (i % 4 == 0) {
+                String name = COUNTER_NAMES[(i / 4) % COUNTER_NAMES.length];
+                Counter counter = registry.counter(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                counter.increment();
+                bh.consume(counter);
+            } else if (i % 4 == 1) {
+                String name = GAUGE_NAMES[(i / 4) % GAUGE_NAMES.length];
+                Gauge gauge = Gauge.builder(name, gaugeValue, AtomicInteger::get)
+                        .tags("uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service")
+                        .register(registry);
+                bh.consume(gauge);
+            } else if (i % 4 == 2) {
+                String name = TIMER_NAMES[(i / 4) % TIMER_NAMES.length];
+                Timer timer = registry.timer(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                bh.consume(timer);
+            } else {
+                String name = SUMMARY_NAMES[(i / 4) % SUMMARY_NAMES.length];
+                DistributionSummary summary = registry.summary(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                bh.consume(summary);
+            }
         }
     }
 

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -48,9 +48,8 @@ public class PrometheusRegistryBenchmark {
 
     public static final int CREATION_BATCH_SIZE = 500;
 
-    private static final String[] URIS = {
-            "/api/v1/users", "/api/v1/orders/{id}", "/api/v1/products", "/health", "/api/v1/checkout"
-    };
+    private static final String[] URIS = { "/api/v1/users", "/api/v1/orders/{id}", "/api/v1/products", "/health",
+            "/api/v1/checkout" };
 
     private static final String[] METHODS = { "GET", "POST", "PUT", "DELETE" };
 
@@ -82,20 +81,21 @@ public class PrometheusRegistryBenchmark {
 
         // System gauges registered once during setup
         Gauge.builder("jvm.memory.used", gaugeValue, AtomicInteger::get)
-                .tags("area", "heap", "id", "G1 Eden Space")
-                .register(scrapeRegistry);
+            .tags("area", "heap", "id", "G1 Eden Space")
+            .register(scrapeRegistry);
         Gauge.builder("jvm.memory.used", gaugeValue, AtomicInteger::get)
-                .tags("area", "heap", "id", "G1 Old Gen")
-                .register(scrapeRegistry);
-        Gauge.builder("system.cpu.usage", gaugeValue, AtomicInteger::get)
-                .register(scrapeRegistry);
+            .tags("area", "heap", "id", "G1 Old Gen")
+            .register(scrapeRegistry);
+        Gauge.builder("system.cpu.usage", gaugeValue, AtomicInteger::get).register(scrapeRegistry);
 
-        // Pre-register realistic meters for scrape benchmarks (~65% Timers, ~30% Counters, ~5% Summaries)
+        // Pre-register realistic meters for scrape benchmarks (~65% Timers, ~30%
+        // Counters, ~5% Summaries)
         for (int i = 0; i < scrapeMeterCount; i++) {
             int modulo = i % 20;
             if (modulo < 13) {
                 // Timer: http.server.requests, http.client.requests, db.statement
                 if (modulo < 8) {
+                    // @formatter:off
                     scrapeRegistry.timer("http.server.requests",
                             "uri", URIS[i % URIS.length],
                             "method", METHODS[i % METHODS.length],
@@ -103,7 +103,10 @@ public class PrometheusRegistryBenchmark {
                             "outcome", OUTCOMES[i % OUTCOMES.length],
                             "exception", EXCEPTIONS[i % EXCEPTIONS.length]
                     ).record(i + 10, TimeUnit.MILLISECONDS);
-                } else if (modulo < 11) {
+                    // @formatter:on
+                }
+                else if (modulo < 11) {
+                    // @formatter:off
                     scrapeRegistry.timer("http.client.requests",
                             "clientName", CLIENT_NAMES[i % CLIENT_NAMES.length],
                             "uri", URIS[i % URIS.length],
@@ -111,28 +114,38 @@ public class PrometheusRegistryBenchmark {
                             "status", STATUSES[i % STATUSES.length],
                             "outcome", OUTCOMES[i % OUTCOMES.length]
                     ).record(i + 5, TimeUnit.MILLISECONDS);
-                } else {
+                    // @formatter:on
+                }
+                else {
+                    // @formatter:off
                     scrapeRegistry.timer("db.statement",
                             "name", DB_STATEMENTS[i % DB_STATEMENTS.length],
                             "status", "success"
                     ).record(i + 1, TimeUnit.MILLISECONDS);
+                    // @formatter:on
                 }
-            } else if (modulo < 19) {
+            }
+            else if (modulo < 19) {
                 // Counter: logback.events, cache.gets
                 if (modulo < 16) {
                     scrapeRegistry.counter("logback.events", "level", LOG_LEVELS[i % LOG_LEVELS.length]).increment();
-                } else {
+                }
+                else {
+                    // @formatter:off
                     scrapeRegistry.counter("cache.gets",
                             "cache", CACHE_NAMES[i % CACHE_NAMES.length],
                             "result", (i % 2 == 0) ? "hit" : "miss"
                     ).increment();
+                    // @formatter:on
                 }
-            } else {
-                // DistributionSummary: http.server.response.size
+            }
+            else {
+                // @formatter:off
                 scrapeRegistry.summary("http.server.response.size",
                         "method", METHODS[i % METHODS.length],
                         "status", STATUSES[i % STATUSES.length]
                 ).record(i * 128.0);
+                // @formatter:on
             }
         }
     }
@@ -140,7 +153,8 @@ public class PrometheusRegistryBenchmark {
     /**
      * Benchmark scenario 1: Meter creation and registration. Uses batching
      * (@OperationsPerInvocation) with 500 fresh meters per invocation using a realistic
-     * mix of web instrumentation (65% Timers, 30% Counters, 5% Summaries) with matching tags.
+     * mix of web instrumentation (65% Timers, 30% Counters, 5% Summaries) with matching
+     * tags.
      */
     @Benchmark
     @OperationsPerInvocation(CREATION_BATCH_SIZE)
@@ -152,41 +166,56 @@ public class PrometheusRegistryBenchmark {
             int modulo = i % 20;
             if (modulo < 13) {
                 if (modulo < 8) {
+                    // @formatter:off
                     Timer timer = registry.timer("http.server.requests",
                             "uri", URIS[i % URIS.length],
                             "method", METHODS[i % METHODS.length],
                             "status", STATUSES[i % STATUSES.length],
                             "outcome", OUTCOMES[i % OUTCOMES.length],
                             "exception", EXCEPTIONS[i % EXCEPTIONS.length]);
+                    // @formatter:on
                     bh.consume(timer);
-                } else if (modulo < 11) {
+                }
+                else if (modulo < 11) {
+                    // @formatter:off
                     Timer timer = registry.timer("http.client.requests",
                             "clientName", CLIENT_NAMES[i % CLIENT_NAMES.length],
                             "uri", URIS[i % URIS.length],
                             "method", METHODS[i % METHODS.length],
                             "status", STATUSES[i % STATUSES.length],
                             "outcome", OUTCOMES[i % OUTCOMES.length]);
+                    // @formatter:on
                     bh.consume(timer);
-                } else {
+                }
+                else {
+                    // @formatter:off
                     Timer timer = registry.timer("db.statement",
                             "name", DB_STATEMENTS[i % DB_STATEMENTS.length],
                             "status", "success");
+                    // @formatter:on
                     bh.consume(timer);
                 }
-            } else if (modulo < 19) {
+            }
+            else if (modulo < 19) {
                 if (modulo < 16) {
                     Counter counter = registry.counter("logback.events", "level", LOG_LEVELS[i % LOG_LEVELS.length]);
                     bh.consume(counter);
-                } else {
+                }
+                else {
+                    // @formatter:off
                     Counter counter = registry.counter("cache.gets",
                             "cache", CACHE_NAMES[i % CACHE_NAMES.length],
                             "result", (i % 2 == 0) ? "hit" : "miss");
+                    // @formatter:on
                     bh.consume(counter);
                 }
-            } else {
+            }
+            else {
+                // @formatter:off
                 DistributionSummary summary = registry.summary("http.server.response.size",
                         "method", METHODS[i % METHODS.length],
                         "status", STATUSES[i % STATUSES.length]);
+                // @formatter:on
                 bh.consume(summary);
             }
         }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -48,20 +48,8 @@ public class PrometheusRegistryBenchmark {
 
     public static final int CREATION_BATCH_SIZE = 500;
 
-    private static final String[] COUNTER_NAMES = {
-            "cache.gets", "executor.completed", "logback.events"
-    };
-
-    private static final String[] GAUGE_NAMES = {
-            "jvm.memory.used", "system.cpu.usage"
-    };
-
-    private static final String[] TIMER_NAMES = {
-            "http.server.requests", "http.client.requests", "db.statement"
-    };
-
-    private static final String[] SUMMARY_NAMES = {
-            "http.server.response.size", "kafka.producer.record.size"
+    private static final String[] URIS = {
+            "/api/v1/users", "/api/v1/orders/{id}", "/api/v1/products", "/health", "/api/v1/checkout"
     };
 
     private static final String[] METHODS = { "GET", "POST", "PUT", "DELETE" };
@@ -69,6 +57,16 @@ public class PrometheusRegistryBenchmark {
     private static final String[] STATUSES = { "200", "201", "400", "404", "500" };
 
     private static final String[] OUTCOMES = { "SUCCESS", "CLIENT_ERROR", "SERVER_ERROR" };
+
+    private static final String[] EXCEPTIONS = { "none", "IllegalArgumentException", "IllegalStateException" };
+
+    private static final String[] CLIENT_NAMES = { "inventory-service", "payment-gateway" };
+
+    private static final String[] DB_STATEMENTS = { "select-user", "insert-order", "update-stock" };
+
+    private static final String[] LOG_LEVELS = { "info", "warn", "error" };
+
+    private static final String[] CACHE_NAMES = { "users", "products", "orders" };
 
     @Param({ "500" })
     private int scrapeMeterCount;
@@ -82,39 +80,67 @@ public class PrometheusRegistryBenchmark {
         scrapeRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         gaugeValue = new AtomicInteger(42);
 
-        // Pre-register realistic meters for scrape benchmarks across 10 metric families with distinct types
-        for (int i = 0; i < scrapeMeterCount; i++) {
-            String uri = "/api/v1/endpoint_" + (i / 10);
-            String method = METHODS[i % METHODS.length];
-            String status = STATUSES[i % STATUSES.length];
-            String outcome = OUTCOMES[i % OUTCOMES.length];
+        // System gauges registered once during setup
+        Gauge.builder("jvm.memory.used", gaugeValue, AtomicInteger::get)
+                .tags("area", "heap", "id", "G1 Eden Space")
+                .register(scrapeRegistry);
+        Gauge.builder("jvm.memory.used", gaugeValue, AtomicInteger::get)
+                .tags("area", "heap", "id", "G1 Old Gen")
+                .register(scrapeRegistry);
+        Gauge.builder("system.cpu.usage", gaugeValue, AtomicInteger::get)
+                .register(scrapeRegistry);
 
-            if (i % 4 == 0) {
-                String name = COUNTER_NAMES[(i / 4) % COUNTER_NAMES.length];
-                Counter counter = scrapeRegistry.counter(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
-                counter.increment(i + 1);
-            } else if (i % 4 == 1) {
-                String name = GAUGE_NAMES[(i / 4) % GAUGE_NAMES.length];
-                Gauge.builder(name, gaugeValue, AtomicInteger::get)
-                        .tags("uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service")
-                        .register(scrapeRegistry);
-            } else if (i % 4 == 2) {
-                String name = TIMER_NAMES[(i / 4) % TIMER_NAMES.length];
-                Timer timer = scrapeRegistry.timer(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
-                timer.record(i + 10, TimeUnit.MILLISECONDS);
+        // Pre-register realistic meters for scrape benchmarks (~65% Timers, ~30% Counters, ~5% Summaries)
+        for (int i = 0; i < scrapeMeterCount; i++) {
+            int modulo = i % 20;
+            if (modulo < 13) {
+                // Timer: http.server.requests, http.client.requests, db.statement
+                if (modulo < 8) {
+                    scrapeRegistry.timer("http.server.requests",
+                            "uri", URIS[i % URIS.length],
+                            "method", METHODS[i % METHODS.length],
+                            "status", STATUSES[i % STATUSES.length],
+                            "outcome", OUTCOMES[i % OUTCOMES.length],
+                            "exception", EXCEPTIONS[i % EXCEPTIONS.length]
+                    ).record(i + 10, TimeUnit.MILLISECONDS);
+                } else if (modulo < 11) {
+                    scrapeRegistry.timer("http.client.requests",
+                            "clientName", CLIENT_NAMES[i % CLIENT_NAMES.length],
+                            "uri", URIS[i % URIS.length],
+                            "method", METHODS[i % METHODS.length],
+                            "status", STATUSES[i % STATUSES.length],
+                            "outcome", OUTCOMES[i % OUTCOMES.length]
+                    ).record(i + 5, TimeUnit.MILLISECONDS);
+                } else {
+                    scrapeRegistry.timer("db.statement",
+                            "name", DB_STATEMENTS[i % DB_STATEMENTS.length],
+                            "status", "success"
+                    ).record(i + 1, TimeUnit.MILLISECONDS);
+                }
+            } else if (modulo < 19) {
+                // Counter: logback.events, cache.gets
+                if (modulo < 16) {
+                    scrapeRegistry.counter("logback.events", "level", LOG_LEVELS[i % LOG_LEVELS.length]).increment();
+                } else {
+                    scrapeRegistry.counter("cache.gets",
+                            "cache", CACHE_NAMES[i % CACHE_NAMES.length],
+                            "result", (i % 2 == 0) ? "hit" : "miss"
+                    ).increment();
+                }
             } else {
-                String name = SUMMARY_NAMES[(i / 4) % SUMMARY_NAMES.length];
-                DistributionSummary summary = scrapeRegistry.summary(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
-                summary.record(i * 1.5);
+                // DistributionSummary: http.server.response.size
+                scrapeRegistry.summary("http.server.response.size",
+                        "method", METHODS[i % METHODS.length],
+                        "status", STATUSES[i % STATUSES.length]
+                ).record(i * 128.0);
             }
         }
     }
 
     /**
      * Benchmark scenario 1: Meter creation and registration. Uses batching
-     * (@OperationsPerInvocation) with 500 fresh meters per invocation across 10
-     * realistic metric family names to accurately quantify per-meter creation
-     * latency and heap allocations under realistic metric distributions.
+     * (@OperationsPerInvocation) with 500 fresh meters per invocation using a realistic
+     * mix of web instrumentation (65% Timers, 30% Counters, 5% Summaries) with matching tags.
      */
     @Benchmark
     @OperationsPerInvocation(CREATION_BATCH_SIZE)
@@ -123,29 +149,44 @@ public class PrometheusRegistryBenchmark {
         PrometheusMeterRegistry registry = state.getRegistry();
 
         for (int i = 0; i < CREATION_BATCH_SIZE; i++) {
-            String uri = "/api/v1/endpoint_" + (i / 10);
-            String method = METHODS[i % METHODS.length];
-            String status = STATUSES[i % STATUSES.length];
-            String outcome = OUTCOMES[i % OUTCOMES.length];
-
-            if (i % 4 == 0) {
-                String name = COUNTER_NAMES[(i / 4) % COUNTER_NAMES.length];
-                Counter counter = registry.counter(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
-                counter.increment();
-                bh.consume(counter);
-            } else if (i % 4 == 1) {
-                String name = GAUGE_NAMES[(i / 4) % GAUGE_NAMES.length];
-                Gauge gauge = Gauge.builder(name, gaugeValue, AtomicInteger::get)
-                        .tags("uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service")
-                        .register(registry);
-                bh.consume(gauge);
-            } else if (i % 4 == 2) {
-                String name = TIMER_NAMES[(i / 4) % TIMER_NAMES.length];
-                Timer timer = registry.timer(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
-                bh.consume(timer);
+            int modulo = i % 20;
+            if (modulo < 13) {
+                if (modulo < 8) {
+                    Timer timer = registry.timer("http.server.requests",
+                            "uri", URIS[i % URIS.length],
+                            "method", METHODS[i % METHODS.length],
+                            "status", STATUSES[i % STATUSES.length],
+                            "outcome", OUTCOMES[i % OUTCOMES.length],
+                            "exception", EXCEPTIONS[i % EXCEPTIONS.length]);
+                    bh.consume(timer);
+                } else if (modulo < 11) {
+                    Timer timer = registry.timer("http.client.requests",
+                            "clientName", CLIENT_NAMES[i % CLIENT_NAMES.length],
+                            "uri", URIS[i % URIS.length],
+                            "method", METHODS[i % METHODS.length],
+                            "status", STATUSES[i % STATUSES.length],
+                            "outcome", OUTCOMES[i % OUTCOMES.length]);
+                    bh.consume(timer);
+                } else {
+                    Timer timer = registry.timer("db.statement",
+                            "name", DB_STATEMENTS[i % DB_STATEMENTS.length],
+                            "status", "success");
+                    bh.consume(timer);
+                }
+            } else if (modulo < 19) {
+                if (modulo < 16) {
+                    Counter counter = registry.counter("logback.events", "level", LOG_LEVELS[i % LOG_LEVELS.length]);
+                    bh.consume(counter);
+                } else {
+                    Counter counter = registry.counter("cache.gets",
+                            "cache", CACHE_NAMES[i % CACHE_NAMES.length],
+                            "result", (i % 2 == 0) ? "hit" : "miss");
+                    bh.consume(counter);
+                }
             } else {
-                String name = SUMMARY_NAMES[(i / 4) % SUMMARY_NAMES.length];
-                DistributionSummary summary = registry.summary(name, "uri", uri, "method", method, "status", status, "outcome", outcome, "service", "payment-service");
+                DistributionSummary summary = registry.summary("http.server.response.size",
+                        "method", METHODS[i % METHODS.length],
+                        "status", STATUSES[i % STATUSES.length]);
                 bh.consume(summary);
             }
         }

--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.benchmark.prometheus;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * JMH Benchmarks for quantifying performance and allocations in {@link PrometheusMeterRegistry}.
+ * <p>
+ * Specifically benchmarks:
+ * 1. Meter Creation: Batch registration of new meters into a fresh registry.
+ * 2. Meter Scrape / Collection: Scraping pre-registered metrics.
+ */
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class PrometheusRegistryBenchmark {
+
+    public static final int CREATION_BATCH_SIZE = 500;
+
+    @Param({"500"})
+    private int scrapeMeterCount;
+
+    private PrometheusMeterRegistry scrapeRegistry;
+    private AtomicInteger gaugeValue;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        scrapeRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        gaugeValue = new AtomicInteger(42);
+
+        // Pre-register meters for the scrape benchmark (500 meter families with tags)
+        for (int i = 0; i < scrapeMeterCount; i++) {
+            String idSuffix = String.valueOf(i);
+            Counter counter = scrapeRegistry.counter("benchmark_counter_" + idSuffix,
+                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            counter.increment(i + 1);
+
+            Gauge.builder("benchmark_gauge_" + idSuffix, gaugeValue, AtomicInteger::get)
+                .tags("region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix)
+                .register(scrapeRegistry);
+
+            Timer timer = scrapeRegistry.timer("benchmark_timer_" + idSuffix,
+                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            timer.record(i + 10, TimeUnit.MILLISECONDS);
+
+            DistributionSummary summary = scrapeRegistry.summary("benchmark_summary_" + idSuffix,
+                    "region", "us-east-1", "env", "production", "service", "payment-service", "instance", idSuffix);
+            summary.record(i * 1.5);
+        }
+    }
+
+    /**
+     * Benchmark scenario 1: Meter creation and registration.
+     * Uses batching (@OperationsPerInvocation) with 500 fresh meters per invocation to accurately
+     * quantify per-meter creation latency and heap allocations while amortizing registry setup overhead.
+     */
+    @Benchmark
+    @OperationsPerInvocation(CREATION_BATCH_SIZE)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public void meterCreation(CreationState state, Blackhole bh) {
+        PrometheusMeterRegistry registry = state.getRegistry();
+
+        for (int i = 0; i < CREATION_BATCH_SIZE; i++) {
+            String idSuffix = String.valueOf(i);
+            Counter counter = registry.counter("created_counter_" + idSuffix,
+                    "region", "us-east-1", "env", "production", "service", "auth-service", "instance", idSuffix);
+            counter.increment();
+            bh.consume(counter);
+        }
+    }
+
+    /**
+     * Benchmark scenario 2: Meter collection only (Phase 1 snapshot collection).
+     */
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public Object collect() {
+        return scrapeRegistry.getPrometheusRegistry().scrape();
+    }
+
+    /**
+     * Benchmark scenario 3: Full meter scrape (snapshot collection + text format serialization).
+     * Evaluates scrape latency and allocations across registered meters.
+     */
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    public String scrape() {
+        return scrapeRegistry.scrape();
+    }
+
+    @State(Scope.Thread)
+    public static class CreationState {
+
+        private PrometheusMeterRegistry registry;
+
+        @Setup(Level.Invocation)
+        public void setupInvocation() {
+            registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        }
+
+        public PrometheusMeterRegistry getRegistry() {
+            return registry;
+        }
+
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder()
+            .include(PrometheusRegistryBenchmark.class.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .build()).run();
+    }
+
+}

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MeterContext.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MeterContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.prometheusmetrics;
+
+import io.micrometer.core.instrument.Meter;
+import io.prometheus.metrics.model.snapshots.Labels;
+
+import java.util.List;
+
+/**
+ * Everything a {@link MicrometerCollector} needs about a meter that must be derived from
+ * the registry when the meter is created rather than when it is scraped: the naming
+ * convention is applied to the tags, the configured help text is resolved, and the
+ * created timestamp is taken from the registry clock. Doing this once per meter keeps the
+ * {@link io.micrometer.core.instrument.config.NamingConvention} off the scrape path.
+ *
+ * @author Tommy Ludwig
+ */
+final class MeterContext {
+
+    final Meter.Id id;
+
+    /**
+     * Convention tag keys, used as the label names of the metric families.
+     */
+    final List<String> tagKeys;
+
+    /**
+     * Tag values in the same order as {@link #tagKeys}.
+     */
+    final List<String> tagValues;
+
+    /**
+     * The labels of the data points, i.e. {@link #tagKeys} zipped with
+     * {@link #tagValues}. Meters that add labels of their own, such as custom meters,
+     * build their labels from the keys and values instead.
+     */
+    final Labels labels;
+
+    final String help;
+
+    final long createdTimestampMillis;
+
+    MeterContext(Meter.Id id, List<String> tagKeys, List<String> tagValues, String help, long createdTimestampMillis) {
+        this.id = id;
+        this.tagKeys = tagKeys;
+        this.tagValues = tagValues;
+        this.labels = Labels.of(tagKeys, tagValues);
+        this.help = help;
+        this.createdTimestampMillis = createdTimestampMillis;
+    }
+
+}

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -60,6 +60,10 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
+    public String getConventionName() {
+        return conventionName;
+    }
+
     public void add(Meter.Id id, Child child, MetricFamilyDescriptor... registeredFamilies) {
         children.put(id, child);
         this.registeredFamilies.put(id, Arrays.asList(registeredFamilies));

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -78,7 +78,7 @@ class MicrometerCollector implements MultiCollector {
 
     private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
 
-    private final Map<String, MetricFamilyDescriptor> descriptorsByFamilyName = new ConcurrentHashMap<>();
+    private final Map<String, MetricFamilyDescriptor> descriptorsByFamilyName = new HashMap<>(2);
 
     final String conventionName;
 
@@ -278,10 +278,13 @@ class MicrometerCollector implements MultiCollector {
      */
     MetricFamilyDescriptor getOrCreateDescriptor(MetricType metricType, String familyName,
             Collection<String> labelNames, String help) {
-        MetricFamilyDescriptor descriptor = descriptorsByFamilyName.computeIfAbsent(familyName,
-                // Unit is intentionally not set, see:
-                // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-                name -> MetricFamilyDescriptor.of(metricType, name).help(help).labelNames(labelNames).build());
+        MetricFamilyDescriptor descriptor = descriptorsByFamilyName.get(familyName);
+        if (descriptor == null) {
+            // Unit is intentionally not set, see:
+            // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
+            descriptor = MetricFamilyDescriptor.of(metricType, familyName).help(help).labelNames(labelNames).build();
+            descriptorsByFamilyName.put(familyName, descriptor);
+        }
         if (descriptor.getType() != metricType) {
             throw new IllegalArgumentException(
                     "Meters with the same name must produce the same Prometheus metric family types. The family ("
@@ -299,9 +302,9 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public MetricSnapshots collect() {
+        int familyCount = descriptorsByFamilyName.size();
         // descriptors are canonical per family
-        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> dataPointsByFamily = new IdentityHashMap<>(
-                descriptorsByFamilyName.size());
+        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> dataPointsByFamily = new IdentityHashMap<>(familyCount);
 
         for (Child child : children.values()) {
             child.collect((family, dataPoint) -> dataPointsByFamily
@@ -309,7 +312,7 @@ class MicrometerCollector implements MultiCollector {
                 .add(dataPoint));
         }
 
-        List<MetricSnapshot> snapshots = new ArrayList<>(dataPointsByFamily.size());
+        List<MetricSnapshot> snapshots = new ArrayList<>(familyCount);
         dataPointsByFamily.forEach((family, dataPoints) -> snapshots.add(createSnapshot(family, dataPoints)));
         return new MetricSnapshots(snapshots);
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -96,7 +96,7 @@ class MicrometerCollector implements MultiCollector {
         Map<String, Family> families = new HashMap<>();
 
         for (Child child : children.values()) {
-            child.samples(conventionName)
+            child.samples()
                 .forEach(family -> families.compute(family.getConventionName(),
                         (name, matchingFamily) -> matchingFamily != null
                                 ? matchingFamily.addSamples(family.dataPointSnapshots) : family));
@@ -112,7 +112,7 @@ class MicrometerCollector implements MultiCollector {
 
     interface Child {
 
-        Stream<Family<?>> samples(String conventionName);
+        Stream<Family<?>> samples();
 
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -78,6 +78,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 class MicrometerCollector implements MultiCollector {
 
+    // avoid cloning each time we want to iterate the enum values
+    private static final Statistic[] STATISTICS = Statistic.values();
+
     private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
 
     private final Map<String, MetricFamilyDescriptor> descriptorsByFamilyName = new ConcurrentHashMap<>();
@@ -199,16 +202,14 @@ class MicrometerCollector implements MultiCollector {
         List<String> statKeys = new ArrayList<>(context.tagKeys);
         statKeys.add("statistic");
 
-        // precompute the family and labels per statistic; statistics that map to the
-        // same Prometheus name (e.g. TOTAL and TOTAL_TIME) get the same family
+        // Pre-populate all Statistic enum values at registration time so the EnumMap
+        // is read-only while supporting dynamic measurements.
         Map<Statistic, MeasurementFamily> familiesByStatistic = new EnumMap<>(Statistic.class);
-        for (Measurement measurement : measurements) {
-            familiesByStatistic.computeIfAbsent(measurement.getStatistic(), statistic -> {
-                List<String> statValues = new ArrayList<>(context.tagValues);
-                statValues.add(statistic.toString());
-                return new MeasurementFamily(customMeterFamily(statistic, statKeys, context.help),
-                        Labels.of(statKeys, statValues));
-            });
+        for (Statistic statistic : STATISTICS) {
+            List<String> statValues = new ArrayList<>(context.tagValues);
+            statValues.add(statistic.toString());
+            familiesByStatistic.put(statistic, new MeasurementFamily(
+                    customMeterFamily(statistic, statKeys, context.help), Labels.of(statKeys, statValues)));
         }
 
         add(context.id, samples -> {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -16,6 +16,7 @@
 package io.micrometer.prometheusmetrics;
 
 import io.micrometer.core.instrument.Meter;
+import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.registry.MultiCollector;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
@@ -29,15 +30,12 @@ import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
-
-import static java.util.stream.Collectors.toList;
+import java.util.function.Supplier;
 
 /**
  * {@link MultiCollector} for Micrometer.
@@ -48,7 +46,9 @@ import static java.util.stream.Collectors.toList;
  */
 class MicrometerCollector implements MultiCollector {
 
-    private final Map<Meter.Id, Registration> registrations = new ConcurrentHashMap<>();
+    private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
+
+    private final Map<String, MetricFamilyDescriptor> descriptorsByFamilyName = new ConcurrentHashMap<>();
 
     final String conventionName;
 
@@ -62,50 +62,58 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
-    public void add(Meter.Id id, Child child, MetricFamilyDescriptor... familyDescriptors) {
-        validateTypesMatchExistingFamilies(familyDescriptors);
-        registrations.put(id, new Registration(child, Arrays.asList(familyDescriptors)));
+    public MetricFamilyDescriptor getOrCreateDescriptor(MetricType metricType, String familyName,
+            Supplier<MetricFamilyDescriptor> factory) {
+        MetricFamilyDescriptor existing = descriptorsByFamilyName.get(familyName);
+        if (existing != null) {
+            if (existing.getType() != metricType) {
+                throw new IllegalArgumentException(
+                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
+                                + familyName + ") was already registered with type " + existing.getType()
+                                + ", but this meter produces type " + metricType
+                                + ". This can happen when only some meters with"
+                                + " the same name publish histogram buckets.");
+            }
+            return existing;
+        }
+        MetricFamilyDescriptor created = factory.get();
+        existing = descriptorsByFamilyName.putIfAbsent(familyName, created);
+        if (existing != null) {
+            if (existing.getType() != metricType) {
+                throw new IllegalArgumentException(
+                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
+                                + familyName + ") was already registered with type " + existing.getType()
+                                + ", but this meter produces type " + metricType
+                                + ". This can happen when only some meters with"
+                                + " the same name publish histogram buckets.");
+            }
+            return existing;
+        }
+        return created;
     }
 
-    /**
-     * Fail registration instead of failing later on scrape if the given family
-     * descriptors conflict in type with the metric families of the already registered
-     * meters, e.g. only some meters with the same name publish histogram buckets.
-     * {@link io.prometheus.metrics.model.registry.PrometheusRegistry} only validates this
-     * for the families present when the collector is registered, not for meters added to
-     * this collector afterwards.
-     */
-    private void validateTypesMatchExistingFamilies(MetricFamilyDescriptor[] familyDescriptors) {
-        // Existing registrations are mutually consistent since each was validated when
-        // added, so validating against a single one of them is sufficient; only the
-        // primary family of distribution meters can vary in type (SUMMARY vs HISTOGRAM)
-        // and every distribution meter registers it.
-        Iterator<Registration> registrationIterator = registrations.values().iterator();
-        if (!registrationIterator.hasNext()) {
-            return;
-        }
-        List<MetricFamilyDescriptor> existingDescriptors = registrationIterator.next().familyDescriptors;
+    public void add(Meter.Id id, Child child, MetricFamilyDescriptor... familyDescriptors) {
         for (MetricFamilyDescriptor descriptor : familyDescriptors) {
-            for (MetricFamilyDescriptor existingDescriptor : existingDescriptors) {
-                if (descriptor.getPrometheusName().equals(existingDescriptor.getPrometheusName())
-                        && descriptor.getType() != existingDescriptor.getType()) {
-                    throw new IllegalArgumentException(
-                            "Meters with the same name must produce the same Prometheus metric family types. The family ("
-                                    + descriptor.getPrometheusName() + ") was already registered with type "
-                                    + existingDescriptor.getType() + ", but this meter produces type "
-                                    + descriptor.getType() + ". This can happen when only some meters with"
-                                    + " the same name publish histogram buckets.");
-                }
+            MetricFamilyDescriptor existing = descriptorsByFamilyName.putIfAbsent(descriptor.getPrometheusName(),
+                    descriptor);
+            if (existing != null && existing.getType() != descriptor.getType()) {
+                throw new IllegalArgumentException(
+                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
+                                + descriptor.getPrometheusName() + ") was already registered with type "
+                                + existing.getType() + ", but this meter produces type " + descriptor.getType()
+                                + ". This can happen when only some meters with"
+                                + " the same name publish histogram buckets.");
             }
         }
+        children.put(id, child);
     }
 
     public void remove(Meter.Id id) {
-        registrations.remove(id);
+        children.remove(id);
     }
 
     public boolean isEmpty() {
-        return registrations.isEmpty();
+        return children.isEmpty();
     }
 
     Meter.Id getOriginalId() {
@@ -114,10 +122,7 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public List<MetricFamilyDescriptor> getMetricFamilyDescriptors() {
-        return registrations.values()
-            .stream()
-            .flatMap(registration -> registration.familyDescriptors.stream())
-            .collect(toList());
+        return new ArrayList<>(descriptorsByFamilyName.values());
     }
 
     @Override
@@ -129,8 +134,8 @@ class MicrometerCollector implements MultiCollector {
             .computeIfAbsent(descriptor.getPrometheusName(), name -> new FamilySamples(descriptor)).dataPoints
             .add(dataPoint);
 
-        for (Registration registration : registrations.values()) {
-            registration.child.collect(sink);
+        for (Child child : children.values()) {
+            child.collect(sink);
         }
 
         List<MetricSnapshot> snapshots = new ArrayList<>(samplesByFamilyName.size());
@@ -168,22 +173,6 @@ class MicrometerCollector implements MultiCollector {
     interface Child {
 
         void collect(BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> samples);
-
-    }
-
-    /**
-     * A {@link Child} together with the family descriptors it was registered with.
-     */
-    private static final class Registration {
-
-        private final Child child;
-
-        private final List<MetricFamilyDescriptor> familyDescriptors;
-
-        private Registration(Child child, List<MetricFamilyDescriptor> familyDescriptors) {
-            this.child = child;
-            this.familyDescriptors = familyDescriptors;
-        }
 
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -15,30 +15,62 @@
  */
 package io.micrometer.prometheusmetrics;
 
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.FunctionTimer;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.LongTaskTimer;
+import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Statistic;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSupport;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.core.instrument.util.TimeUtils;
 import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.Exemplar;
+import io.prometheus.metrics.model.snapshots.Exemplars;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot.HistogramDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.InfoSnapshot;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot.InfoDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
 import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.Quantile;
+import io.prometheus.metrics.model.snapshots.Quantiles;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
- * {@link MultiCollector} for Micrometer.
+ * {@link MultiCollector} for Micrometer. It maps all meters that share a Prometheus name
+ * to the metric families of that name: each meter is added as a {@link Child} that
+ * contributes data points to one or more families, and each family is exposed as a single
+ * {@link MetricSnapshot} on collection.
  *
  * @author Jon Schneider
  * @author Johnny Lim
@@ -62,62 +94,212 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
-    public MetricFamilyDescriptor getOrCreateDescriptor(MetricType metricType, String familyName,
-            Supplier<MetricFamilyDescriptor> factory) {
-        MetricFamilyDescriptor existing = descriptorsByFamilyName.get(familyName);
-        if (existing != null) {
-            if (existing.getType() != metricType) {
-                throw new IllegalArgumentException(
-                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
-                                + familyName + ") was already registered with type " + existing.getType()
-                                + ", but this meter produces type " + metricType
-                                + ". This can happen when only some meters with"
-                                + " the same name publish histogram buckets.");
-            }
-            return existing;
-        }
-        MetricFamilyDescriptor created = factory.get();
-        existing = descriptorsByFamilyName.putIfAbsent(familyName, created);
-        if (existing != null) {
-            if (existing.getType() != metricType) {
-                throw new IllegalArgumentException(
-                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
-                                + familyName + ") was already registered with type " + existing.getType()
-                                + ", but this meter produces type " + metricType
-                                + ". This can happen when only some meters with"
-                                + " the same name publish histogram buckets.");
-            }
-            return existing;
-        }
-        return created;
+    void addCounter(MeterContext context, PrometheusCounter counter) {
+        MetricFamilyDescriptor family = familyDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
+                context.help);
+        addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(counter.count(), context.labels,
+                counter.exemplar(), context.createdTimestampMillis));
     }
 
-    public void add(Meter.Id id, Child child, MetricFamilyDescriptor... familyDescriptors) {
-        for (MetricFamilyDescriptor descriptor : familyDescriptors) {
-            MetricFamilyDescriptor existing = descriptorsByFamilyName.putIfAbsent(descriptor.getPrometheusName(),
-                    descriptor);
-            if (existing != null && existing.getType() != descriptor.getType()) {
-                throw new IllegalArgumentException(
-                        "Meters with the same name must produce the same Prometheus metric family types. The family ("
-                                + descriptor.getPrometheusName() + ") was already registered with type "
-                                + existing.getType() + ", but this meter produces type " + descriptor.getType()
-                                + ". This can happen when only some meters with"
-                                + " the same name publish histogram buckets.");
-            }
+    void addFunctionCounter(MeterContext context, FunctionCounter functionCounter) {
+        MetricFamilyDescriptor family = familyDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
+                context.help);
+        addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(functionCounter.count(), context.labels,
+                null, context.createdTimestampMillis));
+    }
+
+    void addGauge(MeterContext context, Gauge gauge) {
+        if (context.id.getName().endsWith(".info")) {
+            MetricFamilyDescriptor family = familyDescriptor(MetricType.INFO, conventionName, context.tagKeys,
+                    context.help);
+            addSingleDataPoint(context, family, () -> new InfoDataPointSnapshot(context.labels));
         }
+        else {
+            MetricFamilyDescriptor family = familyDescriptor(MetricType.GAUGE, conventionName, context.tagKeys,
+                    context.help);
+            addSingleDataPoint(context, family, () -> new GaugeDataPointSnapshot(gauge.value(), context.labels, null));
+        }
+    }
+
+    void addFunctionTimer(MeterContext context, FunctionTimer functionTimer) {
+        MetricFamilyDescriptor family = familyDescriptor(MetricType.SUMMARY, conventionName, context.tagKeys,
+                context.help);
+        addSingleDataPoint(context, family,
+                () -> new SummaryDataPointSnapshot((long) functionTimer.count(), functionTimer.totalTime(SECONDS),
+                        Quantiles.EMPTY, context.labels, null, context.createdTimestampMillis));
+    }
+
+    void addTimer(MeterContext context, PrometheusTimer timer) {
+        addDistribution(context, timer, () -> exemplarsInSeconds(timer.exemplars()), SECONDS);
+    }
+
+    void addLongTaskTimer(MeterContext context, LongTaskTimer longTaskTimer) {
+        addDistribution(context, longTaskTimer, () -> Exemplars.EMPTY, SECONDS);
+    }
+
+    void addDistributionSummary(MeterContext context, PrometheusDistributionSummary summary) {
+        // a distribution summary records unit-less values, so no conversion is needed
+        addDistribution(context, summary, summary::exemplars, null);
+    }
+
+    /**
+     * Adds a meter with distribution statistics, i.e. a timer, long task timer, or
+     * distribution summary. It contributes a data point to the primary family, which is a
+     * summary or a histogram depending on whether the meter publishes buckets, and one to
+     * the {@code _max} gauge family.
+     * @param timeUnit if {@code null}, snapshot values are used as-is; otherwise
+     * time-based snapshot values are converted to this unit
+     */
+    private void addDistribution(MeterContext context, HistogramSupport histogramSupport,
+            Supplier<Exemplars> exemplarsSupplier, @Nullable TimeUnit timeUnit) {
+        MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
+                : MetricType.HISTOGRAM;
+        MetricFamilyDescriptor family = familyDescriptor(primaryType, conventionName, context.tagKeys, context.help);
+        MetricFamilyDescriptor maxFamily = familyDescriptor(MetricType.GAUGE, conventionName + "_max", context.tagKeys,
+                context.help);
+
+        add(context.id, samples -> {
+            io.micrometer.core.instrument.distribution.HistogramSnapshot snapshot = histogramSupport.takeSnapshot();
+            CountAtBucket[] histogramCounts = snapshot.histogramCounts();
+            long count = snapshot.count();
+            double sum = timeUnit == null ? snapshot.total() : snapshot.total(timeUnit);
+
+            if (histogramCounts.length == 0) {
+                samples.accept(family,
+                        new SummaryDataPointSnapshot(count, sum, quantiles(snapshot.percentileValues(), timeUnit),
+                                context.labels, exemplarsSupplier.get(), context.createdTimestampMillis));
+            }
+            else {
+                samples.accept(family,
+                        new HistogramDataPointSnapshot(nonCumulativeBuckets(histogramCounts, count, timeUnit), sum,
+                                context.labels, exemplarsSupplier.get(), context.createdTimestampMillis));
+
+                // TODO: Add support back for VictoriaMetrics
+                // Previously we had low-level control so a histogram was just
+                // a bunch of Collector.MetricFamilySamples.Sample
+                // that has an le label for Prometheus and a vmrange label for
+                // Victoria.
+                // That control is gone now, so we don’t have control over the
+                // output and when HistogramDataPointSnapshot is written, the
+                // bucket name is hardcoded to le.
+            }
+
+            double max = timeUnit == null ? snapshot.max() : snapshot.max(timeUnit);
+            samples.accept(maxFamily, new GaugeDataPointSnapshot(max, context.labels, null));
+        });
+    }
+
+    /**
+     * Adds a custom meter. Unlike the other meters, the families it contributes to depend
+     * on the statistics of its measurements, it can contribute more than one data point
+     * to the same family, and it adds a {@code statistic} label of its own.
+     */
+    void addCustomMeter(MeterContext context, Iterable<Measurement> measurements) {
+        List<String> statKeys = new ArrayList<>(context.tagKeys);
+        statKeys.add("statistic");
+
+        // precompute the family and labels per statistic; statistics that map to the
+        // same Prometheus name (e.g. TOTAL and TOTAL_TIME) get the same family
+        Map<Statistic, MeasurementFamily> familiesByStatistic = new EnumMap<>(Statistic.class);
+        for (Measurement measurement : measurements) {
+            familiesByStatistic.computeIfAbsent(measurement.getStatistic(), statistic -> {
+                List<String> statValues = new ArrayList<>(context.tagValues);
+                statValues.add(statistic.toString());
+                return new MeasurementFamily(customMeterFamily(statistic, statKeys, context.help),
+                        Labels.of(statKeys, statValues));
+            });
+        }
+
+        add(context.id, samples -> {
+            for (Measurement measurement : measurements) {
+                MeasurementFamily family = requireNonNull(familiesByStatistic.get(measurement.getStatistic()));
+                if (family.descriptor.getType() == MetricType.COUNTER) {
+                    samples.accept(family.descriptor, new CounterDataPointSnapshot(measurement.getValue(),
+                            family.labels, null, context.createdTimestampMillis));
+                }
+                else {
+                    samples.accept(family.descriptor,
+                            new GaugeDataPointSnapshot(measurement.getValue(), family.labels, null));
+                }
+            }
+        });
+    }
+
+    private MetricFamilyDescriptor customMeterFamily(Statistic statistic, Collection<String> labelNames, String help) {
+        switch (statistic) {
+            case TOTAL:
+            case TOTAL_TIME:
+                return familyDescriptor(MetricType.COUNTER, conventionName + "_sum", labelNames, help);
+            case COUNT:
+                return familyDescriptor(MetricType.COUNTER, conventionName, labelNames, help);
+            case MAX:
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_max", labelNames, help);
+            case VALUE:
+            case UNKNOWN:
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_value", labelNames, help);
+            case ACTIVE_TASKS:
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_active_count", labelNames, help);
+            case DURATION:
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_duration_sum", labelNames, help);
+            default:
+                throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
+        }
+    }
+
+    private void addSingleDataPoint(MeterContext context, MetricFamilyDescriptor family,
+            Supplier<DataPointSnapshot> dataPoint) {
+        add(context.id, samples -> samples.accept(family, dataPoint.get()));
+    }
+
+    void add(Meter.Id id, Child child) {
         children.put(id, child);
     }
 
-    public void remove(Meter.Id id) {
+    // Descriptors are intentionally not removed with their meter: a family descriptor is
+    // valid for every meter of the family, and a collector with no meters left is
+    // unregistered and discarded as a whole.
+    void remove(Meter.Id id) {
         children.remove(id);
     }
 
-    public boolean isEmpty() {
+    boolean isEmpty() {
         return children.isEmpty();
     }
 
     Meter.Id getOriginalId() {
         return originalMeterId;
+    }
+
+    /**
+     * Returns the descriptor of the given metric family, creating it if this is the first
+     * meter contributing to the family. All meters of a family share one descriptor since
+     * it is the same for each of them.
+     * <p>
+     * Fails instead of failing later on scrape if the family was already registered with
+     * a different type, e.g. when only some meters with the same name publish histogram
+     * buckets. {@link io.prometheus.metrics.model.registry.PrometheusRegistry} only
+     * validates this for the families present when the collector is registered, not for
+     * meters added to this collector afterwards.
+     */
+    MetricFamilyDescriptor getOrCreateDescriptor(MetricType metricType, String familyName,
+            Supplier<MetricFamilyDescriptor> factory) {
+        MetricFamilyDescriptor descriptor = descriptorsByFamilyName.computeIfAbsent(familyName, name -> factory.get());
+        if (descriptor.getType() != metricType) {
+            throw new IllegalArgumentException(
+                    "Meters with the same name must produce the same Prometheus metric family types. The family ("
+                            + familyName + ") was already registered with type " + descriptor.getType()
+                            + ", but this meter produces type " + metricType + ". This can happen when only some"
+                            + " meters with the same name publish histogram buckets.");
+        }
+        return descriptor;
+    }
+
+    private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String familyName,
+            Collection<String> labelNames, String help) {
+        // Unit is intentionally not set, see:
+        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
+        return getOrCreateDescriptor(metricType, familyName,
+                () -> MetricFamilyDescriptor.of(metricType, familyName).help(help).labelNames(labelNames).build());
     }
 
     @Override
@@ -127,22 +309,18 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public MetricSnapshots collect() {
-        // group data points from all children by family name so that each family is
-        // exposed as a single MetricSnapshot
-        Map<String, FamilySamples> samplesByFamilyName = new LinkedHashMap<>();
-        BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> sink = (descriptor, dataPoint) -> samplesByFamilyName
-            .computeIfAbsent(descriptor.getPrometheusName(), name -> new FamilySamples(descriptor)).dataPoints
-            .add(dataPoint);
+        // descriptors are canonical per family, so grouping by descriptor groups by
+        // family
+        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> dataPointsByFamily = new IdentityHashMap<>();
+        BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> sink = (family,
+                dataPoint) -> dataPointsByFamily.computeIfAbsent(family, f -> new ArrayList<>()).add(dataPoint);
 
         for (Child child : children.values()) {
             child.collect(sink);
         }
 
-        List<MetricSnapshot> snapshots = new ArrayList<>(samplesByFamilyName.size());
-        for (FamilySamples familySamples : samplesByFamilyName.values()) {
-            snapshots.add(createSnapshot(familySamples.descriptor, familySamples.dataPoints));
-        }
-
+        List<MetricSnapshot> snapshots = new ArrayList<>(dataPointsByFamily.size());
+        dataPointsByFamily.forEach((family, dataPoints) -> snapshots.add(createSnapshot(family, dataPoints)));
         return new MetricSnapshots(snapshots);
     }
 
@@ -169,6 +347,57 @@ class MicrometerCollector implements MultiCollector {
         }
     }
 
+    private static Quantiles quantiles(ValueAtPercentile[] percentileValues, @Nullable TimeUnit timeUnit) {
+        if (percentileValues.length == 0) {
+            return Quantiles.EMPTY;
+        }
+        List<Quantile> quantiles = new ArrayList<>(percentileValues.length);
+        for (ValueAtPercentile percentileValue : percentileValues) {
+            quantiles.add(new Quantile(percentileValue.percentile(),
+                    timeUnit == null ? percentileValue.value() : percentileValue.value(timeUnit)));
+        }
+        return Quantiles.of(quantiles);
+    }
+
+    // TODO: remove this cumulative -> non cumulative conversion
+    // ClassicHistogramBuckets is not cumulative but the histograms we use are cumulative
+    // so we convert it to non-cumulative just for the Prometheus client library
+    // can convert it back to cumulative.
+    private static ClassicHistogramBuckets nonCumulativeBuckets(CountAtBucket[] histogramCounts, long count,
+            @Nullable TimeUnit timeUnit) {
+        List<Double> buckets = new ArrayList<>();
+        List<Number> counts = new ArrayList<>();
+        buckets.add(bucket(histogramCounts[0], timeUnit));
+        counts.add(histogramCounts[0].count());
+        for (int i = 1; i < histogramCounts.length; i++) {
+            buckets.add(bucket(histogramCounts[i], timeUnit));
+            counts.add(histogramCounts[i].count() - histogramCounts[i - 1].count());
+        }
+        if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
+            // ClassicHistogramBuckets is not cumulative
+            buckets.add(Double.POSITIVE_INFINITY);
+            double infCount = count - histogramCounts[histogramCounts.length - 1].count();
+            counts.add(infCount >= 0 ? infCount : 0);
+        }
+        return ClassicHistogramBuckets.of(buckets, counts);
+    }
+
+    private static double bucket(CountAtBucket countAtBucket, @Nullable TimeUnit timeUnit) {
+        return timeUnit == null ? countAtBucket.bucket() : countAtBucket.bucket(timeUnit);
+    }
+
+    private static Exemplars exemplarsInSeconds(Exemplars exemplars) {
+        List<Exemplar> scaled = new ArrayList<>(exemplars.size());
+        for (Exemplar exemplar : exemplars) {
+            scaled.add(Exemplar.builder()
+                .value(TimeUtils.convert(exemplar.getValue(), NANOSECONDS, SECONDS))
+                .labels(exemplar.getLabels())
+                .timestampMillis(exemplar.getTimestampMillis())
+                .build());
+        }
+        return Exemplars.of(scaled);
+    }
+
     @FunctionalInterface
     interface Child {
 
@@ -177,18 +406,18 @@ class MicrometerCollector implements MultiCollector {
     }
 
     /**
-     * Data points collected for one metric family during a single {@link #collect()}
-     * call. Since children register their own descriptor instances, the descriptor of the
-     * first child that contributes to the family is used for the snapshot metadata.
+     * The metric family and precomputed labels for the measurements of one
+     * {@link Statistic} of a custom meter.
      */
-    private static final class FamilySamples {
+    private static final class MeasurementFamily {
 
         private final MetricFamilyDescriptor descriptor;
 
-        private final List<DataPointSnapshot> dataPoints = new ArrayList<>();
+        private final Labels labels;
 
-        private FamilySamples(MetricFamilyDescriptor descriptor) {
+        private MeasurementFamily(MetricFamilyDescriptor descriptor, Labels labels) {
             this.descriptor = descriptor;
+            this.labels = labels;
         }
 
     }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -30,11 +30,12 @@ import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 import static java.util.stream.Collectors.toList;
 
@@ -47,11 +48,7 @@ import static java.util.stream.Collectors.toList;
  */
 class MicrometerCollector implements MultiCollector {
 
-    private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
-
-    private final Map<Meter.Id, List<MetricFamilyDescriptor>> registeredFamilies = new ConcurrentHashMap<>();
-
-    private final Map<MetricFamilyDescriptor, SnapshotFactory> customSnapshotFactories = new ConcurrentHashMap<>();
+    private final Map<Meter.Id, Registration> registrations = new ConcurrentHashMap<>();
 
     final String conventionName;
 
@@ -65,29 +62,50 @@ class MicrometerCollector implements MultiCollector {
         this.originalMeterId = id;
     }
 
-    public void add(Meter.Id id, Child child, MetricFamilyDescriptor... registeredFamilies) {
-        children.put(id, child);
-        this.registeredFamilies.put(id, Arrays.asList(registeredFamilies));
+    public void add(Meter.Id id, Child child, MetricFamilyDescriptor... familyDescriptors) {
+        validateTypesMatchExistingFamilies(familyDescriptors);
+        registrations.put(id, new Registration(child, Arrays.asList(familyDescriptors)));
     }
 
-    public void registerCustomSnapshotFactory(MetricFamilyDescriptor descriptor, SnapshotFactory factory) {
-        customSnapshotFactories.put(descriptor, factory);
-    }
-
-    public void remove(Meter.Id id) {
-        children.remove(id);
-        List<MetricFamilyDescriptor> descriptors = registeredFamilies.remove(id);
-        if (descriptors != null) {
-            descriptors.forEach(customSnapshotFactories::remove);
+    /**
+     * Fail registration instead of failing later on scrape if the given family
+     * descriptors conflict in type with the metric families of the already registered
+     * meters, e.g. only some meters with the same name publish histogram buckets.
+     * {@link io.prometheus.metrics.model.registry.PrometheusRegistry} only validates this
+     * for the families present when the collector is registered, not for meters added to
+     * this collector afterwards.
+     */
+    private void validateTypesMatchExistingFamilies(MetricFamilyDescriptor[] familyDescriptors) {
+        // Existing registrations are mutually consistent since each was validated when
+        // added, so validating against a single one of them is sufficient; only the
+        // primary family of distribution meters can vary in type (SUMMARY vs HISTOGRAM)
+        // and every distribution meter registers it.
+        Iterator<Registration> registrationIterator = registrations.values().iterator();
+        if (!registrationIterator.hasNext()) {
+            return;
+        }
+        List<MetricFamilyDescriptor> existingDescriptors = registrationIterator.next().familyDescriptors;
+        for (MetricFamilyDescriptor descriptor : familyDescriptors) {
+            for (MetricFamilyDescriptor existingDescriptor : existingDescriptors) {
+                if (descriptor.getPrometheusName().equals(existingDescriptor.getPrometheusName())
+                        && descriptor.getType() != existingDescriptor.getType()) {
+                    throw new IllegalArgumentException(
+                            "Meters with the same name must produce the same Prometheus metric family types. The family ("
+                                    + descriptor.getPrometheusName() + ") was already registered with type "
+                                    + existingDescriptor.getType() + ", but this meter produces type "
+                                    + descriptor.getType() + ". This can happen when only some meters with"
+                                    + " the same name publish histogram buckets.");
+                }
+            }
         }
     }
 
-    public boolean isEmpty() {
-        return children.isEmpty();
+    public void remove(Meter.Id id) {
+        registrations.remove(id);
     }
 
-    Meter.Type getMeterType() {
-        return originalMeterId.getType();
+    public boolean isEmpty() {
+        return registrations.isEmpty();
     }
 
     Meter.Id getOriginalId() {
@@ -96,24 +114,28 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public List<MetricFamilyDescriptor> getMetricFamilyDescriptors() {
-        return registeredFamilies.values().stream().flatMap(Collection::stream).collect(toList());
+        return registrations.values()
+            .stream()
+            .flatMap(registration -> registration.familyDescriptors.stream())
+            .collect(toList());
     }
 
     @Override
     public MetricSnapshots collect() {
-        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> familyDataPoints = new LinkedHashMap<>();
+        // group data points from all children by family name so that each family is
+        // exposed as a single MetricSnapshot
+        Map<String, FamilySamples> samplesByFamilyName = new LinkedHashMap<>();
+        BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> sink = (descriptor, dataPoint) -> samplesByFamilyName
+            .computeIfAbsent(descriptor.getPrometheusName(), name -> new FamilySamples(descriptor)).dataPoints
+            .add(dataPoint);
 
-        for (Child child : children.values()) {
-            child.collect(familyDataPoints);
+        for (Registration registration : registrations.values()) {
+            registration.child.collect(sink);
         }
 
-        List<MetricSnapshot> snapshots = new ArrayList<>(familyDataPoints.size());
-        for (Map.Entry<MetricFamilyDescriptor, List<DataPointSnapshot>> entry : familyDataPoints.entrySet()) {
-            MetricFamilyDescriptor descriptor = entry.getKey();
-            List<DataPointSnapshot> dataPoints = entry.getValue();
-            if (!dataPoints.isEmpty()) {
-                snapshots.add(createSnapshot(descriptor, dataPoints));
-            }
+        List<MetricSnapshot> snapshots = new ArrayList<>(samplesByFamilyName.size());
+        for (FamilySamples familySamples : samplesByFamilyName.values()) {
+            snapshots.add(createSnapshot(familySamples.descriptor, familySamples.dataPoints));
         }
 
         return new MetricSnapshots(snapshots);
@@ -121,10 +143,6 @@ class MicrometerCollector implements MultiCollector {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private MetricSnapshot createSnapshot(MetricFamilyDescriptor descriptor, List<DataPointSnapshot> dataPoints) {
-        SnapshotFactory customFactory = customSnapshotFactories.get(descriptor);
-        if (customFactory != null) {
-            return customFactory.create(descriptor.getMetadata(), (List) dataPoints);
-        }
         MetricMetadata metadata = descriptor.getMetadata();
         switch (descriptor.getType()) {
             case COUNTER:
@@ -134,7 +152,11 @@ class MicrometerCollector implements MultiCollector {
             case SUMMARY:
                 return new SummarySnapshot(metadata, (List) dataPoints);
             case HISTOGRAM:
-                return new HistogramSnapshot(metadata, (List) dataPoints);
+                // A LongTaskTimer histogram is point-in-time and non-monotonic, which
+                // maps to a Prometheus gauge histogram; it is the only meter for which
+                // we produce one.
+                return new HistogramSnapshot(originalMeterId.getType() == Meter.Type.LONG_TASK_TIMER, metadata,
+                        (List) dataPoints);
             case INFO:
                 return new InfoSnapshot(metadata, (List) dataPoints);
             default:
@@ -145,14 +167,40 @@ class MicrometerCollector implements MultiCollector {
     @FunctionalInterface
     interface Child {
 
-        void collect(Map<MetricFamilyDescriptor, List<DataPointSnapshot>> samples);
+        void collect(BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> samples);
 
     }
 
-    @FunctionalInterface
-    interface SnapshotFactory {
+    /**
+     * A {@link Child} together with the family descriptors it was registered with.
+     */
+    private static final class Registration {
 
-        MetricSnapshot create(MetricMetadata metadata, List<DataPointSnapshot> dataPoints);
+        private final Child child;
+
+        private final List<MetricFamilyDescriptor> familyDescriptors;
+
+        private Registration(Child child, List<MetricFamilyDescriptor> familyDescriptors) {
+            this.child = child;
+            this.familyDescriptors = familyDescriptors;
+        }
+
+    }
+
+    /**
+     * Data points collected for one metric family during a single {@link #collect()}
+     * call. Since children register their own descriptor instances, the descriptor of the
+     * first child that contributes to the family is used for the snapshot metadata.
+     */
+    private static final class FamilySamples {
+
+        private final MetricFamilyDescriptor descriptor;
+
+        private final List<DataPointSnapshot> dataPoints = new ArrayList<>();
+
+        private FamilySamples(MetricFamilyDescriptor descriptor) {
+            this.descriptor = descriptor;
+        }
 
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -95,14 +95,14 @@ class MicrometerCollector implements MultiCollector {
     }
 
     void addCounter(MeterContext context, PrometheusCounter counter) {
-        MetricFamilyDescriptor family = familyDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
+        MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
                 context.help);
         addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(counter.count(), context.labels,
                 counter.exemplar(), context.createdTimestampMillis));
     }
 
     void addFunctionCounter(MeterContext context, FunctionCounter functionCounter) {
-        MetricFamilyDescriptor family = familyDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
+        MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
                 context.help);
         addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(functionCounter.count(), context.labels,
                 null, context.createdTimestampMillis));
@@ -110,19 +110,19 @@ class MicrometerCollector implements MultiCollector {
 
     void addGauge(MeterContext context, Gauge gauge) {
         if (context.id.getName().endsWith(".info")) {
-            MetricFamilyDescriptor family = familyDescriptor(MetricType.INFO, conventionName, context.tagKeys,
+            MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.INFO, conventionName, context.tagKeys,
                     context.help);
             addSingleDataPoint(context, family, () -> new InfoDataPointSnapshot(context.labels));
         }
         else {
-            MetricFamilyDescriptor family = familyDescriptor(MetricType.GAUGE, conventionName, context.tagKeys,
+            MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.GAUGE, conventionName, context.tagKeys,
                     context.help);
             addSingleDataPoint(context, family, () -> new GaugeDataPointSnapshot(gauge.value(), context.labels, null));
         }
     }
 
     void addFunctionTimer(MeterContext context, FunctionTimer functionTimer) {
-        MetricFamilyDescriptor family = familyDescriptor(MetricType.SUMMARY, conventionName, context.tagKeys,
+        MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.SUMMARY, conventionName, context.tagKeys,
                 context.help);
         addSingleDataPoint(context, family,
                 () -> new SummaryDataPointSnapshot((long) functionTimer.count(), functionTimer.totalTime(SECONDS),
@@ -154,9 +154,10 @@ class MicrometerCollector implements MultiCollector {
             Supplier<Exemplars> exemplarsSupplier, @Nullable TimeUnit timeUnit) {
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
-        MetricFamilyDescriptor family = familyDescriptor(primaryType, conventionName, context.tagKeys, context.help);
-        MetricFamilyDescriptor maxFamily = familyDescriptor(MetricType.GAUGE, conventionName + "_max", context.tagKeys,
+        MetricFamilyDescriptor family = getOrCreateDescriptor(primaryType, conventionName, context.tagKeys,
                 context.help);
+        MetricFamilyDescriptor maxFamily = getOrCreateDescriptor(MetricType.GAUGE, conventionName + "_max",
+                context.tagKeys, context.help);
 
         add(context.id, samples -> {
             io.micrometer.core.instrument.distribution.HistogramSnapshot snapshot = histogramSupport.takeSnapshot();
@@ -229,18 +230,18 @@ class MicrometerCollector implements MultiCollector {
         switch (statistic) {
             case TOTAL:
             case TOTAL_TIME:
-                return familyDescriptor(MetricType.COUNTER, conventionName + "_sum", labelNames, help);
+                return getOrCreateDescriptor(MetricType.COUNTER, conventionName + "_sum", labelNames, help);
             case COUNT:
-                return familyDescriptor(MetricType.COUNTER, conventionName, labelNames, help);
+                return getOrCreateDescriptor(MetricType.COUNTER, conventionName, labelNames, help);
             case MAX:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_max", labelNames, help);
+                return getOrCreateDescriptor(MetricType.GAUGE, conventionName + "_max", labelNames, help);
             case VALUE:
             case UNKNOWN:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_value", labelNames, help);
+                return getOrCreateDescriptor(MetricType.GAUGE, conventionName + "_value", labelNames, help);
             case ACTIVE_TASKS:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_active_count", labelNames, help);
+                return getOrCreateDescriptor(MetricType.GAUGE, conventionName + "_active_count", labelNames, help);
             case DURATION:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_duration_sum", labelNames, help);
+                return getOrCreateDescriptor(MetricType.GAUGE, conventionName + "_duration_sum", labelNames, help);
             default:
                 throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
         }
@@ -282,8 +283,11 @@ class MicrometerCollector implements MultiCollector {
      * meters added to this collector afterwards.
      */
     MetricFamilyDescriptor getOrCreateDescriptor(MetricType metricType, String familyName,
-            Supplier<MetricFamilyDescriptor> factory) {
-        MetricFamilyDescriptor descriptor = descriptorsByFamilyName.computeIfAbsent(familyName, name -> factory.get());
+            Collection<String> labelNames, String help) {
+        MetricFamilyDescriptor descriptor = descriptorsByFamilyName.computeIfAbsent(familyName,
+                // Unit is intentionally not set, see:
+                // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
+                name -> MetricFamilyDescriptor.of(metricType, name).help(help).labelNames(labelNames).build());
         if (descriptor.getType() != metricType) {
             throw new IllegalArgumentException(
                     "Meters with the same name must produce the same Prometheus metric family types. The family ("
@@ -292,14 +296,6 @@ class MicrometerCollector implements MultiCollector {
                             + " meters with the same name publish histogram buckets.");
         }
         return descriptor;
-    }
-
-    private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String familyName,
-            Collection<String> labelNames, String help) {
-        // Unit is intentionally not set, see:
-        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return getOrCreateDescriptor(metricType, familyName,
-                () -> MetricFamilyDescriptor.of(metricType, familyName).help(help).labelNames(labelNames).build());
     }
 
     @Override

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -48,7 +48,7 @@ class MicrometerCollector implements MultiCollector {
 
     private final Map<Meter.Id, List<MetricFamilyDescriptor>> registeredFamilies = new ConcurrentHashMap<>();
 
-    private final String conventionName;
+    final String conventionName;
 
     // the id of the meter used to create this MicrometerCollector
     private final Meter.Id originalMeterId;
@@ -58,10 +58,6 @@ class MicrometerCollector implements MultiCollector {
     MicrometerCollector(String name, Meter.Id id) {
         this.conventionName = name;
         this.originalMeterId = id;
-    }
-
-    public String getConventionName() {
-        return conventionName;
     }
 
     public void add(Meter.Id id, Child child, MetricFamilyDescriptor... registeredFamilies) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -51,12 +51,7 @@ import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
 import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -100,36 +95,39 @@ class MicrometerCollector implements MultiCollector {
     void addCounter(MeterContext context, PrometheusCounter counter) {
         MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
                 context.help);
-        addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(counter.count(), context.labels,
-                counter.exemplar(), context.createdTimestampMillis));
+        add(context.id, samples -> samples.accept(family, new CounterDataPointSnapshot(counter.count(), context.labels,
+                counter.exemplar(), context.createdTimestampMillis)));
     }
 
     void addFunctionCounter(MeterContext context, FunctionCounter functionCounter) {
         MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.COUNTER, conventionName, context.tagKeys,
                 context.help);
-        addSingleDataPoint(context, family, () -> new CounterDataPointSnapshot(functionCounter.count(), context.labels,
-                null, context.createdTimestampMillis));
+        add(context.id, samples -> samples.accept(family, new CounterDataPointSnapshot(functionCounter.count(),
+                context.labels, null, context.createdTimestampMillis)));
     }
 
     void addGauge(MeterContext context, Gauge gauge) {
         if (context.id.getName().endsWith(".info")) {
             MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.INFO, conventionName, context.tagKeys,
                     context.help);
-            addSingleDataPoint(context, family, () -> new InfoDataPointSnapshot(context.labels));
+            add(context.id, samples -> samples.accept(family, new InfoDataPointSnapshot(context.labels)));
         }
         else {
             MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.GAUGE, conventionName, context.tagKeys,
                     context.help);
-            addSingleDataPoint(context, family, () -> new GaugeDataPointSnapshot(gauge.value(), context.labels, null));
+            add(context.id,
+                    samples -> samples.accept(family, new GaugeDataPointSnapshot(gauge.value(), context.labels, null)));
         }
     }
 
     void addFunctionTimer(MeterContext context, FunctionTimer functionTimer) {
         MetricFamilyDescriptor family = getOrCreateDescriptor(MetricType.SUMMARY, conventionName, context.tagKeys,
                 context.help);
-        addSingleDataPoint(context, family,
-                () -> new SummaryDataPointSnapshot((long) functionTimer.count(), functionTimer.totalTime(SECONDS),
-                        Quantiles.EMPTY, context.labels, null, context.createdTimestampMillis));
+        add(context.id,
+                samples -> samples.accept(family,
+                        new SummaryDataPointSnapshot((long) functionTimer.count(),
+                                functionTimer.totalTime(TimeUnit.SECONDS), Quantiles.EMPTY, context.labels, null,
+                                context.createdTimestampMillis)));
     }
 
     void addTimer(MeterContext context, PrometheusTimer timer) {
@@ -248,11 +246,6 @@ class MicrometerCollector implements MultiCollector {
         }
     }
 
-    private void addSingleDataPoint(MeterContext context, MetricFamilyDescriptor family,
-            Supplier<DataPointSnapshot> dataPoint) {
-        add(context.id, samples -> samples.accept(family, dataPoint.get()));
-    }
-
     void add(Meter.Id id, Child child) {
         children.put(id, child);
     }
@@ -306,14 +299,14 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public MetricSnapshots collect() {
-        // descriptors are canonical per family, so grouping by descriptor groups by
-        // family
-        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> dataPointsByFamily = new IdentityHashMap<>();
-        BiConsumer<MetricFamilyDescriptor, DataPointSnapshot> sink = (family,
-                dataPoint) -> dataPointsByFamily.computeIfAbsent(family, f -> new ArrayList<>()).add(dataPoint);
+        // descriptors are canonical per family
+        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> dataPointsByFamily = new IdentityHashMap<>(
+                descriptorsByFamilyName.size());
 
         for (Child child : children.values()) {
-            child.collect(sink);
+            child.collect((family, dataPoint) -> dataPointsByFamily
+                .computeIfAbsent(family, f -> new ArrayList<>(children.size()))
+                .add(dataPoint));
         }
 
         List<MetricSnapshot> snapshots = new ArrayList<>(dataPointsByFamily.size());

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -17,21 +17,24 @@ package io.micrometer.prometheusmetrics;
 
 import io.micrometer.core.instrument.Meter;
 import io.prometheus.metrics.model.registry.MultiCollector;
+import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.DataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
+import io.prometheus.metrics.model.snapshots.InfoSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
+import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 
@@ -47,6 +50,8 @@ class MicrometerCollector implements MultiCollector {
     private final Map<Meter.Id, Child> children = new ConcurrentHashMap<>();
 
     private final Map<Meter.Id, List<MetricFamilyDescriptor>> registeredFamilies = new ConcurrentHashMap<>();
+
+    private final Map<MetricFamilyDescriptor, SnapshotFactory> customSnapshotFactories = new ConcurrentHashMap<>();
 
     final String conventionName;
 
@@ -65,9 +70,16 @@ class MicrometerCollector implements MultiCollector {
         this.registeredFamilies.put(id, Arrays.asList(registeredFamilies));
     }
 
+    public void registerCustomSnapshotFactory(MetricFamilyDescriptor descriptor, SnapshotFactory factory) {
+        customSnapshotFactories.put(descriptor, factory);
+    }
+
     public void remove(Meter.Id id) {
         children.remove(id);
-        registeredFamilies.remove(id);
+        List<MetricFamilyDescriptor> descriptors = registeredFamilies.remove(id);
+        if (descriptors != null) {
+            descriptors.forEach(customSnapshotFactories::remove);
+        }
     }
 
     public boolean isEmpty() {
@@ -89,56 +101,58 @@ class MicrometerCollector implements MultiCollector {
 
     @Override
     public MetricSnapshots collect() {
-        Map<String, Family> families = new HashMap<>();
+        Map<MetricFamilyDescriptor, List<DataPointSnapshot>> familyDataPoints = new LinkedHashMap<>();
 
         for (Child child : children.values()) {
-            child.samples()
-                .forEach(family -> families.compute(family.getConventionName(),
-                        (name, matchingFamily) -> matchingFamily != null
-                                ? matchingFamily.addSamples(family.dataPointSnapshots) : family));
+            child.collect(familyDataPoints);
         }
 
-        Collection<MetricSnapshot> metricSnapshots = families.values()
-            .stream()
-            .map(Family::toMetricSnapshot)
-            .collect(toList());
+        List<MetricSnapshot> snapshots = new ArrayList<>(familyDataPoints.size());
+        for (Map.Entry<MetricFamilyDescriptor, List<DataPointSnapshot>> entry : familyDataPoints.entrySet()) {
+            MetricFamilyDescriptor descriptor = entry.getKey();
+            List<DataPointSnapshot> dataPoints = entry.getValue();
+            if (!dataPoints.isEmpty()) {
+                snapshots.add(createSnapshot(descriptor, dataPoints));
+            }
+        }
 
-        return new MetricSnapshots(metricSnapshots);
+        return new MetricSnapshots(snapshots);
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private MetricSnapshot createSnapshot(MetricFamilyDescriptor descriptor, List<DataPointSnapshot> dataPoints) {
+        SnapshotFactory customFactory = customSnapshotFactories.get(descriptor);
+        if (customFactory != null) {
+            return customFactory.create(descriptor.getMetadata(), (List) dataPoints);
+        }
+        MetricMetadata metadata = descriptor.getMetadata();
+        switch (descriptor.getType()) {
+            case COUNTER:
+                return new CounterSnapshot(metadata, (List) dataPoints);
+            case GAUGE:
+                return new GaugeSnapshot(metadata, (List) dataPoints);
+            case SUMMARY:
+                return new SummarySnapshot(metadata, (List) dataPoints);
+            case HISTOGRAM:
+                return new HistogramSnapshot(metadata, (List) dataPoints);
+            case INFO:
+                return new InfoSnapshot(metadata, (List) dataPoints);
+            default:
+                throw new IllegalArgumentException("Unsupported metric type: " + descriptor.getType());
+        }
+    }
+
+    @FunctionalInterface
     interface Child {
 
-        Stream<Family<?>> samples();
+        void collect(Map<MetricFamilyDescriptor, List<DataPointSnapshot>> samples);
 
     }
 
-    static class Family<T extends DataPointSnapshot> {
+    @FunctionalInterface
+    interface SnapshotFactory {
 
-        final String conventionName;
-
-        final List<T> dataPointSnapshots = new ArrayList<>();
-
-        final Function<Family<T>, MetricSnapshot> metricSnapshotFactory;
-
-        Family(String conventionName, Function<Family<T>, MetricSnapshot> metricSnapshotFactory,
-                T... dataPointSnapshots) {
-            this.conventionName = conventionName;
-            this.metricSnapshotFactory = metricSnapshotFactory;
-            Collections.addAll(this.dataPointSnapshots, dataPointSnapshots);
-        }
-
-        String getConventionName() {
-            return conventionName;
-        }
-
-        Family<T> addSamples(Collection<T> dataPointSnapshots) {
-            this.dataPointSnapshots.addAll(dataPointSnapshots);
-            return this;
-        }
-
-        MetricSnapshot toMetricSnapshot() {
-            return metricSnapshotFactory.apply(this);
-        }
+        MetricSnapshot create(MetricMetadata metadata, List<DataPointSnapshot> dataPoints);
 
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -221,7 +221,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
@@ -242,7 +242,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                     id.getDescription());
             String conventionNameMax = conventionName + "_max";
@@ -267,7 +267,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
+                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                     createdTimestampMillis)));
@@ -296,7 +296,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
+                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
                                     familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
@@ -340,7 +340,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
                 familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
@@ -379,7 +379,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
@@ -399,7 +399,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.getConventionName();
+            String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
@@ -423,7 +423,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
 
             for (Measurement measurement : measurements) {
-                CustomMeterMetric metric = customMeterMetric(collector.getConventionName(), measurement.getStatistic());
+                CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
 
                 // De-duplicate names: metrics with the same Prometheus name will use the
                 // same descriptor and metadata
@@ -552,7 +552,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
-        String conventionName = collector.getConventionName();
+        String conventionName = collector.conventionName;
         MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                 id.getDescription());
         String conventionNameMax = conventionName + "_max";

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -46,8 +46,9 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -218,15 +219,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         PrometheusCounter counter = new PrometheusCounter(id, exemplarSamplerFactory);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
-            collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new CounterDataPointSnapshot(counter.count(), Labels.of(tagKeys, tagValues),
-                                    counter.exemplar(), createdTimestampMillis))),
-                    familyDescriptor(MetricType.COUNTER, getConventionName(id), tagKeys, id.getDescription()));
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
+                    tagKeys, id.getDescription());
+            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                    new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis))),
+                    familyDescriptor);
         });
         return counter;
     }
@@ -238,9 +238,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 distributionStatisticConfig, scale, exemplarSamplerFactory);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+                    id.getDescription());
+            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE,
+                    getConventionName(id) + "_max", tagKeys, id.getDescription());
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -261,10 +265,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues),
-                                    exemplars, createdTimestampMillis)));
+                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
+                                    createdTimestampMillis)));
                 }
                 else {
                     List<Double> buckets = new ArrayList<>();
@@ -292,9 +295,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     Exemplars exemplars = summary.exemplars();
                     families.add(new MicrometerCollector.Family<>(conventionName,
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
-                                    getMetadata(family.conventionName, id.getDescription()), family.dataPointSnapshots),
-                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                    Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                                    familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
+                                    exemplars, createdTimestampMillis)));
 
                     // TODO: Add support back for VictoriaMetrics
                     // Previously we had low-level control so a histogram was just
@@ -307,13 +310,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
 
                 families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                        family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new GaugeDataPointSnapshot(summary.max(), Labels.of(tagKeys, tagValues), null)));
+                        family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
+                        new GaugeDataPointSnapshot(summary.max(), labels, null)));
 
                 return families.build();
-            }, familyDescriptor(primaryType, getConventionName(id), tagKeys, id.getDescription()),
-                    familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max", tagKeys, id.getDescription()));
+            }, familyDescriptor, familyDescriptorMax);
         });
 
         return summary;
@@ -334,22 +335,26 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             ToDoubleFunction<T> valueFunction) {
         Gauge gauge = new DefaultGauge<>(id, obj, valueFunction);
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
-                collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                        family -> new InfoSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new InfoDataPointSnapshot(Labels.of(tagKeys, tagValues)))),
-                        familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys, id.getDescription()));
-            }
-            else {
+                familyDescriptor = familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys,
+                        id.getDescription());
                 collector.add(id,
                         (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                        family.dataPointSnapshots),
-                                new GaugeDataPointSnapshot(gauge.value(), Labels.of(tagKeys, tagValues), null))),
-                        familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys, id.getDescription()));
+                                family -> new InfoSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                                new InfoDataPointSnapshot(labels))),
+                        familyDescriptor);
+            }
+            else {
+                familyDescriptor = familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys,
+                        id.getDescription());
+                collector.add(id,
+                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                                family -> new GaugeSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                                new GaugeDataPointSnapshot(gauge.value(), labels, null))),
+                        familyDescriptor);
             }
         });
         return gauge;
@@ -370,15 +375,16 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 totalTimeFunctionUnit, getBaseTimeUnit());
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, getConventionName(id),
+                    tagKeys, id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
+                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
-                                    Quantiles.EMPTY, Labels.of(tagKeys, tagValues), null, createdTimestampMillis))),
-                    familyDescriptor(MetricType.SUMMARY, getConventionName(id), tagKeys, id.getDescription()));
+                                    Quantiles.EMPTY, labels, null, createdTimestampMillis))),
+                    familyDescriptor);
         });
         return ft;
     }
@@ -388,15 +394,15 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         FunctionCounter fc = new CumulativeFunctionCounter<>(id, obj, countFunction);
         long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
+            Labels labels = Labels.of(tagKeys, tagValues(id));
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
+                    tagKeys, id.getDescription());
             collector.add(id,
                     (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                    family.dataPointSnapshots),
-                            new CounterDataPointSnapshot(fc.count(), Labels.of(tagKeys, tagValues), null,
-                                    createdTimestampMillis))),
-                    familyDescriptor(MetricType.COUNTER, getConventionName(id), tagKeys, id.getDescription()));
+                            family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                            new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis))),
+                    familyDescriptor);
         });
         return fc;
     }
@@ -408,45 +414,49 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             List<String> statKeys = new ArrayList<>(tagKeys);
             statKeys.add("statistic");
-            List<MetricFamilyDescriptor> registrationDescriptors = new ArrayList<>();
-            String name = getConventionName(id);
-            Set<String> descriptorNames = new HashSet<>();
+
+            Map<String, MetricFamilyDescriptor> prometheusNameToDescriptor = new LinkedHashMap<>();
+            List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
+
             for (Measurement measurement : measurements) {
-                MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
-                        statKeys);
-                // de-duplicate names
-                if (descriptorNames.add(descriptor.getPrometheusName())) {
-                    registrationDescriptors.add(descriptor);
+                CustomMeterMetric metric = customMeterMetric(collector.getConventionName(), measurement.getStatistic());
+
+                // De-duplicate names: metrics with the same Prometheus name will use the
+                // same descriptor and metadata
+                MetricFamilyDescriptor candidateDescriptor = familyDescriptor(metric.metricType, metric.name, statKeys,
+                        id.getDescription());
+                MetricFamilyDescriptor descriptor;
+                if (prometheusNameToDescriptor.containsKey(candidateDescriptor.getPrometheusName())) {
+                    descriptor = prometheusNameToDescriptor.get(candidateDescriptor.getPrometheusName());
                 }
+                else {
+                    descriptor = candidateDescriptor;
+                    prometheusNameToDescriptor.put(descriptor.getPrometheusName(), descriptor);
+                }
+
+                List<String> statValues = new ArrayList<>(tagValues);
+                statValues.add(measurement.getStatistic().toString());
+                customMeasurements.add(new CustomMeterMeasurement(measurement, metric, descriptor.getMetadata(),
+                        Labels.of(statKeys, statValues)));
             }
+
             collector.add(id, (conventionName) -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-                for (Measurement measurement : measurements) {
-                    List<String> statValues = new ArrayList<>(tagValues);
-                    statValues.add(measurement.getStatistic().toString());
-                    families.add(customMeterFamily(id, conventionName, measurement.getStatistic(),
-                            Labels.of(statKeys, statValues), measurement.getValue()));
+                for (CustomMeterMeasurement measurement : customMeasurements) {
+                    families.add(customMeterFamily(measurement));
                 }
                 return families.build();
-            }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
+            }, prometheusNameToDescriptor.values().toArray(new MetricFamilyDescriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
-            Collection<String> labelNames) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
-    }
-
-    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
-            Labels labels, double value) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        if (metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(id, metric, labels, value);
+    private MicrometerCollector.Family<?> customMeterFamily(CustomMeterMeasurement measurement) {
+        if (measurement.metric.metricType == MetricType.COUNTER) {
+            return customCounterFamily(measurement);
         }
-        return customGaugeFamily(id, metric, labels, value);
+        return customGaugeFamily(measurement);
     }
 
     private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
@@ -470,21 +480,19 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
-            CustomMeterMetric metric, Labels labels, double value) {
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
+            CustomMeterMeasurement measurement) {
         long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
+        return new MicrometerCollector.Family<>(measurement.metric.name,
+                family -> new CounterSnapshot(measurement.metadata, family.dataPointSnapshots),
+                new CounterDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null,
+                        createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, CustomMeterMetric metric,
-            Labels labels, double value) {
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new GaugeDataPointSnapshot(value, labels, null));
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(CustomMeterMeasurement measurement) {
+        return new MicrometerCollector.Family<>(measurement.metric.name,
+                family -> new GaugeSnapshot(measurement.metadata, family.dataPointSnapshots),
+                new GaugeDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null));
     }
 
     private static final class CustomMeterMetric {
@@ -496,6 +504,26 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         private CustomMeterMetric(String name, MetricType metricType) {
             this.name = name;
             this.metricType = metricType;
+        }
+
+    }
+
+    private static final class CustomMeterMeasurement {
+
+        private final Measurement measurement;
+
+        private final CustomMeterMetric metric;
+
+        private final MetricMetadata metadata;
+
+        private final Labels labels;
+
+        private CustomMeterMeasurement(Measurement measurement, CustomMeterMetric metric, MetricMetadata metadata,
+                Labels labels) {
+            this.measurement = measurement;
+            this.metric = metric;
+            this.metadata = metadata;
+            this.labels = labels;
         }
 
     }
@@ -517,8 +545,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             boolean forLongTaskTimer) {
         long createdTimestampMillis = clock.wallTime();
         List<String> tagKeys = tagKeys(id);
+        Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
+        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+                id.getDescription());
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max",
+                tagKeys, id.getDescription());
         collector.add(id, (conventionName) -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
@@ -540,9 +573,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
-                        family -> new SummarySnapshot(getMetadata(family.conventionName, id.getDescription()),
-                                family.dataPointSnapshots),
-                        new SummaryDataPointSnapshot(count, sum, quantiles, Labels.of(tagKeys, tagValues), exemplars,
+                        family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                        new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                 createdTimestampMillis)));
             }
             else {
@@ -571,9 +603,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
                 families.add(new MicrometerCollector.Family<>(conventionName,
                         family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(forLongTaskTimer,
-                                getMetadata(family.conventionName, id.getDescription()), family.dataPointSnapshots),
-                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                Labels.of(tagKeys, tagValues), exemplars, createdTimestampMillis)));
+                                familyDescriptor.getMetadata(), family.dataPointSnapshots),
+                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
+                                exemplars, createdTimestampMillis)));
 
                 // TODO: Add support back for VictoriaMetrics
                 // Previously we had low-level control so a histogram was just
@@ -586,18 +618,17 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             families.add(new MicrometerCollector.Family<>(conventionName + "_max",
-                    family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                            family.dataPointSnapshots),
-                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), Labels.of(tagKeys, tagValues),
-                            null)));
+                    family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
+                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null)));
 
             return families.build();
-        }, familyDescriptor(primaryType, getConventionName(id), tagKeys, id.getDescription()),
-                familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max", tagKeys, id.getDescription()));
+        }, familyDescriptor, familyDescriptorMax);
     }
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
             @Nullable String description) {
+        // Unit is intentionally not set, see:
+        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
     }
 
@@ -629,12 +660,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 getPrometheusRegistry().unregister(collector);
             }
         }
-    }
-
-    private MetricMetadata getMetadata(String name, @Nullable String description) {
-        // Unit is intentionally not set, see:
-        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return new MetricMetadata(name, helpText(description), null);
     }
 
     private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -618,6 +618,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
             @Nullable String description) {
+        // NB: For custom meters that use `getMetadata`, the metadata inside the
+        // descriptor should be consistent with the one returned by `getMetadata`.
+
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
@@ -628,6 +631,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * {@link MetricFamilyDescriptor} returned from {@link familyDescriptor}.
      */
     private MetricMetadata getMetadata(String name, @Nullable String description) {
+        // The returned metadata should be consistent with the metadata in the
+        // `MetricFamilyDescriptor`.
         return new MetricMetadata(name, helpText(description), null);
     }
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -17,6 +17,7 @@ package io.micrometer.prometheusmetrics;
 
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -36,6 +37,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,8 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.*;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.StreamSupport.stream;
 
 /**
  * {@link MeterRegistry} for Prometheus.
@@ -105,12 +105,18 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         config().onMeterRemoved(this::onMeterRemoved);
     }
 
-    private List<String> tagKeys(Meter.Id id) {
-        return getConventionTags(id).stream().map(Tag::getKey).collect(toList());
-    }
-
-    private static List<String> tagValues(Meter.Id id) {
-        return stream(id.getTagsAsIterable().spliterator(), false).map(Tag::getValue).collect(toList());
+    private MeterContext createMeterContext(Meter.Id id) {
+        NamingConvention convention = config().namingConvention();
+        List<Tag> tags = id.getTags();
+        int size = tags.size();
+        List<String> tagKeys = new ArrayList<>(size);
+        List<String> tagValues = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Tag tag = tags.get(i);
+            tagKeys.add(convention.tagKey(tag.getKey()));
+            tagValues.add(convention.tagValue(tag.getValue()));
+        }
+        return new MeterContext(id, tagKeys, tagValues, helpText(id.getDescription()), clock.wallTime());
     }
 
     /**
@@ -290,8 +296,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * that it does not have to be resolved again on every scrape.
      */
     private void applyToCollector(Meter.Id id, BiConsumer<MicrometerCollector, MeterContext> consumer) {
-        MeterContext context = new MeterContext(id, tagKeys(id), tagValues(id), helpText(id.getDescription()),
-                clock.wallTime());
+        MeterContext context = createMeterContext(id);
         collectorMap.compute(getConventionName(id), (name, existingCollector) -> {
             if (existingCollector == null) {
                 MicrometerCollector micrometerCollector = new MicrometerCollector(name, id);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -434,8 +434,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         String conventionName = collector.conventionName;
         MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, primaryType, conventionName, tagKeys,
                 id.getDescription());
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(collector, MetricType.GAUGE, conventionName + "_max",
-                tagKeys, id.getDescription());
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(collector, MetricType.GAUGE,
+                conventionName + "_max", tagKeys, id.getDescription());
 
         collector.add(id, samples -> {
             HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -46,9 +46,8 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -418,49 +417,53 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             List<String> statKeys = new ArrayList<>(tagKeys);
             statKeys.add("statistic");
-
-            Map<String, MetricFamilyDescriptor> prometheusNameToDescriptor = new LinkedHashMap<>();
-            List<CustomMeterMeasurement> customMeasurements = new ArrayList<>();
-
+            List<MetricFamilyDescriptor> registrationDescriptors = new ArrayList<>();
+            String name = collector.conventionName;
+            Set<String> descriptorNames = new HashSet<>();
             for (Measurement measurement : measurements) {
-                CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
-
-                // De-duplicate names: metrics with the same Prometheus name will use the
-                // same descriptor and metadata
-                MetricFamilyDescriptor candidateDescriptor = familyDescriptor(metric.metricType, metric.name, statKeys,
-                        id.getDescription());
-                MetricFamilyDescriptor descriptor;
-                if (prometheusNameToDescriptor.containsKey(candidateDescriptor.getPrometheusName())) {
-                    descriptor = prometheusNameToDescriptor.get(candidateDescriptor.getPrometheusName());
+                MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
+                        statKeys);
+                // de-duplicate names
+                if (descriptorNames.add(descriptor.getPrometheusName())) {
+                    registrationDescriptors.add(descriptor);
                 }
-                else {
-                    descriptor = candidateDescriptor;
-                    prometheusNameToDescriptor.put(descriptor.getPrometheusName(), descriptor);
-                }
-
-                List<String> statValues = new ArrayList<>(tagValues);
-                statValues.add(measurement.getStatistic().toString());
-                customMeasurements.add(new CustomMeterMeasurement(measurement, metric, descriptor.getMetadata(),
-                        Labels.of(statKeys, statValues)));
             }
-
             collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-                for (CustomMeterMeasurement measurement : customMeasurements) {
-                    families.add(customMeterFamily(measurement));
+                for (Measurement measurement : measurements) {
+                    // NB: Unlike all the other meters, where `MetricMetadata` and
+                    // `Labels` are constructed once at registration time, for custom
+                    // meters they are obtained on each scrape. We might construct them at
+                    // registration time and cache them, but this would force us to deal
+                    // with potentially misbehaving `Iterable<Measurement>` (which may
+                    // return different measurements or in different order, breaking
+                    // contract of `Meter#measure`). Custom meters should be rare, so
+                    // this should be a relatively minor performance hit.
+                    List<String> statValues = new ArrayList<>(tagValues);
+                    statValues.add(measurement.getStatistic().toString());
+                    families.add(customMeterFamily(id, collector.conventionName, measurement.getStatistic(),
+                            Labels.of(statKeys, statValues), measurement.getValue()));
                 }
                 return families.build();
-            }, prometheusNameToDescriptor.values().toArray(new MetricFamilyDescriptor[0]));
+            }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MicrometerCollector.Family<?> customMeterFamily(CustomMeterMeasurement measurement) {
-        if (measurement.metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(measurement);
+    private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
+            Collection<String> labelNames) {
+        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
+        return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
+    }
+
+    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
+            Labels labels, double value) {
+        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
+        if (metric.metricType == MetricType.COUNTER) {
+            return customCounterFamily(id, metric, labels, value);
         }
-        return customGaugeFamily(measurement);
+        return customGaugeFamily(id, metric, labels, value);
     }
 
     private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
@@ -484,19 +487,21 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(
-            CustomMeterMeasurement measurement) {
+    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
+            CustomMeterMetric metric, Labels labels, double value) {
         long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(measurement.metric.name,
-                family -> new CounterSnapshot(measurement.metadata, family.dataPointSnapshots),
-                new CounterDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null,
-                        createdTimestampMillis));
+        return new MicrometerCollector.Family<>(metric.name,
+                family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
+                        family.dataPointSnapshots),
+                new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
     }
 
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(CustomMeterMeasurement measurement) {
-        return new MicrometerCollector.Family<>(measurement.metric.name,
-                family -> new GaugeSnapshot(measurement.metadata, family.dataPointSnapshots),
-                new GaugeDataPointSnapshot(measurement.measurement.getValue(), measurement.labels, null));
+    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, CustomMeterMetric metric,
+            Labels labels, double value) {
+        return new MicrometerCollector.Family<>(metric.name,
+                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
+                        family.dataPointSnapshots),
+                new GaugeDataPointSnapshot(value, labels, null));
     }
 
     private static final class CustomMeterMetric {
@@ -508,26 +513,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         private CustomMeterMetric(String name, MetricType metricType) {
             this.name = name;
             this.metricType = metricType;
-        }
-
-    }
-
-    private static final class CustomMeterMeasurement {
-
-        private final Measurement measurement;
-
-        private final CustomMeterMetric metric;
-
-        private final MetricMetadata metadata;
-
-        private final Labels labels;
-
-        private CustomMeterMeasurement(Measurement measurement, CustomMeterMetric metric, MetricMetadata metadata,
-                Labels labels) {
-            this.measurement = measurement;
-            this.metric = metric;
-            this.metadata = metadata;
-            this.labels = labels;
         }
 
     }
@@ -636,6 +621,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
+    }
+
+    /**
+     * Used only for custom meters; all other meters' metadata is obtained through
+     * {@link MetricFamilyDescriptor} returned from {@link familyDescriptor}.
+     */
+    private MetricMetadata getMetadata(String name, @Nullable String description) {
+        return new MetricMetadata(name, helpText(description), null);
     }
 
     private String helpText(@Nullable String description) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -296,8 +296,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * that it does not have to be resolved again on every scrape.
      */
     private void applyToCollector(Meter.Id id, BiConsumer<MicrometerCollector, MeterContext> consumer) {
-        MeterContext context = createMeterContext(id);
         collectorMap.compute(getConventionName(id), (name, existingCollector) -> {
+            MeterContext context = createMeterContext(id);
             if (existingCollector == null) {
                 MicrometerCollector micrometerCollector = new MicrometerCollector(name, id);
                 consumer.accept(micrometerCollector, context);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -47,7 +47,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -223,9 +225,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
-            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                    family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                    new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis))),
+            collector.add(id,
+                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                            .add(new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(),
+                                    createdTimestampMillis)),
                     familyDescriptor);
         });
         return counter;
@@ -247,9 +250,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             String conventionNameMax = conventionName + "_max";
             MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
                     id.getDescription());
-            collector.add(id, () -> {
-                Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
-
+            collector.add(id, samples -> {
                 final ValueAtPercentile[] percentileValues = summary.takeSnapshot().percentileValues();
                 final CountAtBucket[] histogramCounts = summary.histogramCounts();
                 long count = summary.count();
@@ -266,10 +267,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
-                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                            new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
-                                    createdTimestampMillis)));
+                    samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                            .add(new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
+                                    createdTimestampMillis));
                 }
                 else {
                     List<Double> buckets = new ArrayList<>();
@@ -295,11 +295,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(collector.conventionName,
-                            family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
-                                    familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                            new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
-                                    exemplars, createdTimestampMillis)));
+                    samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                            .add(new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
+                                    labels, exemplars, createdTimestampMillis));
 
                     // TODO: Add support back for VictoriaMetrics
                     // Previously we had low-level control so a histogram was just
@@ -311,11 +309,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     // bucket name is hardcoded to le.
                 }
 
-                families.add(new MicrometerCollector.Family<>(conventionNameMax,
-                        family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
-                        new GaugeDataPointSnapshot(summary.max(), labels, null)));
-
-                return families.build();
+                samples.computeIfAbsent(familyDescriptorMax, k -> new ArrayList<>())
+                        .add(new GaugeDataPointSnapshot(summary.max(), labels, null));
             }, familyDescriptor, familyDescriptorMax);
         });
 
@@ -344,17 +339,15 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             if (id.getName().endsWith(".info")) {
                 familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new InfoSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                                new InfoDataPointSnapshot(labels))),
+                        samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                                .add(new InfoDataPointSnapshot(labels)),
                         familyDescriptor);
             }
             else {
                 familyDescriptor = familyDescriptor(MetricType.GAUGE, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                                family -> new GaugeSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                                new GaugeDataPointSnapshot(gauge.value(), labels, null))),
+                        samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                                .add(new GaugeDataPointSnapshot(gauge.value(), labels, null)),
                         familyDescriptor);
             }
         });
@@ -382,10 +375,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
-                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                            new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
-                                    Quantiles.EMPTY, labels, null, createdTimestampMillis))),
+                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                            .add(new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
+                                    Quantiles.EMPTY, labels, null, createdTimestampMillis)),
                     familyDescriptor);
         });
         return ft;
@@ -402,9 +394,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
-                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
-                            family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                            new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis))),
+                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                            .add(new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis)),
                     familyDescriptor);
         });
         return fc;
@@ -417,35 +408,33 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             List<String> statKeys = new ArrayList<>(tagKeys);
             statKeys.add("statistic");
-            List<MetricFamilyDescriptor> registrationDescriptors = new ArrayList<>();
+            Map<String, MetricFamilyDescriptor> descriptorsMap = new LinkedHashMap<>();
             String name = collector.conventionName;
-            Set<String> descriptorNames = new HashSet<>();
             for (Measurement measurement : measurements) {
                 MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
                         statKeys);
-                // de-duplicate names
-                if (descriptorNames.add(descriptor.getPrometheusName())) {
-                    registrationDescriptors.add(descriptor);
-                }
+                descriptorsMap.putIfAbsent(descriptor.getPrometheusName(), descriptor);
             }
-            collector.add(id, () -> {
-                Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
+            MetricFamilyDescriptor[] descriptors = descriptorsMap.values().toArray(new MetricFamilyDescriptor[0]);
+            collector.add(id, samples -> {
                 for (Measurement measurement : measurements) {
-                    // NB: Unlike all the other meters, where `MetricMetadata` and
-                    // `Labels` are constructed once at registration time, for custom
-                    // meters they are obtained on each scrape. We might construct them at
-                    // registration time and cache them, but this would force us to deal
-                    // with potentially misbehaving `Iterable<Measurement>` (which may
-                    // return different measurements or in different order, breaking
-                    // contract of `Meter#measure`). Custom meters should be rare, so
-                    // this should be a relatively minor performance hit.
                     List<String> statValues = new ArrayList<>(tagValues);
                     statValues.add(measurement.getStatistic().toString());
-                    families.add(customMeterFamily(id, collector.conventionName, measurement.getStatistic(),
-                            Labels.of(statKeys, statValues), measurement.getValue()));
+                    Labels labels = Labels.of(statKeys, statValues);
+                    CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
+                    MetricFamilyDescriptor descriptor = descriptorsMap.get(metric.name);
+
+                    if (metric.metricType == MetricType.COUNTER) {
+                        samples.computeIfAbsent(descriptor, k -> new ArrayList<>())
+                                .add(new CounterDataPointSnapshot(measurement.getValue(), labels, null,
+                                        clock.wallTime()));
+                    }
+                    else {
+                        samples.computeIfAbsent(descriptor, k -> new ArrayList<>())
+                                .add(new GaugeDataPointSnapshot(measurement.getValue(), labels, null));
+                    }
                 }
-                return families.build();
-            }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
+            }, descriptors);
         });
 
         return new DefaultMeter(id, type, measurements);
@@ -455,15 +444,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             Collection<String> labelNames) {
         CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
         return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
-    }
-
-    private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
-            Labels labels, double value) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        if (metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(id, metric, labels, value);
-        }
-        return customGaugeFamily(id, metric, labels, value);
     }
 
     private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
@@ -485,23 +465,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             default:
                 throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
         }
-    }
-
-    private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
-            CustomMeterMetric metric, Labels labels, double value) {
-        long createdTimestampMillis = clock.wallTime();
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new CounterDataPointSnapshot(value, labels, null, createdTimestampMillis));
-    }
-
-    private MicrometerCollector.Family<GaugeDataPointSnapshot> customGaugeFamily(Meter.Id id, CustomMeterMetric metric,
-            Labels labels, double value) {
-        return new MicrometerCollector.Family<>(metric.name,
-                family -> new GaugeSnapshot(getMetadata(family.conventionName, id.getDescription()),
-                        family.dataPointSnapshots),
-                new GaugeDataPointSnapshot(value, labels, null));
     }
 
     private static final class CustomMeterMetric {
@@ -529,6 +492,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return registry;
     }
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private void addDistributionStatisticSamples(Meter.Id id, MicrometerCollector collector,
             HistogramSupport histogramSupport, Supplier<Exemplars> exemplarsSupplier, List<String> tagValues,
             boolean forLongTaskTimer) {
@@ -543,9 +507,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         String conventionNameMax = conventionName + "_max";
         MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
                 id.getDescription());
-        collector.add(id, () -> {
-            Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
+        if (forLongTaskTimer && primaryType == MetricType.HISTOGRAM) {
+            collector.registerCustomSnapshotFactory(familyDescriptor,
+                    (metadata, dataPoints) -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(true,
+                            metadata, (List) dataPoints));
+        }
+
+        collector.add(id, samples -> {
             HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
             ValueAtPercentile[] percentileValues = histogramSnapshot.percentileValues();
             CountAtBucket[] histogramCounts = histogramSnapshot.histogramCounts();
@@ -563,10 +532,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
 
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
-                families.add(new MicrometerCollector.Family<>(conventionName,
-                        family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                        new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
-                                createdTimestampMillis)));
+                samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                        .add(new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
+                                createdTimestampMillis));
             }
             else {
                 List<Double> buckets = new ArrayList<>();
@@ -592,11 +560,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
 
                 Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
-                families.add(new MicrometerCollector.Family<>(conventionName,
-                        family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(forLongTaskTimer,
-                                familyDescriptor.getMetadata(), family.dataPointSnapshots),
-                        new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
-                                exemplars, createdTimestampMillis)));
+                samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
+                        .add(new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
+                                exemplars, createdTimestampMillis));
 
                 // TODO: Add support back for VictoriaMetrics
                 // Previously we had low-level control so a histogram was just
@@ -608,11 +574,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 // bucket name is hardcoded to le.
             }
 
-            families.add(new MicrometerCollector.Family<>(conventionNameMax,
-                    family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
-                    new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null)));
-
-            return families.build();
+            samples.computeIfAbsent(familyDescriptorMax, k -> new ArrayList<>())
+                    .add(new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null));
         }, familyDescriptor, familyDescriptorMax);
     }
 
@@ -624,16 +587,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         // Unit is intentionally not set, see:
         // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
         return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
-    }
-
-    /**
-     * Used only for custom meters; all other meters' metadata is obtained through
-     * {@link MetricFamilyDescriptor} returned from {@link familyDescriptor}.
-     */
-    private MetricMetadata getMetadata(String name, @Nullable String description) {
-        // The returned metadata should be consistent with the metadata in the
-        // `MetricFamilyDescriptor`.
-        return new MetricMetadata(name, helpText(description), null);
     }
 
     private String helpText(@Nullable String description) {

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -217,8 +217,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
-                    id.getDescription());
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.COUNTER, conventionName,
+                    tagKeys, id.getDescription());
             collector.add(id, samples -> samples.accept(familyDescriptor,
                     new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis)),
                     familyDescriptor);
@@ -256,12 +256,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
-                familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
+                familyDescriptor = familyDescriptor(collector, MetricType.INFO, conventionName, tagKeys,
+                        id.getDescription());
                 collector.add(id, samples -> samples.accept(familyDescriptor, new InfoDataPointSnapshot(labels)),
                         familyDescriptor);
             }
             else {
-                familyDescriptor = familyDescriptor(MetricType.GAUGE, conventionName, tagKeys, id.getDescription());
+                familyDescriptor = familyDescriptor(collector, MetricType.GAUGE, conventionName, tagKeys,
+                        id.getDescription());
                 collector.add(id, samples -> samples.accept(familyDescriptor,
                         new GaugeDataPointSnapshot(gauge.value(), labels, null)), familyDescriptor);
             }
@@ -287,8 +289,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
-                    id.getDescription());
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.SUMMARY, conventionName,
+                    tagKeys, id.getDescription());
             collector.add(id,
                     samples -> samples.accept(familyDescriptor, new SummaryDataPointSnapshot((long) ft.count(),
                             ft.totalTime(getBaseTimeUnit()), Quantiles.EMPTY, labels, null, createdTimestampMillis)),
@@ -305,8 +307,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
-                    id.getDescription());
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.COUNTER, conventionName,
+                    tagKeys, id.getDescription());
             collector.add(id,
                     samples -> samples.accept(familyDescriptor,
                             new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis)),
@@ -330,8 +332,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             Map<Statistic, MeasurementFamily> familiesByStatistic = new EnumMap<>(Statistic.class);
             for (Measurement measurement : measurements) {
                 familiesByStatistic.computeIfAbsent(measurement.getStatistic(), statistic -> {
-                    MetricFamilyDescriptor descriptor = customMeterDescriptor(id, collector.conventionName, statistic,
-                            statKeys);
+                    MetricFamilyDescriptor descriptor = customMeterDescriptor(collector, id, collector.conventionName,
+                            statistic, statKeys);
                     MetricFamilyDescriptor existing = descriptorsByName.putIfAbsent(descriptor.getPrometheusName(),
                             descriptor);
                     List<String> statValues = new ArrayList<>(tagValues);
@@ -359,24 +361,27 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return new DefaultMeter(id, type, measurements);
     }
 
-    private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
-            Collection<String> labelNames) {
+    private MetricFamilyDescriptor customMeterDescriptor(MicrometerCollector collector, Meter.Id id,
+            String conventionName, Statistic statistic, Collection<String> labelNames) {
         switch (statistic) {
             case TOTAL:
             case TOTAL_TIME:
-                return familyDescriptor(MetricType.COUNTER, conventionName + "_sum", labelNames, id.getDescription());
+                return familyDescriptor(collector, MetricType.COUNTER, conventionName + "_sum", labelNames,
+                        id.getDescription());
             case COUNT:
-                return familyDescriptor(MetricType.COUNTER, conventionName, labelNames, id.getDescription());
+                return familyDescriptor(collector, MetricType.COUNTER, conventionName, labelNames, id.getDescription());
             case MAX:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_max", labelNames, id.getDescription());
+                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_max", labelNames,
+                        id.getDescription());
             case VALUE:
             case UNKNOWN:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_value", labelNames, id.getDescription());
+                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_value", labelNames,
+                        id.getDescription());
             case ACTIVE_TASKS:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_active_count", labelNames,
+                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_active_count", labelNames,
                         id.getDescription());
             case DURATION:
-                return familyDescriptor(MetricType.GAUGE, conventionName + "_duration_sum", labelNames,
+                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_duration_sum", labelNames,
                         id.getDescription());
             default:
                 throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
@@ -427,9 +432,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
         String conventionName = collector.conventionName;
-        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
+        MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, primaryType, conventionName, tagKeys,
                 id.getDescription());
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionName + "_max",
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(collector, MetricType.GAUGE, conventionName + "_max",
                 tagKeys, id.getDescription());
 
         collector.add(id, samples -> {
@@ -501,6 +506,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private static double bucket(CountAtBucket countAtBucket, @Nullable TimeUnit timeUnit) {
         return timeUnit == null ? countAtBucket.bucket() : countAtBucket.bucket(timeUnit);
+    }
+
+    private MetricFamilyDescriptor familyDescriptor(MicrometerCollector collector, MetricType metricType, String name,
+            Collection<String> labelNames, @Nullable String description) {
+        return collector.getOrCreateDescriptor(metricType, name,
+                () -> familyDescriptor(metricType, name, labelNames, description));
     }
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -46,7 +46,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,9 +55,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
@@ -75,6 +75,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private static final WarnThenDebugLogger meterRegistrationFailureLogger = new WarnThenDebugLogger(
             PrometheusMeterRegistry.class);
+
+    private static final String TEXT_004_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
 
     private final PrometheusConfig prometheusConfig;
 
@@ -132,7 +134,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * designated for Prometheus to scrape.
      */
     public String scrape() {
-        return scrape(Format.TEXT_004.getContentType());
+        return scrape(TEXT_004_CONTENT_TYPE);
     }
 
     /**
@@ -142,15 +144,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * @see ExpositionFormats
      */
     public String scrape(String contentType) {
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try {
-            scrape(outputStream, contentType);
-            return outputStream.toString(StandardCharsets.UTF_8.name());
-        }
-        catch (IOException e) {
-            // This should not happen during writing a ByteArrayOutputStream
-            throw new RuntimeException(e);
-        }
+        return scrape(contentType, null);
     }
 
     /**
@@ -159,7 +153,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
      * @throws IOException if writing fails
      */
     public void scrape(OutputStream outputStream) throws IOException {
-        scrape(outputStream, Format.TEXT_004.getContentType());
+        scrape(outputStream, TEXT_004_CONTENT_TYPE);
     }
 
     /**
@@ -225,10 +219,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             String conventionName = collector.conventionName;
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
-            collector.add(id,
-                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                            .add(new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(),
-                                    createdTimestampMillis)),
+            collector.add(id, samples -> samples.accept(familyDescriptor,
+                    new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis)),
                     familyDescriptor);
         });
         return counter;
@@ -239,81 +231,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         PrometheusDistributionSummary summary = new PrometheusDistributionSummary(id, clock,
                 distributionStatisticConfig, scale, exemplarSamplerFactory);
-        long createdTimestampMillis = clock.wallTime();
-        applyToCollector(id, (collector) -> {
-            List<String> tagKeys = tagKeys(id);
-            Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
-            String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
-                    id.getDescription());
-            String conventionNameMax = conventionName + "_max";
-            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
-                    id.getDescription());
-            collector.add(id, samples -> {
-                final ValueAtPercentile[] percentileValues = summary.takeSnapshot().percentileValues();
-                final CountAtBucket[] histogramCounts = summary.histogramCounts();
-                long count = summary.count();
-                double sum = summary.totalAmount();
-
-                if (histogramCounts.length == 0) {
-                    Quantiles quantiles = Quantiles.EMPTY;
-                    if (percentileValues.length > 0) {
-                        List<Quantile> quantileList = new ArrayList<>();
-                        for (ValueAtPercentile v : percentileValues) {
-                            quantileList.add(new Quantile(v.percentile(), v.value()));
-                        }
-                        quantiles = Quantiles.of(quantileList);
-                    }
-
-                    Exemplars exemplars = summary.exemplars();
-                    samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                            .add(new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
-                                    createdTimestampMillis));
-                }
-                else {
-                    List<Double> buckets = new ArrayList<>();
-                    List<Number> counts = new ArrayList<>();
-                    // TODO: remove this cumulative -> non cumulative conversion
-                    // ClassicHistogramBuckets is not cumulative but the
-                    // histograms we use are cumulative
-                    // so we convert it to non-cumulative just for the
-                    // Prometheus client library
-                    // can convert it back to cumulative.
-                    buckets.add(histogramCounts[0].bucket());
-                    counts.add(histogramCounts[0].count());
-                    for (int i = 1; i < histogramCounts.length; i++) {
-                        CountAtBucket countAtBucket = histogramCounts[i];
-                        buckets.add(countAtBucket.bucket());
-                        counts.add(countAtBucket.count() - histogramCounts[i - 1].count());
-                    }
-                    if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
-                        // ClassicHistogramBuckets is not cumulative
-                        buckets.add(Double.POSITIVE_INFINITY);
-                        double infCount = count - histogramCounts[histogramCounts.length - 1].count();
-                        counts.add(infCount >= 0 ? infCount : 0);
-                    }
-
-                    Exemplars exemplars = summary.exemplars();
-                    samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                            .add(new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum,
-                                    labels, exemplars, createdTimestampMillis));
-
-                    // TODO: Add support back for VictoriaMetrics
-                    // Previously we had low-level control so a histogram was just
-                    // a bunch of Collector.MetricFamilySamples.Sample
-                    // that has an le label for Prometheus and a vmrange label for
-                    // Victoria.
-                    // That control is gone now, so we don’t have control over the
-                    // output and when HistogramDataPointSnapshot is written, the
-                    // bucket name is hardcoded to le.
-                }
-
-                samples.computeIfAbsent(familyDescriptorMax, k -> new ArrayList<>())
-                        .add(new GaugeDataPointSnapshot(summary.max(), labels, null));
-            }, familyDescriptor, familyDescriptorMax);
-        });
-
+        applyToCollector(id,
+                (collector) -> addDistributionStatisticSamples(id, collector, summary, summary::exemplars, null));
         return summary;
     }
 
@@ -322,8 +241,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
         PrometheusTimer timer = new PrometheusTimer(id, clock, distributionStatisticConfig, pauseDetector,
                 exemplarSamplerFactory);
-        applyToCollector(id, (collector) -> addDistributionStatisticSamples(id, collector, timer, timer::exemplars,
-                tagValues(id), false));
+        applyToCollector(id, (collector) -> addDistributionStatisticSamples(id, collector, timer,
+                () -> createExemplarsWithScaledValues(timer.exemplars()), getBaseTimeUnit()));
         return timer;
     }
 
@@ -338,17 +257,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
                 familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
-                collector.add(id,
-                        samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                                .add(new InfoDataPointSnapshot(labels)),
+                collector.add(id, samples -> samples.accept(familyDescriptor, new InfoDataPointSnapshot(labels)),
                         familyDescriptor);
             }
             else {
                 familyDescriptor = familyDescriptor(MetricType.GAUGE, conventionName, tagKeys, id.getDescription());
-                collector.add(id,
-                        samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                                .add(new GaugeDataPointSnapshot(gauge.value(), labels, null)),
-                        familyDescriptor);
+                collector.add(id, samples -> samples.accept(familyDescriptor,
+                        new GaugeDataPointSnapshot(gauge.value(), labels, null)), familyDescriptor);
             }
         });
         return gauge;
@@ -358,7 +273,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
         LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit(), distributionStatisticConfig, true);
         applyToCollector(id, (collector) -> addDistributionStatisticSamples(id, collector, ltt, () -> Exemplars.EMPTY,
-                tagValues(id), true));
+                getBaseTimeUnit()));
         return ltt;
     }
 
@@ -375,9 +290,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
-                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                            .add(new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
-                                    Quantiles.EMPTY, labels, null, createdTimestampMillis)),
+                    samples -> samples.accept(familyDescriptor, new SummaryDataPointSnapshot((long) ft.count(),
+                            ft.totalTime(getBaseTimeUnit()), Quantiles.EMPTY, labels, null, createdTimestampMillis)),
                     familyDescriptor);
         });
         return ft;
@@ -394,8 +308,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
                     id.getDescription());
             collector.add(id,
-                    samples -> samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                            .add(new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis)),
+                    samples -> samples.accept(familyDescriptor,
+                            new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis)),
                     familyDescriptor);
         });
         return fc;
@@ -403,38 +317,43 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     @Override
     protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
-            List<String> tagKeys = tagKeys(id);
-            List<String> statKeys = new ArrayList<>(tagKeys);
+            List<String> statKeys = new ArrayList<>(tagKeys(id));
             statKeys.add("statistic");
-            Map<String, MetricFamilyDescriptor> descriptorsMap = new LinkedHashMap<>();
-            String name = collector.conventionName;
+
+            // precompute the family descriptor and labels per statistic; measurements
+            // with statistics that map to the same Prometheus name (e.g. TOTAL and
+            // TOTAL_TIME) share one family descriptor
+            Map<String, MetricFamilyDescriptor> descriptorsByName = new LinkedHashMap<>();
+            Map<Statistic, MeasurementFamily> familiesByStatistic = new EnumMap<>(Statistic.class);
             for (Measurement measurement : measurements) {
-                MetricFamilyDescriptor descriptor = customMeterDescriptor(id, name, measurement.getStatistic(),
-                        statKeys);
-                descriptorsMap.putIfAbsent(descriptor.getPrometheusName(), descriptor);
+                familiesByStatistic.computeIfAbsent(measurement.getStatistic(), statistic -> {
+                    MetricFamilyDescriptor descriptor = customMeterDescriptor(id, collector.conventionName, statistic,
+                            statKeys);
+                    MetricFamilyDescriptor existing = descriptorsByName.putIfAbsent(descriptor.getPrometheusName(),
+                            descriptor);
+                    List<String> statValues = new ArrayList<>(tagValues);
+                    statValues.add(statistic.toString());
+                    return new MeasurementFamily(existing != null ? existing : descriptor,
+                            Labels.of(statKeys, statValues));
+                });
             }
-            MetricFamilyDescriptor[] descriptors = descriptorsMap.values().toArray(new MetricFamilyDescriptor[0]);
+
             collector.add(id, samples -> {
                 for (Measurement measurement : measurements) {
-                    List<String> statValues = new ArrayList<>(tagValues);
-                    statValues.add(measurement.getStatistic().toString());
-                    Labels labels = Labels.of(statKeys, statValues);
-                    CustomMeterMetric metric = customMeterMetric(collector.conventionName, measurement.getStatistic());
-                    MetricFamilyDescriptor descriptor = descriptorsMap.get(metric.name);
-
-                    if (metric.metricType == MetricType.COUNTER) {
-                        samples.computeIfAbsent(descriptor, k -> new ArrayList<>())
-                                .add(new CounterDataPointSnapshot(measurement.getValue(), labels, null,
-                                        clock.wallTime()));
+                    MeasurementFamily family = requireNonNull(familiesByStatistic.get(measurement.getStatistic()));
+                    if (family.descriptor.getType() == MetricType.COUNTER) {
+                        samples.accept(family.descriptor, new CounterDataPointSnapshot(measurement.getValue(),
+                                family.labels, null, createdTimestampMillis));
                     }
                     else {
-                        samples.computeIfAbsent(descriptor, k -> new ArrayList<>())
-                                .add(new GaugeDataPointSnapshot(measurement.getValue(), labels, null));
+                        samples.accept(family.descriptor,
+                                new GaugeDataPointSnapshot(measurement.getValue(), family.labels, null));
                     }
                 }
-            }, descriptors);
+            }, descriptorsByName.values().toArray(new MetricFamilyDescriptor[0]));
         });
 
         return new DefaultMeter(id, type, measurements);
@@ -442,40 +361,41 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     private MetricFamilyDescriptor customMeterDescriptor(Meter.Id id, String conventionName, Statistic statistic,
             Collection<String> labelNames) {
-        CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
-        return familyDescriptor(metric.metricType, metric.name, labelNames, id.getDescription());
-    }
-
-    private CustomMeterMetric customMeterMetric(String conventionName, Statistic statistic) {
         switch (statistic) {
             case TOTAL:
             case TOTAL_TIME:
-                return new CustomMeterMetric(conventionName + "_sum", MetricType.COUNTER);
+                return familyDescriptor(MetricType.COUNTER, conventionName + "_sum", labelNames, id.getDescription());
             case COUNT:
-                return new CustomMeterMetric(conventionName, MetricType.COUNTER);
+                return familyDescriptor(MetricType.COUNTER, conventionName, labelNames, id.getDescription());
             case MAX:
-                return new CustomMeterMetric(conventionName + "_max", MetricType.GAUGE);
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_max", labelNames, id.getDescription());
             case VALUE:
             case UNKNOWN:
-                return new CustomMeterMetric(conventionName + "_value", MetricType.GAUGE);
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_value", labelNames, id.getDescription());
             case ACTIVE_TASKS:
-                return new CustomMeterMetric(conventionName + "_active_count", MetricType.GAUGE);
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_active_count", labelNames,
+                        id.getDescription());
             case DURATION:
-                return new CustomMeterMetric(conventionName + "_duration_sum", MetricType.GAUGE);
+                return familyDescriptor(MetricType.GAUGE, conventionName + "_duration_sum", labelNames,
+                        id.getDescription());
             default:
                 throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
         }
     }
 
-    private static final class CustomMeterMetric {
+    /**
+     * The Prometheus metric family and precomputed labels for the measurements of one
+     * {@link Statistic} of a custom meter.
+     */
+    private static final class MeasurementFamily {
 
-        private final String name;
+        private final MetricFamilyDescriptor descriptor;
 
-        private final MetricType metricType;
+        private final Labels labels;
 
-        private CustomMeterMetric(String name, MetricType metricType) {
-            this.name = name;
-            this.metricType = metricType;
+        private MeasurementFamily(MetricFamilyDescriptor descriptor, Labels labels) {
+            this.descriptor = descriptor;
+            this.labels = labels;
         }
 
     }
@@ -492,77 +412,42 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return registry;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    /**
+     * Adds samples for meters with distribution statistics, i.e. timers, long task
+     * timers, and distribution summaries.
+     * @param timeUnit if {@code null}, snapshot values are used as-is (distribution
+     * summaries); otherwise, time-based snapshot values are converted to this unit
+     * (timers, long task timers)
+     */
     private void addDistributionStatisticSamples(Meter.Id id, MicrometerCollector collector,
-            HistogramSupport histogramSupport, Supplier<Exemplars> exemplarsSupplier, List<String> tagValues,
-            boolean forLongTaskTimer) {
+            HistogramSupport histogramSupport, Supplier<Exemplars> exemplarsSupplier, @Nullable TimeUnit timeUnit) {
         long createdTimestampMillis = clock.wallTime();
         List<String> tagKeys = tagKeys(id);
-        Labels labels = Labels.of(tagKeys, tagValues);
+        Labels labels = Labels.of(tagKeys, tagValues(id));
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
         String conventionName = collector.conventionName;
         MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                 id.getDescription());
-        String conventionNameMax = conventionName + "_max";
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
-                id.getDescription());
-
-        if (forLongTaskTimer && primaryType == MetricType.HISTOGRAM) {
-            collector.registerCustomSnapshotFactory(familyDescriptor,
-                    (metadata, dataPoints) -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(true,
-                            metadata, (List) dataPoints));
-        }
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionName + "_max",
+                tagKeys, id.getDescription());
 
         collector.add(id, samples -> {
             HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
-            ValueAtPercentile[] percentileValues = histogramSnapshot.percentileValues();
             CountAtBucket[] histogramCounts = histogramSnapshot.histogramCounts();
             long count = histogramSnapshot.count();
-            double sum = histogramSnapshot.total(getBaseTimeUnit());
+            double sum = timeUnit == null ? histogramSnapshot.total() : histogramSnapshot.total(timeUnit);
 
             if (histogramCounts.length == 0) {
-                Quantiles quantiles = Quantiles.EMPTY;
-                if (percentileValues.length > 0) {
-                    List<Quantile> quantileList = new ArrayList<>();
-                    for (ValueAtPercentile v : percentileValues) {
-                        quantileList.add(new Quantile(v.percentile(), v.value(getBaseTimeUnit())));
-                    }
-                    quantiles = Quantiles.of(quantileList);
-                }
-
-                Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
-                samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                        .add(new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
-                                createdTimestampMillis));
+                samples.accept(familyDescriptor,
+                        new SummaryDataPointSnapshot(count, sum,
+                                quantiles(histogramSnapshot.percentileValues(), timeUnit), labels,
+                                exemplarsSupplier.get(), createdTimestampMillis));
             }
             else {
-                List<Double> buckets = new ArrayList<>();
-                List<Number> counts = new ArrayList<>();
-                // TODO: remove this cumulative -> non cumulative conversion
-                // ClassicHistogramBuckets is not cumulative but the histograms we
-                // use are cumulative
-                // so we convert it to non-cumulative just for the Prometheus
-                // client library
-                // can convert it back to cumulative.
-                buckets.add(histogramCounts[0].bucket(getBaseTimeUnit()));
-                counts.add(histogramCounts[0].count());
-                for (int i = 1; i < histogramCounts.length; i++) {
-                    CountAtBucket countAtBucket = histogramCounts[i];
-                    buckets.add(countAtBucket.bucket(getBaseTimeUnit()));
-                    counts.add(countAtBucket.count() - histogramCounts[i - 1].count());
-                }
-                if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
-                    // ClassicHistogramBuckets is not cumulative
-                    buckets.add(Double.POSITIVE_INFINITY);
-                    double infCount = count - histogramCounts[histogramCounts.length - 1].count();
-                    counts.add(infCount >= 0 ? infCount : 0);
-                }
-
-                Exemplars exemplars = createExemplarsWithScaledValues(exemplarsSupplier.get());
-                samples.computeIfAbsent(familyDescriptor, k -> new ArrayList<>())
-                        .add(new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
-                                exemplars, createdTimestampMillis));
+                samples.accept(familyDescriptor,
+                        new HistogramDataPointSnapshot(nonCumulativeBuckets(histogramCounts, count, timeUnit), sum,
+                                labels, exemplarsSupplier.get(), createdTimestampMillis));
 
                 // TODO: Add support back for VictoriaMetrics
                 // Previously we had low-level control so a histogram was just
@@ -574,9 +459,48 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 // bucket name is hardcoded to le.
             }
 
-            samples.computeIfAbsent(familyDescriptorMax, k -> new ArrayList<>())
-                    .add(new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null));
+            double max = timeUnit == null ? histogramSnapshot.max() : histogramSnapshot.max(timeUnit);
+            samples.accept(familyDescriptorMax, new GaugeDataPointSnapshot(max, labels, null));
         }, familyDescriptor, familyDescriptorMax);
+    }
+
+    private static Quantiles quantiles(ValueAtPercentile[] percentileValues, @Nullable TimeUnit timeUnit) {
+        if (percentileValues.length == 0) {
+            return Quantiles.EMPTY;
+        }
+        List<Quantile> quantiles = new ArrayList<>(percentileValues.length);
+        for (ValueAtPercentile percentileValue : percentileValues) {
+            quantiles.add(new Quantile(percentileValue.percentile(),
+                    timeUnit == null ? percentileValue.value() : percentileValue.value(timeUnit)));
+        }
+        return Quantiles.of(quantiles);
+    }
+
+    // TODO: remove this cumulative -> non cumulative conversion
+    // ClassicHistogramBuckets is not cumulative but the histograms we use are cumulative
+    // so we convert it to non-cumulative just for the Prometheus client library
+    // can convert it back to cumulative.
+    private static ClassicHistogramBuckets nonCumulativeBuckets(CountAtBucket[] histogramCounts, long count,
+            @Nullable TimeUnit timeUnit) {
+        List<Double> buckets = new ArrayList<>();
+        List<Number> counts = new ArrayList<>();
+        buckets.add(bucket(histogramCounts[0], timeUnit));
+        counts.add(histogramCounts[0].count());
+        for (int i = 1; i < histogramCounts.length; i++) {
+            buckets.add(bucket(histogramCounts[i], timeUnit));
+            counts.add(histogramCounts[i].count() - histogramCounts[i - 1].count());
+        }
+        if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
+            // ClassicHistogramBuckets is not cumulative
+            buckets.add(Double.POSITIVE_INFINITY);
+            double infCount = count - histogramCounts[histogramCounts.length - 1].count();
+            counts.add(infCount >= 0 ? infCount : 0);
+        }
+        return ClassicHistogramBuckets.of(buckets, counts);
+    }
+
+    private static double bucket(CountAtBucket countAtBucket, @Nullable TimeUnit timeUnit) {
+        return timeUnit == null ? countAtBucket.bucket() : countAtBucket.bucket(timeUnit);
     }
 
     private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
@@ -609,11 +533,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private void onMeterRemoved(Meter meter) {
-        MicrometerCollector collector = collectorMap.get(getConventionName(meter.getId()));
+        String conventionName = getConventionName(meter.getId());
+        MicrometerCollector collector = collectorMap.get(conventionName);
         if (collector != null) {
             collector.remove(meter.getId());
             if (collector.isEmpty()) {
-                collectorMap.remove(getConventionName(meter.getId()));
+                collectorMap.remove(conventionName);
                 getPrometheusRegistry().unregister(collector);
             }
         }
@@ -641,7 +566,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 return existingCollector;
             }
 
-            Meter.Type type = existingCollector.getMeterType();
+            Meter.Type type = existingCollector.getOriginalId().getType();
             if (!type.equals(id.getType())) {
                 meterRegistrationFailed(id,
                         "Prometheus requires that all meters with the same name have the same"
@@ -650,7 +575,12 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 return existingCollector;
             }
 
-            consumer.accept(existingCollector);
+            try {
+                consumer.accept(existingCollector);
+            }
+            catch (IllegalArgumentException e) {
+                meterRegistrationFailed(id, e.getMessage());
+            }
             return existingCollector;
         });
     }
@@ -694,22 +624,6 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             message += ".";
         }
         return message;
-    }
-
-    private enum Format {
-
-        TEXT_004("text/plain; version=0.0.4; charset=utf-8");
-
-        private final String contentType;
-
-        Format(String contentType) {
-            this.contentType = contentType;
-        }
-
-        String getContentType() {
-            return contentType;
-        }
-
     }
 
 }

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -19,24 +19,16 @@ import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionCounter;
 import io.micrometer.core.instrument.cumulative.CumulativeFunctionTimer;
-import io.micrometer.core.instrument.distribution.*;
-import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.instrument.internal.DefaultGauge;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.instrument.internal.DefaultMeter;
-import io.micrometer.core.instrument.util.TimeUtils;
 import io.prometheus.metrics.config.PrometheusProperties;
 import io.prometheus.metrics.config.PrometheusPropertiesLoader;
 import io.prometheus.metrics.expositionformats.ExpositionFormats;
-import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
-import io.prometheus.metrics.model.snapshots.*;
-import io.prometheus.metrics.model.snapshots.CounterSnapshot.CounterDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.HistogramSnapshot.HistogramDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.InfoSnapshot.InfoDataPointSnapshot;
-import io.prometheus.metrics.model.snapshots.SummarySnapshot.SummaryDataPointSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
 import io.prometheus.metrics.tracer.common.SpanContext;
 import org.jspecify.annotations.Nullable;
 
@@ -44,21 +36,13 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;
-import java.util.stream.StreamSupport;
 
-import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
@@ -113,7 +97,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         this.registry = registry;
         PrometheusProperties prometheusProperties = config.prometheusProperties() != null
                 ? PrometheusPropertiesLoader.load(config.prometheusProperties()) : PrometheusPropertiesLoader.load();
-        this.expositionFormats = ExpositionFormats.init(prometheusProperties.getExporterProperties());
+        this.expositionFormats = ExpositionFormats.init(prometheusProperties);
         this.exemplarSamplerFactory = spanContext != null
                 ? new DefaultExemplarSamplerFactory(spanContext, prometheusProperties.getExemplarProperties()) : null;
 
@@ -212,17 +196,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     @Override
     public Counter newCounter(Meter.Id id) {
         PrometheusCounter counter = new PrometheusCounter(id, exemplarSamplerFactory);
-        long createdTimestampMillis = clock.wallTime();
-        applyToCollector(id, (collector) -> {
-            List<String> tagKeys = tagKeys(id);
-            Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.COUNTER, conventionName,
-                    tagKeys, id.getDescription());
-            collector.add(id, samples -> samples.accept(familyDescriptor,
-                    new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis)),
-                    familyDescriptor);
-        });
+        applyToCollector(id, (collector, context) -> collector.addCounter(context, counter));
         return counter;
     }
 
@@ -231,18 +205,16 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             DistributionStatisticConfig distributionStatisticConfig, double scale) {
         PrometheusDistributionSummary summary = new PrometheusDistributionSummary(id, clock,
                 distributionStatisticConfig, scale, exemplarSamplerFactory);
-        applyToCollector(id,
-                (collector) -> addDistributionStatisticSamples(id, collector, summary, summary::exemplars, null));
+        applyToCollector(id, (collector, context) -> collector.addDistributionSummary(context, summary));
         return summary;
     }
 
     @Override
-    protected io.micrometer.core.instrument.Timer newTimer(Meter.Id id,
-            DistributionStatisticConfig distributionStatisticConfig, PauseDetector pauseDetector) {
+    protected Timer newTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig,
+            PauseDetector pauseDetector) {
         PrometheusTimer timer = new PrometheusTimer(id, clock, distributionStatisticConfig, pauseDetector,
                 exemplarSamplerFactory);
-        applyToCollector(id, (collector) -> addDistributionStatisticSamples(id, collector, timer,
-                () -> createExemplarsWithScaledValues(timer.exemplars()), getBaseTimeUnit()));
+        applyToCollector(id, (collector, context) -> collector.addTimer(context, timer));
         return timer;
     }
 
@@ -250,32 +222,14 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, @Nullable T obj,
             ToDoubleFunction<T> valueFunction) {
         Gauge gauge = new DefaultGauge<>(id, obj, valueFunction);
-        applyToCollector(id, (collector) -> {
-            List<String> tagKeys = tagKeys(id);
-            Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor;
-            if (id.getName().endsWith(".info")) {
-                familyDescriptor = familyDescriptor(collector, MetricType.INFO, conventionName, tagKeys,
-                        id.getDescription());
-                collector.add(id, samples -> samples.accept(familyDescriptor, new InfoDataPointSnapshot(labels)),
-                        familyDescriptor);
-            }
-            else {
-                familyDescriptor = familyDescriptor(collector, MetricType.GAUGE, conventionName, tagKeys,
-                        id.getDescription());
-                collector.add(id, samples -> samples.accept(familyDescriptor,
-                        new GaugeDataPointSnapshot(gauge.value(), labels, null)), familyDescriptor);
-            }
-        });
+        applyToCollector(id, (collector, context) -> collector.addGauge(context, gauge));
         return gauge;
     }
 
     @Override
     protected LongTaskTimer newLongTaskTimer(Meter.Id id, DistributionStatisticConfig distributionStatisticConfig) {
         LongTaskTimer ltt = new DefaultLongTaskTimer(id, clock, getBaseTimeUnit(), distributionStatisticConfig, true);
-        applyToCollector(id, (collector) -> addDistributionStatisticSamples(id, collector, ltt, () -> Exemplars.EMPTY,
-                getBaseTimeUnit()));
+        applyToCollector(id, (collector, context) -> collector.addLongTaskTimer(context, ltt));
         return ltt;
     }
 
@@ -284,125 +238,21 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             ToDoubleFunction<T> totalTimeFunction, TimeUnit totalTimeFunctionUnit) {
         FunctionTimer ft = new CumulativeFunctionTimer<>(id, obj, countFunction, totalTimeFunction,
                 totalTimeFunctionUnit, getBaseTimeUnit());
-        long createdTimestampMillis = clock.wallTime();
-        applyToCollector(id, (collector) -> {
-            List<String> tagKeys = tagKeys(id);
-            Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.SUMMARY, conventionName,
-                    tagKeys, id.getDescription());
-            collector.add(id,
-                    samples -> samples.accept(familyDescriptor, new SummaryDataPointSnapshot((long) ft.count(),
-                            ft.totalTime(getBaseTimeUnit()), Quantiles.EMPTY, labels, null, createdTimestampMillis)),
-                    familyDescriptor);
-        });
+        applyToCollector(id, (collector, context) -> collector.addFunctionTimer(context, ft));
         return ft;
     }
 
     @Override
     protected <T> FunctionCounter newFunctionCounter(Meter.Id id, T obj, ToDoubleFunction<T> countFunction) {
         FunctionCounter fc = new CumulativeFunctionCounter<>(id, obj, countFunction);
-        long createdTimestampMillis = clock.wallTime();
-        applyToCollector(id, (collector) -> {
-            List<String> tagKeys = tagKeys(id);
-            Labels labels = Labels.of(tagKeys, tagValues(id));
-            String conventionName = collector.conventionName;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, MetricType.COUNTER, conventionName,
-                    tagKeys, id.getDescription());
-            collector.add(id,
-                    samples -> samples.accept(familyDescriptor,
-                            new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis)),
-                    familyDescriptor);
-        });
+        applyToCollector(id, (collector, context) -> collector.addFunctionCounter(context, fc));
         return fc;
     }
 
     @Override
     protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
-        long createdTimestampMillis = clock.wallTime();
-        applyToCollector(id, (collector) -> {
-            List<String> tagValues = tagValues(id);
-            List<String> statKeys = new ArrayList<>(tagKeys(id));
-            statKeys.add("statistic");
-
-            // precompute the family descriptor and labels per statistic; measurements
-            // with statistics that map to the same Prometheus name (e.g. TOTAL and
-            // TOTAL_TIME) share one family descriptor
-            Map<String, MetricFamilyDescriptor> descriptorsByName = new LinkedHashMap<>();
-            Map<Statistic, MeasurementFamily> familiesByStatistic = new EnumMap<>(Statistic.class);
-            for (Measurement measurement : measurements) {
-                familiesByStatistic.computeIfAbsent(measurement.getStatistic(), statistic -> {
-                    MetricFamilyDescriptor descriptor = customMeterDescriptor(collector, id, collector.conventionName,
-                            statistic, statKeys);
-                    MetricFamilyDescriptor existing = descriptorsByName.putIfAbsent(descriptor.getPrometheusName(),
-                            descriptor);
-                    List<String> statValues = new ArrayList<>(tagValues);
-                    statValues.add(statistic.toString());
-                    return new MeasurementFamily(existing != null ? existing : descriptor,
-                            Labels.of(statKeys, statValues));
-                });
-            }
-
-            collector.add(id, samples -> {
-                for (Measurement measurement : measurements) {
-                    MeasurementFamily family = requireNonNull(familiesByStatistic.get(measurement.getStatistic()));
-                    if (family.descriptor.getType() == MetricType.COUNTER) {
-                        samples.accept(family.descriptor, new CounterDataPointSnapshot(measurement.getValue(),
-                                family.labels, null, createdTimestampMillis));
-                    }
-                    else {
-                        samples.accept(family.descriptor,
-                                new GaugeDataPointSnapshot(measurement.getValue(), family.labels, null));
-                    }
-                }
-            }, descriptorsByName.values().toArray(new MetricFamilyDescriptor[0]));
-        });
-
+        applyToCollector(id, (collector, context) -> collector.addCustomMeter(context, measurements));
         return new DefaultMeter(id, type, measurements);
-    }
-
-    private MetricFamilyDescriptor customMeterDescriptor(MicrometerCollector collector, Meter.Id id,
-            String conventionName, Statistic statistic, Collection<String> labelNames) {
-        switch (statistic) {
-            case TOTAL:
-            case TOTAL_TIME:
-                return familyDescriptor(collector, MetricType.COUNTER, conventionName + "_sum", labelNames,
-                        id.getDescription());
-            case COUNT:
-                return familyDescriptor(collector, MetricType.COUNTER, conventionName, labelNames, id.getDescription());
-            case MAX:
-                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_max", labelNames,
-                        id.getDescription());
-            case VALUE:
-            case UNKNOWN:
-                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_value", labelNames,
-                        id.getDescription());
-            case ACTIVE_TASKS:
-                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_active_count", labelNames,
-                        id.getDescription());
-            case DURATION:
-                return familyDescriptor(collector, MetricType.GAUGE, conventionName + "_duration_sum", labelNames,
-                        id.getDescription());
-            default:
-                throw new IllegalArgumentException("Unsupported meter statistic: " + statistic);
-        }
-    }
-
-    /**
-     * The Prometheus metric family and precomputed labels for the measurements of one
-     * {@link Statistic} of a custom meter.
-     */
-    private static final class MeasurementFamily {
-
-        private final MetricFamilyDescriptor descriptor;
-
-        private final Labels labels;
-
-        private MeasurementFamily(MetricFamilyDescriptor descriptor, Labels labels) {
-            this.descriptor = descriptor;
-            this.labels = labels;
-        }
-
     }
 
     @Override
@@ -417,130 +267,8 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         return registry;
     }
 
-    /**
-     * Adds samples for meters with distribution statistics, i.e. timers, long task
-     * timers, and distribution summaries.
-     * @param timeUnit if {@code null}, snapshot values are used as-is (distribution
-     * summaries); otherwise, time-based snapshot values are converted to this unit
-     * (timers, long task timers)
-     */
-    private void addDistributionStatisticSamples(Meter.Id id, MicrometerCollector collector,
-            HistogramSupport histogramSupport, Supplier<Exemplars> exemplarsSupplier, @Nullable TimeUnit timeUnit) {
-        long createdTimestampMillis = clock.wallTime();
-        List<String> tagKeys = tagKeys(id);
-        Labels labels = Labels.of(tagKeys, tagValues(id));
-        MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
-                : MetricType.HISTOGRAM;
-        String conventionName = collector.conventionName;
-        MetricFamilyDescriptor familyDescriptor = familyDescriptor(collector, primaryType, conventionName, tagKeys,
-                id.getDescription());
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(collector, MetricType.GAUGE,
-                conventionName + "_max", tagKeys, id.getDescription());
-
-        collector.add(id, samples -> {
-            HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
-            CountAtBucket[] histogramCounts = histogramSnapshot.histogramCounts();
-            long count = histogramSnapshot.count();
-            double sum = timeUnit == null ? histogramSnapshot.total() : histogramSnapshot.total(timeUnit);
-
-            if (histogramCounts.length == 0) {
-                samples.accept(familyDescriptor,
-                        new SummaryDataPointSnapshot(count, sum,
-                                quantiles(histogramSnapshot.percentileValues(), timeUnit), labels,
-                                exemplarsSupplier.get(), createdTimestampMillis));
-            }
-            else {
-                samples.accept(familyDescriptor,
-                        new HistogramDataPointSnapshot(nonCumulativeBuckets(histogramCounts, count, timeUnit), sum,
-                                labels, exemplarsSupplier.get(), createdTimestampMillis));
-
-                // TODO: Add support back for VictoriaMetrics
-                // Previously we had low-level control so a histogram was just
-                // a bunch of Collector.MetricFamilySamples.Sample
-                // that has an le label for Prometheus and a vmrange label for
-                // Victoria.
-                // That control is gone now, so we don’t have control over the
-                // output and when HistogramDataPointSnapshot is written, the
-                // bucket name is hardcoded to le.
-            }
-
-            double max = timeUnit == null ? histogramSnapshot.max() : histogramSnapshot.max(timeUnit);
-            samples.accept(familyDescriptorMax, new GaugeDataPointSnapshot(max, labels, null));
-        }, familyDescriptor, familyDescriptorMax);
-    }
-
-    private static Quantiles quantiles(ValueAtPercentile[] percentileValues, @Nullable TimeUnit timeUnit) {
-        if (percentileValues.length == 0) {
-            return Quantiles.EMPTY;
-        }
-        List<Quantile> quantiles = new ArrayList<>(percentileValues.length);
-        for (ValueAtPercentile percentileValue : percentileValues) {
-            quantiles.add(new Quantile(percentileValue.percentile(),
-                    timeUnit == null ? percentileValue.value() : percentileValue.value(timeUnit)));
-        }
-        return Quantiles.of(quantiles);
-    }
-
-    // TODO: remove this cumulative -> non cumulative conversion
-    // ClassicHistogramBuckets is not cumulative but the histograms we use are cumulative
-    // so we convert it to non-cumulative just for the Prometheus client library
-    // can convert it back to cumulative.
-    private static ClassicHistogramBuckets nonCumulativeBuckets(CountAtBucket[] histogramCounts, long count,
-            @Nullable TimeUnit timeUnit) {
-        List<Double> buckets = new ArrayList<>();
-        List<Number> counts = new ArrayList<>();
-        buckets.add(bucket(histogramCounts[0], timeUnit));
-        counts.add(histogramCounts[0].count());
-        for (int i = 1; i < histogramCounts.length; i++) {
-            buckets.add(bucket(histogramCounts[i], timeUnit));
-            counts.add(histogramCounts[i].count() - histogramCounts[i - 1].count());
-        }
-        if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
-            // ClassicHistogramBuckets is not cumulative
-            buckets.add(Double.POSITIVE_INFINITY);
-            double infCount = count - histogramCounts[histogramCounts.length - 1].count();
-            counts.add(infCount >= 0 ? infCount : 0);
-        }
-        return ClassicHistogramBuckets.of(buckets, counts);
-    }
-
-    private static double bucket(CountAtBucket countAtBucket, @Nullable TimeUnit timeUnit) {
-        return timeUnit == null ? countAtBucket.bucket() : countAtBucket.bucket(timeUnit);
-    }
-
-    private MetricFamilyDescriptor familyDescriptor(MicrometerCollector collector, MetricType metricType, String name,
-            Collection<String> labelNames, @Nullable String description) {
-        return collector.getOrCreateDescriptor(metricType, name,
-                () -> familyDescriptor(metricType, name, labelNames, description));
-    }
-
-    private MetricFamilyDescriptor familyDescriptor(MetricType metricType, String name, Collection<String> labelNames,
-            @Nullable String description) {
-        // NB: For custom meters that use `getMetadata`, the metadata inside the
-        // descriptor should be consistent with the one returned by `getMetadata`.
-
-        // Unit is intentionally not set, see:
-        // https://github.com/OpenObservability/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#unit
-        return MetricFamilyDescriptor.of(metricType, name).help(helpText(description)).labelNames(labelNames).build();
-    }
-
     private String helpText(@Nullable String description) {
         return prometheusConfig.descriptions() && description != null ? description : " ";
-    }
-
-    private Exemplars createExemplarsWithScaledValues(Exemplars exemplars) {
-        return Exemplars.of(StreamSupport.stream(exemplars.spliterator(), false)
-            .map(exemplar -> createExemplarWithNewValue(
-                    TimeUtils.convert(exemplar.getValue(), NANOSECONDS, getBaseTimeUnit()), exemplar))
-            .collect(toList()));
-    }
-
-    private Exemplar createExemplarWithNewValue(double newValue, Exemplar exemplar) {
-        return Exemplar.builder()
-            .value(newValue)
-            .labels(exemplar.getLabels())
-            .timestampMillis(exemplar.getTimestampMillis())
-            .build();
     }
 
     private void onMeterRemoved(Meter meter) {
@@ -555,11 +283,19 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         }
     }
 
-    private void applyToCollector(Meter.Id id, Consumer<MicrometerCollector> consumer) {
+    /**
+     * Adds a meter to the collector of its Prometheus name, creating and registering the
+     * collector if this is the first meter with that name. Everything the collector needs
+     * from the naming convention and the registry configuration is resolved once here, so
+     * that it does not have to be resolved again on every scrape.
+     */
+    private void applyToCollector(Meter.Id id, BiConsumer<MicrometerCollector, MeterContext> consumer) {
+        MeterContext context = new MeterContext(id, tagKeys(id), tagValues(id), helpText(id.getDescription()),
+                clock.wallTime());
         collectorMap.compute(getConventionName(id), (name, existingCollector) -> {
             if (existingCollector == null) {
                 MicrometerCollector micrometerCollector = new MicrometerCollector(name, id);
-                consumer.accept(micrometerCollector);
+                consumer.accept(micrometerCollector, context);
                 try {
                     registry.register(micrometerCollector);
                     return micrometerCollector;
@@ -587,7 +323,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             }
 
             try {
-                consumer.accept(existingCollector);
+                consumer.accept(existingCollector, context);
             }
             catch (IllegalArgumentException e) {
                 meterRegistrationFailed(id, e.getMessage());

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -221,9 +221,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
-                    tagKeys, id.getDescription());
-            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
+                    id.getDescription());
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                     family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                     new CounterDataPointSnapshot(counter.count(), labels, counter.exemplar(), createdTimestampMillis))),
                     familyDescriptor);
@@ -241,11 +242,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
             MetricType primaryType = summary.histogramCounts().length == 0 ? MetricType.SUMMARY : MetricType.HISTOGRAM;
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                     id.getDescription());
-            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE,
-                    getConventionName(id) + "_max", tagKeys, id.getDescription());
-            collector.add(id, (conventionName) -> {
+            String conventionNameMax = conventionName + "_max";
+            MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
+                    id.getDescription());
+            collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
                 final ValueAtPercentile[] percentileValues = summary.takeSnapshot().percentileValues();
@@ -264,7 +267,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(conventionName,
+                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot(count, sum, quantiles, labels, exemplars,
                                     createdTimestampMillis)));
@@ -293,7 +296,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     }
 
                     Exemplars exemplars = summary.exemplars();
-                    families.add(new MicrometerCollector.Family<>(conventionName,
+                    families.add(new MicrometerCollector.Family<>(collector.getConventionName(),
                             family -> new io.prometheus.metrics.model.snapshots.HistogramSnapshot(false,
                                     familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new HistogramDataPointSnapshot(ClassicHistogramBuckets.of(buckets, counts), sum, labels,
@@ -309,7 +312,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     // bucket name is hardcoded to le.
                 }
 
-                families.add(new MicrometerCollector.Family<>(conventionName + "_max",
+                families.add(new MicrometerCollector.Family<>(conventionNameMax,
                         family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
                         new GaugeDataPointSnapshot(summary.max(), labels, null)));
 
@@ -337,21 +340,20 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
+            String conventionName = collector.getConventionName();
             MetricFamilyDescriptor familyDescriptor;
             if (id.getName().endsWith(".info")) {
-                familyDescriptor = familyDescriptor(MetricType.INFO, getConventionName(id), tagKeys,
-                        id.getDescription());
+                familyDescriptor = familyDescriptor(MetricType.INFO, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new InfoSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                                 new InfoDataPointSnapshot(labels))),
                         familyDescriptor);
             }
             else {
-                familyDescriptor = familyDescriptor(MetricType.GAUGE, getConventionName(id), tagKeys,
-                        id.getDescription());
+                familyDescriptor = familyDescriptor(MetricType.GAUGE, conventionName, tagKeys, id.getDescription());
                 collector.add(id,
-                        (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                        () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                                 family -> new GaugeSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                                 new GaugeDataPointSnapshot(gauge.value(), labels, null))),
                         familyDescriptor);
@@ -377,10 +379,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, getConventionName(id),
-                    tagKeys, id.getDescription());
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.SUMMARY, conventionName, tagKeys,
+                    id.getDescription());
             collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new SummarySnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new SummaryDataPointSnapshot((long) ft.count(), ft.totalTime(getBaseTimeUnit()),
                                     Quantiles.EMPTY, labels, null, createdTimestampMillis))),
@@ -396,10 +399,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         applyToCollector(id, (collector) -> {
             List<String> tagKeys = tagKeys(id);
             Labels labels = Labels.of(tagKeys, tagValues(id));
-            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, getConventionName(id),
-                    tagKeys, id.getDescription());
+            String conventionName = collector.getConventionName();
+            MetricFamilyDescriptor familyDescriptor = familyDescriptor(MetricType.COUNTER, conventionName, tagKeys,
+                    id.getDescription());
             collector.add(id,
-                    (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+                    () -> Stream.of(new MicrometerCollector.Family<>(conventionName,
                             family -> new CounterSnapshot(familyDescriptor.getMetadata(), family.dataPointSnapshots),
                             new CounterDataPointSnapshot(fc.count(), labels, null, createdTimestampMillis))),
                     familyDescriptor);
@@ -440,7 +444,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                         Labels.of(statKeys, statValues)));
             }
 
-            collector.add(id, (conventionName) -> {
+            collector.add(id, () -> {
                 Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
                 for (CustomMeterMeasurement measurement : customMeasurements) {
                     families.add(customMeterFamily(measurement));
@@ -548,11 +552,13 @@ public class PrometheusMeterRegistry extends MeterRegistry {
         Labels labels = Labels.of(tagKeys, tagValues);
         MetricType primaryType = histogramSupport.takeSnapshot().histogramCounts().length == 0 ? MetricType.SUMMARY
                 : MetricType.HISTOGRAM;
-        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, getConventionName(id), tagKeys,
+        String conventionName = collector.getConventionName();
+        MetricFamilyDescriptor familyDescriptor = familyDescriptor(primaryType, conventionName, tagKeys,
                 id.getDescription());
-        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, getConventionName(id) + "_max",
-                tagKeys, id.getDescription());
-        collector.add(id, (conventionName) -> {
+        String conventionNameMax = conventionName + "_max";
+        MetricFamilyDescriptor familyDescriptorMax = familyDescriptor(MetricType.GAUGE, conventionNameMax, tagKeys,
+                id.getDescription());
+        collector.add(id, () -> {
             Stream.Builder<MicrometerCollector.Family<?>> families = Stream.builder();
 
             HistogramSnapshot histogramSnapshot = histogramSupport.takeSnapshot();
@@ -617,7 +623,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 // bucket name is hardcoded to le.
             }
 
-            families.add(new MicrometerCollector.Family<>(conventionName + "_max",
+            families.add(new MicrometerCollector.Family<>(conventionNameMax,
                     family -> new GaugeSnapshot(familyDescriptorMax.getMetadata(), family.dataPointSnapshots),
                     new GaugeDataPointSnapshot(histogramSnapshot.max(getBaseTimeUnit()), labels, null)));
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -48,7 +48,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                     family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                     sample)));
         }
@@ -69,10 +69,10 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(sample2Id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -91,10 +91,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -113,10 +113,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -135,10 +135,10 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, (conventionName) -> Stream.of(new MicrometerCollector.Family<>(conventionName,
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -153,7 +153,7 @@ class MicrometerCollectorTest {
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of("k", "v"), null, 0);
         collector.add(id,
-                (conventionName) -> Stream.of(new MicrometerCollector.Family<>("my_counter",
+                () -> Stream.of(new MicrometerCollector.Family<>("my_counter",
                         family -> new CounterSnapshot(new MetricMetadata(family.conventionName),
                                 family.dataPointSnapshots),
                         sample)),

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -25,10 +25,9 @@ import io.prometheus.metrics.model.registry.MetricType;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
-import io.prometheus.metrics.model.snapshots.MetricMetadata;
 import org.junit.jupiter.api.Test;
 
-import java.util.stream.Stream;
+import java.util.ArrayList;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,15 +41,15 @@ class MicrometerCollectorTest {
     void manyTags() {
         Meter.Id id = Metrics.counter("my.counter").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
         for (int i = 0; i < 20_000; i++) {
             id = id.withTag(Tag.of("k", Integer.toString(i)));
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                    family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                    sample)));
+            collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                    descriptor);
         }
 
         // Threw StackOverflowException because of too many nested streams originally
@@ -61,6 +60,7 @@ class MicrometerCollectorTest {
     void sameValuesDifferentOrder() {
         Meter.Id id = Metrics.counter("my.counter").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of("k", "v1", "k2", "v2"), null, 0);
@@ -69,12 +69,10 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample)));
-        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample2)));
+        collector.add(sampleId, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                descriptor);
+        collector.add(sample2Id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
+                descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -84,6 +82,7 @@ class MicrometerCollectorTest {
     void sameMetricDifferentTagKeysCounter() {
         Meter.Id id = Metrics.counter("my.counter", "k1", "v1", "k2", "v2", "k3", "v3").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of(asList("k1", "k2", "k3"), asList("v1", "v2", "v3")), null, 0);
@@ -91,12 +90,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample2)));
+        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                descriptor);
+        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
+                descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -106,6 +103,7 @@ class MicrometerCollectorTest {
     void oneSampleHasSubsetOfTagKeysOfAnotherSample() {
         Meter.Id id = Metrics.counter("my.counter", "k1", "v1", "k2", "v2", "k3", "v3").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of(asList("k1", "k2", "k3"), asList("v1", "v2", "v3")), null, 0);
@@ -113,12 +111,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample2)));
+        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                descriptor);
+        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
+                descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -128,6 +124,7 @@ class MicrometerCollectorTest {
     void sameMetricNameWithNoTagsAndAListOfTags() {
         Meter.Id id = Metrics.counter("my.counter", "k1", "v1", "k2", "v2", "k3", "v3").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of(asList("k1", "k2", "k3"), asList("v1", "v2", "v3")), null, 0);
@@ -135,12 +132,10 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
-                family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
-                sample2)));
+        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                descriptor);
+        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
+                descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -149,21 +144,21 @@ class MicrometerCollectorTest {
     void registrationDescriptorUsesPrometheusFamilyName() {
         Meter.Id id = Metrics.counter("my.counter").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter("my_counter")
+            .help("help")
+            .labelNames(asList("k"))
+            .build();
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of("k", "v"), null, 0);
-        collector.add(id,
-                () -> Stream.of(new MicrometerCollector.Family<>("my_counter",
-                        family -> new CounterSnapshot(new MetricMetadata(family.conventionName),
-                                family.dataPointSnapshots),
-                        sample)),
-                MetricFamilyDescriptor.counter("my_counter").help("help").labelNames(asList("k")).build());
+        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
+                descriptor);
 
-        assertThat(collector.getMetricFamilyDescriptors()).singleElement().satisfies(descriptor -> {
-            assertThat(descriptor.getPrometheusName()).isEqualTo("my_counter");
-            assertThat(descriptor.getType()).isEqualTo(MetricType.COUNTER);
-            assertThat(descriptor.getLabelNames()).containsExactly("k");
-            assertThat(descriptor.getMetadata().getName()).isEqualTo("my_counter");
+        assertThat(collector.getMetricFamilyDescriptors()).singleElement().satisfies(d -> {
+            assertThat(d.getPrometheusName()).isEqualTo("my_counter");
+            assertThat(d.getType()).isEqualTo(MetricType.COUNTER);
+            assertThat(d.getLabelNames()).containsExactly("k");
+            assertThat(d.getMetadata().getName()).isEqualTo("my_counter");
         });
     }
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -22,15 +22,20 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.prometheus.metrics.model.registry.MetricType;
+import io.prometheus.metrics.model.snapshots.ClassicHistogramBuckets;
 import io.prometheus.metrics.model.snapshots.CounterSnapshot;
+import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import io.prometheus.metrics.model.snapshots.Quantiles;
+import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MicrometerCollectorTest {
 
@@ -48,8 +53,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                    descriptor);
+            collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
         }
 
         // Threw StackOverflowException because of too many nested streams originally
@@ -69,10 +73,8 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                descriptor);
-        collector.add(sample2Id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
-                descriptor);
+        collector.add(sampleId, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.add(sample2Id, samples -> samples.accept(descriptor, sample2), descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -90,10 +92,8 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                descriptor);
-        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
-                descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -111,10 +111,8 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                descriptor);
-        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
-                descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -132,12 +130,85 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                descriptor);
-        collector.add(id2, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample2),
-                descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
+    }
+
+    @Test
+    void separateDescriptorInstancesWithSameNameProduceOneSnapshot() {
+        // children register their own descriptor instances (as the registry does per
+        // meter) and descriptors have identity equality; they should still be collected
+        // into a single snapshot per family name
+        Meter.Id id = Metrics.counter("my.counter", "k", "v1").getId();
+        MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
+        MetricFamilyDescriptor descriptor2 = MetricFamilyDescriptor.counter(collector.conventionName).build();
+
+        CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
+                Labels.of("k", "v1"), null, 0);
+        CounterSnapshot.CounterDataPointSnapshot sample2 = new CounterSnapshot.CounterDataPointSnapshot(1.0,
+                Labels.of("k", "v2"), null, 0);
+        Meter.Id id2 = id.replaceTags(Tags.of("k", "v2"));
+
+        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.add(id2, samples -> samples.accept(descriptor2, sample2), descriptor2);
+
+        MetricSnapshots snapshots = collector.collect();
+        assertThat(snapshots.size()).isOne();
+        assertThat(snapshots.get(0).getDataPoints()).hasSize(2);
+    }
+
+    @Test
+    void conflictingFamilyTypesUnderSameNameFailToAdd() {
+        Meter.Id id = Metrics.timer("my.timer", "k", "v1").getId();
+        MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor summaryDescriptor = MetricFamilyDescriptor.summary(collector.conventionName).build();
+        MetricFamilyDescriptor histogramDescriptor = MetricFamilyDescriptor.histogram(collector.conventionName).build();
+
+        SummarySnapshot.SummaryDataPointSnapshot summaryDataPoint = new SummarySnapshot.SummaryDataPointSnapshot(1, 1.0,
+                Quantiles.EMPTY, Labels.of("k", "v1"), null, 0);
+        Meter.Id id2 = id.replaceTags(Tags.of("k", "v2"));
+
+        collector.add(id, samples -> samples.accept(summaryDescriptor, summaryDataPoint), summaryDescriptor);
+
+        assertThatThrownBy(() -> collector.add(id2, samples -> {
+        }, histogramDescriptor)).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("same Prometheus metric family types");
+
+        // the conflicting child was not added; collecting still works
+        assertThat(collector.collect().size()).isOne();
+    }
+
+    @Test
+    void longTaskTimerHistogramFamilyIsGaugeHistogram() {
+        Meter.Id id = Metrics.more().longTaskTimer("my.ltt").getId();
+        MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.histogram(collector.conventionName).build();
+
+        HistogramSnapshot.HistogramDataPointSnapshot dataPoint = new HistogramSnapshot.HistogramDataPointSnapshot(
+                ClassicHistogramBuckets.of(asList(Double.POSITIVE_INFINITY), asList(0L)), 0.0, Labels.EMPTY, null, 0);
+        collector.add(id, samples -> samples.accept(descriptor, dataPoint), descriptor);
+
+        MetricSnapshot snapshot = collector.collect().get(0);
+        assertThat(snapshot).isInstanceOf(HistogramSnapshot.class);
+        assertThat(((HistogramSnapshot) snapshot).isGaugeHistogram()).isTrue();
+    }
+
+    @Test
+    void timerHistogramFamilyIsNotGaugeHistogram() {
+        Meter.Id id = Metrics.timer("my.histogram.timer").getId();
+        MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
+        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.histogram(collector.conventionName).build();
+
+        HistogramSnapshot.HistogramDataPointSnapshot dataPoint = new HistogramSnapshot.HistogramDataPointSnapshot(
+                ClassicHistogramBuckets.of(asList(Double.POSITIVE_INFINITY), asList(0L)), 0.0, Labels.EMPTY, null, 0);
+        collector.add(id, samples -> samples.accept(descriptor, dataPoint), descriptor);
+
+        MetricSnapshot snapshot = collector.collect().get(0);
+        assertThat(snapshot).isInstanceOf(HistogramSnapshot.class);
+        assertThat(((HistogramSnapshot) snapshot).isGaugeHistogram()).isFalse();
     }
 
     @Test
@@ -151,8 +222,7 @@ class MicrometerCollectorTest {
 
         CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                 Labels.of("k", "v"), null, 0);
-        collector.add(id, samples -> samples.computeIfAbsent(descriptor, k -> new ArrayList<>()).add(sample),
-                descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
 
         assertThat(collector.getMetricFamilyDescriptors()).singleElement().satisfies(d -> {
             assertThat(d.getPrometheusName()).isEqualTo("my_counter");

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -28,9 +28,6 @@ import io.prometheus.metrics.model.snapshots.HistogramSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
 import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
-import io.prometheus.metrics.model.snapshots.MetricSnapshots;
-import io.prometheus.metrics.model.snapshots.Quantiles;
-import io.prometheus.metrics.model.snapshots.SummarySnapshot;
 import org.junit.jupiter.api.Test;
 
 import static java.util.Arrays.asList;
@@ -53,7 +50,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+            collector.add(id, samples -> samples.accept(descriptor, sample));
         }
 
         // Threw StackOverflowException because of too many nested streams originally
@@ -73,8 +70,8 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, samples -> samples.accept(descriptor, sample), descriptor);
-        collector.add(sample2Id, samples -> samples.accept(descriptor, sample2), descriptor);
+        collector.add(sampleId, samples -> samples.accept(descriptor, sample));
+        collector.add(sample2Id, samples -> samples.accept(descriptor, sample2));
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -92,8 +89,8 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
-        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample));
+        collector.add(id2, samples -> samples.accept(descriptor, sample2));
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -111,8 +108,8 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
-        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample));
+        collector.add(id2, samples -> samples.accept(descriptor, sample2));
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
@@ -130,55 +127,43 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
-        collector.add(id2, samples -> samples.accept(descriptor, sample2), descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, sample));
+        collector.add(id2, samples -> samples.accept(descriptor, sample2));
 
         assertThat(collector.collect().get(0).getDataPoints()).hasSize(2);
     }
 
     @Test
-    void separateDescriptorInstancesWithSameNameProduceOneSnapshot() {
-        // children register their own descriptor instances (as the registry does per
-        // meter) and descriptors have identity equality; they should still be collected
-        // into a single snapshot per family name
+    void descriptorIsCreatedOnceAndReusedForTheSameFamily() {
         Meter.Id id = Metrics.counter("my.counter", "k", "v1").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
-        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter(collector.conventionName).build();
-        MetricFamilyDescriptor descriptor2 = MetricFamilyDescriptor.counter(collector.conventionName).build();
 
-        CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
-                Labels.of("k", "v1"), null, 0);
-        CounterSnapshot.CounterDataPointSnapshot sample2 = new CounterSnapshot.CounterDataPointSnapshot(1.0,
-                Labels.of("k", "v2"), null, 0);
-        Meter.Id id2 = id.replaceTags(Tags.of("k", "v2"));
+        MetricFamilyDescriptor descriptor = collector.getOrCreateDescriptor(MetricType.COUNTER,
+                collector.conventionName, () -> MetricFamilyDescriptor.counter(collector.conventionName).build());
+        MetricFamilyDescriptor descriptor2 = collector.getOrCreateDescriptor(MetricType.COUNTER,
+                collector.conventionName, () -> {
+                    throw new AssertionError("descriptor should have been reused");
+                });
 
-        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
-        collector.add(id2, samples -> samples.accept(descriptor2, sample2), descriptor2);
-
-        MetricSnapshots snapshots = collector.collect();
-        assertThat(snapshots.size()).isOne();
-        assertThat(snapshots.get(0).getDataPoints()).hasSize(2);
+        assertThat(descriptor2).isSameAs(descriptor);
+        assertThat(collector.getMetricFamilyDescriptors()).containsExactly(descriptor);
     }
 
     @Test
-    void conflictingFamilyTypesUnderSameNameFailToAdd() {
+    void conflictingFamilyTypesUnderSameNameFail() {
         Meter.Id id = Metrics.timer("my.timer", "k", "v1").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
-        MetricFamilyDescriptor summaryDescriptor = MetricFamilyDescriptor.summary(collector.conventionName).build();
-        MetricFamilyDescriptor histogramDescriptor = MetricFamilyDescriptor.histogram(collector.conventionName).build();
 
-        SummarySnapshot.SummaryDataPointSnapshot summaryDataPoint = new SummarySnapshot.SummaryDataPointSnapshot(1, 1.0,
-                Quantiles.EMPTY, Labels.of("k", "v1"), null, 0);
-        Meter.Id id2 = id.replaceTags(Tags.of("k", "v2"));
+        MetricFamilyDescriptor summaryDescriptor = collector.getOrCreateDescriptor(MetricType.SUMMARY,
+                collector.conventionName, () -> MetricFamilyDescriptor.summary(collector.conventionName).build());
 
-        collector.add(id, samples -> samples.accept(summaryDescriptor, summaryDataPoint), summaryDescriptor);
-
-        assertThatThrownBy(() -> collector.add(id2, samples -> {
-        }, histogramDescriptor)).isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> collector.getOrCreateDescriptor(MetricType.HISTOGRAM, collector.conventionName,
+                () -> MetricFamilyDescriptor.histogram(collector.conventionName).build()))
+            .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("same Prometheus metric family types");
 
-        // the conflicting child was not added; collecting still works
-        assertThat(collector.collect().size()).isOne();
+        // the conflicting type was not cached
+        assertThat(collector.getMetricFamilyDescriptors()).containsExactly(summaryDescriptor);
     }
 
     @Test
@@ -189,7 +174,7 @@ class MicrometerCollectorTest {
 
         HistogramSnapshot.HistogramDataPointSnapshot dataPoint = new HistogramSnapshot.HistogramDataPointSnapshot(
                 ClassicHistogramBuckets.of(asList(Double.POSITIVE_INFINITY), asList(0L)), 0.0, Labels.EMPTY, null, 0);
-        collector.add(id, samples -> samples.accept(descriptor, dataPoint), descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, dataPoint));
 
         MetricSnapshot snapshot = collector.collect().get(0);
         assertThat(snapshot).isInstanceOf(HistogramSnapshot.class);
@@ -204,7 +189,7 @@ class MicrometerCollectorTest {
 
         HistogramSnapshot.HistogramDataPointSnapshot dataPoint = new HistogramSnapshot.HistogramDataPointSnapshot(
                 ClassicHistogramBuckets.of(asList(Double.POSITIVE_INFINITY), asList(0L)), 0.0, Labels.EMPTY, null, 0);
-        collector.add(id, samples -> samples.accept(descriptor, dataPoint), descriptor);
+        collector.add(id, samples -> samples.accept(descriptor, dataPoint));
 
         MetricSnapshot snapshot = collector.collect().get(0);
         assertThat(snapshot).isInstanceOf(HistogramSnapshot.class);
@@ -215,14 +200,8 @@ class MicrometerCollectorTest {
     void registrationDescriptorUsesPrometheusFamilyName() {
         Meter.Id id = Metrics.counter("my.counter").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
-        MetricFamilyDescriptor descriptor = MetricFamilyDescriptor.counter("my_counter")
-            .help("help")
-            .labelNames(asList("k"))
-            .build();
-
-        CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
-                Labels.of("k", "v"), null, 0);
-        collector.add(id, samples -> samples.accept(descriptor, sample), descriptor);
+        collector.getOrCreateDescriptor(MetricType.COUNTER, "my_counter",
+                () -> MetricFamilyDescriptor.counter("my_counter").help("help").labelNames(asList("k")).build());
 
         assertThat(collector.getMetricFamilyDescriptors()).singleElement().satisfies(d -> {
             assertThat(d.getPrometheusName()).isEqualTo("my_counter");

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -48,7 +48,7 @@ class MicrometerCollectorTest {
             CounterSnapshot.CounterDataPointSnapshot sample = new CounterSnapshot.CounterDataPointSnapshot(1.0,
                     Labels.of("k", Integer.toString(i)), null, 0);
 
-            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+            collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                     family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                     sample)));
         }
@@ -69,10 +69,10 @@ class MicrometerCollectorTest {
                 Labels.of("k", "v2", "k2", "v1"), null, 0);
         Meter.Id sample2Id = id.withTags(Tags.of("k", "v2", "k2", "v1"));
 
-        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(sampleId, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(sample2Id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -91,10 +91,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k4"), asList("v1", "v4")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k4", "v4"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -113,10 +113,10 @@ class MicrometerCollectorTest {
                 Labels.of(asList("k1", "k2"), asList("v1", "v2")), null, 0);
         Meter.Id id2 = id.replaceTags(Tags.of("k1", "v1", "k2", "v2"));
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 
@@ -135,10 +135,10 @@ class MicrometerCollectorTest {
                 Labels.EMPTY, null, 0);
         Meter.Id id2 = id.replaceTags(Tags.empty());
 
-        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample)));
-        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.getConventionName(),
+        collector.add(id2, () -> Stream.of(new MicrometerCollector.Family<>(collector.conventionName,
                 family -> new CounterSnapshot(new MetricMetadata(family.conventionName), family.dataPointSnapshots),
                 sample2)));
 

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/MicrometerCollectorTest.java
@@ -30,6 +30,9 @@ import io.prometheus.metrics.model.snapshots.MetricFamilyDescriptor;
 import io.prometheus.metrics.model.snapshots.MetricSnapshot;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -139,11 +142,9 @@ class MicrometerCollectorTest {
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
 
         MetricFamilyDescriptor descriptor = collector.getOrCreateDescriptor(MetricType.COUNTER,
-                collector.conventionName, () -> MetricFamilyDescriptor.counter(collector.conventionName).build());
+                collector.conventionName, Collections.singletonList("k"), " ");
         MetricFamilyDescriptor descriptor2 = collector.getOrCreateDescriptor(MetricType.COUNTER,
-                collector.conventionName, () -> {
-                    throw new AssertionError("descriptor should have been reused");
-                });
+                collector.conventionName, Collections.singletonList("k"), " ");
 
         assertThat(descriptor2).isSameAs(descriptor);
         assertThat(collector.getMetricFamilyDescriptors()).containsExactly(descriptor);
@@ -155,10 +156,10 @@ class MicrometerCollectorTest {
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
 
         MetricFamilyDescriptor summaryDescriptor = collector.getOrCreateDescriptor(MetricType.SUMMARY,
-                collector.conventionName, () -> MetricFamilyDescriptor.summary(collector.conventionName).build());
+                collector.conventionName, Collections.singletonList("k"), " ");
 
         assertThatThrownBy(() -> collector.getOrCreateDescriptor(MetricType.HISTOGRAM, collector.conventionName,
-                () -> MetricFamilyDescriptor.histogram(collector.conventionName).build()))
+                Collections.singletonList("k"), " "))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("same Prometheus metric family types");
 
@@ -200,8 +201,7 @@ class MicrometerCollectorTest {
     void registrationDescriptorUsesPrometheusFamilyName() {
         Meter.Id id = Metrics.counter("my.counter").getId();
         MicrometerCollector collector = new MicrometerCollector(id.getConventionName(convention), id);
-        collector.getOrCreateDescriptor(MetricType.COUNTER, "my_counter",
-                () -> MetricFamilyDescriptor.counter("my_counter").help("help").labelNames(asList("k")).build());
+        collector.getOrCreateDescriptor(MetricType.COUNTER, "my_counter", List.of("k"), "help");
 
         assertThat(collector.getMetricFamilyDescriptors()).singleElement().satisfies(d -> {
             assertThat(d.getPrometheusName()).isEqualTo("my_counter");

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -1235,6 +1235,22 @@ class PrometheusMeterRegistryTest {
     }
 
     @Test
+    void customMeterWithDynamicMeasurements() {
+        List<Measurement> measurements = new ArrayList<>();
+        // At registration time, the meter only returns a COUNT measurement
+        measurements.add(new Measurement(() -> 1.0, Statistic.COUNT));
+
+        Meter.builder("test.dynamic.custom", Meter.Type.OTHER, measurements).register(registry);
+
+        // Dynamically add a new MAX measurement after registration
+        measurements.add(new Measurement(() -> 5.0, Statistic.MAX));
+
+        String scraped = registry.scrape();
+        assertThat(scraped).contains("test_dynamic_custom_total{statistic=\"COUNT\"} 1")
+            .contains("test_dynamic_custom_max{statistic=\"MAX\"} 5");
+    }
+
+    @Test
     void gaugeWithTotalSuffixBehavior() {
         // A gauge ending in .total with a base unit (like DiskSpaceMetrics)
         // should retain '_total' in its Prometheus name (since it's followed by '_bytes')

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -31,7 +31,6 @@ import io.prometheus.metrics.model.snapshots.*;
 import io.prometheus.metrics.tracer.common.SpanContext;
 import org.assertj.core.api.Condition;
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -124,7 +123,6 @@ class PrometheusMeterRegistryTest {
     }
 
     @Test
-    @Disabled("We don't detect this situation yet; scrape will fail")
     void differentTypesThatProduceSamePrometheusMetricFamilyFailsToRegister() {
         AtomicBoolean failed = new AtomicBoolean(false);
         registry.config().onMeterRegistrationFailed((name, reason) -> failed.set(true));
@@ -133,6 +131,33 @@ class PrometheusMeterRegistryTest {
         assertThat(failed.get()).isFalse();
         Gauge.builder("test_seconds_max", new AtomicInteger(42), AtomicInteger::get).register(registry);
         assertThat(failed.get()).isTrue();
+    }
+
+    @Test
+    void timersWithSameNameButOnlyOnePublishingHistogramFailToRegister() {
+        registry.throwExceptionOnRegistrationFailure();
+        Timer.builder("my.timer").tag("k", "v1").register(registry);
+
+        assertThatThrownBy(
+                () -> Timer.builder("my.timer").tag("k", "v2").publishPercentileHistogram().register(registry))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("my_timer_seconds")
+            .hasMessageContaining("SUMMARY")
+            .hasMessageContaining("HISTOGRAM");
+
+        assertThat(registry.scrape()).contains("my_timer_seconds_count");
+    }
+
+    @Test
+    void timersWithSameNameButOnlyOnePublishingHistogramFailToRegisterHistogramFirst() {
+        AtomicBoolean failed = new AtomicBoolean();
+        registry.config().onMeterRegistrationFailed((id, reason) -> failed.set(true));
+
+        Timer.builder("my.timer").tag("k", "v1").publishPercentileHistogram().register(registry);
+        Timer.builder("my.timer").tag("k", "v2").register(registry);
+
+        assertThat(failed).isTrue();
+        assertThat(registry.scrape()).contains("my_timer_seconds_bucket");
     }
 
     @Test


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #7454.** That PR's head branch lives on a fork, so this PR has to target `main` and its diff includes #7454's commits until it merges.

Further simplification of `MicrometerCollector`/`PrometheusMeterRegistry` on top of #7454, continuing the move away from code structured around the 0.x Prometheus client. Public API and exposition output are unchanged (except where noted below, in the spirit of #7487's fail-at-registration behavior).

### Changes

- **One `MetricSnapshot` per metric family again.** `MetricFamilyDescriptor` has identity equality, so keying collected samples by descriptor produced one single-data-point snapshot per meter (e.g. 20k snapshots for 20k same-name meters) and relied on the exposition writers merging duplicate families on every scrape. `MicrometerCollector` now groups data points by Prometheus family name, restoring the pre-1.16 snapshot granularity observable via `PrometheusRegistry#scrape`. `Child` is now `void collect(BiConsumer<MetricFamilyDescriptor, DataPointSnapshot>)`, which also removes the `computeIfAbsent` boilerplate from every meter factory.
- **Gauge histogram flag derived from the meter type.** `LongTaskTimer` is the only meter producing a gauge histogram, and all meters in a collector share one type, so the `SnapshotFactory`/`registerCustomSnapshotFactory` mechanism collapses to one boolean in `createSnapshot`.
- **Fail registration instead of scrape on conflicting family types.** `PrometheusRegistry` validates family descriptors only when a collector is first registered; meters joining an existing collector are never re-validated by the client. `MicrometerCollector#add` now rejects type conflicts (e.g. same-name timers where only one publishes histogram buckets) through the standard `meterRegistrationFailed` path. Previously this registered "successfully" and then every scrape threw from inside the client. Also enabled the previously `@Disabled` `differentTypesThatProduceSamePrometheusMetricFamilyFailsToRegister`, which passes since #7487.
- **`newDistributionSummary` unified onto `addDistributionStatisticSamples`** (~70 duplicated lines removed). A `@Nullable TimeUnit` distinguishes raw summary values from time-converted timer/LTT values; exemplar scaling moved into the per-type supplier; the summary path takes a single `takeSnapshot()` per scrape instead of 4–5 independent reads.
- **Custom meters precompute per-statistic descriptor + `Labels` at registration**; scrapes no longer rebuild label lists or re-run the statistic-name switch. The created timestamp is captured at creation time, consistent with all other meter types (previously read at scrape time).
- Collector internals merged into a single registration map; `Format` enum replaced with a constant; `scrape(String)` delegates to the two-arg overload; unused imports removed.

### Behavior notes

- `getPrometheusRegistry().scrape()` returns one snapshot per family instead of one per meter; text/OpenMetrics output is byte-identical.
- Conflicting histogram/summary config under one name now fails at registration (like #7487's collisions) instead of throwing on every scrape.
- Custom meters' `_created` timestamp is the meter creation time instead of the scrape time.

### Testing

`MicrometerCollectorTest` updated to the new `Child` signature plus new tests pinning: one snapshot per family across separate descriptor instances, gauge-histogram on/off by meter type, and add-time type-conflict rejection. New registry tests cover same-name timers with mismatched histogram config in both registration orders. All existing `PrometheusMeterRegistryTest` assertions pass unchanged (61 tests) along with the compatibility TCK.
