### PR TITLE
Update MultiGauge Gauges instead of remove/add

### DIFF
--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -977,7 +977,7 @@ class PrometheusMeterRegistryTest {
         MultiGauge multiGauge = MultiGauge.builder("my.metric").register(registry);
         List<MultiGauge.Row<?>> rows = IntStream.range(0, 100)
             .mapToObj(i -> MultiGauge.Row
-                .of(Tags.of("tag1", "abc", "poll_count", Integer.toString(i), "some_other_tag", "cde"), i))
+                .of(Tags.of("tag1", "abc", "poll.count", Integer.toString(i), "some.other.tag", "cde"), i))
             .collect(toList());
 
         multiGauge.register(rows, true);

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -40,10 +40,12 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.micrometer.core.instrument.MockClock.clock;
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.*;
 
 /**
@@ -967,6 +969,39 @@ class PrometheusMeterRegistryTest {
         assertThat(registry.get("another.gauge").gauge().value()).isEqualTo(2d);
 
         executorService.shutdownNow();
+    }
+
+    @Issue("#6851")
+    @Test
+    void scrapeWhileOverwritingMultiGaugeRowsDoesNotCreateDuplicateLabels() throws Exception {
+        MultiGauge multiGauge = MultiGauge.builder("my.metric").register(registry);
+        List<MultiGauge.Row<?>> rows = IntStream.range(0, 100)
+            .mapToObj(i -> MultiGauge.Row
+                .of(Tags.of("tag1", "abc", "poll_count", Integer.toString(i), "some_other_tag", "cde"), i))
+            .collect(toList());
+
+        multiGauge.register(rows, true);
+
+        AtomicBoolean stop = new AtomicBoolean();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> scraperTask = executor.submit(() -> {
+            while (!stop.get()) {
+                registry.scrape();
+            }
+        });
+
+        try {
+            for (int i = 1; i < 1_000; i++) {
+                multiGauge.register(rows, true);
+            }
+        }
+        finally {
+            stop.set(true);
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        scraperTask.get();
     }
 
     @Test

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
@@ -18,15 +18,12 @@ package io.micrometer.core.instrument;
 import io.micrometer.core.annotation.Incubating;
 import org.jspecify.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-
-import static java.util.Collections.emptySet;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * A virtual meter that manages a dynamic set of gauges with a common name and common
@@ -47,7 +44,7 @@ public class MultiGauge {
 
     private final Meter.Id commonId;
 
-    private final AtomicReference<Set<Meter.Id>> registeredRows = new AtomicReference<>(emptySet());
+    private final Map<Meter.Id, RowState> registeredRows = new HashMap<>();
 
     private MultiGauge(MeterRegistry registry, Meter.Id commonId) {
         this.registry = registry;
@@ -83,37 +80,55 @@ public class MultiGauge {
      * @param overwrite whether to replace rows that have already been registered with the
      * same tags
      */
-    @SuppressWarnings("unchecked")
     public void register(Iterable<? extends Row<?>> rows, boolean overwrite) {
-        registeredRows.getAndUpdate(oldRows -> {
-            // for some reason the compiler needs type assistance by creating this
-            // intermediate variable.
-            Stream<Meter.Id> idStream = StreamSupport.stream(rows.spliterator(), false).map(row -> {
-                Row r = row;
-                Meter.Id preFilteredId = commonId.withTags(r.uniqueTags);
+        synchronized (registeredRows) {
+            Set<Meter.Id> newRowIds = new HashSet<>();
+
+            for (Row<?> row : rows) {
+                Meter.Id preFilteredId = commonId.withTags(row.uniqueTags);
                 Meter.Id rowId = registry.getMappedId(preFilteredId);
-                boolean previouslyDefined = oldRows.contains(rowId);
+                newRowIds.add(rowId);
 
-                if (overwrite && previouslyDefined) {
-                    registry.removeByPreFilterId(preFilteredId);
+                RowState existingState = registeredRows.get(rowId);
+                if (existingState != null) {
+                    if (overwrite) {
+                        existingState.setRow(row);
+                    }
                 }
-
-                if (overwrite || !previouslyDefined) {
-                    registry.gauge(preFilteredId, r.obj, new StrongReferenceGaugeFunction<>(r.obj, r.valueFunction));
+                else {
+                    RowState newState = new RowState(row);
+                    registry.gauge(preFilteredId, newState, RowState::value);
+                    registeredRows.put(rowId, newState);
                 }
-
-                return rowId;
-            });
-
-            Set<Meter.Id> newRows = idStream.collect(toSet());
-
-            for (Meter.Id oldRow : oldRows) {
-                if (!newRows.contains(oldRow))
-                    registry.remove(oldRow);
             }
 
-            return newRows;
-        });
+            registeredRows.keySet().removeIf(id -> {
+                if (!newRowIds.contains(id)) {
+                    registry.remove(id);
+                    return true;
+                }
+                return false;
+            });
+        }
+    }
+
+    private static final class RowState {
+
+        private volatile Row<?> row;
+
+        RowState(Row<?> row) {
+            this.row = row;
+        }
+
+        void setRow(Row<?> row) {
+            this.row = row;
+        }
+
+        double value() {
+            Row<?> r = this.row;
+            return r != null ? r.value() : Double.NaN;
+        }
+
     }
 
     public static class Row<T> {
@@ -128,6 +143,10 @@ public class MultiGauge {
             this.uniqueTags = uniqueTags;
             this.obj = obj;
             this.valueFunction = valueFunction;
+        }
+
+        double value() {
+            return valueFunction.applyAsDouble(obj);
         }
 
         /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MultiGauge.java
@@ -72,13 +72,25 @@ public class MultiGauge {
      * Register rows for this multi-gauge.
      * <p>
      * Each row is registered as a gauge using this multi-gauge's common name and tags,
-     * combined with the row's unique tags. When {@code overwrite} is {@code true}, rows
-     * that were previously registered with the same tags are replaced with the latest
-     * values. When {@code overwrite} is {@code false}, previously registered rows with
-     * the same tags are left unchanged. Rows that are no longer present are removed.
+     * combined with the row's unique tags, after applying any configured
+     * {@link io.micrometer.core.instrument.config.MeterFilter MeterFilter}s.
+     * <ul>
+     * <li>Previously registered rows that are no longer present in {@code rows} are
+     * removed from the registry.</li>
+     * <li>When {@code overwrite} is {@code true}, existing gauges are updated to track
+     * the new row values. If multiple rows in {@code rows} resolve to the same meter ID
+     * (either directly or after filter transformations), the last row in iteration order
+     * takes precedence.</li>
+     * <li>When {@code overwrite} is {@code false}, previously registered rows are left
+     * unchanged. If multiple rows in {@code rows} resolve to the same meter ID, the first
+     * row in iteration order takes precedence.</li>
+     * </ul>
+     * <p>
+     * Note: If a {@code MeterFilter} removes or modifies tags such that multiple rows
+     * share the same mapped tags, those rows will contend for the same single gauge.
      * @param rows rows to register
-     * @param overwrite whether to replace rows that have already been registered with the
-     * same tags
+     * @param overwrite whether to update previously registered rows and overwrite
+     * duplicate rows within the batch
      */
     public void register(Iterable<? extends Row<?>> rows, boolean overwrite) {
         synchronized (registeredRows) {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -15,15 +15,19 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MultiGauge.Row;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -184,6 +188,71 @@ class MultiGaugeTest {
         multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "3"), 3d)), true);
         assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(3d);
+    }
+
+    @Test
+    void overwriteReusesExistingGaugeInstances() {
+        colorGauges.register(List.of(RED.toRow(1.0)));
+        Gauge initialGauge = registry.get("colors").tag("color", "red").gauge();
+
+        colorGauges.register(List.of(RED.toRow(2.0)), true);
+        Gauge updatedGauge = registry.get("colors").tag("color", "red").gauge();
+
+        assertThat(updatedGauge).isSameAs(initialGauge);
+        assertThat(updatedGauge.value()).isEqualTo(2.0);
+    }
+
+    @Test
+    void overwriteDoesNotTriggerMeterRemovalOrAdditionListeners() {
+        AtomicInteger addedCount = new AtomicInteger();
+        AtomicInteger removedCount = new AtomicInteger();
+        registry.config()
+            .onMeterAdded(m -> addedCount.incrementAndGet())
+            .onMeterRemoved(m -> removedCount.incrementAndGet());
+
+        colorGauges.register(List.of(RED.toRow(1.0)));
+        assertThat(addedCount.get()).isEqualTo(1);
+        assertThat(removedCount.get()).isEqualTo(0);
+
+        colorGauges.register(List.of(RED.toRow(2.0)), true);
+        assertThat(addedCount.get()).isEqualTo(1);
+        assertThat(removedCount.get()).isEqualTo(0);
+
+        colorGauges.register(Collections.emptyList(), true);
+        assertThat(addedCount.get()).isEqualTo(1);
+        assertThat(removedCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    @Issue("#6851")
+    void concurrentOverwriteAndRead() throws Exception {
+        MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
+        List<MultiGauge.Row<?>> rows = IntStream.range(0, 100)
+            .mapToObj(i -> MultiGauge.Row.of(Tags.of("id", Integer.toString(i)), i))
+            .collect(toList());
+
+        multiGauge.register(rows, true);
+
+        AtomicBoolean stop = new AtomicBoolean();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> readerTask = executor.submit(() -> {
+            while (!stop.get()) {
+                assertThat(registry.getMeters()).hasSize(100);
+            }
+        });
+
+        try {
+            for (int i = 0; i < 1_000; i++) {
+                multiGauge.register(rows, true);
+            }
+        }
+        finally {
+            stop.set(true);
+            executor.shutdown();
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+        }
+
+        readerTask.get();
     }
 
     private static class Color {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -191,7 +191,7 @@ class MultiGaugeTest {
     }
 
     @Test
-    void overwriteDuplicateRows_withIgnoredTags() {
+    void overwriteIntraBatchDuplicateRows_withIgnoredTags() {
         registry.config().meterFilter(MeterFilter.ignoreTags("ignored"));
         MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
 
@@ -210,7 +210,7 @@ class MultiGaugeTest {
     }
 
     @Test
-    void overwriteDuplicateRows() {
+    void overwriteIntraBatchDuplicateRows() {
         MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
 
         // @formatter:off
@@ -228,7 +228,7 @@ class MultiGaugeTest {
     }
 
     @Test
-    void duplicateRows() {
+    void intraBatchDuplicateRows() {
         MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
 
         // @formatter:off

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -207,6 +207,19 @@ class MultiGaugeTest {
         // @formatter:on
         assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(6d);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2", "ignored", "7"), 7d),
+                Row.of(Tags.of("key", "2", "ignored", "8"), 8d),
+                Row.of(Tags.of("key", "2", "ignored", "9"), 9d)
+            ),
+            true
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(9d);
     }
 
     @Test
@@ -225,6 +238,19 @@ class MultiGaugeTest {
         // @formatter:on
         assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(6d);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2"), 7d),
+                Row.of(Tags.of("key", "2"), 8d),
+                Row.of(Tags.of("key", "2"), 9d)
+            ),
+            true
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(9d);
     }
 
     @Test
@@ -243,6 +269,32 @@ class MultiGaugeTest {
         // @formatter:on
         assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(4d);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2"), 7d),
+                Row.of(Tags.of("key", "2"), 8d),
+                Row.of(Tags.of("key", "2"), 9d)
+            ),
+            false
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(4d);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2"), 7d),
+                Row.of(Tags.of("key", "2"), 8d),
+                Row.of(Tags.of("key", "2"), 9d)
+            ),
+            true
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(9d);
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -188,6 +188,12 @@ class MultiGaugeTest {
         multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "3"), 3d)), true);
         assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(3d);
+    }
+
+    @Test
+    void overwriteDuplicateRows_withIgnoredTags() {
+        registry.config().meterFilter(MeterFilter.ignoreTags("ignored"));
+        MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
 
         // @formatter:off
         multiGauge.register(
@@ -201,6 +207,42 @@ class MultiGaugeTest {
         // @formatter:on
         assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(6d);
+    }
+
+    @Test
+    void overwriteDuplicateRows() {
+        MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2"), 4d),
+                Row.of(Tags.of("key", "2"), 5d),
+                Row.of(Tags.of("key", "2"), 6d)
+            ),
+            true
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(6d);
+    }
+
+    @Test
+    void duplicateRows() {
+        MultiGauge multiGauge = MultiGauge.builder("mg").register(registry);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2"), 4d),
+                Row.of(Tags.of("key", "2"), 5d),
+                Row.of(Tags.of("key", "2"), 6d)
+            ),
+            false
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(4d);
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MultiGaugeTest.java
@@ -188,6 +188,19 @@ class MultiGaugeTest {
         multiGauge.register(List.of(Row.of(Tags.of("key", "1", "ignored", "3"), 3d)), true);
         assertThat(registry.get("mg").tag("key", "1").gauges()).hasSize(1);
         assertThat(registry.get("mg").tag("key", "1").gauge().value()).isEqualTo(3d);
+
+        // @formatter:off
+        multiGauge.register(
+            List.of(
+                Row.of(Tags.of("key", "2", "ignored", "4"), 4d),
+                Row.of(Tags.of("key", "2", "ignored", "5"), 5d),
+                Row.of(Tags.of("key", "2", "ignored", "6"), 6d)
+            ),
+            true
+        );
+        // @formatter:on
+        assertThat(registry.get("mg").tag("key", "2").gauges()).hasSize(1);
+        assertThat(registry.get("mg").tag("key", "2").gauge().value()).isEqualTo(6d);
     }
 
     @Test


### PR DESCRIPTION
Previously, the corresponding Gauge for a MultiGauge Row was removed and re-registered if `overwrite` was `true`. This introduces a timing for the Gauge to be missed in publishing (or in the case of the Prometheus registry, to be read multiple times). Instead, update the backing object for the Gauge by introducing a RowState and tracking tracking it in the MultiGauge.

This fixes #6851, but due to the nature of the changes, I'm not sure we should apply this to maintenance branches. #7508 has a fix for the Prometheus registry specifically that looks safer to apply to maintenance branches.