### PR TITLE
Do not add web fonts to javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,11 +204,11 @@ subprojects {
                 targetCompatibility = JavaVersion.VERSION_11
             }
 
-
             javadoc {
                 if (project.name.contains('samples') || project.name.contains("-test-aspectj")) {
                     enabled = false
-                } else {
+                }
+                else {
                     configure(options) {
                         tags(
                                 'apiNote:a:API Note:',
@@ -216,6 +216,7 @@ subprojects {
                                 'implNote:a:Implementation Note:'
                         )
                         options.addBooleanOption('Xdoclint:all,-missing', true)
+                        options.addBooleanOption('-no-fonts', true)
                     }
                 }
             }


### PR DESCRIPTION
Prior to this change, every module that generated a javadoc.jar included web fonts that add about 4MiB to the size of the generated jar.

On my machine, by running `./gradlew pTML`, this means the following change in size of the publishing folder:
- `1.18.x`: `144.0` -> `16.7` MiB
- `1.16.x`: `142.4` -> `15.1` MiB
