### PR TITLE
Store AbstractTimer pause detector as Object for optional LatencyUtils

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -52,7 +52,8 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     // Only used when pause detection is enabled
     private @Nullable Object intervalEstimator;
 
-    private org.LatencyUtils.@Nullable PauseDetector pauseDetector;
+    // Object so field resolution does not require optional LatencyUtils on the classpath
+    private @Nullable Object pauseDetector;
 
     /**
      * Creates a new timer.
@@ -158,9 +159,11 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
                 });
 
         if (pauseDetector instanceof SimplePauseDetector) {
-            this.intervalEstimator = new TimeCappedMovingAverageIntervalEstimator(128, 10000000000L, pauseDetector);
+            org.LatencyUtils.PauseDetector latencyPauseDetector = (org.LatencyUtils.PauseDetector) pauseDetector;
+            this.intervalEstimator = new TimeCappedMovingAverageIntervalEstimator(128, 10000000000L,
+                    latencyPauseDetector);
 
-            pauseDetector.addListener((pauseLength, pauseEndTime) -> {
+            latencyPauseDetector.addListener((pauseLength, pauseEndTime) -> {
                 if (intervalEstimator != null) {
                     long estimatedInterval = ((IntervalEstimator) intervalEstimator).getEstimatedInterval(pauseEndTime);
                     long observedLatencyMinbar = pauseLength - estimatedInterval;
@@ -300,7 +303,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
     public void close() {
         histogram.close();
         if (pauseDetector != null) {
-            pauseDetector.shutdown();
+            ((org.LatencyUtils.PauseDetector) pauseDetector).shutdown();
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MissingLatencyUtilsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MissingLatencyUtilsTest.java
@@ -64,4 +64,16 @@ class MissingLatencyUtilsTest {
         assertThat(output).contains("LatencyUtils is not on the runtime classpath");
     }
 
+    @Test
+    @Issue("7815")
+    void abstractTimerFieldsAreIntrospectableWithoutLatencyUtils() {
+        assertThatCode(() -> {
+            for (java.lang.reflect.Field field : AbstractTimer.class.getDeclaredFields()) {
+                // Force resolution of each field type, matching Spring ReflectionUtils
+                // introspection.
+                field.getType();
+            }
+        }).doesNotThrowAnyException();
+    }
+
 }


### PR DESCRIPTION
## Statement of purpose

Fixes #7815.

When optional LatencyUtils is not on the classpath, Spring reflective introspection of `AbstractTimer` fails because the `pauseDetector` field is typed as `org.LatencyUtils.PauseDetector`. That field type forces class resolution even when pause detection is disabled (the default).

## Changes

- Store the pause detector value as `Object` and cast only on the LatencyUtils-enabled path
- Add a regression test under `@ClassPathExclusions("LatencyUtils-*.jar")` that resolves all `AbstractTimer` field types

## How to verify

```bash
./gradlew :micrometer-core:test --tests io.micrometer.core.instrument.MissingLatencyUtilsTest --tests io.micrometer.core.instrument.AbstractTimerTests
```

Executed locally: both test classes GREEN.