### PR TITLE
Remove buildscript cacheDynamicVersionsFor configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,6 @@ buildscript {
             }
         }
     }
-
-    configurations.classpath.resolutionStrategy.cacheDynamicVersionsFor 0, 'minutes'
 }
 
 plugins {


### PR DESCRIPTION
- Removes `configurations.classpath.resolutionStrategy.cacheDynamicVersionsFor 0, 'minutes'` from `build.gradle`.
- Buildscript dependencies are statically declared with fixed versions in `gradle/libs.versions.toml`, making this legacy configuration unnecessary.