### PR TITLE
Make HdrHistogram an optional dependency

### DIFF
--- a/docs/modules/ROOT/pages/concepts.adoc
+++ b/docs/modules/ROOT/pages/concepts.adoc
@@ -19,4 +19,7 @@ It does not require any third-party (non-Micrometer) dependencies on the classpa
 Use of the xref:./concepts/timers.adoc#_pause_detection[pause detection] feature requires the https://github.com/LatencyUtils/LatencyUtils[LatencyUtils] dependency (`org.latencyutils:LatencyUtils`) to be available on the classpath at runtime.
 Micrometer does not include LatencyUtils on the runtime classpath by default because pause detection is turned off by default.
 
-If you use xref:./concepts/histogram-quantiles.adoc[client-side percentiles], you need https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] on the classpath at runtime. If you do not use client-side percentiles, you may exclude HdrHistogram from your application's runtime classpath.
+Use of xref:./concepts/histogram-quantiles.adoc[client-side percentiles] requires the https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] dependency (`org.hdrhistogram:HdrHistogram`) to be available on the classpath at runtime.
+As of Micrometer 1.18.0, HdrHistogram is an optional dependency and is no longer pulled in transitively by `micrometer-core`, so you must declare it explicitly if you publish client-side percentiles.
+Registering a meter that publishes percentiles without HdrHistogram on the classpath fails with an `InvalidConfigurationException` naming the missing dependency.
+Note that `publishPercentileHistogram` and `serviceLevelObjectives` do not use HdrHistogram, so they work without it.

--- a/docs/modules/ROOT/pages/concepts/histogram-quantiles.adoc
+++ b/docs/modules/ROOT/pages/concepts/histogram-quantiles.adoc
@@ -23,6 +23,10 @@ Timer.builder("my.timer")
 <3> `serviceLevelObjectives`: Used to publish a cumulative histogram with buckets defined by your SLOs. When used in concert with `publishPercentileHistogram` on a monitoring system that supports aggregable percentiles, this setting adds additional buckets to the published histogram. When used on a system that does not support aggregable percentiles, this setting causes a histogram to be published with only these buckets.
 <4> `minimumExpectedValue`/`maximumExpectedValue`: Controls the number of buckets shipped by `publishPercentileHistogram` and controls the accuracy and memory footprint of the underlying HdrHistogram structure.
 
+NOTE: `publishPercentiles` requires the optional https://github.com/HdrHistogram/HdrHistogram[HdrHistogram] dependency (`org.hdrhistogram:HdrHistogram`) on the runtime classpath.
+As of Micrometer 1.18.0 it is no longer pulled in transitively, so declare it explicitly if you publish client-side percentiles; registering such a meter without it fails with an `InvalidConfigurationException` that names the missing dependency.
+`publishPercentileHistogram` and `serviceLevelObjectives` do not need HdrHistogram.
+
 NOTE: For those monitoring systems, where percentiles can be approximated using the histogram (see `publishPercentileHistogram` above), it is usually unnecessary to also publish client-side percentiles (`publishPercentiles`) since in those scenarios client-side percentiles are redundant and also non-aggregable across dimensions (unlike histograms). Prometheus Java Client (1.x) does not support having both under the same metric name.
 
 Since shipping percentiles to the monitoring system generates additional time series, it is generally preferable to *not* configure them in core libraries that are included as dependencies in applications. Instead, applications can turn on this behavior for some set of timers and distribution summaries by using a meter filter.

--- a/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
+++ b/implementations/micrometer-registry-otlp/src/main/java/io/micrometer/registry/otlp/OtlpMeterRegistry.java
@@ -485,6 +485,7 @@ public class OtlpMeterRegistry extends PushMeterRegistry {
         }
 
         if (distributionStatisticConfig.isPublishingPercentiles()) {
+            HdrHistogramAvailability.requireAvailable();
             return new TimeWindowPercentileHistogram(clock, distributionStatisticConfig, false);
         }
         return NoopHistogram.INSTANCE;

--- a/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
+++ b/implementations/micrometer-registry-stackdriver/src/main/java/io/micrometer/stackdriver/StackdriverHistogramUtil.java
@@ -26,6 +26,7 @@ final class StackdriverHistogramUtil {
     // copied and modified from AbstractDistributionSummary/AbstractTimer
     static Histogram stackdriverHistogram(Clock clock, DistributionStatisticConfig distributionStatisticConfig) {
         if (distributionStatisticConfig.isPublishingPercentiles()) {
+            HdrHistogramAvailability.requireAvailable();
             return new StackdriverClientSidePercentilesHistogram(clock, distributionStatisticConfig);
         }
         if (distributionStatisticConfig.isPublishingHistogram()) {

--- a/micrometer-core/build.gradle
+++ b/micrometer-core/build.gradle
@@ -93,8 +93,10 @@ dependencies {
     api project(":micrometer-commons")
     api project(":micrometer-observation")
 
-    // HdrHistogram is needed at runtime when client-side percentiles are configured
-    implementation libs.hdrhistogram
+    // HdrHistogram is only needed when client-side percentiles are configured, so it is
+    // optional. Micrometer fails with an actionable message if it is missing when needed;
+    // see HdrHistogramAvailability.
+    optionalApi libs.hdrhistogram
     // We need LatencyUtils to compile but users by default do not need it
     compileOnly(libs.latencyUtils) {
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractDistributionSummary.java
@@ -54,6 +54,7 @@ public abstract class AbstractDistributionSummary extends AbstractMeter implemen
             boolean supportsAggregablePercentiles) {
         if (distributionStatisticConfig.isPublishingPercentiles()) {
             // hdr-based histogram
+            HdrHistogramAvailability.requireAvailable();
             return new TimeWindowPercentileHistogram(clock, distributionStatisticConfig, supportsAggregablePercentiles);
         }
         if (distributionStatisticConfig.isPublishingHistogram()) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/AbstractTimer.java
@@ -122,6 +122,7 @@ public abstract class AbstractTimer extends AbstractMeter implements Timer {
             boolean supportsAggregablePercentiles) {
         if (distributionStatisticConfig.isPublishingPercentiles()) {
             // hdr-based histogram
+            HdrHistogramAvailability.requireAvailable();
             return new TimeWindowPercentileHistogram(clock, distributionStatisticConfig, supportsAggregablePercentiles);
         }
         if (distributionStatisticConfig.isPublishingHistogram()) {

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HdrHistogramAvailability.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/HdrHistogramAvailability.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.core.instrument.distribution;
+
+import io.micrometer.core.instrument.config.InvalidConfigurationException;
+
+/**
+ * <b>NOTE: This class is intended for internal use as an implementation detail. You
+ * should not compile against its API. Please contact the project maintainers if you need
+ * this as public API.</b>
+ * <p>
+ * Detects whether the optional HdrHistogram dependency is present on the runtime
+ * classpath.
+ * <p>
+ * HdrHistogram is needed only by {@link TimeWindowPercentileHistogram}, which in turn is
+ * used only when client-side percentiles are configured. Loading that histogram resolves
+ * the HdrHistogram types it refers to, so callers must consult this class <em>before</em>
+ * instantiating it (or any subclass of it). Otherwise a bare {@link NoClassDefFoundError}
+ * escapes to the caller, which gives no indication of what is missing or why.
+ *
+ * @author Rafael Winterhalter
+ * @since 1.18.0
+ */
+public final class HdrHistogramAvailability {
+
+    /**
+     * One of the two types {@link TimeWindowPercentileHistogram} refers to. Both ship in
+     * the same artifact, so probing for either is sufficient.
+     */
+    private static final String PROBED_CLASS_NAME = "org.HdrHistogram.DoubleRecorder";
+
+    private static final boolean AVAILABLE = probe();
+
+    private HdrHistogramAvailability() {
+    }
+
+    private static boolean probe() {
+        try {
+            Class.forName(PROBED_CLASS_NAME, false, HdrHistogramAvailability.class.getClassLoader());
+            return true;
+        }
+        catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether HdrHistogram can be loaded, and therefore whether client-side percentiles
+     * can be computed. The classpath is probed once, when this class is initialized.
+     * @return {@code true} if HdrHistogram is on the runtime classpath
+     */
+    public static boolean isAvailable() {
+        return AVAILABLE;
+    }
+
+    /**
+     * Verify that HdrHistogram is on the runtime classpath before a
+     * {@link TimeWindowPercentileHistogram} is instantiated.
+     * @throws InvalidConfigurationException if HdrHistogram is not on the runtime
+     * classpath
+     */
+    public static void requireAvailable() {
+        if (!AVAILABLE) {
+            throw new InvalidConfigurationException(
+                    "Client-side percentiles are configured (see publishPercentiles) but HdrHistogram, "
+                            + "which Micrometer needs to compute them, is not on the runtime classpath. "
+                            + "HdrHistogram is an optional dependency: add org.hdrhistogram:HdrHistogram to "
+                            + "your application, or stop publishing percentiles. Note that "
+                            + "publishPercentileHistogram and serviceLevelObjectives do not require HdrHistogram.");
+        }
+    }
+
+}

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/distribution/TimeWindowPercentileHistogram.java
@@ -31,6 +31,11 @@ import java.util.Set;
  * <p>
  * A histogram implementation that supports the computation of percentiles by Micrometer
  * for publishing to a monitoring system.
+ * <p>
+ * This class is backed by HdrHistogram, which is an optional dependency of Micrometer.
+ * Loading this class fails with a {@link NoClassDefFoundError} when HdrHistogram is not
+ * on the runtime classpath, so callers should consult {@link HdrHistogramAvailability}
+ * before instantiating it.
  *
  * @author Jon Schneider
  * @author Trustin Heuiseung Lee

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/MissingHdrHistogramTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/MissingHdrHistogramTest.java
@@ -15,18 +15,22 @@
  */
 package io.micrometer.core.instrument;
 
+import io.micrometer.core.instrument.config.InvalidConfigurationException;
+import io.micrometer.core.instrument.distribution.HdrHistogramAvailability;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.core.testsupport.classpath.ClassPathExclusions;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Tests for demonstrating that a timer works without HdrHistogram dependency if
- * percentiles are not used.
+ * Tests for demonstrating that meters work without the optional HdrHistogram dependency
+ * unless client-side percentiles are used, in which case a descriptive error is raised.
  *
  * @author Johnny Lim
+ * @author Rafael Winterhalter
  */
 @ClassPathExclusions("HdrHistogram-*.jar")
 class MissingHdrHistogramTest {
@@ -34,14 +38,39 @@ class MissingHdrHistogramTest {
     private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
 
     @Test
+    void reportsHdrHistogramAsUnavailable() {
+        assertThat(HdrHistogramAvailability.isAvailable()).isFalse();
+    }
+
+    @Test
     void doesNotThrowAnyExceptionWhenPercentilesAreNotUsed() {
         assertThatCode(() -> Timer.builder("my.timer").register(registry)).doesNotThrowAnyException();
     }
 
     @Test
-    void throwsClassNotFoundExceptionWhenPercentilesAreUsed() {
+    void doesNotThrowAnyExceptionForHistogramsAndServiceLevelObjectives() {
+        assertThatCode(() -> Timer.builder("my.histogram.timer").publishPercentileHistogram().register(registry))
+            .doesNotThrowAnyException();
+        assertThatCode(
+                () -> DistributionSummary.builder("my.slo.summary").serviceLevelObjectives(1.0, 2.0).register(registry))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void throwsDescriptiveExceptionWhenTimerPercentilesAreUsed() {
         assertThatThrownBy(() -> Timer.builder("my.timer").publishPercentiles(0.5d, 0.9d).register(registry))
-            .hasCauseExactlyInstanceOf(ClassNotFoundException.class);
+            .isInstanceOf(InvalidConfigurationException.class)
+            .hasMessageContaining("HdrHistogram")
+            .hasMessageContaining("org.hdrhistogram:HdrHistogram")
+            .hasMessageContaining("not on the runtime classpath");
+    }
+
+    @Test
+    void throwsDescriptiveExceptionWhenDistributionSummaryPercentilesAreUsed() {
+        assertThatThrownBy(
+                () -> DistributionSummary.builder("my.summary").publishPercentiles(0.5d, 0.9d).register(registry))
+            .isInstanceOf(InvalidConfigurationException.class)
+            .hasMessageContaining("org.hdrhistogram:HdrHistogram");
     }
 
 }

--- a/micrometer-test/build.gradle
+++ b/micrometer-test/build.gradle
@@ -12,6 +12,10 @@ dependencies {
     api project(':micrometer-observation')
     api project(':micrometer-observation-test')
 
+    // The compatibility kit exercises client-side percentiles, so it needs the optional
+    // HdrHistogram dependency at runtime, as would any user of client-side percentiles.
+    implementation libs.hdrhistogram
+
     api libs.assertj
 
     implementation platform(libs.junitBom)

--- a/samples/micrometer-samples-core/build.gradle
+++ b/samples/micrometer-samples-core/build.gradle
@@ -8,6 +8,9 @@ dependencies {
 
     implementation project(':micrometer-core')
     implementation project(':micrometer-observation')
+    // several samples publish client-side percentiles, which need the optional
+    // HdrHistogram dependency at runtime
+    implementation libs.hdrhistogram
     implementation(libs.colt)
     implementation("ch.qos.logback:logback-classic:$logback12Version")
     implementation(libs.slf4jApi)


### PR DESCRIPTION
I suggest turning HdrHistogram into an optional dependency. This pattern of optional dependencies is already present within micrometer, and the majority of users of micrometer likely do not rely on it. If the feature is used without adding the dependency, this can be indicated by an explicit error message. The current behaviour can easily be reinstated by simply adding HdrHistogram explicitly, which also states this need in a clearer way.

The background for this suggestion is also that the project seems abandoned. There has not been any activity in almost two years, tickets are not answered and the project seems abandoned (https://github.com/HdrHistogram/HdrHistogram).

To make things worse, the latest release removed its previous module name as the build file was misconfigured.

For a possible alternative, DataDog offers a library that could fit, but this would maybe be an awkward dependency to a Vendor what does not sound well for a vendor-independent API.

Alternatively, one could keep HdrHistorgram as a regular dependency, but still make the code changes, so it can be removed cleanly with a meaningful error message if the library was excluded.