### PR TITLE
Document garbage collection behavior for function meters

### DIFF
--- a/docs/modules/ROOT/pages/concepts/gauges.adoc
+++ b/docs/modules/ROOT/pages/concepts/gauges.adoc
@@ -71,6 +71,8 @@ It is your responsibility to hold a strong reference to the state object that yo
 
 If you see your gauge reporting for a few minutes and then disappearing or reporting NaN, it almost certainly suggests that the underlying object being gauged has been garbage collected.
 
+Similarly, `FunctionCounter` and `FunctionTimer` hold only weak references to their state objects, so you are responsible for maintaining a strong reference to those as well. Unlike gauges, when their underlying state object is garbage collected, function meters do not report `NaN` or disappear. Instead, cumulative registries continue reporting the last recorded value, while step-based registries report zero once the current step rolls over. If you see a function counter or function timer series go flat (at either a constant value or zero), it usually indicates that the underlying state object was garbage collected.
+
 == Nullable state objects
 
 It can happen that you have a nullable object that you want to measure with a `Gauge`. You should avoid passing nullable state objects to Micrometer, but if you have one, there are multiple solutions, depending on your scenario:


### PR DESCRIPTION
Docs only, no code change.

The "Why is My Gauge Reporting NaN or Disappearing?" section only covers `Gauge`, but `FunctionCounter` and `FunctionTimer` hold weak references to their state objects too. They just fail differently, and that isn't written down anywhere.

When the state object is collected they never report NaN and never disappear. They split two ways:

- `CumulativeFunctionCounter` / `CumulativeFunctionTimer` keep returning the last recorded value (`return obj2 != null ? (last = f.applyAsDouble(obj2)) : last;`). `StatsdFunctionCounter` and `OtlpCumulativeFunctionCounter` extend those, and `DropwizardFunctionCounter` does the same thing explicitly with `if (obj == null) return last.get();`.
- `StepFunctionCounter` / `StepFunctionTimer` stop accumulating, so `StepValue.rollCount` sets `previous = noValue()` and they report zero once the step rolls over.

So the symptom is a flat series rather than NaN, which is harder to notice — a flat counter looks like an idle one.

The wording says "cumulative registries" / "step-based registries" instead of naming classes because `SimpleMeterRegistry` picks either one depending on `config.mode()`.

This is the garbage-collection half of the NOTE added in #7856, which covers the non-null requirement for `TimeGauge`, `FunctionTimer` and `FunctionCounter`.

Ran `./gradelw format` but did not run the Antora build locally as the change adds no new markup, only inline backticks that already appear in this file.
