### PR TITLE
fix(prometheus): capture custom meter creation timestamps at registration

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -386,6 +386,9 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     @Override
     protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        // Capture at registration so custom counter `_created` timestamps match other
+        // meters (not recomputed on each scrape). See gh-7798.
+        long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             collector.add(tagValues, (conventionName, tagKeys) -> {
@@ -399,11 +402,11 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                         case TOTAL:
                         case TOTAL_TIME:
                             families.add(customCounterFamily(id, conventionName, "_sum",
-                                    Labels.of(statKeys, statValues), measurement.getValue()));
+                                    Labels.of(statKeys, statValues), measurement.getValue(), createdTimestampMillis));
                             break;
                         case COUNT:
                             families.add(customCounterFamily(id, conventionName, "", Labels.of(statKeys, statValues),
-                                    measurement.getValue()));
+                                    measurement.getValue(), createdTimestampMillis));
                             break;
                         case MAX:
                             families.add(customGaugeFamily(id, conventionName, "_max", Labels.of(statKeys, statValues),
@@ -432,8 +435,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id, String conventionName,
-            String suffix, Labels labels, double value) {
-        long createdTimestampMillis = clock.wallTime();
+            String suffix, Labels labels, double value, long createdTimestampMillis) {
         return new MicrometerCollector.Family<>(conventionName + suffix,
                 family -> new CounterSnapshot(family.metadata, family.dataPointSnapshots),
                 getMetadata(conventionName + suffix, id.getDescription()),

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -1076,6 +1076,7 @@ class PrometheusMeterRegistryTest {
     }
 
     @Test
+    @Issue("gh-7798")
     void createdTimestampEnabled() {
         PrometheusConfig config = new PrometheusConfig() {
             @Override
@@ -1101,7 +1102,12 @@ class PrometheusMeterRegistryTest {
         clock.addSeconds(1);
         registry.summary("s").record(4);
         registry.newMeter(new Meter.Id("custom.meter", Tags.empty(), null, null, Meter.Type.OTHER), Meter.Type.OTHER,
-                List.of(new Measurement(() -> 11, Statistic.COUNT)));
+                List.of(new Measurement(() -> 11, Statistic.COUNT), new Measurement(() -> 22, Statistic.TOTAL)));
+
+        // Advance the clock after registration so scrapes would report a different
+        // `_created` value if it were recomputed per scrape (the previous custom-meter
+        // bug).
+        clock.addSeconds(10);
 
         String openMetricsScrape = registry.scrape(OpenMetricsTextFormatWriter.CONTENT_TYPE);
         String prometheusTextScrape = registry.scrape(PrometheusTextFormatWriter.CONTENT_TYPE);
@@ -1111,7 +1117,10 @@ class PrometheusMeterRegistryTest {
                 .contains("t_seconds_created 4.001")
                 .contains("ft_seconds_created 4.001")
                 .contains("s_created 5.001")
-                .contains("custom_meter_created{statistic=\"COUNT\"} 5.001"));
+                .contains("custom_meter_created{statistic=\"COUNT\"} 5.001")
+                .contains("custom_meter_sum_created{statistic=\"TOTAL\"} 5.001")
+                .doesNotContain("custom_meter_created{statistic=\"COUNT\"} 15.001")
+                .doesNotContain("custom_meter_sum_created{statistic=\"TOTAL\"} 15.001"));
     }
 
     @Test


### PR DESCRIPTION
## Description

Custom Prometheus meters (registered via `Meter.builder` / `newMeter`) were computing `_created` timestamps with `clock.wallTime()` inside `customCounterFamily`, which runs on every scrape. That made creation timestamps advance with scrape time instead of reflecting actual meter registration time.

Other meter types already capture `createdTimestampMillis` once at registration (outside the scrape lambda) and reuse it. This change does the same for custom meters: capture once in `newMeter` and pass the value through `customMeterFamily` → `customCounterFamily`.

Fixes #7798

## Related work

#7802 also notes fixing custom-meter `_created` as part of a broader `MicrometerCollector` / `PrometheusMeterRegistry` refactor. This PR is a focused fix for the bug only, so it can land independently (and is easier to backport toward 1.16.7 if desired).

## Testing

- Strengthened `PrometheusMeterRegistryTest#createdTimestampEnabled` (`@Issue("gh-7798")`): advances the mock clock by 10s after registration, asserts COUNT and TOTAL custom-meter `_created` stay at registration time (5.001), and asserts they do not report scrape-time 15.001.
- `./gradlew :micrometer-registry-prometheus:test --tests 'io.micrometer.prometheusmetrics.PrometheusMeterRegistryTest'`
- `./gradlew :micrometer-registry-prometheus:checkFormat`

JDK 21 (Temurin 21.0.12).