### PR TITLE
fix: sanitize carriage returns in Influx tag values

### DIFF
--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxNamingConvention.java
@@ -62,7 +62,7 @@ public class InfluxNamingConvention implements NamingConvention {
 
     @Override
     public String tagValue(String value) {
-        return escape(this.delegate.tagValue(value).replace('\n', ' '));
+        return escape(this.delegate.tagValue(value).replace('\r', ' ').replace('\n', ' '));
     }
 
     private String escape(String string) {

--- a/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxNamingConventionTest.java
+++ b/implementations/micrometer-registry-influx/src/test/java/io/micrometer/influx/InfluxNamingConventionTest.java
@@ -84,6 +84,11 @@ class InfluxNamingConventionTest {
         assertThat(convention.tagValue("hello\nworld\n")).isEqualTo("hello\\ world\\ ");
     }
 
+    @Test
+    void carriageReturnCharReplacedInTagValues() {
+        assertThat(convention.tagValue("hello\rworld\r")).isEqualTo("hello\\ world\\ ");
+    }
+
     private static class CustomNamingConvention implements NamingConvention {
 
         @Override


### PR DESCRIPTION
This change extends the existing Influx tag-value sanitization to replace carriage returns (\r) with spaces, matching the current handling of line feeds (\n).
Meter names and tag keys are unchanged.
Adds a regression test covering carriage returns in tag values.
Closes #7865