### PR TITLE
JvmThreadMetrics: include daemon flag on OTel thread count metric

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetrics.java
@@ -25,8 +25,13 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.MeterConvention;
 import io.micrometer.core.instrument.binder.jvm.convention.JvmThreadMeterConventions;
 import io.micrometer.core.instrument.binder.jvm.convention.micrometer.MicrometerJvmThreadMeterConventions;
+import org.jspecify.annotations.Nullable;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 
@@ -39,6 +44,23 @@ import static java.util.Collections.emptyList;
  * @author Johnny Lim
  */
 public class JvmThreadMetrics implements MeterBinder {
+
+    /**
+     * {@link ThreadInfo#isDaemon()} was added in Java 9. Resolved reflectively so this
+     * binder remains compatible with Java 8 bytecode.
+     */
+    private static final @Nullable MethodHandle THREAD_INFO_IS_DAEMON;
+
+    static {
+        MethodHandle isDaemon = null;
+        try {
+            isDaemon = MethodHandles.publicLookup()
+                .findVirtual(ThreadInfo.class, "isDaemon", MethodType.methodType(boolean.class));
+        }
+        catch (NoSuchMethodException | IllegalAccessException ignored) {
+        }
+        THREAD_INFO_IS_DAEMON = isDaemon;
+    }
 
     private final Tags extraTags;
 
@@ -100,12 +122,29 @@ public class JvmThreadMetrics implements MeterBinder {
         try {
             threadBean.getAllThreadIds();
             MeterConvention<Thread.State> threadCountConvention = conventions.threadCountConvention();
+            boolean includeDaemon = conventions.includeDaemonTag();
             for (Thread.State state : Thread.State.values()) {
-                Gauge.builder(threadCountConvention.getName(), threadBean, (bean) -> getThreadStateCount(bean, state))
-                    .tags(threadCountConvention.getTags(state))
-                    .description("The current number of threads")
-                    .baseUnit(BaseUnits.THREADS)
-                    .register(registry);
+                if (includeDaemon) {
+                    for (boolean daemon : new boolean[] { false, true }) {
+                        Tags tags = threadCountConvention.getTags(state).and(conventions.daemonTags(daemon));
+                        Gauge
+                            .builder(threadCountConvention.getName(), threadBean,
+                                    (bean) -> getThreadStateCount(bean, state, daemon))
+                            .tags(tags)
+                            .description("The current number of threads")
+                            .baseUnit(BaseUnits.THREADS)
+                            .register(registry);
+                    }
+                }
+                else {
+                    Gauge
+                        .builder(threadCountConvention.getName(), threadBean,
+                                (bean) -> getThreadStateCount(bean, state))
+                        .tags(threadCountConvention.getTags(state))
+                        .description("The current number of threads")
+                        .baseUnit(BaseUnits.THREADS)
+                        .register(registry);
+                }
             }
         }
         catch (Error error) {
@@ -119,6 +158,29 @@ public class JvmThreadMetrics implements MeterBinder {
         return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
             .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state)
             .count();
+    }
+
+    // VisibleForTesting
+    static long getThreadStateCount(ThreadMXBean threadBean, Thread.State state, boolean daemon) {
+        return Arrays.stream(threadBean.getThreadInfo(threadBean.getAllThreadIds()))
+            .filter(threadInfo -> threadInfo != null && threadInfo.getThreadState() == state
+                    && isDaemon(threadInfo) == daemon)
+            .count();
+    }
+
+    private static boolean isDaemon(ThreadInfo threadInfo) {
+        if (THREAD_INFO_IS_DAEMON == null) {
+            // Java 8: ThreadInfo#isDaemon is unavailable; cannot classify by daemon.
+            // Count as non-daemon so at least one series receives the total for the
+            // state.
+            return false;
+        }
+        try {
+            return (boolean) THREAD_INFO_IS_DAEMON.invoke(threadInfo);
+        }
+        catch (Throwable ex) {
+            throw new IllegalStateException("Unexpected error invoking ThreadInfo#isDaemon()", ex);
+        }
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/JvmThreadMeterConventions.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.jvm.convention;
 
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterConvention;
 
 /**
@@ -26,5 +27,30 @@ import io.micrometer.core.instrument.binder.MeterConvention;
 public interface JvmThreadMeterConventions {
 
     MeterConvention<Thread.State> threadCountConvention();
+
+    /**
+     * Whether thread count gauges should be further broken down by daemon status. When
+     * {@code true}, {@link io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics}
+     * registers a gauge for each combination of {@link Thread.State} and daemon flag, and
+     * combines {@link #threadCountConvention()} tags with {@link #daemonTags(boolean)}.
+     * Defaults to {@code false} to preserve historical cardinality of
+     * {@code jvm.threads.states}.
+     * @return {@code true} to include the daemon dimension
+     * @since 1.17.0
+     */
+    default boolean includeDaemonTag() {
+        return false;
+    }
+
+    /**
+     * Tags describing whether a thread is a daemon thread. Only used when
+     * {@link #includeDaemonTag()} is {@code true}.
+     * @param daemon whether the thread is a daemon thread
+     * @return tags for the daemon dimension
+     * @since 1.17.0
+     */
+    default Tags daemonTags(boolean daemon) {
+        return Tags.of("daemon", Boolean.toString(daemon));
+    }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadMeterConventions.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/convention/otel/OpenTelemetryJvmThreadMeterConventions.java
@@ -46,4 +46,27 @@ public class OpenTelemetryJvmThreadMeterConventions extends MicrometerJvmThreadM
         return new SimpleMeterConvention<>("jvm.thread.count", this::getThreadStateTags);
     }
 
+    /**
+     * OpenTelemetry recommends the {@code jvm.thread.daemon} attribute on
+     * {@code jvm.thread.count}.
+     * @return {@code true}
+     * @since 1.17.0
+     */
+    @Override
+    public boolean includeDaemonTag() {
+        return true;
+    }
+
+    /**
+     * {@code jvm.thread.daemon} boolean attribute as recommended by the OpenTelemetry
+     * semantic conventions.
+     * @param daemon whether the thread is a daemon thread
+     * @return tags for the daemon dimension
+     * @since 1.17.0
+     */
+    @Override
+    public Tags daemonTags(boolean daemon) {
+        return Tags.of("jvm.thread.daemon", Boolean.toString(daemon));
+    }
+
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jvm/JvmThreadMetricsTest.java
@@ -70,6 +70,29 @@ class JvmThreadMetricsTest {
     }
 
     @Test
+    void getThreadStateCountWithDaemonFilter() {
+        ThreadMXBean threadBean = mock(ThreadMXBean.class);
+        long[] threadIds = { 1L, 2L, 3L };
+        when(threadBean.getAllThreadIds()).thenReturn(threadIds);
+        ThreadInfo daemonRunnable = mock(ThreadInfo.class);
+        when(daemonRunnable.getThreadState()).thenReturn(Thread.State.RUNNABLE);
+        when(daemonRunnable.isDaemon()).thenReturn(true);
+        ThreadInfo nonDaemonRunnable = mock(ThreadInfo.class);
+        when(nonDaemonRunnable.getThreadState()).thenReturn(Thread.State.RUNNABLE);
+        when(nonDaemonRunnable.isDaemon()).thenReturn(false);
+        ThreadInfo daemonWaiting = mock(ThreadInfo.class);
+        when(daemonWaiting.getThreadState()).thenReturn(Thread.State.WAITING);
+        when(daemonWaiting.isDaemon()).thenReturn(true);
+        when(threadBean.getThreadInfo(threadIds))
+            .thenReturn(new ThreadInfo[] { daemonRunnable, nonDaemonRunnable, daemonWaiting });
+
+        assertThat(JvmThreadMetrics.getThreadStateCount(threadBean, Thread.State.RUNNABLE, true)).isEqualTo(1);
+        assertThat(JvmThreadMetrics.getThreadStateCount(threadBean, Thread.State.RUNNABLE, false)).isEqualTo(1);
+        assertThat(JvmThreadMetrics.getThreadStateCount(threadBean, Thread.State.WAITING, true)).isEqualTo(1);
+        assertThat(JvmThreadMetrics.getThreadStateCount(threadBean, Thread.State.WAITING, false)).isEqualTo(0);
+    }
+
+    @Test
     void extraTagsAreApplied() {
         Tags extraTags = Tags.of("extra", "tag");
         new JvmThreadMetrics(extraTags).bindTo(registry);
@@ -79,6 +102,8 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.peak").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.states").tags(extraTags).tag("state", "runnable").gauge().value())
             .isPositive();
+        // Default Micrometer convention does not add a daemon dimension
+        assertThat(registry.find("jvm.threads.states").tagKeys("daemon").gauges()).isEmpty();
     }
 
     @Test
@@ -89,15 +114,15 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.live").gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.daemon").gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.peak").gauge().value()).isPositive();
-        assertThat(registry.get("jvm.thread.count").tag("jvm.thread.state", "runnable").gauge().value()).isPositive();
+        assertThat(runnableThreadCount()).isPositive();
+        assertThat(daemonAndNonDaemonRunnableCountsSum()).isEqualTo(runnableThreadCount());
 
         createBlockedThread();
-        assertThat(registry.get("jvm.thread.count").tag("jvm.thread.state", "blocked").gauge().value()).isPositive();
-        assertThat(registry.get("jvm.thread.count").tag("jvm.thread.state", "waiting").gauge().value()).isPositive();
+        assertThat(threadCount("blocked")).isPositive();
+        assertThat(threadCount("waiting")).isPositive();
 
         createTimedWaitingThread();
-        assertThat(registry.get("jvm.thread.count").tag("jvm.thread.state", "timed_waiting").gauge().value())
-            .isPositive();
+        assertThat(threadCount("timed_waiting")).isPositive();
         assertThat(registry.get("jvm.threads.started").functionCounter().count()).isGreaterThan(initialThreadCount);
     }
 
@@ -110,23 +135,90 @@ class JvmThreadMetricsTest {
         assertThat(registry.get("jvm.threads.live").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.daemon").tags(extraTags).gauge().value()).isPositive();
         assertThat(registry.get("jvm.threads.peak").tags(extraTags).gauge().value()).isPositive();
-        assertThat(registry.get("jvm.thread.count").tags(extraTags).tag("jvm.thread.state", "runnable").gauge().value())
-            .isPositive();
+        assertThat(threadCount(extraTags, "runnable")).isPositive();
 
         createBlockedThread();
-        assertThat(registry.get("jvm.thread.count").tags(extraTags).tag("jvm.thread.state", "blocked").gauge().value())
-            .isPositive();
-        assertThat(registry.get("jvm.thread.count").tags(extraTags).tag("jvm.thread.state", "waiting").gauge().value())
-            .isPositive();
+        assertThat(threadCount(extraTags, "blocked")).isPositive();
+        assertThat(threadCount(extraTags, "waiting")).isPositive();
 
         createTimedWaitingThread();
-        assertThat(registry.get("jvm.thread.count")
-            .tags(extraTags)
-            .tag("jvm.thread.state", "timed_waiting")
-            .gauge()
-            .value()).isPositive();
+        assertThat(threadCount(extraTags, "timed_waiting")).isPositive();
         assertThat(registry.get("jvm.threads.started").tags(extraTags).functionCounter().count())
             .isGreaterThan(initialThreadCount);
+    }
+
+    @Test
+    void otelThreadCountIncludesDaemonTag() {
+        new JvmThreadMetrics(Tags.empty(), new OpenTelemetryJvmThreadMeterConventions(Tags.empty())).bindTo(registry);
+
+        // Both daemon series exist for each state (OpenTelemetry recommended attributes)
+        assertThat(registry.get("jvm.thread.count")
+            .tag("jvm.thread.state", "runnable")
+            .tag("jvm.thread.daemon", "true")
+            .gauge()
+            .value()).isNotNegative();
+        assertThat(registry.get("jvm.thread.count")
+            .tag("jvm.thread.state", "runnable")
+            .tag("jvm.thread.daemon", "false")
+            .gauge()
+            .value()).isNotNegative();
+
+        Thread daemon = new Thread(() -> sleep(5));
+        daemon.setDaemon(true);
+        daemon.setName("micrometer-daemon-test");
+        daemon.start();
+        sleep(1);
+
+        assertThat(registry.get("jvm.thread.count")
+            .tag("jvm.thread.state", "timed_waiting")
+            .tag("jvm.thread.daemon", "true")
+            .gauge()
+            .value()).isPositive();
+    }
+
+    private double runnableThreadCount() {
+        return threadCount("runnable");
+    }
+
+    private double daemonAndNonDaemonRunnableCountsSum() {
+        return registry.get("jvm.thread.count")
+            .tag("jvm.thread.state", "runnable")
+            .tag("jvm.thread.daemon", "true")
+            .gauge()
+            .value()
+                + registry.get("jvm.thread.count")
+                    .tag("jvm.thread.state", "runnable")
+                    .tag("jvm.thread.daemon", "false")
+                    .gauge()
+                    .value();
+    }
+
+    private double threadCount(String state) {
+        return registry.get("jvm.thread.count")
+            .tag("jvm.thread.state", state)
+            .tag("jvm.thread.daemon", "true")
+            .gauge()
+            .value()
+                + registry.get("jvm.thread.count")
+                    .tag("jvm.thread.state", state)
+                    .tag("jvm.thread.daemon", "false")
+                    .gauge()
+                    .value();
+    }
+
+    private double threadCount(Tags extraTags, String state) {
+        return registry.get("jvm.thread.count")
+            .tags(extraTags)
+            .tag("jvm.thread.state", state)
+            .tag("jvm.thread.daemon", "true")
+            .gauge()
+            .value()
+                + registry.get("jvm.thread.count")
+                    .tags(extraTags)
+                    .tag("jvm.thread.state", state)
+                    .tag("jvm.thread.daemon", "false")
+                    .gauge()
+                    .value();
     }
 
     private void createTimedWaitingThread() {


### PR DESCRIPTION
## Description

Adds the OpenTelemetry-recommended `jvm.thread.daemon` attribute to `jvm.thread.count` when using `OpenTelemetryJvmThreadMeterConventions`.

### Changes
- `JvmThreadMeterConventions` gains optional `includeDaemonTag()` / `daemonTags(boolean)` (default: off, so historical `jvm.threads.states` cardinality is unchanged)
- `OpenTelemetryJvmThreadMeterConventions` enables the daemon dimension with tag `jvm.thread.daemon` = `true`|`false`
- `JvmThreadMetrics` registers a gauge per `(Thread.State, daemon)` when the convention opts in
- `ThreadInfo#isDaemon()` is called via `MethodHandle` so micrometer-core stays Java 8 bytecode compatible (method exists on Java 9+)

This aligns Micrometer’s OTel JVM thread convention with the [stable `jvm.thread.count` semantic conventions](https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/#metric-jvmthreadcount) (`jvm.thread.state` + `jvm.thread.daemon`).

Default Micrometer naming (`jvm.threads.states` + `state` only) is intentionally left alone to avoid a silent cardinality change for existing dashboards. Apps that want full OTel attributes should pass `OpenTelemetryJvmThreadMeterConventions`.

Fixes #7702

## Motivation and Context

#7702 requests a daemon flag on the JVM thread-count metric so Micrometer can fully adopt the OTel attributes for `jvm.thread.count`. The OTel path is already modeled via meter conventions; this completes the recommended attributes there.

## How Has This Been Tested?

- `./gradlew :micrometer-core:test --tests 'io.micrometer.core.instrument.binder.jvm.JvmThreadMetricsTest'`
- **7/7 passed** (Temurin 21), including:
  - `otelThreadCountIncludesDaemonTag`
  - `getThreadStateCountWithDaemonFilter`
  - existing default + OTel state tests (daemon series summed for totals)
- `./gradlew :micrometer-core:checkFormat` clean

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have signed the commits (`Signed-off-by`)