### PR TITLE
Make state objects non-nullable for function-based meter registration

### DIFF
--- a/docs/modules/ROOT/pages/concepts/gauges.adoc
+++ b/docs/modules/ROOT/pages/concepts/gauges.adoc
@@ -71,6 +71,17 @@ It is your responsibility to hold a strong reference to the state object that yo
 
 If you see your gauge reporting for a few minutes and then disappearing or reporting NaN, it almost certainly suggests that the underlying object being gauged has been garbage collected.
 
+== Nullable state objects
+
+It can happen that you have a nullable object that you want to measure with a `Gauge`. You should avoid passing nullable state objects to Micrometer, but if you have one, there are multiple solutions, depending on your scenario:
+
+1. Check if the state object is `null` and do not register a `Gauge` if so (the time series will be missing).
+2. Check if the state object is `null` and, instead, register a `Gauge` that reports a value signaling the nullness, for example: `+Gauge.builder("gauge", () -> Double.NaN).register(registry);+`.
+3. Wrap your state object in a non-null, immutable wrapper (you need to write one) and use the wrapper as your state object. Your `ToDoubleFunction` needs to handle the case where the wrapped value is `null`.
+4. Similarly, you can wrap your nullable state object in a (mutable) `AtomicReference`. Your `ToDoubleFunction` needs to handle the case where `AtomicReference#get()` returns `null`. This solution also handles the case where the nullness is temporary: you can set a non-null value on the `AtomicReference` later, once one becomes available.
+
+NOTE: The same applies to other function-based meter registrations: `TimeGauge`, `FunctionTimer`, and `FunctionCounter`, since their state object has the same non-null requirement.
+
 == `TimeGauge`
 
 `TimeGauge` is a specialized gauge that tracks a time value, to be scaled to the base unit of time expected by each registry implementation.

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/AtlasMeterRegistry.java
@@ -33,7 +33,6 @@ import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.step.StepFunctionCounter;
 import io.micrometer.core.instrument.step.StepFunctionTimer;
 import io.micrometer.core.instrument.util.DoubleFormat;
-import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -181,8 +180,7 @@ public class AtlasMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, @Nullable T obj,
-            ToDoubleFunction<T> valueFunction) {
+    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         com.netflix.spectator.api.Gauge gauge = new SpectatorToDoubleGauge<>(registry.clock(), spectatorId(id), obj,
                 valueFunction);
         registry.register(gauge);

--- a/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorToDoubleGauge.java
+++ b/implementations/micrometer-registry-atlas/src/main/java/io/micrometer/atlas/SpectatorToDoubleGauge.java
@@ -16,7 +16,6 @@
 package io.micrometer.atlas;
 
 import com.netflix.spectator.api.*;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.function.ToDoubleFunction;
@@ -30,7 +29,7 @@ class SpectatorToDoubleGauge<T> extends AbstractMeter<T> implements Gauge {
 
     private final ToDoubleFunction<T> f;
 
-    SpectatorToDoubleGauge(Clock clock, Id id, @Nullable T obj, ToDoubleFunction<T> f) {
+    SpectatorToDoubleGauge(Clock clock, Id id, T obj, ToDoubleFunction<T> f) {
         super(clock, id, obj);
         this.f = f;
     }

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -18,7 +18,6 @@ package io.micrometer.elastic;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import org.jspecify.annotations.Nullable;
-import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -165,7 +164,7 @@ class ElasticMeterRegistryTest {
 
     @Issue("#497")
     @Test
-    @NullUnmarked
+    @SuppressWarnings("NullAway")
     void nullGauge() {
         Gauge g = Gauge.builder("gauge", null, o -> 1).register(registry);
         assertThat(registry.writeGauge(g)).isNotPresent();

--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -18,6 +18,7 @@ package io.micrometer.elastic;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -164,6 +165,7 @@ class ElasticMeterRegistryTest {
 
     @Issue("#497")
     @Test
+    @NullUnmarked
     void nullGauge() {
         Gauge g = Gauge.builder("gauge", null, o -> 1).register(registry);
         assertThat(registry.writeGauge(g)).isNotPresent();

--- a/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBMeterRegistry.java
+++ b/implementations/micrometer-registry-opentsdb/src/main/java/io/micrometer/opentsdb/OpenTSDBMeterRegistry.java
@@ -122,7 +122,7 @@ public class OpenTSDBMeterRegistry extends PushMeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new DefaultGauge<>(id, obj, valueFunction);
     }
 

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -232,7 +232,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new DefaultGauge<>(id, obj, valueFunction);
     }
 

--- a/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -331,8 +331,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, @Nullable T obj,
-            ToDoubleFunction<T> valueFunction) {
+    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         Gauge gauge = new DefaultGauge<>(id, obj, valueFunction);
         applyToCollector(id, (collector) -> {
             List<String> tagValues = tagValues(id);

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistry.java
@@ -225,8 +225,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, @Nullable T obj,
-            ToDoubleFunction<T> valueFunction) {
+    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         Gauge gauge = new DefaultGauge<>(id, obj, valueFunction);
         applyToCollector(id, (collector, context) -> collector.addGauge(context, gauge));
         return gauge;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdGauge.java
@@ -17,7 +17,6 @@ package io.micrometer.statsd;
 
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
-import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.FluxSink;
 
 import java.lang.ref.WeakReference;
@@ -38,7 +37,7 @@ public class StatsdGauge<T> extends AbstractMeter implements Gauge, StatsdPollab
 
     private final boolean alwaysPublish;
 
-    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, @Nullable T obj, ToDoubleFunction<T> value,
+    StatsdGauge(Id id, StatsdLineBuilder lineBuilder, FluxSink<String> sink, T obj, ToDoubleFunction<T> value,
             boolean alwaysPublish) {
         super(id);
         this.lineBuilder = lineBuilder;

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -329,7 +329,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         StatsdGauge<T> gauge = new StatsdGauge<>(id, lineBuilder(id), this.sink, obj, valueFunction,
                 statsdConfig.publishUnchangedMeters());
         pollableMeters.put(id, gauge);

--- a/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
+++ b/implementations/micrometer-registry-wavefront/src/main/java/io/micrometer/wavefront/WavefrontMeterRegistry.java
@@ -119,7 +119,7 @@ public class WavefrontMeterRegistry extends PushMeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new DefaultGauge<>(id, obj, valueFunction);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/Gauge.java
@@ -40,7 +40,7 @@ public interface Gauge extends Meter {
      * @param <T> The type of object to gauge.
      * @return A new gauge builder.
      */
-    static <T> Builder<T> builder(String name, @Nullable T obj, ToDoubleFunction<T> f) {
+    static <T> Builder<T> builder(String name, T obj, ToDoubleFunction<T> f) {
         return new Builder<>(name, obj, f);
     }
 
@@ -89,13 +89,13 @@ public interface Gauge extends Meter {
 
         private Meter.@Nullable Id syntheticAssociation = null;
 
-        private final @Nullable T obj;
+        private final T obj;
 
         private @Nullable String description;
 
         private @Nullable String baseUnit;
 
-        private Builder(String name, @Nullable T obj, ToDoubleFunction<T> f) {
+        private Builder(String name, T obj, ToDoubleFunction<T> f) {
             this.name = name;
             this.obj = obj;
             this.f = f;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -15,7 +15,6 @@
  */
 package io.micrometer.core.instrument;
 
-import io.micrometer.common.lang.internal.Contract;
 import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
@@ -165,7 +164,7 @@ public abstract class MeterRegistry {
      * @param <T> The type of the state object from which the gauge value is extracted.
      * @return A new gauge.
      */
-    protected abstract <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction);
+    protected abstract <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction);
 
     /**
      * Build a new counter to be added to the registry. This is guaranteed to only be
@@ -249,7 +248,7 @@ public abstract class MeterRegistry {
      * measurement.
      * @return A new time gauge.
      */
-    protected <T> TimeGauge newTimeGauge(Meter.Id id, @Nullable T obj, TimeUnit valueFunctionUnit,
+    protected <T> TimeGauge newTimeGauge(Meter.Id id, T obj, TimeUnit valueFunctionUnit,
             ToDoubleFunction<T> valueFunction) {
         Meter.Id withUnit = id.withBaseUnit(getBaseTimeUnitStr());
         Gauge gauge = newGauge(withUnit, obj,
@@ -356,7 +355,7 @@ public abstract class MeterRegistry {
      * @param <T> The type of the state object from which the gauge value is extracted.
      * @return A new or existing gauge.
      */
-    <T> Gauge gauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    <T> Gauge gauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return registerMeterIfNecessary(Gauge.class, id,
                 (registry, mappedId) -> registry.newGauge(mappedId, obj, valueFunction), NoopGauge::new);
     }
@@ -564,9 +563,7 @@ public abstract class MeterRegistry {
      * @return The state object that was passed in so the registration can be done as part
      * of an assignment statement.
      */
-    @Contract("_, _, null, _ -> null; _, _, !null, _ -> !null")
-    public <T> @Nullable T gauge(String name, Iterable<Tag> tags, @Nullable T stateObject,
-            ToDoubleFunction<T> valueFunction) {
+    public <T> T gauge(String name, Iterable<Tag> tags, T stateObject, ToDoubleFunction<T> valueFunction) {
         Gauge.builder(name, stateObject, valueFunction).tags(tags).register(this);
         return stateObject;
     }
@@ -1272,8 +1269,7 @@ public abstract class MeterRegistry {
          * extracted.
          * @return A new or existing time gauge.
          */
-        <T> TimeGauge timeGauge(Meter.Id id, @Nullable T obj, TimeUnit timeFunctionUnit,
-                ToDoubleFunction<T> timeFunction) {
+        <T> TimeGauge timeGauge(Meter.Id id, T obj, TimeUnit timeFunctionUnit, ToDoubleFunction<T> timeFunction) {
             return registerMeterIfNecessary(TimeGauge.class, id,
                     (registry, mappedId) -> registry.newTimeGauge(mappedId, obj, timeFunctionUnit, timeFunction),
                     NoopTimeGauge::new);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/StrongReferenceGaugeFunction.java
@@ -15,8 +15,6 @@
  */
 package io.micrometer.core.instrument;
 
-import org.jspecify.annotations.Nullable;
-
 import java.util.function.ToDoubleFunction;
 
 /**
@@ -33,11 +31,11 @@ class StrongReferenceGaugeFunction<T> implements ToDoubleFunction<T> {
      * If obj is {@code null} initially then this gauge will not be reported.
      */
     @SuppressWarnings("FieldCanBeLocal")
-    private final @Nullable T obj;
+    private final T obj;
 
     private final ToDoubleFunction<T> f;
 
-    StrongReferenceGaugeFunction(@Nullable T obj, ToDoubleFunction<T> f) {
+    StrongReferenceGaugeFunction(T obj, ToDoubleFunction<T> f) {
         this.obj = obj;
         this.f = f;
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/TimeGauge.java
@@ -32,7 +32,7 @@ import java.util.function.ToDoubleFunction;
  */
 public interface TimeGauge extends Gauge {
 
-    static <T> Builder<T> builder(String name, @Nullable T obj, TimeUnit fUnits, ToDoubleFunction<T> f) {
+    static <T> Builder<T> builder(String name, T obj, TimeUnit fUnits, ToDoubleFunction<T> f) {
         return new Builder<>(name, obj, fUnits, f);
     }
 
@@ -84,11 +84,11 @@ public interface TimeGauge extends Gauge {
 
         private boolean strongReference = false;
 
-        private final @Nullable T obj;
+        private final T obj;
 
         private @Nullable String description;
 
-        private Builder(String name, @Nullable T obj, TimeUnit fUnits, ToDoubleFunction<T> f) {
+        private Builder(String name, T obj, TimeUnit fUnits, ToDoubleFunction<T> f) {
             this.name = name;
             this.obj = obj;
             this.fUnits = fUnits;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeGauge.java
@@ -30,7 +30,7 @@ class CompositeGauge<T> extends AbstractCompositeMeter<Gauge> implements Gauge {
 
     private final ToDoubleFunction<T> f;
 
-    CompositeGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> f) {
+    CompositeGauge(Meter.Id id, T obj, ToDoubleFunction<T> f) {
         super(id);
         ref = new WeakReference<>(obj);
         this.f = f;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeMeterRegistry.java
@@ -20,7 +20,6 @@ import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.config.NamingConvention;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.PauseDetector;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -102,12 +101,12 @@ public class CompositeMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new CompositeGauge<>(id, obj, valueFunction);
     }
 
     @Override
-    protected <T> TimeGauge newTimeGauge(Meter.Id id, @Nullable T obj, TimeUnit valueFunctionUnit,
+    protected <T> TimeGauge newTimeGauge(Meter.Id id, T obj, TimeUnit valueFunctionUnit,
             ToDoubleFunction<T> valueFunction) {
         return new CompositeTimeGauge<>(id, obj, valueFunctionUnit, valueFunction);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimeGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/composite/CompositeTimeGauge.java
@@ -32,7 +32,7 @@ class CompositeTimeGauge<T> extends AbstractCompositeMeter<TimeGauge> implements
 
     private final TimeUnit fUnit;
 
-    CompositeTimeGauge(Id id, @Nullable T obj, TimeUnit fUnit, ToDoubleFunction<T> f) {
+    CompositeTimeGauge(Id id, T obj, TimeUnit fUnit, ToDoubleFunction<T> f) {
         super(id);
         ref = new WeakReference<>(obj);
         this.f = f;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistry.java
@@ -87,8 +87,7 @@ public abstract class DropwizardMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, @Nullable T obj,
-            ToDoubleFunction<T> valueFunction) {
+    protected <T> io.micrometer.core.instrument.Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         final WeakReference<T> ref = new WeakReference<>(obj);
         Gauge<Double> gauge = () -> {
             T obj2 = ref.get();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/DefaultGauge.java
@@ -19,7 +19,6 @@ import io.micrometer.common.util.internal.logging.WarnThenDebugLogger;
 import io.micrometer.core.instrument.AbstractMeter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
-import org.jspecify.annotations.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.function.ToDoubleFunction;
@@ -39,7 +38,7 @@ public class DefaultGauge<T> extends AbstractMeter implements Gauge {
 
     private final ToDoubleFunction<T> value;
 
-    public DefaultGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> value) {
+    public DefaultGauge(Meter.Id id, T obj, ToDoubleFunction<T> value) {
         super(id);
         this.ref = new WeakReference<>(obj);
         this.value = value;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/simple/SimpleMeterRegistry.java
@@ -25,7 +25,6 @@ import io.micrometer.core.instrument.internal.DefaultGauge;
 import io.micrometer.core.instrument.internal.DefaultLongTaskTimer;
 import io.micrometer.core.instrument.internal.DefaultMeter;
 import io.micrometer.core.instrument.step.*;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Comparator;
 import java.util.Locale;
@@ -108,7 +107,7 @@ public class SimpleMeterRegistry extends MeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new DefaultGauge<>(id, obj, valueFunction);
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -58,7 +58,7 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
     }
 
     @Override
-    protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+    protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
         return new DefaultGauge<>(id, obj, valueFunction);
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
@@ -17,7 +17,6 @@ package io.micrometer.core.instrument;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
-import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +43,7 @@ class MeterTest {
 
     @Test
     void matchWhenFunctionReturnsNullShouldReturnNull() {
-        @Nullable String matched = gauge.match((gauge) -> "gauge", (counter) -> "counter", (timer) -> "timer",
+        String matched = gauge.match((gauge) -> "gauge", (counter) -> "counter", (timer) -> "timer",
                 (distributionSummary) -> "distributionSummary", (longTaskTimer) -> "longTaskTimer", (timeGauge) -> null,
                 (functionCounter) -> "functionCounter", (functionTimer) -> "functionTimer", (meter) -> "meter");
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MeterTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class MeterTest {
 
-    TimeGauge gauge = TimeGauge.builder("time.gauge", null, TimeUnit.MILLISECONDS, o -> 1.0)
+    TimeGauge gauge = TimeGauge.builder("time.gauge", new Object(), TimeUnit.MILLISECONDS, o -> 1.0)
         .register(new SimpleMeterRegistry());
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.MetricRegistry;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
+import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -60,8 +61,9 @@ class DropwizardMeterRegistryTest {
     };
 
     @Test
+    @NullUnmarked
     void gaugeOnNullValue() {
-        registry.gauge("gauge", emptyList(), null, obj -> 1.0);
+        registry.gauge("gauge", emptyList(), (Object) null, obj -> 1.0);
         assertThat(registry.get("gauge").gauge().value()).isNaN();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
@@ -19,7 +19,6 @@ import com.codahale.metrics.MetricRegistry;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.util.HierarchicalNameMapper;
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -61,9 +60,9 @@ class DropwizardMeterRegistryTest {
     };
 
     @Test
-    @NullUnmarked
+    @SuppressWarnings("NullAway")
     void gaugeOnNullValue() {
-        registry.gauge("gauge", emptyList(), (Object) null, obj -> 1.0);
+        registry.gauge("gauge", emptyList(), null, obj -> 1.0);
         assertThat(registry.get("gauge").gauge().value()).isNaN();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/push/PushMeterRegistryTest.java
@@ -364,7 +364,7 @@ class PushMeterRegistryTest {
         }
 
         @Override
-        protected <T> Gauge newGauge(Meter.Id id, @Nullable T obj, ToDoubleFunction<T> valueFunction) {
+        protected <T> Gauge newGauge(Meter.Id id, T obj, ToDoubleFunction<T> valueFunction) {
             return mock(Gauge.class);
         }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -18,8 +18,8 @@ package io.micrometer.core.tck;
 import io.micrometer.common.KeyValue;
 import io.micrometer.core.Issue;
 import io.micrometer.core.annotation.Timed;
-import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
@@ -34,14 +34,12 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
-import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 import java.time.Duration;
 import java.util.*;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -429,10 +427,10 @@ public abstract class MeterRegistryCompatibilityKit {
         }
 
         @Test
-        @DisplayName("gauges with a null source object report NaN")
-        @NullUnmarked
-        void nullSourceObjectReportsNaN() {
-            registry.gauge("my.gauge", emptyList(), (Map) null, Map::size);
+        @DisplayName("gauges that reference an object that is garbage collected report NaN")
+        @SuppressWarnings("NullAway")
+        void garbageCollectedSourceObject() {
+            registry.gauge("my.gauge", emptyList(), (Map<?, ?>) null, Map::size);
             assertThat(registry.get("my.gauge").gauge().value())
                 .matches(val -> val == null || Double.isNaN(val) || val == 0.0);
         }

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.jspecify.annotations.NullUnmarked;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -428,8 +429,9 @@ public abstract class MeterRegistryCompatibilityKit {
         }
 
         @Test
-        @DisplayName("gauges that reference an object that is garbage collected report NaN")
-        void garbageCollectedSourceObject() {
+        @DisplayName("gauges with a null source object report NaN")
+        @NullUnmarked
+        void nullSourceObjectReportsNaN() {
             registry.gauge("my.gauge", emptyList(), (Map) null, Map::size);
             assertThat(registry.get("my.gauge").gauge().value())
                 .matches(val -> val == null || Double.isNaN(val) || val == 0.0);


### PR DESCRIPTION
Implements option 2 from #6416, per team's direction.

Annotation-only. no runtime requireNonNull, so callers passing null today behave exactly as before. 

the `@Contract on MeterRegistry.gauge(...)` came from #6546, so removing it partially reverts that.

The three tests that pass null are marked @NullUnmarked rather than deleted, since the implementations still tolerate null at runtime. The TCK one is renamed to nullSourceObjectReportsNaN — it never garbage-collected anything, it just passed a literal null, and a real GC test would be non-deterministic.

`./gradlew check` also fails on unmodified main here, in an unrelated class, so the local suite looks flaky under parallel execution.

fixes #6416 