### PR TITLE
Fix histogram gauges for changing snapshots

### DIFF
--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -111,12 +111,17 @@ public class HistogramGauges {
         this.polledGaugesLatch = new CountDownLatch(0);
 
         for (int i = 0; i < valueAtPercentiles.length; i++) {
-            final int index = i;
+            ValueAtPercentile registeredPercentile = valueAtPercentiles[i];
 
             ToDoubleFunction<HistogramSupport> percentileValueFunction = m -> {
-                snapshotIfNecessary();
-                polledGaugesLatch.countDown();
-                return percentileValue.apply(snapshot.percentileValues()[index]);
+                HistogramSnapshot currentSnapshot = pollSnapshot();
+                for (ValueAtPercentile currentPercentile : currentSnapshot.percentileValues()) {
+                    if (Double.compare(currentPercentile.percentile(), registeredPercentile.percentile()) == 0) {
+                        return percentileValue.apply(currentPercentile);
+                    }
+                }
+                return percentileValue
+                    .apply(new ValueAtPercentile(registeredPercentile.percentile(), currentSnapshot.max()));
             };
 
             Gauge.builder(percentileName.apply(valueAtPercentiles[i]), meter, percentileValueFunction)
@@ -127,12 +132,16 @@ public class HistogramGauges {
         }
 
         for (int i = 0; i < countAtBuckets.length; i++) {
-            final int index = i;
+            CountAtBucket registeredBucket = countAtBuckets[i];
 
             ToDoubleFunction<HistogramSupport> bucketCountFunction = m -> {
-                snapshotIfNecessary();
-                polledGaugesLatch.countDown();
-                return snapshot.histogramCounts()[index].count();
+                HistogramSnapshot currentSnapshot = pollSnapshot();
+                for (CountAtBucket currentBucket : currentSnapshot.histogramCounts()) {
+                    if (sameBucket(currentBucket, registeredBucket)) {
+                        return currentBucket.count();
+                    }
+                }
+                return Double.NaN;
             };
 
             Gauge.builder(bucketName.apply(countAtBuckets[i]), meter, bucketCountFunction)
@@ -142,11 +151,19 @@ public class HistogramGauges {
         }
     }
 
-    private void snapshotIfNecessary() {
+    private synchronized HistogramSnapshot pollSnapshot() {
         if (polledGaugesLatch.getCount() == 0) {
             snapshot = meter.takeSnapshot();
             polledGaugesLatch = new CountDownLatch(totalGauges);
         }
+        HistogramSnapshot currentSnapshot = snapshot;
+        polledGaugesLatch.countDown();
+        return currentSnapshot;
+    }
+
+    private static boolean sameBucket(CountAtBucket current, CountAtBucket registered) {
+        return (current.isPositiveInf() && registered.isPositiveInf())
+                || Double.compare(current.bucket(), registered.bucket()) == 0;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -20,15 +20,15 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.util.DoubleFormat;
 
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.ToDoubleFunction;
 
 @Incubating(since = "1.0.3")
 public class HistogramGauges {
 
-    private final AtomicReference<SnapshotState> snapshotState;
+    private HistogramSnapshot snapshot;
+
+    private int remainingGauges;
 
     private final HistogramSupport meter;
 
@@ -96,7 +96,7 @@ public class HistogramGauges {
         this.meter = meter;
 
         HistogramSnapshot initialSnapshot = meter.takeSnapshot();
-        this.snapshotState = new AtomicReference<>(new SnapshotState(initialSnapshot, 0));
+        this.snapshot = initialSnapshot;
 
         ValueAtPercentile[] valueAtPercentiles = initialSnapshot.percentileValues();
         CountAtBucket[] countAtBuckets = initialSnapshot.histogramCounts();
@@ -144,49 +144,18 @@ public class HistogramGauges {
         }
     }
 
-    private HistogramSnapshot pollSnapshot() {
-        while (true) {
-            SnapshotState current = snapshotState.get();
-            if (current.tryPoll()) {
-                return current.snapshot;
-            }
-
-            // Concurrent callers may create duplicate candidates, but only one complete
-            // snapshot generation can be installed.
-            SnapshotState replacement = new SnapshotState(meter.takeSnapshot(), totalGauges);
-            if (snapshotState.compareAndSet(current, replacement) && replacement.tryPoll()) {
-                return replacement.snapshot;
-            }
+    private synchronized HistogramSnapshot pollSnapshot() {
+        if (remainingGauges == 0) {
+            snapshot = meter.takeSnapshot();
+            remainingGauges = totalGauges;
         }
+        remainingGauges--;
+        return snapshot;
     }
 
     private static boolean sameBucket(CountAtBucket current, CountAtBucket registered) {
         return (current.isPositiveInf() && registered.isPositiveInf())
                 || Double.compare(current.bucket(), registered.bucket()) == 0;
-    }
-
-    private static final class SnapshotState {
-
-        private final HistogramSnapshot snapshot;
-
-        private final AtomicInteger remainingGauges;
-
-        private SnapshotState(HistogramSnapshot snapshot, int remainingGauges) {
-            this.snapshot = snapshot;
-            this.remainingGauges = new AtomicInteger(remainingGauges);
-        }
-
-        private boolean tryPoll() {
-            int remaining = remainingGauges.get();
-            while (remaining > 0) {
-                if (remainingGauges.compareAndSet(remaining, remaining - 1)) {
-                    return true;
-                }
-                remaining = remainingGauges.get();
-            }
-            return false;
-        }
-
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HistogramGauges.java
@@ -19,18 +19,16 @@ import io.micrometer.core.annotation.Incubating;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.util.DoubleFormat;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.ToDoubleFunction;
 
 @Incubating(since = "1.0.3")
 public class HistogramGauges {
 
-    // How many gauges have been polled so far on this publish cycle
-    volatile CountDownLatch polledGaugesLatch;
-
-    private volatile HistogramSnapshot snapshot;
+    private final AtomicReference<SnapshotState> snapshotState;
 
     private final HistogramSupport meter;
 
@@ -98,17 +96,12 @@ public class HistogramGauges {
         this.meter = meter;
 
         HistogramSnapshot initialSnapshot = meter.takeSnapshot();
-        this.snapshot = initialSnapshot;
+        this.snapshotState = new AtomicReference<>(new SnapshotState(initialSnapshot, 0));
 
         ValueAtPercentile[] valueAtPercentiles = initialSnapshot.percentileValues();
         CountAtBucket[] countAtBuckets = initialSnapshot.histogramCounts();
 
         this.totalGauges = valueAtPercentiles.length + countAtBuckets.length;
-
-        // set to zero initially, so the first polling of one of the gauges on each
-        // publish cycle results in a
-        // new snapshot
-        this.polledGaugesLatch = new CountDownLatch(0);
 
         for (int i = 0; i < valueAtPercentiles.length; i++) {
             ValueAtPercentile registeredPercentile = valueAtPercentiles[i];
@@ -151,19 +144,49 @@ public class HistogramGauges {
         }
     }
 
-    private synchronized HistogramSnapshot pollSnapshot() {
-        if (polledGaugesLatch.getCount() == 0) {
-            snapshot = meter.takeSnapshot();
-            polledGaugesLatch = new CountDownLatch(totalGauges);
+    private HistogramSnapshot pollSnapshot() {
+        while (true) {
+            SnapshotState current = snapshotState.get();
+            if (current.tryPoll()) {
+                return current.snapshot;
+            }
+
+            // Concurrent callers may create duplicate candidates, but only one complete
+            // snapshot generation can be installed.
+            SnapshotState replacement = new SnapshotState(meter.takeSnapshot(), totalGauges);
+            if (snapshotState.compareAndSet(current, replacement) && replacement.tryPoll()) {
+                return replacement.snapshot;
+            }
         }
-        HistogramSnapshot currentSnapshot = snapshot;
-        polledGaugesLatch.countDown();
-        return currentSnapshot;
     }
 
     private static boolean sameBucket(CountAtBucket current, CountAtBucket registered) {
         return (current.isPositiveInf() && registered.isPositiveInf())
                 || Double.compare(current.bucket(), registered.bucket()) == 0;
+    }
+
+    private static final class SnapshotState {
+
+        private final HistogramSnapshot snapshot;
+
+        private final AtomicInteger remainingGauges;
+
+        private SnapshotState(HistogramSnapshot snapshot, int remainingGauges) {
+            this.snapshot = snapshot;
+            this.remainingGauges = new AtomicInteger(remainingGauges);
+        }
+
+        private boolean tryPoll() {
+            int remaining = remainingGauges.get();
+            while (remaining > 0) {
+                if (remainingGauges.compareAndSet(remaining, remaining - 1)) {
+                    return true;
+                }
+                remaining = remainingGauges.get();
+            }
+            return false;
+        }
+
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -25,7 +26,17 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -41,12 +52,13 @@ class HistogramGaugesTest {
 
         Timer timer = Timer.builder("my.timer").serviceLevelObjectives(Duration.ofMillis(1)).register(registry);
 
-        HistogramGauges gauges = HistogramGauges.registerWithCommonFormat(timer, registry);
+        HistogramGauges.registerWithCommonFormat(timer, registry);
 
         timer.record(1, TimeUnit.MILLISECONDS);
 
         assertThat(registry.get("my.timer.histogram").gauge().value()).isEqualTo(1);
-        assertThat(gauges.polledGaugesLatch.getCount()).isEqualTo(0);
+        timer.record(1, TimeUnit.MILLISECONDS);
+        assertThat(registry.get("my.timer.histogram").gauge().value()).isEqualTo(2);
     }
 
     @Test
@@ -131,6 +143,51 @@ class HistogramGaugesTest {
         assertThat(registry.get("my.timer.histogram").tag("le", "20.0").gauge().value()).isNaN();
         assertThat(registry.get("my.timer.histogram").tag("le", "Infinity").gauge().value()).isEqualTo(6);
         verify(meter, times(2)).takeSnapshot();
+    }
+
+    @Test
+    void concurrentPollingUsesOneCoherentSnapshotGeneration() throws Exception {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        HistogramSupport meter = mock(HistogramSupport.class);
+        Meter.Id meterId = new Meter.Id("my.timer", Tags.empty(), null, null, Meter.Type.LONG_TASK_TIMER);
+        AtomicInteger snapshotSequence = new AtomicInteger();
+        when(meter.getId()).thenReturn(meterId);
+        when(meter.takeSnapshot()).thenAnswer(invocation -> percentileSnapshot(snapshotSequence.incrementAndGet()));
+
+        HistogramGauges.register(meter, registry, percentile -> "my.timer.percentile",
+                percentile -> Tags.of("phi", Double.toString(percentile.percentile())), ValueAtPercentile::value,
+                bucket -> "my.timer.histogram", bucket -> Tags.of("le", Double.toString(bucket.bucket())));
+
+        Collection<Gauge> gauges = registry.find("my.timer.percentile").gauges();
+        ExecutorService executor = Executors.newFixedThreadPool(gauges.size());
+        CountDownLatch ready = new CountDownLatch(gauges.size());
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Double>> futures = gauges.stream().map(gauge -> executor.submit(() -> {
+                ready.countDown();
+                assertThat(start.await(10, TimeUnit.SECONDS)).isTrue();
+                return gauge.value();
+            })).collect(Collectors.toList());
+            assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            Set<Double> observedGenerations = new HashSet<>();
+            for (Future<Double> future : futures) {
+                observedGenerations.add(future.get(10, TimeUnit.SECONDS));
+            }
+
+            assertThat(observedGenerations).hasSize(1);
+        }
+        finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+    }
+
+    private static HistogramSnapshot percentileSnapshot(double value) {
+        return snapshot(value, new ValueAtPercentile(0.5, value), new ValueAtPercentile(0.75, value),
+                new ValueAtPercentile(0.95, value), new ValueAtPercentile(0.99, value),
+                new ValueAtPercentile(0.999, value));
     }
 
     private static HistogramSnapshot snapshot(double max, ValueAtPercentile... percentiles) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/distribution/HistogramGaugesTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.distribution;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -27,6 +28,10 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class HistogramGaugesTest {
 
@@ -82,6 +87,60 @@ class HistogramGaugesTest {
 
         assertThat(registry.get("my.distribution.histogram").tag("le", "+Inf").gauge()).isNotNull();
         assertThat(registry.get("my.timer.histogram").tag("le", "+Inf").gauge()).isNotNull();
+    }
+
+    @Test
+    void changingSnapshotShapeKeepsGaugesAssociatedWithRegisteredPercentiles() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        HistogramSupport meter = mock(HistogramSupport.class);
+        Meter.Id meterId = new Meter.Id("my.timer", Tags.empty(), null, null, Meter.Type.LONG_TASK_TIMER);
+        HistogramSnapshot initialSnapshot = snapshot(30, new ValueAtPercentile(0.5, 10),
+                new ValueAtPercentile(0.75, 20), new ValueAtPercentile(0.99, 30));
+        HistogramSnapshot shortenedSnapshot = snapshot(100, new ValueAtPercentile(0.5, 50),
+                new ValueAtPercentile(0.99, 99));
+        when(meter.getId()).thenReturn(meterId);
+        when(meter.takeSnapshot()).thenReturn(initialSnapshot, shortenedSnapshot);
+
+        HistogramGauges.register(meter, registry, percentile -> "my.timer.percentile",
+                percentile -> Tags.of("phi", Double.toString(percentile.percentile())), ValueAtPercentile::value,
+                bucket -> "my.timer.histogram", bucket -> Tags.of("le", Double.toString(bucket.bucket())));
+
+        assertThat(registry.get("my.timer.percentile").tag("phi", "0.5").gauge().value()).isEqualTo(50);
+        assertThat(registry.get("my.timer.percentile").tag("phi", "0.75").gauge().value()).isEqualTo(100);
+        assertThat(registry.get("my.timer.percentile").tag("phi", "0.99").gauge().value()).isEqualTo(99);
+        verify(meter, times(2)).takeSnapshot();
+    }
+
+    @Test
+    void changingSnapshotShapeKeepsGaugesAssociatedWithRegisteredBuckets() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        HistogramSupport meter = mock(HistogramSupport.class);
+        Meter.Id meterId = new Meter.Id("my.timer", Tags.empty(), null, null, Meter.Type.LONG_TASK_TIMER);
+        HistogramSnapshot initialSnapshot = snapshot(new CountAtBucket(10.0, 1), new CountAtBucket(20.0, 2),
+                new CountAtBucket(Double.POSITIVE_INFINITY, 3));
+        HistogramSnapshot shortenedSnapshot = snapshot(new CountAtBucket(10.0, 4),
+                new CountAtBucket(Double.POSITIVE_INFINITY, 6));
+        when(meter.getId()).thenReturn(meterId);
+        when(meter.takeSnapshot()).thenReturn(initialSnapshot, shortenedSnapshot);
+
+        HistogramGauges.register(meter, registry, percentile -> "my.timer.percentile",
+                percentile -> Tags.of("phi", Double.toString(percentile.percentile())), ValueAtPercentile::value,
+                bucket -> "my.timer.histogram", bucket -> Tags.of("le", Double.toString(bucket.bucket())));
+
+        assertThat(registry.get("my.timer.histogram").tag("le", "10.0").gauge().value()).isEqualTo(4);
+        assertThat(registry.get("my.timer.histogram").tag("le", "20.0").gauge().value()).isNaN();
+        assertThat(registry.get("my.timer.histogram").tag("le", "Infinity").gauge().value()).isEqualTo(6);
+        verify(meter, times(2)).takeSnapshot();
+    }
+
+    private static HistogramSnapshot snapshot(double max, ValueAtPercentile... percentiles) {
+        return new HistogramSnapshot(1, max, max, percentiles, null, (printStream, scaling) -> {
+        });
+    }
+
+    private static HistogramSnapshot snapshot(CountAtBucket... buckets) {
+        return new HistogramSnapshot(1, 0, 0, null, buckets, (printStream, scaling) -> {
+        });
     }
 
 }


### PR DESCRIPTION
## Summary

Make synthetic histogram gauges resilient when a `HistogramSupport` implementation returns snapshots whose percentile or bucket arrays change shape between publish cycles.

## Context

`HistogramGauges` registers callbacks from an initial `HistogramSnapshot`. Each callback currently captures its array index and uses that same index in every later snapshot.

For example, if the initial percentile array is `[0.50, 0.75, 0.99]` and a later snapshot is `[0.50, 0.99]`:

- the `0.75` gauge reads the `0.99` value under the wrong label;
- the `0.99` gauge reads index `2` and throws `ArrayIndexOutOfBoundsException`.

This is a defensive follow-up to #3877 and #7507. That change fixed a deterministic omission in `DefaultLongTaskTimer.takeSnapshot()`, but a long-task timer can still change while a snapshot is being built. The snapshot consistency concerns are also related to #3993.

## Changes

- Capture the registered percentile or bucket boundary instead of its initial array index.
- Resolve each gauge value by that stable key in the current snapshot.
- Use the current snapshot maximum when a registered percentile is temporarily absent, consistent with long-task timer percentiles above the interpolatable range.
- Return `NaN` when a registered bucket is absent instead of reading a different bucket.
- Treat all positive-infinity bucket representations as the same boundary.
- Synchronize only snapshot rollover and poll accounting so concurrent callbacks use a coherent snapshot cycle; value conversion remains outside the synchronized section.
- Preserve the existing behavior of taking one snapshot for a complete gauge polling cycle.

## Tests

Added deterministic regression coverage for:

- a shortened percentile snapshot, including stable label/value association and maximum fallback;
- a shortened bucket snapshot, including a missing bucket and positive infinity;
- one shared snapshot per complete gauge polling cycle.

Validated with the repository wrapper on JDK 17, as supported by `CONTRIBUTING.md`:

```text
./gradlew :micrometer-core:test --tests io.micrometer.core.instrument.distribution.HistogramGaugesTest
./gradlew :micrometer-core:check
```

Both pass. `:micrometer-core:check` covers formatting, license headers, Checkstyle, binary compatibility, module checks, and the complete core test suite.

The commit includes the required DCO `Signed-off-by` trailer.

Draft for maintainer and human review.