### PR TITLE
GH-7367: Update Composite Instructions 

### DIFF
--- a/docs/modules/ROOT/pages/concepts/registry.adoc
+++ b/docs/modules/ROOT/pages/concepts/registry.adoc
@@ -37,6 +37,8 @@ compositeCounter.increment(); <3>
 <3> The simple registry counter is incremented, along with counters for any other registries in the composite.
 ====
 
+NOTE: Meters should only be registered _after_ CompositeMeterRegistry completes configuration
+
 == Global Registry
 
 Micrometer provides a static global registry called `Metrics.globalRegistry` and a set of static builders for generating meters based on this registry (note that `globalRegistry` is a composite registry):


### PR DESCRIPTION
Closes #7367

- Added a Note to the composite meter registry documentation instructing users to register meters after configuration completes