### PR TITLE
Relocate netty native-image config during statsd shading

### DIFF
--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -1,4 +1,10 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
+import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
+import org.apache.tools.zip.ZipEntry
+import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.GradleException
+import org.gradle.api.file.FileTreeElement
 
 plugins {
     alias(libs.plugins.shadow)
@@ -59,6 +65,9 @@ def shadowJar = tasks.named('shadowJar', ShadowJar) {
     relocate 'org.reactivestreams', 'io.micrometer.shaded.org.reactorstreams'
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
     relocate 'META-INF/native/libnetty', 'META-INF/native/libio_micrometer_shaded_netty'
+    // see gh-3212: rewrite class-name string literals in shaded netty/reactor's
+    // GraalVM native-image config so they match the relocated (shaded) class names
+    transform(NativeImageConfigRelocatingTransformer)
     metaInf {
         from "$rootDir/LICENSE"
         from "$rootDir/NOTICE"
@@ -87,4 +96,45 @@ publishing {
 dockerTest {
     systemProperty 'telegraf-image.version', '1.37.1'
     systemProperty 'influxdb-image.version', '2.8.0'
+}
+
+// Shadow relocates class bytecode but not string literals inside resource files, so
+// GraalVM's native-image config (META-INF/native-image/**/*.json, native-image.properties)
+// bundled in the shaded netty/reactor jars still names the pre-shading classes. Without this,
+// native-image can't find those classes anymore and reflective/JNI hints silently no-op.
+class NativeImageConfigRelocatingTransformer implements ResourceTransformer {
+
+    private final Map<String, String> transformedResources = new LinkedHashMap<>()
+
+    @Override
+    boolean canTransformResource(FileTreeElement element) {
+        def path = element.relativePath.pathString
+        return path.startsWith('META-INF/native-image/') &&
+                (path.endsWith('.json') || path.endsWith('.properties'))
+    }
+
+    @Override
+    void transform(TransformerContext context) {
+        String content = context.inputStream.getText('UTF-8')
+        for (relocator in context.relocators) {
+            content = relocator.applyToSourceContent(content)
+        }
+        if (transformedResources.putIfAbsent(context.path, content) != null) {
+            throw new GradleException("Duplicate native-image config resource at ${context.path}")
+        }
+    }
+
+    @Override
+    boolean hasTransformedResource() {
+        return !transformedResources.isEmpty()
+    }
+
+    @Override
+    void modifyOutputStream(ZipOutputStream os, boolean preserveFileTimestamps) {
+        transformedResources.each { path, content ->
+            os.putNextEntry(new ZipEntry(path))
+            os.write(content.getBytes('UTF-8'))
+            os.closeEntry()
+        }
+    }
 }

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -65,8 +65,7 @@ def shadowJar = tasks.named('shadowJar', ShadowJar) {
     relocate 'org.reactivestreams', 'io.micrometer.shaded.org.reactorstreams'
     relocate 'io.netty', 'io.micrometer.shaded.io.netty'
     relocate 'META-INF/native/libnetty', 'META-INF/native/libio_micrometer_shaded_netty'
-    // see gh-3212: rewrite class-name string literals in shaded netty/reactor's
-    // GraalVM native-image config so they match the relocated (shaded) class names
+    // see gh-3212
     transform(NativeImageConfigRelocatingTransformer)
     metaInf {
         from "$rootDir/LICENSE"
@@ -98,10 +97,8 @@ dockerTest {
     systemProperty 'influxdb-image.version', '2.8.0'
 }
 
-// Shadow relocates class bytecode but not string literals inside resource files, so
-// GraalVM's native-image config (META-INF/native-image/**/*.json, native-image.properties)
-// bundled in the shaded netty/reactor jars still names the pre-shading classes. Without this,
-// native-image can't find those classes anymore and reflective/JNI hints silently no-op.
+// Shadow relocates class bytecode but not string literals in resource files, so GraalVM
+// native-image config shipped in shaded jars still names the pre-shading classes.
 class NativeImageConfigRelocatingTransformer implements ResourceTransformer {
 
     private final Map<String, String> transformedResources = new LinkedHashMap<>()


### PR DESCRIPTION
## What changed

The statsd jar shades netty/reactor-netty under `io.micrometer.shaded`, but Shadow rewrites `.class` bytecode only — not the class names embedded as string literals in the GraalVM native-image config those dependencies ship. So the published jar carries native-image metadata naming classes that no longer exist, and the hints silently fail to apply.

Adds a Shadow `ResourceTransformer` that rewrites `META-INF/native-image/**` `.json` and `.properties` content using the relocators already configured on the `shadowJar` task, so the mappings can't drift from the `relocate` declarations above it. Files referencing unshaded names: 12 before, 0 after.

## Verification

No native-image CI exists here (gh-7326), so this was verified manually with GraalVM CE 25.0.1 using a minimal app that constructs a `StatsdMeterRegistry` and publishes over UDP.

Before, the native binary reproduces the reported failure exactly:

```
Caused by: java.lang.IllegalArgumentException: Can't find '[toLeakAwareBuffer]' in io.micrometer.shaded.io.netty.buffer.AbstractByteBufAllocator
	at io.micrometer.shaded.io.netty.util.ResourceLeakDetector.addExclusions(ResourceLeakDetector.java:654)
	at io.micrometer.shaded.io.netty.buffer.AbstractByteBufAllocator.<clinit>(AbstractByteBufAllocator.java:37)
```

After, the same binary runs to completion and publishes normally.

## Notes

The transformer is declared inline because `buildSrc` and `apply from:` both fail to resolve `ResourceTransformer` (the `plugins { }` DSL scopes the plugin to this script's classloader); extracting it would need a precompiled script plugin, which I'm glad to do if you'd prefer. I also tried `filesMatching` with a `filter` closure, which produces byte-identical output with no custom class, but rejected it because `filter` closures aren't tracked as task inputs and returned a stale jar on edit — a poor fit given the shared remote build cache.

Fixes gh-3212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
