### PR TITLE
Enable NullAway JSpecifyExperimental and fix nullability issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ subprojects {
                     // see https://bugs.openjdk.org/browse/JDK-8346471
                     // see https://github.com/uber/NullAway/wiki/JSpecify-Support
                     option("NullAway:JSpecifyMode", "true")
+                    option("NullAway:JSpecifyExperimental", "true")
                 }
                 if (!javaLanguageVersion.canCompileOrRun(21)) {
                     // Error Prone 2.43.0 requires JDK 21+

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,8 @@ subprojects {
                     // see https://bugs.openjdk.org/browse/JDK-8346471
                     // see https://github.com/uber/NullAway/wiki/JSpecify-Support
                     option("NullAway:JSpecifyMode", "true")
+                }
+                if (javaLanguageVersion.canCompileOrRun(22)) {
                     option("NullAway:JSpecifyExperimental", "true")
                 }
                 if (!javaLanguageVersion.canCompileOrRun(21)) {

--- a/build.gradle
+++ b/build.gradle
@@ -72,11 +72,6 @@ subprojects {
 
     if (project.name != 'micrometer-bom') {
         tasks.withType(JavaCompile).configureEach {
-            if (javaLanguageVersion.asInt() == 21) {
-                // Helps NullAway with type annotations on JDK 21
-                // See https://github.com/uber/NullAway/wiki/JSpecify-Support#supported-jdk-versions
-                options.compilerArgs.add("-XDaddTypeAnnotationsToSymbol=true")
-            }
             if (it.name == "compileJava" && !(it.project.name in ["micrometer-java11"])) {
                 options.errorprone.disable(
                     "JavaDurationGetSecondsToToSeconds" // Requires JDK 9+
@@ -127,12 +122,10 @@ subprojects {
                 option("NullAway:CustomContractAnnotations", "io.micrometer.common.lang.internal.Contract,org.assertj.core.internal.annotation.Contract")
                 option("NullAway:CheckContracts", "true")
                 option("NullAway:HandleTestAssertionLibraries", "true")
-                if (javaLanguageVersion.canCompileOrRun(21)) {
+                if (javaLanguageVersion.canCompileOrRun(22)) {
                     // see https://bugs.openjdk.org/browse/JDK-8346471
                     // see https://github.com/uber/NullAway/wiki/JSpecify-Support
                     option("NullAway:JSpecifyMode", "true")
-                }
-                if (javaLanguageVersion.canCompileOrRun(22)) {
                     option("NullAway:JSpecifyExperimental", "true")
                 }
                 if (!javaLanguageVersion.canCompileOrRun(21)) {

--- a/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
+++ b/implementations/micrometer-registry-cloudwatch2/src/main/java/io/micrometer/cloudwatch2/CloudWatchMeterRegistry.java
@@ -182,20 +182,29 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             return Stream.of(metricDatum);
         }
 
+        private void addMetricDatum(Stream.Builder<MetricDatum> builder, @Nullable MetricDatum datum) {
+            if (datum != null) {
+                builder.add(datum);
+            }
+        }
+
         private Stream<MetricDatum> counterData(Counter counter) {
-            return Stream.of(metricDatum(counter.getId(), "count", StandardUnit.COUNT, counter.count()));
+            MetricDatum metricDatum = metricDatum(counter.getId(), "count", StandardUnit.COUNT, counter.count());
+            return metricDatum != null ? Stream.of(metricDatum) : Stream.empty();
         }
 
         // VisibleForTesting
         Stream<MetricDatum> timerData(Timer timer) {
             Stream.Builder<MetricDatum> metrics = Stream.builder();
-            metrics
-                .add(metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
+            addMetricDatum(metrics,
+                    metricDatum(timer.getId(), "sum", getBaseTimeUnit().name(), timer.totalTime(getBaseTimeUnit())));
             long count = timer.count();
-            metrics.add(metricDatum(timer.getId(), "count", StandardUnit.COUNT, (double) count));
+            addMetricDatum(metrics, metricDatum(timer.getId(), "count", StandardUnit.COUNT, (double) count));
             if (count > 0) {
-                metrics.add(metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
-                metrics.add(metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
+                addMetricDatum(metrics,
+                        metricDatum(timer.getId(), "avg", getBaseTimeUnit().name(), timer.mean(getBaseTimeUnit())));
+                addMetricDatum(metrics,
+                        metricDatum(timer.getId(), "max", getBaseTimeUnit().name(), timer.max(getBaseTimeUnit())));
             }
             return metrics.build();
         }
@@ -203,19 +212,22 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
         // VisibleForTesting
         Stream<MetricDatum> summaryData(DistributionSummary summary) {
             Stream.Builder<MetricDatum> metrics = Stream.builder();
-            metrics.add(metricDatum(summary.getId(), "sum", summary.totalAmount()));
+            addMetricDatum(metrics, metricDatum(summary.getId(), "sum", summary.totalAmount()));
             long count = summary.count();
-            metrics.add(metricDatum(summary.getId(), "count", StandardUnit.COUNT, (double) count));
+            addMetricDatum(metrics, metricDatum(summary.getId(), "count", StandardUnit.COUNT, (double) count));
             if (count > 0) {
-                metrics.add(metricDatum(summary.getId(), "avg", summary.mean()));
-                metrics.add(metricDatum(summary.getId(), "max", summary.max()));
+                addMetricDatum(metrics, metricDatum(summary.getId(), "avg", summary.mean()));
+                addMetricDatum(metrics, metricDatum(summary.getId(), "max", summary.max()));
             }
             return metrics.build();
         }
 
         private Stream<MetricDatum> longTaskTimerData(LongTaskTimer longTaskTimer) {
-            return Stream.of(metricDatum(longTaskTimer.getId(), "activeTasks", longTaskTimer.activeTasks()),
+            Stream.Builder<MetricDatum> metrics = Stream.builder();
+            addMetricDatum(metrics, metricDatum(longTaskTimer.getId(), "activeTasks", longTaskTimer.activeTasks()));
+            addMetricDatum(metrics,
                     metricDatum(longTaskTimer.getId(), "duration", longTaskTimer.duration(getBaseTimeUnit())));
+            return metrics.build();
         }
 
         private Stream<MetricDatum> timeGaugeData(TimeGauge gauge) {
@@ -245,10 +257,10 @@ public class CloudWatchMeterRegistry extends StepMeterRegistry {
             }
             Stream.Builder<MetricDatum> metrics = Stream.builder();
             double count = timer.count();
-            metrics.add(metricDatum(timer.getId(), "count", StandardUnit.COUNT, count));
-            metrics.add(metricDatum(timer.getId(), "sum", sum));
+            addMetricDatum(metrics, metricDatum(timer.getId(), "count", StandardUnit.COUNT, count));
+            addMetricDatum(metrics, metricDatum(timer.getId(), "sum", sum));
             if (count > 0) {
-                metrics.add(metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
+                addMetricDatum(metrics, metricDatum(timer.getId(), "avg", timer.mean(getBaseTimeUnit())));
             }
             return metrics.build();
         }

--- a/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
+++ b/implementations/micrometer-registry-dynatrace/src/test/java/io/micrometer/dynatrace/v2/DynatraceExporterV2Test.java
@@ -406,10 +406,10 @@ class DynatraceExporterV2Test {
             .compile("^.+,.+,min=(?<min>.+),max=(?<max>.+),sum=(?<sum>.+),count=(?<count>.+) \\d+$")
             .matcher(lines.get(0));
         assertThat(matcher.matches()).isTrue();
-        double min = Double.parseDouble(matcher.group("min"));
-        double max = Double.parseDouble(matcher.group("max"));
-        double sum = Double.parseDouble(matcher.group("sum"));
-        int count = Integer.parseInt(matcher.group("count"));
+        double min = Double.parseDouble(Objects.requireNonNull(matcher.group("min")));
+        double max = Double.parseDouble(Objects.requireNonNull(matcher.group("max")));
+        double sum = Double.parseDouble(Objects.requireNonNull(matcher.group("sum")));
+        int count = Integer.parseInt(Objects.requireNonNull(matcher.group("count")));
         double mean = sum / count;
         assertThat(min).isLessThanOrEqualTo(mean);
         assertThat(mean).isLessThanOrEqualTo(max);
@@ -601,7 +601,7 @@ class DynatraceExporterV2Test {
         Counter counter = meterRegistry.counter("my.counter");
         counter.increment(12d);
         meterRegistry.gauge("my.gauge", 42d);
-        Gauge gauge = meterRegistry.find("my.gauge").gauge();
+        Gauge gauge = Objects.requireNonNull(meterRegistry.find("my.gauge").gauge());
         Timer timer = meterRegistry.timer("my.timer");
         timer.record(22, MILLISECONDS);
         clock.add(config.step());

--- a/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
+++ b/implementations/micrometer-registry-elastic/src/main/java/io/micrometer/elastic/ElasticMeterRegistry.java
@@ -200,7 +200,11 @@ public class ElasticMeterRegistry extends StepMeterRegistry {
         if (!matcher.find()) {
             throw new IllegalArgumentException("Unexpected response body: " + responseBody);
         }
-        return Integer.parseInt(matcher.group(1));
+        String version = matcher.group(1);
+        if (version == null) {
+            throw new IllegalArgumentException("Unexpected response body: " + responseBody);
+        }
+        return Integer.parseInt(version);
     }
 
     // VisibleForTesting

--- a/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxApiVersion.java
+++ b/implementations/micrometer-registry-influx/src/main/java/io/micrometer/influx/InfluxApiVersion.java
@@ -53,8 +53,9 @@ public enum InfluxApiVersion {
         @Override
         String writeEndpoint(final InfluxConfig config) throws UnsupportedEncodingException {
             String bucket = URLEncoder.encode(config.bucket(), "UTF-8");
-            String org = URLEncoder.encode(config.org(), "UTF-8");
-            return config.uri() + "/api/v2/write?precision=ms&bucket=" + bucket + "&org=" + org;
+            String org = config.org();
+            String orgParam = org != null ? "&org=" + URLEncoder.encode(org, "UTF-8") : "";
+            return config.uri() + "/api/v2/write?precision=ms&bucket=" + bucket + orgParam;
         }
 
         @Override

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -202,6 +202,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         return Stream.of(event(meter.getId(), attributes.values().toArray(new Attribute[0])));
     }
 
+    // Arrays.copyOf expands the array with null elements that are immediately populated
     @SuppressWarnings("NullAway")
     private String event(Meter.Id id, Attribute... attributes) {
         if (!config.meterNameEventTypeEnabled()) {

--- a/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
+++ b/implementations/micrometer-registry-new-relic/src/main/java/io/micrometer/newrelic/NewRelicInsightsApiClientProvider.java
@@ -202,6 +202,7 @@ public class NewRelicInsightsApiClientProvider implements NewRelicClientProvider
         return Stream.of(event(meter.getId(), attributes.values().toArray(new Attribute[0])));
     }
 
+    @SuppressWarnings("NullAway")
     private String event(Meter.Id id, Attribute... attributes) {
         if (!config.meterNameEventTypeEnabled()) {
             // Include contextual attributes when publishing all metrics under a single

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpHttpMetricsSender.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpHttpMetricsSender.java
@@ -71,7 +71,8 @@ public class OtlpHttpMetricsSender implements OtlpMetricsSender {
 
     private String getUserAgentHeader() {
         String userAgent = "Micrometer-OTLP-Exporter-Java";
-        String version = getClass().getPackage().getImplementationVersion();
+        Package pkg = getClass().getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
         if (version != null) {
             userAgent += "/" + version;
         }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -432,7 +432,8 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         AttributesBuilder builder = Attributes.builder();
         builder.put(TELEMETRY_SDK_NAME, "io.micrometer");
         builder.put(TELEMETRY_SDK_LANGUAGE, "java");
-        String micrometerCoreVersion = MeterRegistry.class.getPackage().getImplementationVersion();
+        Package pkg = MeterRegistry.class.getPackage();
+        String micrometerCoreVersion = pkg != null ? pkg.getImplementationVersion() : null;
         if (micrometerCoreVersion != null) {
             builder.put(TELEMETRY_SDK_VERSION, micrometerCoreVersion);
         }

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMetricConverter.java
@@ -337,7 +337,7 @@ class OtlpMetricConverter {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o)
                 return true;
             if (!(o instanceof MetricMetaData))

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1029,7 +1030,8 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
+        Future<?> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
+        });
 
         TestOtlpMeterRegistry() {
             this(otlpConfig(), OtlpDeltaMeterRegistryTest.this.clock);

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -1029,7 +1029,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        CompletableFuture<Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
+        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
 
         TestOtlpMeterRegistry() {
             this(otlpConfig(), OtlpDeltaMeterRegistryTest.this.clock);

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpDeltaMeterRegistryTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1030,7 +1029,7 @@ class OtlpDeltaMeterRegistryTest extends OtlpMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        Future<?> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
+        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
         });
 
         TestOtlpMeterRegistry() {

--- a/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
+++ b/implementations/micrometer-registry-otlp/src/test/java/io/micrometer/registry/otlp/OtlpMeterRegistryTest.java
@@ -137,7 +137,7 @@ abstract class OtlpMeterRegistryTest {
     @Test
     void setResourceAttributesAsString() throws IOException {
         Properties propertiesConfig = new Properties();
-        propertiesConfig.load(this.getClass().getResourceAsStream("/otlp-config.properties"));
+        propertiesConfig.load(Objects.requireNonNull(this.getClass().getResourceAsStream("/otlp-config.properties")));
         registry = new OtlpMeterRegistry(key -> (String) propertiesConfig.get(key), Clock.SYSTEM);
         assertThat(registry.getResource().getAttributes().get(AttributeKey.stringKey("key1"))).isEqualTo("value1");
         assertThat(registry.getResource().getAttributes().get(AttributeKey.stringKey("key2"))).isEqualTo("value2");

--- a/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -474,7 +474,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
             }
 
-            @Nullable Exemplar lastExemplar = lastExemplarSupplier.get();
+            Exemplar lastExemplar = lastExemplarSupplier.get();
             Collector.Type type = distributionStatisticConfig.isPublishingHistogram() ? Collector.Type.HISTOGRAM
                     : Collector.Type.SUMMARY;
             if (histogramCounts.length > 0) {
@@ -489,7 +489,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     case Prometheus:
                         histogramKeys.add("le");
 
-                        Exemplar @Nullable [] exemplars = histogramExemplarsSupplier.get();
+                        Exemplar[] exemplars = histogramExemplarsSupplier.get();
 
                         // satisfies
                         // https://prometheus.io/docs/concepts/metric_types/#histogram

--- a/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
+++ b/implementations/micrometer-registry-prometheus-simpleclient/src/main/java/io/micrometer/prometheus/PrometheusMeterRegistry.java
@@ -449,8 +449,10 @@ public class PrometheusMeterRegistry extends MeterRegistry {
     }
 
     private void addDistributionStatisticSamples(DistributionStatisticConfig distributionStatisticConfig,
-            MicrometerCollector collector, HistogramSupport histogramSupport, Supplier<Exemplar> lastExemplarSupplier,
-            Supplier<Exemplar[]> histogramExemplarsSupplier, List<String> tagValues, boolean forLongTaskTimer) {
+            MicrometerCollector collector, HistogramSupport histogramSupport,
+            Supplier<@Nullable Exemplar> lastExemplarSupplier,
+            Supplier<Exemplar @Nullable []> histogramExemplarsSupplier, List<String> tagValues,
+            boolean forLongTaskTimer) {
         collector.add(tagValues, (conventionName, tagKeys) -> {
             Stream.Builder<Collector.MetricFamilySamples.Sample> samples = Stream.builder();
 
@@ -472,7 +474,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                 }
             }
 
-            Exemplar lastExemplar = lastExemplarSupplier.get();
+            @Nullable Exemplar lastExemplar = lastExemplarSupplier.get();
             Collector.Type type = distributionStatisticConfig.isPublishingHistogram() ? Collector.Type.HISTOGRAM
                     : Collector.Type.SUMMARY;
             if (histogramCounts.length > 0) {
@@ -487,7 +489,7 @@ public class PrometheusMeterRegistry extends MeterRegistry {
                     case Prometheus:
                         histogramKeys.add("le");
 
-                        Exemplar[] exemplars = histogramExemplarsSupplier.get();
+                        Exemplar @Nullable [] exemplars = histogramExemplarsSupplier.get();
 
                         // satisfies
                         // https://prometheus.io/docs/concepts/metric_types/#histogram

--- a/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
+++ b/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheusmetrics/DefaultExemplarSamplerFactory.java
@@ -19,6 +19,7 @@ import io.prometheus.metrics.config.ExemplarsProperties;
 import io.prometheus.metrics.core.exemplars.ExemplarSampler;
 import io.prometheus.metrics.core.exemplars.ExemplarSamplerConfig;
 import io.prometheus.metrics.tracer.common.SpanContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,7 +73,7 @@ class DefaultExemplarSamplerFactory implements ExemplarSamplerFactory {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -511,13 +511,12 @@ class PrometheusMeterRegistryTest {
     }
 
     private Condition<Iterable<? extends MetricSnapshot>> withNameAndQuantile(String name) {
-        return new Condition<>(
-                metricSnapshots -> ((MetricSnapshots) metricSnapshots).stream()
-                    .filter(snapshot -> snapshot.getMetadata().getPrometheusName().equals(name))
-                    .flatMap(snapshot -> snapshot.getDataPoints().stream())
-                    .filter(SummarySnapshot.SummaryDataPointSnapshot.class::isInstance)
-                    .map(SummarySnapshot.SummaryDataPointSnapshot.class::cast)
-                    .anyMatch(summaryDataPoint -> summaryDataPoint.getQuantiles().size() > 0),
+        return new Condition<>(metricSnapshots -> ((MetricSnapshots) metricSnapshots).stream()
+            .filter(snapshot -> snapshot.getMetadata().getPrometheusName().equals(name))
+            .flatMap(snapshot -> snapshot.getDataPoints().stream())
+            .filter(SummarySnapshot.SummaryDataPointSnapshot.class::isInstance)
+            .map(SummarySnapshot.SummaryDataPointSnapshot.class::cast)
+            .anyMatch(summaryDataPoint -> summaryDataPoint != null && summaryDataPoint.getQuantiles().size() > 0),
                 "a summary with name `%s` and at least one quantile", name);
     }
 
@@ -1200,7 +1199,10 @@ class PrometheusMeterRegistryTest {
             @Override
             public Properties prometheusProperties() {
                 Properties properties = new Properties();
-                properties.putAll(PrometheusConfig.super.prometheusProperties());
+                Properties defaultProperties = PrometheusConfig.super.prometheusProperties();
+                if (defaultProperties != null) {
+                    properties.putAll(defaultProperties);
+                }
                 properties.setProperty("io.prometheus.exporter.includeCreatedTimestamps", "true");
                 return properties;
             }
@@ -1247,7 +1249,10 @@ class PrometheusMeterRegistryTest {
             @Override
             public Properties prometheusProperties() {
                 Properties properties = new Properties();
-                properties.putAll(PrometheusConfig.super.prometheusProperties());
+                Properties defaultProperties = PrometheusConfig.super.prometheusProperties();
+                if (defaultProperties != null) {
+                    properties.putAll(defaultProperties);
+                }
                 properties.setProperty("io.prometheus.exporter.includeCreatedTimestamps", "false");
                 return properties;
             }
@@ -1346,7 +1351,10 @@ class PrometheusMeterRegistryTest {
             @Override
             public Properties prometheusProperties() {
                 Properties mergedProperties = new Properties();
-                mergedProperties.putAll(PrometheusConfig.super.prometheusProperties());
+                Properties defaultProperties = PrometheusConfig.super.prometheusProperties();
+                if (defaultProperties != null) {
+                    mergedProperties.putAll(defaultProperties);
+                }
                 properties.forEach((key, value) -> mergedProperties.setProperty(key.toString(), value.toString()));
                 return mergedProperties;
             }

--- a/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
+++ b/implementations/micrometer-registry-prometheus/src/test/java/io/micrometer/prometheusmetrics/PrometheusMeterRegistryTest.java
@@ -514,6 +514,7 @@ class PrometheusMeterRegistryTest {
         return new Condition<>(metricSnapshots -> ((MetricSnapshots) metricSnapshots).stream()
             .filter(snapshot -> snapshot.getMetadata().getPrometheusName().equals(name))
             .flatMap(snapshot -> snapshot.getDataPoints().stream())
+            .filter(Objects::nonNull)
             .filter(SummarySnapshot.SummaryDataPointSnapshot.class::isInstance)
             .map(SummarySnapshot.SummaryDataPointSnapshot.class::cast)
             .anyMatch(summaryDataPoint -> summaryDataPoint != null && summaryDataPoint.getQuantiles().size() > 0),

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/UserAgentHeaderProvider.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/UserAgentHeaderProvider.java
@@ -54,7 +54,8 @@ class UserAgentHeaderProvider implements HeaderProvider {
 
     private String computeUserAgent(String component) {
         String library = "micrometer-registry-" + component;
-        String version = getClass().getPackage().getImplementationVersion();
+        Package pkg = getClass().getPackage();
+        String version = pkg != null ? pkg.getImplementationVersion() : null;
 
         return "Micrometer/" + version + " " + library + "/" + version;
     }

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
@@ -44,7 +44,8 @@ class StackdriverIntegrationTest {
     static final StackdriverConfig CONFIG = new StackdriverConfig() {
         @Override
         public String projectId() {
-            return System.getenv("GOOGLE_CLOUD_PROJECT_ID");
+            String projectId = System.getenv("GOOGLE_CLOUD_PROJECT_ID");
+            return projectId != null ? projectId : "projectId";
         }
 
         @Override

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,7 +45,8 @@ class StackdriverIntegrationTest {
     static final StackdriverConfig CONFIG = new StackdriverConfig() {
         @Override
         public String projectId() {
-            return Objects.requireNonNull(System.getenv("GOOGLE_CLOUD_PROJECT_ID"), "GOOGLE_CLOUD_PROJECT_ID env var needs to be set!");
+            return Objects.requireNonNull(System.getenv("GOOGLE_CLOUD_PROJECT_ID"),
+                    "GOOGLE_CLOUD_PROJECT_ID env var needs to be set!");
         }
 
         @Override

--- a/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
+++ b/implementations/micrometer-registry-stackdriver/src/test/java/io/micrometer/stackdriver/StackdriverIntegrationTest.java
@@ -44,8 +44,7 @@ class StackdriverIntegrationTest {
     static final StackdriverConfig CONFIG = new StackdriverConfig() {
         @Override
         public String projectId() {
-            String projectId = System.getenv("GOOGLE_CLOUD_PROJECT_ID");
-            return projectId != null ? projectId : "projectId";
+            return Objects.requireNonNull(System.getenv("GOOGLE_CLOUD_PROJECT_ID"), "GOOGLE_CLOUD_PROJECT_ID env var needs to be set!");
         }
 
         @Override

--- a/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
+++ b/implementations/micrometer-registry-statsd/src/main/java/io/micrometer/statsd/StatsdMeterRegistry.java
@@ -100,7 +100,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     private Disposable.Swap meterPoller = Disposables.swap();
 
-    private @Nullable BiFunction<Meter.Id, DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction;
+    private @Nullable BiFunction<Meter.Id, @Nullable DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction;
 
     private @Nullable Consumer<String> lineSink;
 
@@ -124,7 +124,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
     private StatsdMeterRegistry(StatsdConfig config, HierarchicalNameMapper nameMapper,
             NamingConvention namingConvention, Clock clock,
-            @Nullable BiFunction<Meter.Id, DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction,
+            @Nullable BiFunction<Meter.Id, @Nullable DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction,
             @Nullable Consumer<String> lineSink) {
         super(clock);
 
@@ -500,7 +500,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
 
         private HierarchicalNameMapper nameMapper = HierarchicalNameMapper.DEFAULT;
 
-        private @Nullable BiFunction<Meter.Id, DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction = null;
+        private @Nullable BiFunction<Meter.Id, @Nullable DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction = null;
 
         private @Nullable Consumer<String> lineSink;
 
@@ -524,7 +524,7 @@ public class StatsdMeterRegistry extends MeterRegistry {
          * @since 1.8.0
          */
         public Builder lineBuilder(
-                BiFunction<Meter.Id, DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction) {
+                BiFunction<Meter.Id, @Nullable DistributionStatisticConfig, StatsdLineBuilder> lineBuilderFunction) {
             this.lineBuilderFunction = lineBuilderFunction;
             return this;
         }

--- a/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontConfigTest.java
+++ b/implementations/micrometer-registry-wavefront/src/test/java/io/micrometer/wavefront/WavefrontConfigTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +34,7 @@ class WavefrontConfigTest {
     @Test
     void defaultUriImplementationWorksWithProxyUri() throws IOException {
         Properties wavefrontProps = new Properties();
-        wavefrontProps.load(this.getClass().getResourceAsStream("/valid.properties"));
+        wavefrontProps.load(Objects.requireNonNull(this.getClass().getResourceAsStream("/valid.properties")));
         WavefrontConfig config = wavefrontProps::getProperty;
         assertThatCode(config::uri).doesNotThrowAnyException();
     }
@@ -41,7 +42,7 @@ class WavefrontConfigTest {
     @Test
     void defaultUriImplementationThrowsForInvalidUri() throws IOException {
         Properties wavefrontProps = new Properties();
-        wavefrontProps.load(this.getClass().getResourceAsStream("/invalid.properties"));
+        wavefrontProps.load(Objects.requireNonNull(this.getClass().getResourceAsStream("/invalid.properties")));
         WavefrontConfig config = wavefrontProps::getProperty;
         assertThatCode(config::uri).isExactlyInstanceOf(ValidationException.class)
             .hasMessageContaining("it must be a valid URI");

--- a/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/annotation/AnnotationHandler.java
@@ -57,7 +57,7 @@ public class AnnotationHandler<T> {
 
     private final Class<? extends Annotation> annotationClass;
 
-    private final BiFunction<Annotation, Object, KeyValue> toKeyValue;
+    private final BiFunction<Annotation, @Nullable Object, @Nullable KeyValue> toKeyValue;
 
     /**
      * Creates a new instance of {@link AnnotationHandler}.
@@ -74,7 +74,8 @@ public class AnnotationHandler<T> {
     public AnnotationHandler(BiConsumer<KeyValue, T> keyValueConsumer,
             Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider,
             Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider,
-            Class<? extends Annotation> annotation, BiFunction<Annotation, Object, KeyValue> toKeyValue) {
+            Class<? extends Annotation> annotation,
+            BiFunction<Annotation, @Nullable Object, @Nullable KeyValue> toKeyValue) {
         this.keyValueConsumer = keyValueConsumer;
         this.resolverProvider = resolverProvider;
         this.expressionResolverProvider = expressionResolverProvider;
@@ -180,7 +181,7 @@ public class AnnotationHandler<T> {
         Set<String> seen = new HashSet<>();
         for (AnnotatedObject container : toBeAdded) {
             KeyValue keyValue = toKeyValue.apply(container.annotation, container.object);
-            if (seen.add(keyValue.getKey())) {
+            if (keyValue != null && seen.add(keyValue.getKey())) {
                 keyValueConsumer.accept(keyValue, objectToModify);
             }
         }

--- a/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/JdkLogger.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/JdkLogger.java
@@ -74,7 +74,7 @@ class JdkLogger extends AbstractInternalLogger {
     final transient Logger logger;
 
     JdkLogger(Logger logger) {
-        super(logger.getName() != null ? logger.getName() : "");
+        super(logger.getName() != null ? logger.getName() : "unnamed");
         this.logger = logger;
     }
 

--- a/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/JdkLogger.java
+++ b/micrometer-commons/src/main/java/io/micrometer/common/util/internal/logging/JdkLogger.java
@@ -74,7 +74,7 @@ class JdkLogger extends AbstractInternalLogger {
     final transient Logger logger;
 
     JdkLogger(Logger logger) {
-        super(logger.getName());
+        super(logger.getName() != null ? logger.getName() : "");
         this.logger = logger;
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/CountedAspect.java
@@ -198,6 +198,9 @@ public class CountedAspect {
             declaringClass = pjp.getTarget().getClass();
         }
         Counted counted = declaringClass.getAnnotation(Counted.class);
+        if (counted == null) {
+            return pjp.proceed();
+        }
 
         return perform(pjp, counted);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -194,6 +194,9 @@ public class TimedAspect {
             declaringClass = pjp.getTarget().getClass();
         }
         Timed timed = declaringClass.getAnnotation(Timed.class);
+        if (timed == null) {
+            return pjp.proceed();
+        }
 
         return perform(pjp, timed, method);
     }
@@ -209,6 +212,9 @@ public class TimedAspect {
         if (timed == null) {
             method = pjp.getTarget().getClass().getMethod(method.getName(), method.getParameterTypes());
             timed = method.getAnnotation(Timed.class);
+        }
+        if (timed == null) {
+            return pjp.proceed();
         }
 
         return perform(pjp, timed, method);

--- a/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/aop/TimedAspect.java
@@ -212,9 +212,9 @@ public class TimedAspect {
         if (timed == null) {
             method = pjp.getTarget().getClass().getMethod(method.getName(), method.getParameterTypes());
             timed = method.getAnnotation(Timed.class);
-        }
-        if (timed == null) {
-            return pjp.proceed();
+            if (timed == null) {
+                return pjp.proceed();
+            }
         }
 
         return perform(pjp, timed, method);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -147,15 +147,12 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
                         e);
                 return;
             }
-        }
-        pauseDetector = pauseDetectorCache.computeIfAbsent(pauseDetectorType, detector -> {
-            if (detector instanceof ClockDriftPauseDetector) {
+            pauseDetector = pauseDetectorCache.computeIfAbsent(pauseDetectorType, detector -> {
                 ClockDriftPauseDetector clockDriftPauseDetector = (ClockDriftPauseDetector) detector;
                 return new SimplePauseDetector(clockDriftPauseDetector.getSleepInterval().toNanos(),
                         clockDriftPauseDetector.getPauseThreshold().toNanos(), 1, false);
-            }
-            return null;
-        });
+            });
+        }
 
         if (pauseDetector instanceof SimplePauseDetector) {
             org.LatencyUtils.PauseDetector pauseDetector = (org.LatencyUtils.PauseDetector) this.pauseDetector;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;
@@ -357,10 +358,10 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
          * @return This builder.
          * @since 1.5.0
          */
-        public Builder serviceLevelObjectives(@Nullable Duration... slos) {
+        public Builder serviceLevelObjectives(Duration @Nullable ... slos) {
             if (slos != null) {
-                this.distributionConfigBuilder
-                    .serviceLevelObjectives(Arrays.stream(slos).mapToDouble(Duration::toNanos).toArray());
+                this.distributionConfigBuilder.serviceLevelObjectives(
+                        Arrays.stream(slos).filter(Objects::nonNull).mapToDouble(Duration::toNanos).toArray());
             }
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/LongTaskTimer.java
@@ -22,7 +22,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.*;
@@ -360,8 +359,8 @@ public interface LongTaskTimer extends Meter, HistogramSupport {
          */
         public Builder serviceLevelObjectives(Duration @Nullable ... slos) {
             if (slos != null) {
-                this.distributionConfigBuilder.serviceLevelObjectives(
-                        Arrays.stream(slos).filter(Objects::nonNull).mapToDouble(Duration::toNanos).toArray());
+                this.distributionConfigBuilder
+                    .serviceLevelObjectives(Arrays.stream(slos).mapToDouble(Duration::toNanos).toArray());
             }
             return this;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/MeterRegistry.java
@@ -92,7 +92,7 @@ public abstract class MeterRegistry {
 
     private final List<Consumer<Meter>> meterRemovedListeners = new CopyOnWriteArrayList<>();
 
-    private final List<BiConsumer<Meter.Id, String>> meterRegistrationFailedListeners = new CopyOnWriteArrayList<>();
+    private final List<BiConsumer<Meter.Id, @Nullable String>> meterRegistrationFailedListeners = new CopyOnWriteArrayList<>();
 
     private final Config config = new Config();
 
@@ -866,7 +866,7 @@ public abstract class MeterRegistry {
      */
     @Incubating(since = "1.2.0")
     public void clear() {
-        meterMap.keySet().forEach(this::remove);
+        meterMap.keySet().forEach(id -> remove(id));
     }
 
     /**
@@ -961,7 +961,8 @@ public abstract class MeterRegistry {
          * @since 1.6.0
          */
         @Incubating(since = "1.6.0")
-        public Config onMeterRegistrationFailed(BiConsumer<Meter.Id, String> meterRegistrationFailedListener) {
+        public Config onMeterRegistrationFailed(
+                BiConsumer<Meter.Id, @Nullable String> meterRegistrationFailedListener) {
             meterRegistrationFailedListeners.add(meterRegistrationFailedListener);
             return this;
         }
@@ -1310,7 +1311,7 @@ public abstract class MeterRegistry {
      * @since 1.6.0
      */
     protected void meterRegistrationFailed(Meter.Id id, @Nullable String reason) {
-        for (BiConsumer<Meter.Id, String> listener : meterRegistrationFailedListeners) {
+        for (BiConsumer<Meter.Id, @Nullable String> listener : meterRegistrationFailedListeners) {
             listener.accept(id, reason);
         }
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -175,6 +175,7 @@ public class CommonsObjectPool2Metrics implements MeterBinder, AutoCloseable {
      * @param type The pool type to listen for.
      * @param perObject Metric registration handler when a new MBean is created.
      */
+    // Passing null handback to MBeanServer.addNotificationListener
     @SuppressWarnings("NullAway")
     private void registerNotificationListener(String type, BiConsumer<ObjectName, Tags> perObject) {
         NotificationListener notificationListener =

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/commonspool2/CommonsObjectPool2Metrics.java
@@ -175,6 +175,7 @@ public class CommonsObjectPool2Metrics implements MeterBinder, AutoCloseable {
      * @param type The pool type to listen for.
      * @param perObject Metric registration handler when a new MBean is created.
      */
+    @SuppressWarnings("NullAway")
     private void registerNotificationListener(String type, BiConsumer<ObjectName, Tags> perObject) {
         NotificationListener notificationListener =
                 // in notification listener, we cannot get attributes for the registered

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -85,6 +85,7 @@ public class MetricsDSLContext extends DefaultDSLContext {
         return derive(c, () -> new JooqExecuteListener(registry, tags, () -> queryTags));
     }
 
+    @SuppressWarnings("NullAway")
     private static Configuration derive(Configuration configuration, ExecuteListenerProvider executeListenerProvider) {
         ExecuteListenerProvider[] providers = configuration.executeListenerProviders();
         for (int i = 0; i < providers.length; i++) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/MetricsDSLContext.java
@@ -85,6 +85,7 @@ public class MetricsDSLContext extends DefaultDSLContext {
         return derive(c, () -> new JooqExecuteListener(registry, tags, () -> queryTags));
     }
 
+    // Arrays.copyOf expands the array with null elements that are immediately populated
     @SuppressWarnings("NullAway")
     private static Configuration derive(Configuration configuration, ExecuteListenerProvider executeListenerProvider) {
         ExecuteListenerProvider[] providers = configuration.executeListenerProviders();

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/db/PostgreSQLDatabaseMetrics.java
@@ -21,6 +21,7 @@ import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.*;
 import io.micrometer.core.instrument.binder.BaseUnits;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import org.jspecify.annotations.Nullable;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -355,7 +356,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
                 Statement statement = connection.createStatement();
                 ResultSet resultSet = statement.executeQuery(query)) {
             if (resultSet.next()) {
-                return Optional.of(resultSetGetter.get(resultSet));
+                return Optional.ofNullable(resultSetGetter.get(resultSet));
             }
         }
         catch (SQLException ignored) {
@@ -414,7 +415,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
     @FunctionalInterface
     interface ResultSetGetter<T> {
 
-        T get(ResultSet resultSet) throws SQLException;
+        @Nullable T get(ResultSet resultSet) throws SQLException;
 
     }
 
@@ -438,7 +439,11 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
                             VERSION_PATTERN.pattern());
                     return EMPTY;
                 }
-                final String[] versionArr = matcher.group(1).split("\\.", 3);
+                String group1 = matcher.group(1);
+                if (group1 == null) {
+                    return EMPTY;
+                }
+                final String[] versionArr = group1.split("\\.", 3);
                 if (versionArr.length == 1) {
                     return new Version(Integer.parseInt(versionArr[0]));
                 }
@@ -475,7 +480,7 @@ public class PostgreSQLDatabaseMetrics implements MeterBinder {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (!(o instanceof Version))
                 return false;
             Version version = (Version) o;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandler.java
@@ -142,11 +142,11 @@ public class ObservationExecChainHandler implements ExecChainHandler, AsyncExecC
 
         private final Observation observation;
 
-        private final AtomicMarkableReference<Cancellable> dependencyRef;
+        private final AtomicMarkableReference<@Nullable Cancellable> dependencyRef;
 
         ObservableCancellableDependency(Observation observation) {
             this.observation = observation;
-            this.dependencyRef = new AtomicMarkableReference<>(null, false);
+            this.dependencyRef = new AtomicMarkableReference<@Nullable Cancellable>(null, false);
         }
 
         @Override

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetrics.java
@@ -70,7 +70,7 @@ public class JettyClientMetrics implements Request.Listener {
     protected JettyClientMetrics(MeterRegistry registry, JettyClientTagsProvider tagsProvider, String timingMetricName,
             String contentSizeMetricName, int maxUriTags) {
         this(registry, ObservationRegistry.NOOP, null, tagsProvider, timingMetricName, contentSizeMetricName,
-                maxUriTags, (request, result) -> tagsProvider.uriPattern(result));
+                maxUriTags, (request, result) -> result != null ? tagsProvider.uriPattern(result) : "UNKNOWN");
     }
 
     private JettyClientMetrics(MeterRegistry registry, ObservationRegistry observationRegistry,
@@ -131,7 +131,7 @@ public class JettyClientMetrics implements Request.Listener {
      */
     @Deprecated
     public static Builder builder(MeterRegistry registry, JettyClientTagsProvider tagsProvider) {
-        return new Builder(registry, (request, result) -> tagsProvider.uriPattern(result));
+        return new Builder(registry, (request, result) -> result != null ? tagsProvider.uriPattern(result) : "UNKNOWN");
     }
 
     /**

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jetty/JettyServerThreadPoolMetrics.java
@@ -120,7 +120,7 @@ public class JettyServerThreadPoolMetrics implements MeterBinder, AutoCloseable 
     @Override
     public void close() throws Exception {
         if (registry != null) {
-            registeredMeterIds.forEach(registry::remove);
+            registeredMeterIds.forEach(id -> registry.remove(id));
             registeredMeterIds.clear();
         }
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/ExecutorServiceMetrics.java
@@ -355,7 +355,11 @@ public class ExecutorServiceMetrics implements MeterBinder {
      * {@link Executors#newSingleThreadExecutor()} wrap a regular
      * {@link ThreadPoolExecutor}.
      */
-    private @Nullable ThreadPoolExecutor unwrapThreadPoolExecutor(ExecutorService executor, Class<?> wrapper) {
+    private @Nullable ThreadPoolExecutor unwrapThreadPoolExecutor(ExecutorService executor,
+            @Nullable Class<?> wrapper) {
+        if (wrapper == null) {
+            return null;
+        }
         try {
             Field e = wrapper.getDeclaredField("e");
             e.setAccessible(true);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmGcMetrics.java
@@ -170,11 +170,16 @@ public class JvmGcMetrics implements MeterBinder, AutoCloseable {
         MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
         try {
             Method m = MemoryMXBean.class.getMethod("getTotalGcCpuTime");
-            if ((Long) m.invoke(memoryMXBean) >= 0) {
+            Object initialValue = m.invoke(memoryMXBean);
+            if (initialValue instanceof Long && (Long) initialValue >= 0) {
                 FunctionCounter.builder("jvm.gc.cpu.time", memoryMXBean, bean -> {
                     try {
-                        long nanos = (Long) m.invoke(bean);
-                        return nanos >= 0 ? (double) nanos : 0;
+                        Object val = m.invoke(bean);
+                        if (val instanceof Long) {
+                            long nanos = (Long) val;
+                            return nanos >= 0 ? (double) nanos : 0;
+                        }
+                        return 0;
                     }
                     catch (Exception e) {
                         return 0;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmInfoMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmInfoMetrics.java
@@ -31,11 +31,16 @@ public class JvmInfoMetrics implements MeterBinder {
     public void bindTo(MeterRegistry registry) {
         Gauge.builder("jvm.info", () -> 1L)
             .description("JVM version info")
-            .tags("version", System.getProperty("java.runtime.version", "unknown"), "vendor",
-                    System.getProperty("java.vm.vendor", "unknown"), "runtime",
-                    System.getProperty("java.runtime.name", "unknown"))
+            .tags("version", getSystemProperty("java.runtime.version", "unknown"), "vendor",
+                    getSystemProperty("java.vm.vendor", "unknown"), "runtime",
+                    getSystemProperty("java.runtime.name", "unknown"))
             .strongReference(true)
             .register(registry);
+    }
+
+    private static String getSystemProperty(String key, String defaultValue) {
+        String value = System.getProperty(key, defaultValue);
+        return value != null ? value : defaultValue;
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -389,6 +389,7 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
         };
     }
 
+    // Passing null handback to MBeanServer.addNotificationListener
     @SuppressWarnings("NullAway")
     private void addNotificationListener(NotificationListener listener, NotificationFilter filter) {
         try {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/kafka/KafkaConsumerMetrics.java
@@ -369,7 +369,7 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
                 MBeanServerNotification mbs2 = (MBeanServerNotification) notification2;
                 ObjectName o2 = mbs2.getMBeanName();
                 if (o2.equals(o)) {
-                    meters.stream().forEach(registry::remove);
+                    meters.forEach(m -> registry.remove(m));
                 }
                 removeNotificationListener(this);
             }
@@ -389,6 +389,7 @@ public class KafkaConsumerMetrics implements MeterBinder, AutoCloseable {
         };
     }
 
+    @SuppressWarnings("NullAway")
     private void addNotificationListener(NotificationListener listener, NotificationFilter filter) {
         try {
             mBeanServer.addNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetrics.java
@@ -102,7 +102,13 @@ public class FileDescriptorMetrics implements MeterBinder {
 
     private double invoke(@Nullable Method method) {
         try {
-            return method != null ? (double) (long) method.invoke(osBean) : Double.NaN;
+            if (method != null) {
+                Object result = method.invoke(osBean);
+                if (result instanceof Number) {
+                    return ((Number) result).doubleValue();
+                }
+            }
+            return Double.NaN;
         }
         catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
             return Double.NaN;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -261,6 +261,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
      * register an MBean registration listener with the MBeanServer and register metrics
      * when/if the MBeans becomes available.
      */
+    // Passing null filter/handback to MBeanServer.addNotificationListener
     @SuppressWarnings("NullAway")
     private void registerMetricsEventually(String namePatternSuffix, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
         if (getJmxDomain() != null) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetrics.java
@@ -261,6 +261,7 @@ public class TomcatMetrics implements MeterBinder, AutoCloseable {
      * register an MBean registration listener with the MBeanServer and register metrics
      * when/if the MBeans becomes available.
      */
+    @SuppressWarnings("NullAway")
     private void registerMetricsEventually(String namePatternSuffix, BiConsumer<ObjectName, Iterable<Tag>> perObject) {
         if (getJmxDomain() != null) {
             Set<ObjectName> objectNames = this.mBeanServer.queryNames(getNamePattern(namePatternSuffix), null);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/CountAtBucket.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/CountAtBucket.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.util.TimeUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -75,7 +76,7 @@ public final class CountAtBucket {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o)
             return true;
         if (o == null || getClass() != o.getClass())

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/DistributionStatisticConfig.java
@@ -103,8 +103,12 @@ public class DistributionStatisticConfig implements Mergeable<DistributionStatis
 
         if (percentileHistogram != null && percentileHistogram && supportsAggregablePercentiles) {
             buckets.addAll(PercentileHistogramBuckets.buckets(this));
-            buckets.add(minimumExpectedValue);
-            buckets.add(maximumExpectedValue);
+            if (minimumExpectedValue != null) {
+                buckets.add(minimumExpectedValue);
+            }
+            if (maximumExpectedValue != null) {
+                buckets.add(maximumExpectedValue);
+            }
         }
 
         if (serviceLevelObjectives != null) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryVictoriaMetricsHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/FixedBoundaryVictoriaMetricsHistogram.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.core.instrument.distribution;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.PrintStream;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -22,6 +24,7 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -99,7 +102,7 @@ public class FixedBoundaryVictoriaMetricsHistogram implements Histogram {
         }
     }
 
-    final AtomicReferenceArray<AtomicLongArray> values;
+    final AtomicReferenceArray<@Nullable AtomicLongArray> values;
 
     final AtomicLong zeros;
 
@@ -141,8 +144,9 @@ public class FixedBoundaryVictoriaMetricsHistogram implements Histogram {
         AtomicLongArray hb = values.get(inxs.bucketIdx);
         if (hb == null) {
             hb = new AtomicLongArray(BUCKET_SIZE);
-            if (!values.compareAndSet(inxs.bucketIdx, null, hb))
-                hb = values.get(inxs.bucketIdx);
+            if (!values.compareAndSet(inxs.bucketIdx, null, hb)) {
+                hb = Objects.requireNonNull(values.get(inxs.bucketIdx));
+            }
         }
 
         hb.incrementAndGet(inxs.offset);

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/PercentileHistogramBuckets.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/PercentileHistogramBuckets.java
@@ -78,8 +78,10 @@ public class PercentileHistogramBuckets {
      * @return The set of histogram buckets for use in computing aggregable percentiles.
      */
     public static NavigableSet<Double> buckets(DistributionStatisticConfig distributionStatisticConfig) {
-        return PERCENTILE_BUCKETS.subSet(distributionStatisticConfig.getMinimumExpectedValueAsDouble(), true,
-                distributionStatisticConfig.getMaximumExpectedValueAsDouble(), true);
+        Double min = distributionStatisticConfig.getMinimumExpectedValueAsDouble();
+        Double max = distributionStatisticConfig.getMaximumExpectedValueAsDouble();
+        return PERCENTILE_BUCKETS.subSet(min == null ? 1.0 : min, true, max == null ? Double.POSITIVE_INFINITY : max,
+                true);
     }
 
 }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/ValueAtPercentile.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/ValueAtPercentile.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.distribution;
 
 import io.micrometer.core.instrument.util.TimeUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 
@@ -53,7 +54,7 @@ public final class ValueAtPercentile {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o)
             return true;
         if (o == null || getClass() != o.getClass())

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedCallable.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedCallable.java
@@ -17,13 +17,14 @@ package io.micrometer.core.instrument.internal;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.Callable;
 
 /**
  * A wrapper for a {@link Callable} with idle and execution timings.
  */
-class TimedCallable<V> implements Callable<V> {
+class TimedCallable<V extends @Nullable Object> implements Callable<V> {
 
     private final MeterRegistry registry;
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedExecutorService.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.internal;
 
 import io.micrometer.core.instrument.*;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -91,12 +92,12 @@ public class TimedExecutorService implements ExecutorService {
     }
 
     @Override
-    public <T> Future<T> submit(Callable<T> task) {
+    public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
         return delegate.submit(wrap(task));
     }
 
     @Override
-    public <T> Future<T> submit(Runnable task, T result) {
+    public <T extends @Nullable Object> Future<T> submit(Runnable task, T result) {
         return delegate.submit(wrap(task), result);
     }
 
@@ -106,24 +107,26 @@ public class TimedExecutorService implements ExecutorService {
     }
 
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    public <T extends @Nullable Object> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException {
         return delegate.invokeAll(wrapAll(tasks));
     }
 
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException {
+    public <T extends @Nullable Object> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit) throws InterruptedException {
         return delegate.invokeAll(wrapAll(tasks), timeout, unit);
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    public <T extends @Nullable Object> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
         return delegate.invokeAny(wrapAll(tasks));
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public <T extends @Nullable Object> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         return delegate.invokeAny(wrapAll(tasks), timeout, unit);
     }
 
@@ -136,11 +139,12 @@ public class TimedExecutorService implements ExecutorService {
         return new TimedRunnable(registry, executionTimer, idleTimer, task);
     }
 
-    private <T> Callable<T> wrap(Callable<T> task) {
+    private <T extends @Nullable Object> Callable<T> wrap(Callable<T> task) {
         return new TimedCallable<>(registry, executionTimer, idleTimer, task);
     }
 
-    private <T> Collection<? extends Callable<T>> wrapAll(Collection<? extends Callable<T>> tasks) {
+    private <T extends @Nullable Object> Collection<? extends Callable<T>> wrapAll(
+            Collection<? extends Callable<T>> tasks) {
         return tasks.stream().map(this::wrap).collect(toList());
     }
 

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/internal/TimedScheduledExecutorService.java
@@ -16,6 +16,7 @@
 package io.micrometer.core.instrument.internal;
 
 import io.micrometer.core.instrument.*;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -97,12 +98,12 @@ public class TimedScheduledExecutorService implements ScheduledExecutorService {
     }
 
     @Override
-    public <T> Future<T> submit(Callable<T> task) {
+    public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
         return delegate.submit(wrap(task));
     }
 
     @Override
-    public <T> Future<T> submit(Runnable task, T result) {
+    public <T extends @Nullable Object> Future<T> submit(Runnable task, T result) {
         return delegate.submit(wrap(task), result);
     }
 
@@ -112,24 +113,26 @@ public class TimedScheduledExecutorService implements ScheduledExecutorService {
     }
 
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+    public <T extends @Nullable Object> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException {
         return delegate.invokeAll(wrapAll(tasks));
     }
 
     @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException {
+    public <T extends @Nullable Object> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit) throws InterruptedException {
         return delegate.invokeAll(wrapAll(tasks), timeout, unit);
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+    public <T extends @Nullable Object> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
         return delegate.invokeAny(wrapAll(tasks));
     }
 
     @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
+    public <T extends @Nullable Object> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
+            TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
         return delegate.invokeAny(wrapAll(tasks), timeout, unit);
     }
 
@@ -145,7 +148,7 @@ public class TimedScheduledExecutorService implements ScheduledExecutorService {
     }
 
     @Override
-    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    public <V extends @Nullable Object> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
         scheduledOnce.increment();
         return delegate.schedule(executionTimer.wrap(callable), delay, unit);
     }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/ObservationOrTimerCompatibleInstrumentation.java
@@ -109,7 +109,7 @@ public class ObservationOrTimerCompatibleInstrumentation<T extends Observation.C
      * @param response response for the RequestReplySenderContext
      * @param <RES> type of the response
      */
-    public <RES> void setResponse(RES response) {
+    public <RES extends @Nullable Object> void setResponse(@Nullable RES response) {
         if (observationRegistry.isNoop() || !(context instanceof ResponseContext)) {
             return;
         }

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/step/StepMeterRegistry.java
@@ -175,10 +175,11 @@ public abstract class StepMeterRegistry extends PushMeterRegistry {
      * Performs closing rollover on StepMeters.
      */
     private void closingRolloverStepMeters() {
-        getMeters().stream()
-            .filter(StepMeter.class::isInstance)
-            .map(StepMeter.class::cast)
-            .forEach(StepMeter::_closingRollover);
+        for (Meter meter : getMeters()) {
+            if (meter instanceof StepMeter) {
+                ((StepMeter) meter)._closingRollover();
+            }
+        }
     }
 
     /**

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
@@ -68,7 +68,9 @@ class AbstractTimerTests {
         Field loggerField = clazz.getDeclaredField("logger");
         loggerField.setAccessible(true);
         Logger logbackLogger = (Logger) loggerField.get(internalLogger);
-        logbackLogger.setLevel(Level.DEBUG);
+        if (logbackLogger != null) {
+            logbackLogger.setLevel(Level.DEBUG);
+        }
     }
 
     static class MyTimer extends AbstractTimer {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/AbstractTimerTests.java
@@ -21,6 +21,7 @@ import io.micrometer.common.util.internal.logging.InternalLogger;
 import io.micrometer.common.util.internal.logging.InternalLoggerFactory;
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
 import io.micrometer.core.instrument.distribution.pause.NoPauseDetector;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
 import io.micrometer.core.testsupport.system.CapturedOutput;
 import io.micrometer.core.testsupport.system.OutputCaptureExtension;
 import org.junit.jupiter.api.Test;
@@ -73,11 +74,46 @@ class AbstractTimerTests {
         }
     }
 
+    @Test
+    void customPauseDetectorShouldNotThrowClassCastException() {
+        AbstractTimer timer = new MyTimerWithCustomPauseDetector();
+        assertThat(timer).isNotNull();
+    }
+
     static class MyTimer extends AbstractTimer {
 
         MyTimer() {
             super(new Meter.Id("name", Tags.empty(), null, null, Meter.Type.TIMER), Clock.SYSTEM,
                     DistributionStatisticConfig.DEFAULT, NoPauseDetector.INSTANCE, TimeUnit.SECONDS, false);
+        }
+
+        @Override
+        protected void recordNonNegative(long amount, TimeUnit unit) {
+        }
+
+        @Override
+        public long count() {
+            return 0;
+        }
+
+        @Override
+        public double totalTime(TimeUnit unit) {
+            return 0;
+        }
+
+        @Override
+        public double max(TimeUnit unit) {
+            return 0;
+        }
+
+    }
+
+    static class MyTimerWithCustomPauseDetector extends AbstractTimer {
+
+        MyTimerWithCustomPauseDetector() {
+            super(new Meter.Id("name", Tags.empty(), null, null, Meter.Type.TIMER), Clock.SYSTEM,
+                    DistributionStatisticConfig.DEFAULT, new PauseDetector() {
+                    }, TimeUnit.SECONDS, false);
         }
 
         @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/ObservationExecChainHandlerIntegrationTest.java
@@ -50,6 +50,7 @@ import ru.lanwen.wiremock.ext.WiremockResolver;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -480,7 +481,7 @@ class ObservationExecChainHandlerIntegrationTest {
                             .withValue("GET"))
                 .hasLowCardinalityKeyValue(
                         OpenTelemetryApacheHttpClientObservationDocumentation.LowCardinalityKeyNames.SERVER_ADDRESS
-                            .withValue(java.net.URI.create(server.baseUrl()).getHost()))
+                            .withValue(Objects.requireNonNull(java.net.URI.create(server.baseUrl()).getHost())))
                 .hasLowCardinalityKeyValue(
                         OpenTelemetryApacheHttpClientObservationDocumentation.LowCardinalityKeyNames.SERVER_PORT
                             .withValue(String.valueOf(server.port())))

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherThreadPoolTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/hystrix/MicrometerMetricsPublisherThreadPoolTest.java
@@ -22,6 +22,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -127,7 +128,7 @@ class MicrometerMetricsPublisherThreadPoolTest {
         }
 
         @Override
-        public boolean equals(final Object o) {
+        public boolean equals(final @Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
@@ -21,6 +21,7 @@ import io.micrometer.core.instrument.simple.SimpleConfig;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.api.Result;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
@@ -73,10 +74,7 @@ class JettyClientMetricsTest {
         httpClient.setFollowRedirects(false);
         // noinspection deprecation
         httpClient.getRequestListeners()
-            .add(JettyClientMetrics.builder(registry,
-                    result -> (result.getRequest() != null && result.getRequest().getURI().getPath() != null)
-                            ? result.getRequest().getURI().getPath() : "UNKNOWN")
-                .build());
+            .add(JettyClientMetrics.builder(registry, JettyClientMetricsTest::getUriPath).build());
 
         httpClient.addLifeCycleListener(new LifeCycle.Listener() {
             @Override
@@ -196,6 +194,11 @@ class JettyClientMetricsTest {
             .tag("host", "localhost")
             .timer()
             .count()).isEqualTo(1);
+    }
+
+    private static String getUriPath(Result result) {
+        return (result.getRequest() != null && result.getRequest().getURI().getPath() != null)
+                ? result.getRequest().getURI().getPath() : "UNKNOWN";
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsTest.java
@@ -73,7 +73,10 @@ class JettyClientMetricsTest {
         httpClient.setFollowRedirects(false);
         // noinspection deprecation
         httpClient.getRequestListeners()
-            .add(JettyClientMetrics.builder(registry, result -> result.getRequest().getURI().getPath()).build());
+            .add(JettyClientMetrics.builder(registry,
+                    result -> (result.getRequest() != null && result.getRequest().getURI().getPath() != null)
+                            ? result.getRequest().getURI().getPath() : "UNKNOWN")
+                .build());
 
         httpClient.addLifeCycleListener(new LifeCycle.Listener() {
             @Override

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
@@ -36,7 +36,10 @@ class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
         this.httpClient.getRequestListeners().removeIf(listener -> true);
         // noinspection deprecation
         this.httpClient.getRequestListeners()
-            .add(JettyClientMetrics.builder(registry, (request, result) -> request.getURI().getPath())
+            .add(JettyClientMetrics
+                .builder(registry,
+                        (request, result) -> (request != null && request.getURI().getPath() != null)
+                                ? request.getURI().getPath() : "UNKNOWN")
                 .observationRegistry(observationRegistry)
                 .build());
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
@@ -18,6 +18,7 @@ package io.micrometer.core.instrument.binder.jetty;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
+import org.eclipse.jetty.client.api.Request;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,12 +37,13 @@ class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
         this.httpClient.getRequestListeners().removeIf(listener -> true);
         // noinspection deprecation
         this.httpClient.getRequestListeners()
-            .add(JettyClientMetrics
-                .builder(registry,
-                        (request, result) -> (request != null && request.getURI().getPath() != null)
-                                ? request.getURI().getPath() : "UNKNOWN")
+            .add(JettyClientMetrics.builder(registry, (request, result) -> getUriPath(request))
                 .observationRegistry(observationRegistry)
                 .build());
+    }
+
+    private static String getUriPath(Request request) {
+        return (request != null && request.getURI().getPath() != null) ? request.getURI().getPath() : "UNKNOWN";
     }
 
     @Test

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/kafka/KafkaMetricsTest.java
@@ -542,7 +542,7 @@ class KafkaMetricsTest {
         assertThat(registry.getMeters()).hasSize(1);
 
         kafkaMetricMap.clear();
-        registry.forEachMeter(registry::remove);
+        registry.forEachMeter(m -> registry.remove(m));
         kafkaMetrics.checkAndBindMetrics(registry);
         assertThat(registry.getMeters()).hasSize(0);
     }

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/DiskSpaceMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/DiskSpaceMetricsTest.java
@@ -38,7 +38,8 @@ class DiskSpaceMetricsTest {
     @Test
     void diskSpaceMetrics() {
         // tag::example[]
-        new DiskSpaceMetrics(new File(System.getProperty("user.dir"))).bindTo(registry);
+        String userDir = System.getProperty("user.dir");
+        new DiskSpaceMetrics(new File(userDir != null ? userDir : ".")).bindTo(registry);
 
         assertThat(registry.get("disk.free").gauge().value()).isNotNaN().isGreaterThan(0);
         assertThat(registry.get("disk.total").gauge().value()).isNotNaN().isGreaterThan(0);
@@ -47,7 +48,8 @@ class DiskSpaceMetricsTest {
 
     @Test
     void diskSpaceMetricsWithTags() {
-        new DiskSpaceMetrics(new File(System.getProperty("user.dir")), Tags.of("key1", "value1")).bindTo(registry);
+        String userDir = System.getProperty("user.dir");
+        new DiskSpaceMetrics(new File(userDir != null ? userDir : "."), Tags.of("key1", "value1")).bindTo(registry);
 
         assertThat(registry.get("disk.free").tags("key1", "value1").gauge().value()).isNotNaN().isGreaterThan(0);
         assertThat(registry.get("disk.total").tags("key1", "value1").gauge().value()).isNotNaN().isGreaterThan(0);
@@ -55,7 +57,8 @@ class DiskSpaceMetricsTest {
 
     @Test
     void garbageCollectionDoesNotLoseGaugeValue() {
-        new DiskSpaceMetrics(new File(System.getProperty("user.dir"))).bindTo(registry);
+        String userDir = System.getProperty("user.dir");
+        new DiskSpaceMetrics(new File(userDir != null ? userDir : ".")).bindTo(registry);
 
         System.gc();
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -19,13 +19,13 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.lang.management.OperatingSystemMXBean;
-import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -47,10 +47,8 @@ class FileDescriptorMetricsTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void unixFileDescriptorMetrics() {
-        String osName = System.getProperty("os.name");
-        assumeFalse(osName != null && osName.toLowerCase(Locale.ROOT).contains("win"));
-
         // tag::example[]
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 
@@ -60,10 +58,8 @@ class FileDescriptorMetricsTest {
     }
 
     @Test
+    @EnabledOnOs(OS.WINDOWS)
     void windowsFileDescriptorMetrics() {
-        String osName = System.getProperty("os.name");
-        assumeTrue(osName != null && osName.toLowerCase(Locale.ROOT).contains("win"));
-
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 
         assertThat(registry.find("process.files.open").gauge()).isNull();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/FileDescriptorMetricsTest.java
@@ -48,7 +48,8 @@ class FileDescriptorMetricsTest {
 
     @Test
     void unixFileDescriptorMetrics() {
-        assumeFalse(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+        String osName = System.getProperty("os.name");
+        assumeFalse(osName != null && osName.toLowerCase(Locale.ROOT).contains("win"));
 
         // tag::example[]
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
@@ -60,7 +61,8 @@ class FileDescriptorMetricsTest {
 
     @Test
     void windowsFileDescriptorMetrics() {
-        assumeTrue(System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win"));
+        String osName = System.getProperty("os.name");
+        assumeTrue(osName != null && osName.toLowerCase(Locale.ROOT).contains("win"));
 
         new FileDescriptorMetrics(Tags.of("some", "tag")).bindTo(registry);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/system/ProcessorMetricsTest.java
@@ -47,7 +47,8 @@ class ProcessorMetricsTest {
         new ProcessorMetrics().bindTo(registry);
         // end::setup[]
         assertThat(registry.get("system.cpu.count").gauge().value()).isPositive();
-        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")) {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
             assertThat(registry.find("system.load.average.1m").gauge()).describedAs("Not present on windows").isNull();
         }
         else {
@@ -94,7 +95,8 @@ class ProcessorMetricsTest {
         new ProcessorMetrics(extraTags, new OpenTelemetryJvmCpuMeterConventions(extraTags)).bindTo(registry);
 
         assertThat(registry.get("jvm.cpu.count").gauge().value()).isPositive();
-        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")) {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
             assertThat(registry.find("jvm.cpu.recent_utilization").gauge()).describedAs("Not present on windows")
                 .isNull();
         }
@@ -110,7 +112,8 @@ class ProcessorMetricsTest {
         new ProcessorMetrics(extraTags, new OpenTelemetryJvmCpuMeterConventions(extraTags)).bindTo(registry);
 
         assertThat(registry.get("jvm.cpu.count").tags(extraTags).gauge().value()).isPositive();
-        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("win")) {
+        String osName = System.getProperty("os.name");
+        if (osName != null && osName.toLowerCase(Locale.ROOT).contains("win")) {
             assertThat(registry.find("jvm.cpu.recent_utilization").tags(extraTags).gauge())
                 .describedAs("Not present on windows")
                 .isNull();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -316,11 +316,11 @@ class TomcatMetricsTest {
         });
     }
 
-    void runTomcat(HttpServlet servlet, Callable<Void> doWithTomcat) throws Exception {
+    void runTomcat(HttpServlet servlet, Callable<?> doWithTomcat) throws Exception {
         runTomcat(Collections.singleton(servlet), doWithTomcat);
     }
 
-    void runTomcat(Collection<Servlet> servlets, Callable<Void> doWithTomcat) throws Exception {
+    void runTomcat(Collection<Servlet> servlets, Callable<?> doWithTomcat) throws Exception {
         Tomcat server = new Tomcat();
         try {
             StandardHost host = new StandardHost();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/tomcat/TomcatMetricsTest.java
@@ -36,6 +36,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import javax.servlet.Servlet;
@@ -316,11 +317,11 @@ class TomcatMetricsTest {
         });
     }
 
-    void runTomcat(HttpServlet servlet, Callable<?> doWithTomcat) throws Exception {
+    void runTomcat(HttpServlet servlet, Callable<@Nullable Void> doWithTomcat) throws Exception {
         runTomcat(Collections.singleton(servlet), doWithTomcat);
     }
 
-    void runTomcat(Collection<Servlet> servlets, Callable<?> doWithTomcat) throws Exception {
+    void runTomcat(Collection<Servlet> servlets, Callable<@Nullable Void> doWithTomcat) throws Exception {
         Tomcat server = new Tomcat();
         try {
             StandardHost host = new StandardHost();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepFunctionTimerTest.java
@@ -65,7 +65,7 @@ class StepFunctionTimerTest {
 
         Duration stepDuration = Duration.ofMillis(10);
         StepFunctionTimer<Object> ft = new StepFunctionTimer<>(mock(Meter.Id.class), clock, stepDuration.toMillis(),
-                new Object(), (o) -> counts.poll(), (o) -> totalTimes.poll(), TimeUnit.SECONDS, TimeUnit.SECONDS);
+                new Object(), (o) -> counts.remove(), (o) -> totalTimes.remove(), TimeUnit.SECONDS, TimeUnit.SECONDS);
 
         assertThat(ft.count()).isEqualTo(0.0);
 
@@ -90,7 +90,7 @@ class StepFunctionTimerTest {
 
         Duration stepDuration = Duration.ofMillis(10);
         StepFunctionTimer<Object> timer = new StepFunctionTimer<>(mock(Meter.Id.class), clock, stepDuration.toMillis(),
-                new Object(), (o) -> counts.poll(), (o) -> totalTimes.poll(), TimeUnit.SECONDS, TimeUnit.SECONDS);
+                new Object(), (o) -> counts.remove(), (o) -> totalTimes.remove(), TimeUnit.SECONDS, TimeUnit.SECONDS);
 
         assertThat(timer.count()).isZero();
         assertThat(timer.totalTime(TimeUnit.SECONDS)).isZero();

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -635,7 +635,7 @@ class StepMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        CompletableFuture<Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
+        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
 
         MyStepMeterRegistry() {
             this(StepMeterRegistryTest.this.config, StepMeterRegistryTest.this.clock);

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -636,7 +635,7 @@ class StepMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        Future<?> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
+        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
         });
 
         MyStepMeterRegistry() {

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/step/StepMeterRegistryTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -635,7 +636,8 @@ class StepMeterRegistryTest {
 
         AtomicBoolean isPublishing = new AtomicBoolean(false);
 
-        CompletableFuture<@Nullable Void> scheduledPublishingFuture = CompletableFuture.completedFuture(null);
+        Future<?> scheduledPublishingFuture = CompletableFuture.runAsync(() -> {
+        });
 
         MyStepMeterRegistry() {
             this(StepMeterRegistryTest.this.config, StepMeterRegistryTest.this.clock);

--- a/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathClassLoader.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathClassLoader.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -75,7 +76,7 @@ final class ModifiedClassPathClassLoader extends URLClassLoader {
 
     private final ClassLoader junitLoader;
 
-    ModifiedClassPathClassLoader(URL[] urls, ClassLoader parent, ClassLoader junitLoader) {
+    ModifiedClassPathClassLoader(URL[] urls, @Nullable ClassLoader parent, ClassLoader junitLoader) {
         super(urls, parent);
         this.junitLoader = junitLoader;
     }
@@ -100,11 +101,16 @@ final class ModifiedClassPathClassLoader extends URLClassLoader {
         if (annotatedElements.isEmpty()) {
             return null;
         }
-        return cache.computeIfAbsent(annotatedElements, (key) -> compute(testClass.getClassLoader(), key));
+        ClassLoader classLoader = testClass.getClassLoader() != null ? testClass.getClassLoader()
+                : ClassLoader.getSystemClassLoader();
+        return cache.computeIfAbsent(annotatedElements, (key) -> compute(classLoader, key));
     }
 
-    private static Collection<AnnotatedElement> getAnnotatedElements(Object[] array) {
+    private static Collection<AnnotatedElement> getAnnotatedElements(@Nullable Object @Nullable [] array) {
         Set<AnnotatedElement> result = new LinkedHashSet<>();
+        if (array == null) {
+            return result;
+        }
         for (Object item : array) {
             if (item instanceof AnnotatedElement) {
                 result.add((AnnotatedElement) item);
@@ -202,7 +208,8 @@ final class ModifiedClassPathClassLoader extends URLClassLoader {
 
     private static Attributes getManifestMainAttributesFromUrl(URL url) throws Exception {
         try (JarFile jarFile = new JarFile(new File(url.toURI()))) {
-            return jarFile.getManifest().getMainAttributes();
+            Manifest manifest = jarFile.getManifest();
+            return manifest != null ? manifest.getMainAttributes() : new Attributes();
         }
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathExtension.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/testsupport/classpath/ModifiedClassPathExtension.java
@@ -132,7 +132,8 @@ class ModifiedClassPathExtension implements InvocationInterceptor {
     private boolean isModifiedClassPathClassLoader(ExtensionContext extensionContext) {
         Class<?> testClass = extensionContext.getRequiredTestClass();
         ClassLoader classLoader = testClass.getClassLoader();
-        return classLoader.getClass().getName().equals(ModifiedClassPathClassLoader.class.getName());
+        return classLoader != null
+                && classLoader.getClass().getName().equals(ModifiedClassPathClassLoader.class.getName());
     }
 
 }

--- a/micrometer-core/src/test/java/io/micrometer/core/testsupport/system/OutputCapture.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/testsupport/system/OutputCapture.java
@@ -16,6 +16,7 @@
 
 package io.micrometer.core.testsupport.system;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -75,7 +77,7 @@ class OutputCapture implements CapturedOutput {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (obj == this) {
             return true;
         }
@@ -128,7 +130,7 @@ class OutputCapture implements CapturedOutput {
      */
     void reset() {
         clearExisting();
-        this.systemCaptures.peek().reset();
+        Objects.requireNonNull(this.systemCaptures.peek()).reset();
     }
 
     void clearExisting() {

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageConsumerInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageConsumerInvocationHandler.java
@@ -20,6 +20,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageListener;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -50,16 +51,17 @@ class MessageConsumerInvocationHandler implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    public @Nullable Object invoke(Object proxy, Method method, @Nullable Object @Nullable [] args) throws Throwable {
         try {
-            if ("setMessageListener".equals(method.getName()) && args[0] != null) {
+            if ("setMessageListener".equals(method.getName()) && args != null && args[0] != null) {
                 MessageListener listener = (MessageListener) args[0];
                 return method.invoke(this.target, new ObservedMessageListener(listener, this.registry));
             }
             return method.invoke(this.target, args);
         }
         catch (InvocationTargetException exc) {
-            throw exc.getTargetException();
+            Throwable targetException = exc.getTargetException();
+            throw targetException != null ? targetException : exc;
         }
     }
 

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageProducerInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageProducerInvocationHandler.java
@@ -49,8 +49,8 @@ class MessageProducerInvocationHandler implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        if ("send".equals(method.getName()) && args[0] != null) {
+    public @Nullable Object invoke(Object proxy, Method method, @Nullable Object @Nullable [] args) throws Throwable {
+        if ("send".equals(method.getName()) && args != null && args[0] != null) {
             Message message = findMessageArgument(args);
             Observation observation = JmsObservationDocumentation.JMS_MESSAGE_PUBLISH.observation(null,
                     DEFAULT_CONVENTION, () -> new JmsPublishObservationContext(message), this.registry);
@@ -59,8 +59,13 @@ class MessageProducerInvocationHandler implements InvocationHandler {
                 return method.invoke(this.target, args);
             }
             catch (InvocationTargetException exc) {
-                observation.error(exc.getTargetException());
-                throw exc.getTargetException();
+                Throwable targetException = exc.getTargetException();
+                if (targetException != null) {
+                    observation.error(targetException);
+                    throw targetException;
+                }
+                observation.error(exc);
+                throw exc;
             }
             catch (Throwable error) {
                 observation.error(error);
@@ -74,11 +79,15 @@ class MessageProducerInvocationHandler implements InvocationHandler {
             return method.invoke(this.target, args);
         }
         catch (InvocationTargetException exc) {
-            throw exc.getTargetException();
+            Throwable targetException = exc.getTargetException();
+            throw targetException != null ? targetException : exc;
         }
     }
 
-    private @Nullable Message findMessageArgument(Object[] args) {
+    private @Nullable Message findMessageArgument(@Nullable Object @Nullable [] args) {
+        if (args == null) {
+            return null;
+        }
         for (Object arg : args) {
             if (arg instanceof Message) {
                 return (Message) arg;

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
@@ -19,6 +19,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -50,7 +51,7 @@ class SessionInvocationHandler implements InvocationHandler {
     }
 
     @Override
-    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    public @Nullable Object invoke(Object proxy, Method method, @Nullable Object @Nullable [] args) throws Throwable {
         try {
             Object result = method.invoke(this.target, args);
             if (result instanceof MessageProducer) {
@@ -70,7 +71,8 @@ class SessionInvocationHandler implements InvocationHandler {
             return result;
         }
         catch (InvocationTargetException exc) {
-            throw exc.getTargetException();
+            Throwable targetException = exc.getTargetException();
+            throw targetException != null ? targetException : exc;
         }
     }
 

--- a/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
+++ b/micrometer-java11/src/main/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClient.java
@@ -32,6 +32,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -269,7 +270,7 @@ public class MicrometerHttpClient extends HttpClient {
             }
             else {
                 stopObservationOrTimer(instrumentation, request, response);
-                return response;
+                return Objects.requireNonNull(response);
             }
         });
     }

--- a/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsReflectiveTests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsReflectiveTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.LockSupport;
 
@@ -74,7 +75,7 @@ class VirtualThreadMetricsReflectiveTests {
     void submitFailedEventsShouldBeRecorded() {
         try (ExecutorService cachedPool = Executors.newCachedThreadPool()) {
             ThreadFactory factory = virtualThreadFactoryFor(cachedPool);
-            Thread thread = factory.newThread(LockSupport::park);
+            Thread thread = Objects.requireNonNull(factory.newThread(LockSupport::park));
             thread.start();
 
             await().atMost(Duration.ofSeconds(2)).until(() -> thread.getState() == WAITING);
@@ -87,7 +88,7 @@ class VirtualThreadMetricsReflectiveTests {
             await().atMost(Duration.ofSeconds(2)).until(() -> counter.count() == 1);
 
             // park, the pool was shut down, this should fail
-            assertThatThrownBy(() -> factory.newThread(LockSupport::park).start())
+            assertThatThrownBy(() -> Objects.requireNonNull(factory.newThread(LockSupport::park)).start())
                 .isInstanceOf(RejectedExecutionException.class);
             await().atMost(Duration.ofSeconds(2)).until(() -> counter.count() == 2);
         }

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/Jetty12ClientTimingInstrumentationVerificationTests.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/Jetty12ClientTimingInstrumentationVerificationTests.java
@@ -71,7 +71,8 @@ class Jetty12ClientTimingInstrumentationVerificationTests
     private HttpClient createHttpClient(boolean withObservationRegistry) {
         HttpClient httpClient = new HttpClient();
         JettyClientMetrics.Builder builder = JettyClientMetrics.builder(getRegistry(),
-                (request, result) -> request.getHeaders().get(HEADER_URI_PATTERN));
+                (request, result) -> request != null && request.getHeaders().get(HEADER_URI_PATTERN) != null
+                        ? request.getHeaders().get(HEADER_URI_PATTERN) : "UNKNOWN");
         if (withObservationRegistry) {
             builder.observationRegistry(getObservationRegistry());
         }

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsTest.java
@@ -61,7 +61,10 @@ class JettyClientMetricsTest {
 
     protected void addInstrumentingListener() {
         httpClient.getRequestListeners()
-            .addListener(JettyClientMetrics.builder(registry, (request, result) -> request.getURI().getPath()).build());
+            .addListener(JettyClientMetrics
+                .builder(registry, (request, result) -> (request != null && request.getURI().getPath() != null)
+                        ? request.getURI().getPath() : "UNKNOWN")
+                .build());
     }
 
     @Test

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsWithObservationTest.java
@@ -44,7 +44,10 @@ class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
     @Override
     protected void addInstrumentingListener() {
         this.httpClient.getRequestListeners()
-            .addListener(JettyClientMetrics.builder(registry, (request, result) -> request.getURI().getPath())
+            .addListener(JettyClientMetrics
+                .builder(registry,
+                        (request, result) -> (request != null && request.getURI().getPath() != null)
+                                ? request.getURI().getPath() : "UNKNOWN")
                 .observationRegistry(observationRegistry)
                 .build());
     }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
@@ -17,7 +17,6 @@ package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Context;
-import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,7 +32,7 @@ import java.util.stream.Collectors;
  */
 public class InvalidObservationException extends RuntimeException {
 
-    private static final @Nullable StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     private final Context context;
 
@@ -72,7 +71,7 @@ public class InvalidObservationException extends RuntimeException {
 
         private final EventName eventName;
 
-        private final @Nullable StackTraceElement[] stackTrace;
+        private final StackTraceElement[] stackTrace;
 
         HistoryElement(EventName eventName) {
             this.eventName = eventName;
@@ -80,7 +79,8 @@ public class InvalidObservationException extends RuntimeException {
             this.stackTrace = findRelevantStackTraceElements(currentStackTrace);
         }
 
-        private @Nullable StackTraceElement[] findRelevantStackTraceElements(@Nullable StackTraceElement[] stackTrace) {
+        @SuppressWarnings("NullAway")
+        private StackTraceElement[] findRelevantStackTraceElements(StackTraceElement[] stackTrace) {
             int index = findFirstRelevantStackTraceElementIndex(stackTrace);
             if (index == -1) {
                 return EMPTY_STACK_TRACE;
@@ -90,7 +90,7 @@ public class InvalidObservationException extends RuntimeException {
             }
         }
 
-        private int findFirstRelevantStackTraceElementIndex(@Nullable StackTraceElement[] stackTrace) {
+        private int findFirstRelevantStackTraceElementIndex(StackTraceElement[] stackTrace) {
             int index = -1;
             for (int i = 0; i < stackTrace.length; i++) {
                 if (isObservationRelated(stackTrace[i])) {
@@ -102,10 +102,7 @@ public class InvalidObservationException extends RuntimeException {
             return (index >= stackTrace.length) ? -1 : index;
         }
 
-        private boolean isObservationRelated(@Nullable StackTraceElement stackTraceElement) {
-            if (stackTraceElement == null) {
-                return false;
-            }
+        private boolean isObservationRelated(StackTraceElement stackTraceElement) {
             String className = stackTraceElement.getClassName();
             return className.equals(Observation.class.getName())
                     || className.equals("io.micrometer.observation.SimpleObservation")
@@ -116,7 +113,7 @@ public class InvalidObservationException extends RuntimeException {
             return eventName;
         }
 
-        public @Nullable StackTraceElement[] getStackTrace() {
+        public StackTraceElement[] getStackTrace() {
             return stackTrace;
         }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
@@ -17,6 +17,7 @@ package io.micrometer.observation.tck;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Context;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -32,7 +33,7 @@ import java.util.stream.Collectors;
  */
 public class InvalidObservationException extends RuntimeException {
 
-    private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
+    private static final @Nullable StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
     private final Context context;
 
@@ -71,7 +72,7 @@ public class InvalidObservationException extends RuntimeException {
 
         private final EventName eventName;
 
-        private final StackTraceElement[] stackTrace;
+        private final @Nullable StackTraceElement[] stackTrace;
 
         HistoryElement(EventName eventName) {
             this.eventName = eventName;
@@ -79,7 +80,7 @@ public class InvalidObservationException extends RuntimeException {
             this.stackTrace = findRelevantStackTraceElements(currentStackTrace);
         }
 
-        private StackTraceElement[] findRelevantStackTraceElements(StackTraceElement[] stackTrace) {
+        private @Nullable StackTraceElement[] findRelevantStackTraceElements(@Nullable StackTraceElement[] stackTrace) {
             int index = findFirstRelevantStackTraceElementIndex(stackTrace);
             if (index == -1) {
                 return EMPTY_STACK_TRACE;
@@ -89,7 +90,7 @@ public class InvalidObservationException extends RuntimeException {
             }
         }
 
-        private int findFirstRelevantStackTraceElementIndex(StackTraceElement[] stackTrace) {
+        private int findFirstRelevantStackTraceElementIndex(@Nullable StackTraceElement[] stackTrace) {
             int index = -1;
             for (int i = 0; i < stackTrace.length; i++) {
                 if (isObservationRelated(stackTrace[i])) {
@@ -101,7 +102,10 @@ public class InvalidObservationException extends RuntimeException {
             return (index >= stackTrace.length) ? -1 : index;
         }
 
-        private boolean isObservationRelated(StackTraceElement stackTraceElement) {
+        private boolean isObservationRelated(@Nullable StackTraceElement stackTraceElement) {
+            if (stackTraceElement == null) {
+                return false;
+            }
             String className = stackTraceElement.getClassName();
             return className.equals(Observation.class.getName())
                     || className.equals("io.micrometer.observation.SimpleObservation")
@@ -112,7 +116,7 @@ public class InvalidObservationException extends RuntimeException {
             return eventName;
         }
 
-        public StackTraceElement[] getStackTrace() {
+        public @Nullable StackTraceElement[] getStackTrace() {
             return stackTrace;
         }
 

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/InvalidObservationException.java
@@ -79,6 +79,8 @@ public class InvalidObservationException extends RuntimeException {
             this.stackTrace = findRelevantStackTraceElements(currentStackTrace);
         }
 
+        // NullAway models Arrays.copyOfRange return type as nullable due to potential
+        // null padding
         @SuppressWarnings("NullAway")
         private StackTraceElement[] findRelevantStackTraceElements(StackTraceElement[] stackTrace) {
             int index = findFirstRelevantStackTraceElementIndex(stackTrace);

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistry.java
@@ -263,7 +263,7 @@ public final class TestObservationRegistry
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) {
                 return true;
             }

--- a/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
+++ b/micrometer-observation-test/src/main/java/io/micrometer/observation/tck/TestObservationRegistryAssert.java
@@ -80,7 +80,8 @@ public class TestObservationRegistryAssert
                     "There must be only a single observation, however there are <%s> registered observations with names <%s>",
                     contexts.size(), observationNames(contexts));
         }
-        return new TestObservationRegistryAssertReturningObservationContextAssert(contexts.peek(), this);
+        return new TestObservationRegistryAssertReturningObservationContextAssert(
+                Objects.requireNonNull(contexts.peek()), this);
     }
 
     private void failForNoObservations() {

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationPredicate.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationPredicate.java
@@ -15,6 +15,8 @@
  */
 package io.micrometer.observation;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.BiPredicate;
 
 /**
@@ -26,6 +28,6 @@ import java.util.function.BiPredicate;
  * @author Marcin Grzejszczak
  * @since 1.10.0
  */
-public interface ObservationPredicate extends BiPredicate<String, Observation.Context> {
+public interface ObservationPredicate extends BiPredicate<@Nullable String, Observation.Context> {
 
 }

--- a/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/ObservationRegistry.java
@@ -199,7 +199,7 @@ public interface ObservationRegistry {
          * @param context context
          * @return {@code true} when observation is enabled
          */
-        boolean isObservationEnabled(@Nullable String name, Observation.@Nullable Context context) {
+        boolean isObservationEnabled(@Nullable String name, Observation.Context context) {
             for (ObservationPredicate predicate : this.observationPredicates) {
                 if (!predicate.test(name, context)) {
                     return false;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservationKeyValueAnnotationHandler.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/aop/ObservationKeyValueAnnotationHandler.java
@@ -21,6 +21,7 @@ import io.micrometer.common.annotation.ValueExpressionResolver;
 import io.micrometer.common.annotation.ValueResolver;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.annotation.ObservationKeyValue;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.function.Function;
@@ -60,7 +61,7 @@ public class ObservationKeyValueAnnotationHandler extends AnnotationHandler<Obse
         }
     }
 
-    private static KeyValueWithCardinality toKeyValue(Annotation annotation, Object object,
+    private static KeyValueWithCardinality toKeyValue(Annotation annotation, @Nullable Object object,
             Function<Class<? extends ValueResolver>, ? extends ValueResolver> resolverProvider,
             Function<Class<? extends ValueExpressionResolver>, ? extends ValueExpressionResolver> expressionResolverProvider) {
         ObservationKeyValue observationKeyValue = (ObservationKeyValue) annotation;

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplyReceiverContext.java
@@ -53,7 +53,7 @@ public class RequestReplyReceiverContext<C, RES> extends ReceiverContext<C> impl
     }
 
     @Override
-    public void setResponse(RES response) {
+    public void setResponse(@Nullable RES response) {
         this.response = response;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/RequestReplySenderContext.java
@@ -53,7 +53,7 @@ public class RequestReplySenderContext<C, RES> extends SenderContext<C> implemen
     }
 
     @Override
-    public void setResponse(RES response) {
+    public void setResponse(@Nullable RES response) {
         this.response = response;
     }
 

--- a/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
+++ b/micrometer-observation/src/main/java/io/micrometer/observation/transport/ResponseContext.java
@@ -37,6 +37,6 @@ public interface ResponseContext<RES> {
      * Setter for the response object.
      * @param response the response
      */
-    void setResponse(RES response);
+    void setResponse(@Nullable RES response);
 
 }

--- a/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/CurrentObservationTest.java
@@ -147,7 +147,7 @@ class CurrentObservationTest {
         registry.observationConfig()
             .observationHandler(context -> true)
             // .observationHandler(new ObservationTextPublisher())
-            .observationPredicate((name, context) -> !name.equals("b"));
+            .observationPredicate((name, context) -> !"b".equals(name));
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {
             assertThat(registry.getCurrentObservation()).isNull();

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationRegistryTest.java
@@ -63,7 +63,7 @@ class ObservationRegistryTest {
 
     @Test
     void observationShouldBeNoopWhenPredicateApplicable() {
-        registry.observationConfig().observationPredicate((name, context) -> !name.equals("test.timer"));
+        registry.observationConfig().observationPredicate((name, context) -> !"test.timer".equals(name));
 
         Observation sample = Observation.start("test.timer", registry);
 

--- a/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
+++ b/micrometer-observation/src/test/java/io/micrometer/observation/ObservationTests.java
@@ -88,7 +88,7 @@ class ObservationTests {
     void usingParentObservationToMatchPredicate() {
         registry.observationConfig().observationHandler(context -> true);
         registry.observationConfig()
-            .observationPredicate((s, context) -> !s.equals("child") || context.getParentObservation() != null);
+            .observationPredicate((s, context) -> !"child".equals(s) || context.getParentObservation() != null);
 
         Observation childWithoutParent = Observation.createNotStarted("child", registry);
         assertThat(childWithoutParent.isNoop()).isTrue();

--- a/micrometer-test/src/main/java/io/micrometer/common/util/internal/logging/LogEvent.java
+++ b/micrometer-test/src/main/java/io/micrometer/common/util/internal/logging/LogEvent.java
@@ -57,7 +57,7 @@ public class LogEvent {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o)
             return true;
         if (!(o instanceof LogEvent))

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -729,7 +729,7 @@ public abstract class MeterRegistryCompatibilityKit {
         @Test
         @DisplayName("attributes from @Timed annotation apply to builder")
         void timedAnnotation() {
-            Timed timed = AnnotationHolder.class.getAnnotation(Timed.class);
+            Timed timed = requireNonNull(AnnotationHolder.class.getAnnotation(Timed.class));
             LongTaskTimer ltt = LongTaskTimer.builder(timed).register(registry);
             Meter.Id id = ltt.getId();
             assertThat(id.getName()).isEqualTo("my.name");

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/DiskMetricsSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/DiskMetricsSample.java
@@ -29,7 +29,8 @@ public class DiskMetricsSample {
 
     public static void main(String[] args) {
         MeterRegistry registry = SampleConfig.myMonitoringSystem();
-        new DiskSpaceMetrics(new File(System.getProperty("user.dir"))).bindTo(registry);
+        String userDir = System.getProperty("user.dir");
+        new DiskSpaceMetrics(new File(userDir != null ? userDir : ".")).bindTo(registry);
 
         Flux.never().blockLast();
     }

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -24,6 +24,7 @@ import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.ObservationTextPublisher;
 import io.micrometer.observation.GlobalObservationConvention;
 import io.micrometer.observation.ObservationConvention;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -127,7 +128,7 @@ public class ObservationHandlerSample {
     static class IgnoringObservationPredicate implements ObservationPredicate {
 
         @Override
-        public boolean test(String name, Observation.Context context) {
+        public boolean test(@Nullable String name, Observation.Context context) {
             boolean observationIgnored = "sample.ignored".equals(name);
             if (observationIgnored) {
                 System.out.println("Ignoring " + name);


### PR DESCRIPTION
Enable the `NullAway:JSpecifyMode` and `NullAway:JSpecifyExperimental` flags (on JDK 22+) and resolve all resulting NullAway errors across the codebase.

With NullAway 0.14.0 and `JSpecifyExperimental` enabled, NullAway activates stricter JSpecify enforcement, better wildcard support, and standard library nullability models from `jspecify/jdk`.

The `NullAway:JSpecifyMode` and `NullAway:JSpecifyExperimental` flags are restricted to JDK 22 and higher (`canCompileOrRun(22)`) because on JDK 21, `javac` has bytecode type-use annotation limitations ([JDK-8346471](https://bugs.openjdk.org/browse/JDK-8346471)). Restricting JSpecify checking to JDK 22+ ensures all nullability checks run cleanly without needing source code workarounds or JDK 21 compiler flags.

Key areas of note for review:
1. **Public API and Generics adjustments**:
   - `TimedExecutorService`, `TimedScheduledExecutorService`, `TimedCallable`: Added `<T extends @Nullable Object>` bounds on generic task and future methods, allowing tasks that return `null` (matching standard `ExecutorService` under JSpecify).
   - `ObservationPredicate`: First parameter is now `@Nullable String` (`BiPredicate<@Nullable String, Context>`), as convention names can be null before resolution.
   - `ResponseContext`: Updated `void setResponse(@Nullable RES response)` to accept `@Nullable RES` since client/server transport errors leave the response object null.
   - `LongTaskTimer.Builder`: Fixed `serviceLevelObjectives(Duration @Nullable ... slos)` (nullable array of non-null durations) to align with `AbstractTimerBuilder` and `Timer.Builder`.
   - `StatsdMeterRegistry.Builder`: Parameter type for `lineBuilder` changed to `BiFunction<Meter.Id, @Nullable DistributionStatisticConfig, StatsdLineBuilder>` since non-distribution meters do not supply a configuration.
2. **Null handling / logic improvements**:
   - `AbstractTimer`: Refactored pause detector initialization to avoid returning `null` in `computeIfAbsent`.
   - `CloudWatchMeterRegistry`: Used a null-safe builder helper for `Stream<MetricDatum>` to safely drop `NaN` metric values.
   - `TimedAspect` and `CountedAspect`: Added null check when looking up annotations before invoking join points.
   - `InfluxApiVersion`: Safely handled optional `config.org()` when building Influx V2 write endpoints.
3. **Suppressions**:
   - Added `@SuppressWarnings("NullAway")` for `MBeanServer.addNotificationListener` calls passing `null` handback objects (`CommonsObjectPool2Metrics`, `TomcatMetrics`, `KafkaConsumerMetrics`), and `Arrays.copyOf` array expansions (`MetricsDSLContext`, `NewRelicInsightsApiClientProvider`).