### PR TITLE
Fix tests passing null state objects

### DIFF
--- a/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
+++ b/implementations/micrometer-registry-elastic/src/test/java/io/micrometer/elastic/ElasticMeterRegistryTest.java
@@ -164,12 +164,11 @@ class ElasticMeterRegistryTest {
 
     @Issue("#497")
     @Test
-    @SuppressWarnings("NullAway")
-    void nullGauge() {
-        Gauge g = Gauge.builder("gauge", null, o -> 1).register(registry);
+    void NaNGauge() {
+        Gauge g = Gauge.builder("gauge", this, o -> Double.NaN).register(registry);
         assertThat(registry.writeGauge(g)).isNotPresent();
 
-        TimeGauge tg = TimeGauge.builder("time.gauge", null, TimeUnit.MILLISECONDS, o -> 1).register(registry);
+        TimeGauge tg = TimeGauge.builder("time.gauge", this, TimeUnit.MILLISECONDS, o -> Double.NaN).register(registry);
         assertThat(registry.writeTimeGauge(tg)).isNotPresent();
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/dropwizard/DropwizardMeterRegistryTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -60,9 +59,9 @@ class DropwizardMeterRegistryTest {
     };
 
     @Test
-    @SuppressWarnings("NullAway")
-    void gaugeOnNullValue() {
-        registry.gauge("gauge", emptyList(), null, obj -> 1.0);
+    void gaugeValueWhenStateObjectIsGarbageCollected() {
+        registry.gauge("gauge", Tags.empty(), new Object(), obj -> 1.0);
+        System.gc(); // collect unreferenced state object
         assertThat(registry.get("gauge").gauge().value()).isNaN();
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -428,11 +428,10 @@ public abstract class MeterRegistryCompatibilityKit {
 
         @Test
         @DisplayName("gauges that reference an object that is garbage collected report NaN")
-        @SuppressWarnings("NullAway")
         void garbageCollectedSourceObject() {
-            registry.gauge("my.gauge", emptyList(), (Map<?, ?>) null, Map::size);
-            assertThat(registry.get("my.gauge").gauge().value())
-                .matches(val -> val == null || Double.isNaN(val) || val == 0.0);
+            registry.gauge("my.gauge", Tags.empty(), new Object(), o -> 2.3);
+            System.gc(); // collect unreferenced state object
+            assertThat(registry.get("my.gauge").gauge().value()).isNaN();
         }
 
         @Test


### PR DESCRIPTION
Function-based meters no longer mark the state object as nullable anywhere but some tests still passed null.

Update all such tests to test what they actually intended to test.

Follow-up to #7856