### PR TITLE
Make japicmp baseline dependency declarative

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -424,20 +424,10 @@ subprojects {
             if (!(project.name in [])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
 
-                def baselineConfig = configurations.create('japicmpBaseline') {
-                    visible = false
-                    canBeConsumed = false
-                    canBeResolved = true
-                    description = "Baseline dependency for Japicmp binary compatibility check"
-                }
-                if (compatibleVersion != 'SKIP') {
-                    dependencies.add(baselineConfig.name, "${project.group}:${project.name}:${compatibleVersion}@jar")
-                }
-
                 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
                     dependsOn jar
-                    oldClasspath.from(baselineConfig)
-                    newClasspath.from(files(jar.archiveFile, project(":${project.name}").jar))
+                    oldClasspath.from(configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")))
+                    newClasspath.from(jar.archiveFile)
                     onlyBinaryIncompatibleModified = true
                     failOnModification = true
                     failOnSourceIncompatibility = true

--- a/build.gradle
+++ b/build.gradle
@@ -424,22 +424,19 @@ subprojects {
             if (!(project.name in [])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
 
-                tasks.register('downloadBaseline') {
-                    doLast {
-                        Set<File> baselineFiles = configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")).files
-                        logger.info("Downloaded for baseline comparison: $baselineFiles")
-                        assert baselineFiles.size() == 1
-                        assert baselineFiles.first().name.endsWith("${project.name}-${compatibleVersion}.jar")
-                        copy {
-                            from baselineFiles.first()
-                            into layout.buildDirectory.dir('baselineLibs')
-                        }
-                    }
+                def baselineConfig = configurations.create('japicmpBaseline') {
+                    visible = false
+                    canBeConsumed = false
+                    canBeResolved = true
+                    description = "Baseline dependency for Japicmp binary compatibility check"
+                }
+                if (compatibleVersion != 'SKIP') {
+                    dependencies.add(baselineConfig.name, "${project.group}:${project.name}:${compatibleVersion}@jar")
                 }
 
                 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
-                    dependsOn downloadBaseline, jar
-                    oldClasspath.from(layout.buildDirectory.file("baselineLibs/${project.name}-${compatibleVersion}.jar"))
+                    dependsOn jar
+                    oldClasspath.from(baselineConfig)
                     newClasspath.from(files(jar.archiveFile, project(":${project.name}").jar))
                     onlyBinaryIncompatibleModified = true
                     failOnModification = true

--- a/build.gradle
+++ b/build.gradle
@@ -373,7 +373,7 @@ subprojects {
     }
 
     // Do not publish some modules
-    if (!['samples', 'benchmarks', 'micrometer-osgi-test', 'micrometer-osgi-test-slf4j2', 'concurrency-tests', 'micrometer-test-aspectj-ctw', 'micrometer-test-aspectj-ltw'].find { project.name.contains(it) }) {
+    if (!['docs', 'samples', 'benchmarks', 'micrometer-osgi-test', 'micrometer-osgi-test-slf4j2', 'concurrency-tests', 'micrometer-test-aspectj-ctw', 'micrometer-test-aspectj-ltw'].find { project.name.contains(it) }) {
         apply plugin: 'com.netflix.nebula.maven-publish'
         apply plugin: 'com.netflix.nebula.maven-manifest'
         apply plugin: 'com.netflix.nebula.maven-developer'
@@ -424,10 +424,14 @@ subprojects {
             if (!(project.name in [])) { // add projects here that do not exist in the previous minor so should be excluded from japicmp
                 apply plugin: 'me.champeau.gradle.japicmp'
 
+                String expectedJarName = "${project.name}-${compatibleVersion}.jar"
                 tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
                     dependsOn jar
                     oldClasspath.from(configurations.detachedConfiguration(dependencies.create("${project.group}:${project.name}:${compatibleVersion}@jar")))
                     newClasspath.from(jar.archiveFile)
+                    doFirst {
+                        assert oldClasspath.files.any { it.name.endsWith(expectedJarName) }
+                    }
                     onlyBinaryIncompatibleModified = true
                     failOnModification = true
                     failOnSourceIncompatibility = true

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -118,10 +118,6 @@ tasks.withType(AbstractPublishToMaven).configureEach {
     enabled = false
 }
 
-downloadBaseline {
-    enabled = false
-}
-
 japicmp {
     enabled = false
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -113,11 +113,3 @@ jar {
 javadoc {
     enabled = false
 }
-
-tasks.withType(AbstractPublishToMaven).configureEach {
-    enabled = false
-}
-
-japicmp {
-    enabled = false
-}


### PR DESCRIPTION
## Summary
- Replaces the imperative `downloadBaseline` copy task with a declarative detached configuration wired directly to `japicmp.oldClasspath`.
- Bypasses Gradle's automatic project dependency substitution to ensure published baseline artifacts are resolved without self-referencing.
- Adds an execution-time assertion in `japicmp.doFirst` to verify that the resolved baseline JAR matches the expected baseline version.
- Wires `jar.archiveFile` directly into `japicmp.newClasspath` using Gradle Provider APIs.
- Adds `docs` to the non-published modules check in `build.gradle`, eliminating obsolete publishing and `japicmp` disable blocks from `docs/build.gradle`.
- Enables native Gradle `UP-TO-DATE` checks and build caching (`FROM-CACHE`) for `japicmp` tasks while unblocking Gradle Configuration Cache support.

## Test plan
- Verified `./gradlew :micrometer-core:japicmp` correctly compares against `micrometer-core-1.15.0.jar` (not self).
- Verified second execution of `./gradlew :micrometer-core:japicmp` is `UP-TO-DATE`.
- Verified `./gradlew japicmp --configuration-cache` stores and reuses configuration cache cleanly across all subprojects.
- Verified `./gradlew check -x test` builds successfully.