### PR TITLE
Report Kafka Streams application state out of the box

### DIFF
--- a/docs/modules/ROOT/pages/reference/kafka.adoc
+++ b/docs/modules/ROOT/pages/reference/kafka.adoc
@@ -29,6 +29,25 @@ Setting up instrumentation with Apache Kafka using Kafka Streams.
 include::{include-core-test-java}/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetricsTest.java[tags=example, indent=0]
 -----
 
+[[kafka-streams-state]]
+== Kafka Streams Application State
+
+`KafkaStreamsMetrics` reports the current https://kafka.apache.org/documentation/streams/[Kafka Streams] application state through the `kafka.stream.state` gauge.
+
+Kafka reports the state as an enum, which cannot be published as a numeric value directly. Rather than relying on the enum's numeric ordering (which is not part of Kafka's public API), the state is published following the https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset-1[OpenMetrics StateSet] pattern: one time series is registered per possible state, tagged with `state`, where the current state reports `1` and all others report `0`.
+
+For example, while the client is `RUNNING`:
+
+[source]
+-----
+kafka_stream_state{state="RUNNING"} 1.0
+kafka_stream_state{state="REBALANCING"} 0.0
+kafka_stream_state{state="ERROR"} 0.0
+# ... one series per state
+-----
+
+This lets you build dashboards and alerts on the current state (for example, alerting when `state="ERROR"` reports `1`) and visualize state transitions over time.
+
 [[lifecycle]]
 == Lifecycle
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaMetrics.java
@@ -348,11 +348,11 @@ class KafkaMetrics implements MeterBinder, AutoCloseable {
         return tags;
     }
 
-    private List<Tag> meterTags(MetricName metricName) {
+    List<Tag> meterTags(MetricName metricName) {
         return meterTags(metricName, false);
     }
 
-    private String meterName(MetricName metricName) {
+    String meterName(MetricName metricName) {
         String name = METRIC_NAME_PREFIX + metricName.group() + "." + metricName.name();
         return name.replaceAll("-metrics", "").replace('-', '.');
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetrics.java
@@ -16,12 +16,24 @@
 package io.micrometer.core.instrument.binder.kafka;
 
 import io.micrometer.core.annotation.Incubating;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.MultiGauge.Row;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.streams.KafkaStreams;
+import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
 
 /**
  * Kafka Streams metrics binder.
@@ -43,6 +55,14 @@ import java.util.concurrent.ScheduledExecutorService;
 @Incubating(since = "1.4.0")
 public class KafkaStreamsMetrics extends KafkaMetrics {
 
+    private static final String STREAM_METRICS_GROUP = "stream-metrics";
+
+    private static final String STATE_METRIC_NAME = "state";
+
+    private final KafkaStreams kafkaStreams;
+
+    private @Nullable MultiGauge stateGauge;
+
     /**
      * {@link KafkaStreams} metrics binder
      * @param kafkaStreams instance to be instrumented
@@ -50,6 +70,7 @@ public class KafkaStreamsMetrics extends KafkaMetrics {
      */
     public KafkaStreamsMetrics(KafkaStreams kafkaStreams, Iterable<Tag> tags) {
         super(kafkaStreams::metrics, tags);
+        this.kafkaStreams = kafkaStreams;
     }
 
     /**
@@ -58,6 +79,7 @@ public class KafkaStreamsMetrics extends KafkaMetrics {
      */
     public KafkaStreamsMetrics(KafkaStreams kafkaStreams) {
         super(kafkaStreams::metrics);
+        this.kafkaStreams = kafkaStreams;
     }
 
     /**
@@ -73,6 +95,7 @@ public class KafkaStreamsMetrics extends KafkaMetrics {
      */
     public KafkaStreamsMetrics(KafkaStreams kafkaStreams, Iterable<Tag> tags, ScheduledExecutorService scheduler) {
         super(kafkaStreams::metrics, tags, scheduler);
+        this.kafkaStreams = kafkaStreams;
     }
 
     /**
@@ -100,6 +123,57 @@ public class KafkaStreamsMetrics extends KafkaMetrics {
     public KafkaStreamsMetrics(KafkaStreams kafkaStreams, Iterable<Tag> tags, ScheduledExecutorService scheduler,
             Duration refreshInterval) {
         super(kafkaStreams::metrics, tags, scheduler, refreshInterval);
+        this.kafkaStreams = kafkaStreams;
+    }
+
+    /**
+     * Registers a gauge reporting the current {@link KafkaStreams.State application
+     * state}.
+     * <p>
+     * The Kafka client reports the state as an enum, which Micrometer cannot publish as a
+     * numeric value, so it is normally filtered out. Following the <a href=
+     * "https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset-1">OpenMetrics
+     * StateSet</a> pattern, this registers one time series per possible state, tagged
+     * with {@code state}; the current state has value {@code 1} and all others {@code 0}.
+     * This avoids depending on the non-public numeric ordering of the state enum.
+     */
+    @Override
+    void prepareToBindMetrics(MeterRegistry registry) {
+        super.prepareToBindMetrics(registry);
+        MetricName stateMetricName = findStateMetricName();
+        if (stateMetricName == null) {
+            return;
+        }
+        MultiGauge gauge = MultiGauge.builder(meterName(stateMetricName))
+            .tags(meterTags(stateMetricName))
+            .description("The current state of the Kafka Streams client")
+            .register(registry);
+        List<Row<KafkaStreams.State>> rows = Arrays.stream(KafkaStreams.State.values())
+            .map(state -> Row.of(Tags.of("state", state.name()), state,
+                    candidate -> kafkaStreams.state() == candidate ? 1 : 0))
+            .collect(Collectors.toList());
+        gauge.register(rows);
+        this.stateGauge = gauge;
+    }
+
+    private @Nullable MetricName findStateMetricName() {
+        Map<MetricName, ? extends Metric> metrics = kafkaStreams.metrics();
+        for (MetricName name : metrics.keySet()) {
+            if (STREAM_METRICS_GROUP.equals(name.group()) && STATE_METRIC_NAME.equals(name.name())) {
+                return name;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void close() {
+        if (stateGauge != null) {
+            // remove the per-state gauges this binder registered
+            stateGauge.register(emptyList());
+            stateGauge = null;
+        }
+        super.close();
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaStreamsMetricsTest.java
@@ -15,6 +15,7 @@
  */
 package io.micrometer.core.instrument.binder.kafka;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -22,9 +23,12 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
 
 import static io.micrometer.core.instrument.binder.kafka.KafkaStreamsMetrics.METRIC_NAME_PREFIX;
 import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
@@ -34,6 +38,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class KafkaStreamsMetricsTest {
 
     private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+
+    private static final String STATE_METER_NAME = "kafka.stream.state";
 
     private Tags tags = Tags.of("app", "myapp", "version", "1");
 
@@ -85,6 +91,58 @@ class KafkaStreamsMetricsTest {
         finally {
             customScheduler.shutdownNow();
             assertThat(customScheduler.isShutdown()).isTrue();
+        }
+    }
+
+    @Test
+    void shouldReportApplicationStateAsStateSet() {
+        try (KafkaStreams kafkaStreams = createStreams();
+                KafkaStreamsMetrics metrics = new KafkaStreamsMetrics(kafkaStreams)) {
+            MeterRegistry registry = new SimpleMeterRegistry();
+
+            metrics.bindTo(registry);
+
+            List<Gauge> stateGauges = registry.find(STATE_METER_NAME).gauges().stream().collect(Collectors.toList());
+            // one time series per possible state
+            assertThat(stateGauges).extracting(gauge -> gauge.getId().getTag("state"))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.stream(KafkaStreams.State.values()).map(Enum::name).collect(Collectors.toList()));
+            // exactly the current state reports 1, everything else 0
+            String currentState = kafkaStreams.state().name();
+            assertThat(stateGauges).allSatisfy(gauge -> {
+                double expected = gauge.getId().getTag("state").equals(currentState) ? 1 : 0;
+                assertThat(gauge.value()).isEqualTo(expected);
+            });
+            assertThat(stateGauges).filteredOn(gauge -> gauge.value() == 1)
+                .extracting(gauge -> gauge.getId().getTag("state"))
+                .containsExactly(currentState);
+        }
+    }
+
+    @Test
+    void stateGaugeShouldCarryConfiguredTags() {
+        try (KafkaStreams kafkaStreams = createStreams();
+                KafkaStreamsMetrics metrics = new KafkaStreamsMetrics(kafkaStreams, tags)) {
+            MeterRegistry registry = new SimpleMeterRegistry();
+
+            metrics.bindTo(registry);
+
+            assertThat(registry.find(STATE_METER_NAME).gauges()).isNotEmpty()
+                .allSatisfy(gauge -> assertThat(gauge.getId().getTag("app")).isEqualTo("myapp"));
+        }
+    }
+
+    @Test
+    void closeShouldRemoveStateGauges() {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        try (KafkaStreams kafkaStreams = createStreams()) {
+            KafkaStreamsMetrics metrics = new KafkaStreamsMetrics(kafkaStreams);
+            metrics.bindTo(registry);
+            assertThat(registry.find(STATE_METER_NAME).gauges()).isNotEmpty();
+
+            metrics.close();
+
+            assertThat(registry.find(STATE_METER_NAME).gauges()).isEmpty();
         }
     }
 


### PR DESCRIPTION
Publishes the Kafka Streams application state through the `kafka.stream.state` gauge, following the discussion in gh-6079.

The Kafka Streams client reports its state (`CREATED`, `RUNNING`, `REBALANCING`, `ERROR`, and so on) as an enum. Since Micrometer cannot publish an enum as a numeric value, `KafkaMetrics` filters it out, so this signal — one of the most useful for operating a Streams application — was not available out of the box.

As suggested by @shakuzen in the issue, this uses the [OpenMetrics StateSet](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset-1) pattern instead of a numeric mapping: a `MultiGauge` registers one time series per possible state, tagged with `state`, where the current state reports `1` and all others `0`. This avoids depending on the enum's numeric ordering, which is not part of Kafka's public API. (Confirmed while implementing: the ordering proposed earlier in the issue is already off for Kafka 2.8.x, where `PENDING_ERROR` sits between `NOT_RUNNING` and `ERROR`.)

The state gauges carry the same tags as the other Streams meters (`client.id`, `kafka.version`, plus any user tags) and are removed on `close()`.

Example output while the client is `RUNNING`:

```
kafka_stream_state{state="RUNNING"} 1.0
kafka_stream_state{state="REBALANCING"} 0.0
kafka_stream_state{state="ERROR"} 0.0
# ... one series per state
```

Notes for reviewers:
- `KafkaMetrics#meterName` / `meterTags` were relaxed from `private` to package-private so the subclass can reuse the existing tag/name logic for consistency. No public API change (verified with `japicmp`).
- Added unit tests for the StateSet output, tag propagation, and `close()` cleanup, plus a short reference-docs section.

Fixes gh-6079

Link: https://github.com/micrometer-metrics/micrometer/issues/6079
