### PR TITLE
Prometheus: reduce allocations for histogram buckets

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/prometheus/PrometheusRegistryBenchmark.java
@@ -18,9 +18,13 @@ package io.micrometer.benchmark.prometheus;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import org.jspecify.annotations.NonNull;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.profile.GCProfiler;
@@ -70,6 +74,9 @@ public class PrometheusRegistryBenchmark {
     @Param({ "500" })
     private int scrapeMeterCount;
 
+    @Param({ "true", "false" })
+    private boolean useHistograms;
+
     private PrometheusMeterRegistry scrapeRegistry;
 
     private AtomicInteger gaugeValue;
@@ -77,6 +84,16 @@ public class PrometheusRegistryBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() {
         scrapeRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        if (useHistograms) {
+            scrapeRegistry.config().meterFilter(new MeterFilter() {
+                @Override
+                public DistributionStatisticConfig configure(Meter.@NonNull Id id,
+                        @NonNull DistributionStatisticConfig config) {
+                    return DistributionStatisticConfig.builder().percentilesHistogram(true).build().merge(config);
+                }
+            });
+        }
+
         gaugeValue = new AtomicInteger(42);
 
         // System gauges registered once during setup

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -360,6 +360,12 @@ class MicrometerCollector implements MultiCollector {
             @Nullable TimeUnit timeUnit) {
         boolean hasInfinityBucket = Double.isInfinite(histogramCounts[histogramCounts.length - 1].bucket());
         int bucketCount = histogramCounts.length + (hasInfinityBucket ? 0 : 1);
+
+        // We use `ClassicHistogramBuckets.of(double[], long[])` instead of
+        // `ClassicHistogramBuckets.of(List<Double>, List<Number>)` to avoid boxing the
+        // primitive values. Using `long`s for values instead of `Number`s looks like it
+        // can lose precision, but in fact `ClassicHistogramBuckets` would convert the
+        // `Number`s to `long`s anyway via `Number.longValue()`.
         double[] buckets = new double[bucketCount];
         long[] counts = new long[bucketCount];
 

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/MicrometerCollector.java
@@ -358,19 +358,22 @@ class MicrometerCollector implements MultiCollector {
     // can convert it back to cumulative.
     private static ClassicHistogramBuckets nonCumulativeBuckets(CountAtBucket[] histogramCounts, long count,
             @Nullable TimeUnit timeUnit) {
-        List<Double> buckets = new ArrayList<>();
-        List<Number> counts = new ArrayList<>();
-        buckets.add(bucket(histogramCounts[0], timeUnit));
-        counts.add(histogramCounts[0].count());
+        boolean hasInfinityBucket = Double.isInfinite(histogramCounts[histogramCounts.length - 1].bucket());
+        int bucketCount = histogramCounts.length + (hasInfinityBucket ? 0 : 1);
+        double[] buckets = new double[bucketCount];
+        long[] counts = new long[bucketCount];
+
+        buckets[0] = bucket(histogramCounts[0], timeUnit);
+        counts[0] = (long) histogramCounts[0].count();
         for (int i = 1; i < histogramCounts.length; i++) {
-            buckets.add(bucket(histogramCounts[i], timeUnit));
-            counts.add(histogramCounts[i].count() - histogramCounts[i - 1].count());
+            buckets[i] = bucket(histogramCounts[i], timeUnit);
+            counts[i] = (long) (histogramCounts[i].count() - histogramCounts[i - 1].count());
         }
-        if (Double.isFinite(histogramCounts[histogramCounts.length - 1].bucket())) {
+        if (!hasInfinityBucket) {
             // ClassicHistogramBuckets is not cumulative
-            buckets.add(Double.POSITIVE_INFINITY);
+            buckets[bucketCount - 1] = Double.POSITIVE_INFINITY;
             double infCount = count - histogramCounts[histogramCounts.length - 1].count();
-            counts.add(infCount >= 0 ? infCount : 0);
+            counts[bucketCount - 1] = (long) (infCount >= 0 ? infCount : 0);
         }
         return ClassicHistogramBuckets.of(buckets, counts);
     }


### PR DESCRIPTION
## Overview

Continuation of https://github.com/micrometer-metrics/micrometer/pull/7802#discussion_r3736655735

This PR aims to reduce allocations during Prometheus scrape even further, specifically for the histogram buckets and values: 
* Currently they are stored in `List<Double>` and `List<Number>` respectively, which boxes the primitives and has to reallocate the underlying array.
* This PR changes this to store them in primitive arrays (`double[]` and `long[]` respectively).
	* Using `long`s for values rather than `Number`s does not lead to any precision loss, because Prometheus' `ClassicHistogramBuckets` would convert them to `long`s anyway, as documented in its javadoc.

## Benchmarks

The pre-existing benchmarks did not exercise the histogram code, so I added a benchmark parameter to force the histogram for all distribution metrics.

(Disclaimer: I ran the benchmarks on my laptop, not in a specialized benchmark environment)

As expected, the `collect` benchmark with histograms enabled shows a significant reduction in allocation rate:
```
Benchmark                                                     (scrapeMeterCount)  (useHistograms)  Mode  Cnt        Score     Error   Units
[before]
PrometheusRegistryBenchmark.collect                                          500             true  avgt    5       54.274 ±   0.981   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500             true  avgt    5   374792.190 ±   0.005    B/op
[after]
PrometheusRegistryBenchmark.collect                                          500             true  avgt    5       39.604 ±   3.022   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500             true  avgt    5   213264.139 ±   0.010    B/op
```

If the histograms are disabled, there are no changes.
```
Benchmark                                                     (scrapeMeterCount)  (useHistograms)  Mode  Cnt        Score     Error   Units
[before]
PrometheusRegistryBenchmark.collect                                          500            false  avgt    5        7.919 ±   0.016   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500            false  avgt    5    18336.028 ±   0.001    B/op
[after]
PrometheusRegistryBenchmark.collect                                          500            false  avgt    5        7.991 ±   0.123   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500            false  avgt    5    18336.028 ±   0.001    B/op
```

<details><summary>Full results on main branch</summary>

```
Benchmark                                                     (scrapeMeterCount)  (useHistograms)  Mode  Cnt        Score     Error   Units
PrometheusRegistryBenchmark.collect                                          500             true  avgt    5       54.274 ±   0.981   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate                            500             true  avgt    5     6585.412 ± 118.608  MB/sec
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500             true  avgt    5   374792.190 ±   0.005    B/op
PrometheusRegistryBenchmark.collect:gc.count                                 500             true  avgt    5       99.000            counts
PrometheusRegistryBenchmark.collect:gc.time                                  500             true  avgt    5       49.000                ms
PrometheusRegistryBenchmark.collect                                          500            false  avgt    5        7.919 ±   0.016   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate                            500            false  avgt    5     2207.905 ±   4.439  MB/sec
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500            false  avgt    5    18336.028 ±   0.001    B/op
PrometheusRegistryBenchmark.collect:gc.count                                 500            false  avgt    5       50.000            counts
PrometheusRegistryBenchmark.collect:gc.time                                  500            false  avgt    5       24.000                ms
PrometheusRegistryBenchmark.meterCreation                                    500             true  avgt    5      105.283 ±   3.985   ns/op
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate                      500             true  avgt    5     4218.366 ± 139.693  MB/sec
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate.norm                 500             true  avgt    5      548.034 ±   4.218    B/op
PrometheusRegistryBenchmark.meterCreation:gc.count                           500             true  avgt    5       77.000            counts
PrometheusRegistryBenchmark.meterCreation:gc.time                            500             true  avgt    5       39.000                ms
PrometheusRegistryBenchmark.meterCreation                                    500            false  avgt    5      104.627 ±   3.312   ns/op
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate                      500            false  avgt    5     4288.597 ± 110.213  MB/sec
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate.norm                 500            false  avgt    5      550.334 ±   3.929    B/op
PrometheusRegistryBenchmark.meterCreation:gc.count                           500            false  avgt    5       77.000            counts
PrometheusRegistryBenchmark.meterCreation:gc.time                            500            false  avgt    5       40.000                ms
PrometheusRegistryBenchmark.scrape                                           500             true  avgt    5      727.487 ±  31.384   us/op
PrometheusRegistryBenchmark.scrape:gc.alloc.rate                             500             true  avgt    5     2990.106 ± 128.705  MB/sec
PrometheusRegistryBenchmark.scrape:gc.alloc.rate.norm                        500             true  avgt    5  2280844.123 ±  13.583    B/op
PrometheusRegistryBenchmark.scrape:gc.count                                  500             true  avgt    5       68.000            counts
PrometheusRegistryBenchmark.scrape:gc.time                                   500             true  avgt    5       33.000                ms
PrometheusRegistryBenchmark.scrape                                           500            false  avgt    5       36.369 ±   0.925   us/op
PrometheusRegistryBenchmark.scrape:gc.alloc.rate                             500            false  avgt    5     2547.438 ±  64.749  MB/sec
PrometheusRegistryBenchmark.scrape:gc.alloc.rate.norm                        500            false  avgt    5    97152.127 ±   0.003    B/op
PrometheusRegistryBenchmark.scrape:gc.count                                  500            false  avgt    5       57.000            counts
PrometheusRegistryBenchmark.scrape:gc.time                                   500            false  avgt    5       27.000                ms
```

</details>

<details><summary>Full results on this branch</summary>

```
After

Benchmark                                                     (scrapeMeterCount)  (useHistograms)  Mode  Cnt        Score     Error   Units
PrometheusRegistryBenchmark.collect                                          500             true  avgt    5       39.604 ±   3.022   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate                            500             true  avgt    5     5136.640 ± 382.939  MB/sec
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500             true  avgt    5   213264.139 ±   0.010    B/op
PrometheusRegistryBenchmark.collect:gc.count                                 500             true  avgt    5       94.000            counts
PrometheusRegistryBenchmark.collect:gc.time                                  500             true  avgt    5       69.000                ms
PrometheusRegistryBenchmark.collect                                          500            false  avgt    5        7.991 ±   0.123   us/op
PrometheusRegistryBenchmark.collect:gc.alloc.rate                            500            false  avgt    5     2188.217 ±  33.663  MB/sec
PrometheusRegistryBenchmark.collect:gc.alloc.rate.norm                       500            false  avgt    5    18336.028 ±   0.001    B/op
PrometheusRegistryBenchmark.collect:gc.count                                 500            false  avgt    5       49.000            counts
PrometheusRegistryBenchmark.collect:gc.time                                  500            false  avgt    5       24.000                ms
PrometheusRegistryBenchmark.meterCreation                                    500             true  avgt    5      104.512 ±   2.415   ns/op
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate                      500             true  avgt    5     4271.373 ±  54.876  MB/sec
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate.norm                 500             true  avgt    5      547.224 ±   4.712    B/op
PrometheusRegistryBenchmark.meterCreation:gc.count                           500             true  avgt    5       77.000            counts
PrometheusRegistryBenchmark.meterCreation:gc.time                            500             true  avgt    5       42.000                ms
PrometheusRegistryBenchmark.meterCreation                                    500            false  avgt    5      105.117 ±   1.719   ns/op
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate                      500            false  avgt    5     4272.260 ±  37.427  MB/sec
PrometheusRegistryBenchmark.meterCreation:gc.alloc.rate.norm                 500            false  avgt    5      550.465 ±   3.924    B/op
PrometheusRegistryBenchmark.meterCreation:gc.count                           500            false  avgt    5       78.000            counts
PrometheusRegistryBenchmark.meterCreation:gc.time                            500            false  avgt    5       41.000                ms
PrometheusRegistryBenchmark.scrape                                           500             true  avgt    5      709.040 ±   3.747   us/op
PrometheusRegistryBenchmark.scrape:gc.alloc.rate                             500             true  avgt    5     2850.365 ±  15.023  MB/sec
PrometheusRegistryBenchmark.scrape:gc.alloc.rate.norm                        500             true  avgt    5  2119315.987 ±  13.010    B/op
PrometheusRegistryBenchmark.scrape:gc.count                                  500             true  avgt    5       64.000            counts
PrometheusRegistryBenchmark.scrape:gc.time                                   500             true  avgt    5       31.000                ms
PrometheusRegistryBenchmark.scrape                                           500            false  avgt    5       36.181 ±   0.345   us/op
PrometheusRegistryBenchmark.scrape:gc.alloc.rate                             500            false  avgt    5     2560.661 ±  24.383  MB/sec
PrometheusRegistryBenchmark.scrape:gc.alloc.rate.norm                        500            false  avgt    5    97152.127 ±   0.003    B/op
PrometheusRegistryBenchmark.scrape:gc.count                                  500            false  avgt    5       58.000            counts
PrometheusRegistryBenchmark.scrape:gc.time                                   500            false  avgt    5       29.000                ms
```

</details>