### PR TITLE
Proxy JMS session results using the method's declared return type

### DIFF
--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
@@ -58,14 +58,14 @@ class SessionInvocationHandler implements InvocationHandler {
                 MessageProducerInvocationHandler producerHandler = new MessageProducerInvocationHandler(producer,
                         this.registry);
                 return Proxy.newProxyInstance(this.target.getClass().getClassLoader(),
-                        new Class[] { MessageProducer.class }, producerHandler);
+                        new Class[] { method.getReturnType() }, producerHandler);
             }
             if (result instanceof MessageConsumer) {
                 MessageConsumer consumer = (MessageConsumer) result;
                 MessageConsumerInvocationHandler consumerHandler = new MessageConsumerInvocationHandler(consumer,
                         this.registry);
                 return Proxy.newProxyInstance(this.target.getClass().getClassLoader(),
-                        new Class[] { MessageConsumer.class }, consumerHandler);
+                        new Class[] { method.getReturnType() }, consumerHandler);
             }
             return result;
         }

--- a/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandlerTests.java
+++ b/micrometer-jakarta9/src/test/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandlerTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 VMware, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micrometer.jakarta9.instrument.jms;
+
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.jms.*;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the proxies created by {@link JmsInstrumentation#instrumentSession}.
+ *
+ * @author Kumar Gaurav
+ */
+class SessionInvocationHandlerTests {
+
+    private final ObservationRegistry registry = ObservationRegistry.create();
+
+    @Test
+    void shouldReturnProxyAssignableToDeclaredReturnType() throws JMSException {
+        Session session = mock(Session.class);
+        Topic topic = mock(Topic.class);
+        when(session.createDurableSubscriber(topic, "sub")).thenReturn(mock(TopicSubscriber.class));
+
+        Session instrumented = JmsInstrumentation.instrumentSession(session, this.registry);
+
+        assertThatCode(() -> instrumented.createDurableSubscriber(topic, "sub")).doesNotThrowAnyException();
+        assertThat(instrumented.createDurableSubscriber(topic, "sub")).isInstanceOf(TopicSubscriber.class);
+    }
+
+    @Test
+    void shouldStillProxyPlainConsumers() throws JMSException {
+        Session session = mock(Session.class);
+        Queue queue = mock(Queue.class);
+        when(session.createConsumer(queue)).thenReturn(mock(MessageConsumer.class));
+
+        Session instrumented = JmsInstrumentation.instrumentSession(session, this.registry);
+
+        assertThat(instrumented.createConsumer(queue)).isInstanceOf(MessageConsumer.class);
+    }
+
+    @Test
+    void shouldStillProxyProducers() throws JMSException {
+        Session session = mock(Session.class);
+        Queue queue = mock(Queue.class);
+        when(session.createProducer(queue)).thenReturn(mock(MessageProducer.class));
+
+        Session instrumented = JmsInstrumentation.instrumentSession(session, this.registry);
+
+        assertThat(instrumented.createProducer(queue)).isInstanceOf(MessageProducer.class);
+    }
+
+}


### PR DESCRIPTION
**Problem**

`SessionInvocationHandler` wraps every `MessageProducer` result as `MessageProducer.class` and every `MessageConsumer` result as `MessageConsumer.class`, without consulting the intercepted method's declared return type.

`jakarta.jms.Session` declares:

```java
TopicSubscriber createDurableSubscriber(Topic topic, String name) throws JMSException;
TopicSubscriber createDurableSubscriber(Topic topic, String name, String messageSelector, boolean noLocal) throws JMSException;
```

`TopicSubscriber` is a `MessageConsumer` subtype, so the `instanceof MessageConsumer` branch fires, but the proxy handed back implements only `MessageConsumer`. Calling that method on an instrumented session fails:

```java
Session instrumented = JmsInstrumentation.instrumentSession(session, registry);
instrumented.createDurableSubscriber(topic, "sub");
// java.lang.ClassCastException: class jdk.proxy3.$Proxy74 cannot be cast to
// class jakarta.jms.TopicSubscriber
```

So durable topic subscriptions stop working as soon as JMS instrumentation is applied — adding observability to a working application turns subscription setup into a hard runtime failure.

**Solution**

Use `method.getReturnType()` as the proxy interface in both branches. Every relevant `Session` return type (`MessageProducer`, `MessageConsumer`, `TopicSubscriber`, `QueueReceiver`, `TopicPublisher`) is an interface, so this is safe. The producer path is behaviourally unchanged, since `createProducer` already declares `MessageProducer`.

**Tests**

Added `SessionInvocationHandlerTests` covering the durable-subscriber case plus the plain consumer and producer paths, so the existing behaviour is pinned.

The new test fails on current `main` with the `ClassCastException` above and passes with this change. I also reverted only the production hunk while keeping the test and confirmed it fails again as an assertion rather than a compile error, so the test genuinely exercises the fix.

Locally on JDK 21: `micrometer-jakarta9` is 87 tests / 0 failures, and `checkFormatMain` / `checkFormatTest` are clean.

**Notes**

There is no existing coverage of `createDurableSubscriber` anywhere in the repository, which is likely why this went unnoticed.

I noticed #7880 also touches this file (adding `@Nullable` to the `invoke` signature) — happy to rebase if that lands first.
