### PR TITLE
Apply Spotless plugin only to Kotlin projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ subprojects {
     apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'signing'
     apply plugin: 'io.spring.javaformat'
-    apply plugin: 'com.diffplug.spotless'
 
     if (project.name != 'micrometer-bom') {
         tasks.withType(JavaCompile).configureEach {
@@ -296,12 +295,6 @@ subprojects {
             exclude '**/*.json' // comments not supported
         }
 
-        spotless {
-            kotlin {
-                ktlint().editorConfigOverride(['ktlint_standard_no-wildcard-imports': 'disabled'])
-            }
-        }
-
         // Publish resolved versions.
         plugins.withId('maven-publish') {
             publishing {
@@ -367,6 +360,14 @@ subprojects {
     }
 
     plugins.withId('org.jetbrains.kotlin.jvm') {
+        apply plugin: 'com.diffplug.spotless'
+
+        spotless {
+            kotlin {
+                ktlint().editorConfigOverride(['ktlint_standard_no-wildcard-imports': 'disabled'])
+            }
+        }
+
         // We disable the kotlinSourcesJar task since it conflicts with the sourcesJar task of the Java plugin
         // See: https://github.com/micrometer-metrics/micrometer/issues/5151
         // See: https://youtrack.jetbrains.com/issue/KT-54207/Kotlin-has-two-sources-tasks-kotlinSourcesJar-and-sourcesJar-that-archives-sources-to-the-same-artifact


### PR DESCRIPTION
## Summary
- Moves `apply plugin: 'com.diffplug.spotless'` and `spotless { kotlin { ... } }` inside `plugins.withId('org.jetbrains.kotlin.jvm')`.
- Restricts Spotless tasks to the 2 modules containing Kotlin source code (`micrometer-core` and `micrometer-samples-kotlin`), removing redundant tasks from the other 50 Java-only modules.

## Test plan
- Verified `./gradlew :micrometer-core:spotlessCheck :micrometer-samples-kotlin:spotlessCheck` executes and checks formatting properly.
- Verified `./gradlew check --dry-run` shows Spotless tasks registered only on `:micrometer-core` and `:micrometer-samples-kotlin`.
- Verified full `./gradlew check -x test` builds successfully.