### PR TITLE
Fix/issue 7798 prometheus custom meter timestamp

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -412,6 +412,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
 
     @Override
     protected Meter newMeter(Meter.Id id, Meter.Type type, Iterable<Measurement> measurements) {
+        long createdTimestampMillis = clock.wallTime();
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);
             List<String> tagKeys = tagKeys(id);
@@ -442,7 +443,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     List<String> statValues = new ArrayList<>(tagValues);
                     statValues.add(measurement.getStatistic().toString());
                     families.add(customMeterFamily(id, collector.conventionName, measurement.getStatistic(),
-                            Labels.of(statKeys, statValues), measurement.getValue()));
+                            Labels.of(statKeys, statValues), measurement.getValue(), createdTimestampMillis));
                 }
                 return families.build();
             }, registrationDescriptors.toArray(new MetricFamilyDescriptor[0]));
@@ -458,10 +459,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MicrometerCollector.Family<?> customMeterFamily(Meter.Id id, String conventionName, Statistic statistic,
-            Labels labels, double value) {
+            Labels labels, double value, long createdTimestampMillis) {
         CustomMeterMetric metric = customMeterMetric(conventionName, statistic);
         if (metric.metricType == MetricType.COUNTER) {
-            return customCounterFamily(id, metric, labels, value);
+            return customCounterFamily(id, metric, labels, value, createdTimestampMillis);
         }
         return customGaugeFamily(id, metric, labels, value);
     }
@@ -488,8 +489,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private MicrometerCollector.Family<CounterDataPointSnapshot> customCounterFamily(Meter.Id id,
-            CustomMeterMetric metric, Labels labels, double value) {
-        long createdTimestampMillis = clock.wallTime();
+            CustomMeterMetric metric, Labels labels, double value, long createdTimestampMillis) {
         return new MicrometerCollector.Family<>(metric.name,
                 family -> new CounterSnapshot(getMetadata(family.conventionName, id.getDescription()),
                         family.dataPointSnapshots),

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -1189,6 +1189,35 @@ class PrometheusMeterRegistryTest {
     }
 
     @Test
+    void customCounterCreationTimestampNotUpdatedOnScrape() {
+        PrometheusConfig config = new PrometheusConfig() {
+            @Override
+            public @Nullable String get(String key) {
+                return null;
+            }
+
+            @Override
+            public Properties prometheusProperties() {
+                Properties properties = new Properties();
+                properties.putAll(PrometheusConfig.super.prometheusProperties());
+                properties.setProperty("io.prometheus.exporter.includeCreatedTimestamps", "true");
+                return properties;
+            }
+        };
+        PrometheusMeterRegistry registry = new PrometheusMeterRegistry(config, prometheusRegistry, clock);
+        clock.addSeconds(1);
+        registry.newMeter(new Meter.Id("custom.counter", Tags.empty(), null, null, Meter.Type.OTHER), Meter.Type.OTHER,
+                List.of(new Measurement(() -> 11, Statistic.COUNT)));
+
+        String scrape1 = registry.scrape(OpenMetricsTextFormatWriter.CONTENT_TYPE);
+        clock.addSeconds(5);
+        String scrape2 = registry.scrape(OpenMetricsTextFormatWriter.CONTENT_TYPE);
+
+        assertThat(scrape1).contains("custom_counter_created{statistic=\"COUNT\"} 1.001");
+        assertThat(scrape2).contains("custom_counter_created{statistic=\"COUNT\"} 1.001");
+    }
+
+    @Test
     void customMeterWithAllStatistics() {
         List<Measurement> measurements = new ArrayList<>();
         int i = 0;


### PR DESCRIPTION
This PR addresses an issue in `PrometheusMeterRegistry` where the creation timestamp for custom counters was being incorrectly recomputed on every scrape event. This caused Prometheus to receive dynamic, changing `_created` timestamps for the same metric, which breaks the OpenMetrics standard and can cause data to be dropped.