### PR TITLE
Make testModules task incremental

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -406,16 +406,25 @@ subprojects {
             }
 
             tasks.register("testModules", Exec) {
+                onlyIf { jar.enabled || tasks.findByName('shadowJar')?.enabled }
                 dependsOn jar
-                String executablePath = javaToolchains.launcherFor { languageVersion = javaLanguageVersion }.get().executablePath
-                commandLine "$executablePath", '-p', "$jar.archiveFile", '--list-modules'
-                standardOutput = new ByteArrayOutputStream()
+                inputs.file(jar.archiveFile)
+                def outputFile = layout.buildDirectory.file("reports/testModules/list-modules.txt")
+                outputs.file(outputFile)
+                executable = javaToolchains.launcherFor { languageVersion = javaLanguageVersion }.get().executablePath.asFile.absolutePath
+                argumentProviders.add({
+                    ['-p', jar.archiveFile.get().asFile.absolutePath, '--list-modules']
+                } as CommandLineArgumentProvider)
+                def outputStream = new ByteArrayOutputStream()
+                standardOutput = outputStream
                 ignoreExitValue = true
 
                 doLast {
                     if (executionResult.get().getExitValue() != 0) {
-                        throw new GradleException("Command finished with non-zero exit value ${executionResult.get().getExitValue()}:\n$standardOutput")
+                        throw new GradleException("Command finished with non-zero exit value ${executionResult.get().getExitValue()}:\n$outputStream")
                     }
+                    outputFile.get().asFile.parentFile.mkdirs()
+                    outputFile.get().asFile.text = outputStream.toString()
                 }
             }
 

--- a/implementations/micrometer-registry-statsd/build.gradle
+++ b/implementations/micrometer-registry-statsd/build.gradle
@@ -65,6 +65,7 @@ def shadowJar = tasks.named('shadowJar', ShadowJar) {
 }
 
 tasks.japicmp.dependsOn(shadowJar)
+tasks.testModules.dependsOn(shadowJar)
 
 // The Nebula Publishing plugin automatically configures the publication of the shadow jar but
 // shadow dependencies are added to the POM as runtime so we manually clean up the POM.


### PR DESCRIPTION
## Summary
- Declares input (`jar.archiveFile`) and output (`layout.buildDirectory.file("reports/testModules/list-modules.txt")`) on the `testModules` `Exec` task.
- Uses `argumentProviders` with the resolved JAR path to correctly pass the archive path to `java -p <jar> --list-modules`.
- Allows Gradle to mark `testModules` as `UP-TO-DATE` on subsequent builds when the archive has not changed.

## Test plan
- Verified `./gradlew :micrometer-core:testModules` succeeds and produces the expected report.
- Verified `./gradlew :micrometer-core:testModules` is marked `UP-TO-DATE` on subsequent runs.
- Verified full `./gradlew check -x test` builds successfully.