### PR TITLE
Wait for InfluxDB readiness in TelegrafStatsdLineBuilderIntegrationTest

### DIFF
--- a/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/TelegrafStatsdLineBuilderIntegrationTest.java
+++ b/implementations/micrometer-registry-statsd/src/test/java/io/micrometer/statsd/TelegrafStatsdLineBuilderIntegrationTest.java
@@ -74,7 +74,7 @@ class TelegrafStatsdLineBuilderIntegrationTest {
         .withEnv("DOCKER_INFLUXDB_INIT_ORG", "my-org")
         .withEnv("DOCKER_INFLUXDB_INIT_BUCKET", "metrics_db")
         .withEnv("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", "my-test-token")
-        .waitingFor(Wait.forHttp("/ping").forStatusCode(204));
+        .waitingFor(Wait.forHttp("/ready").forPort(8086).forStatusCode(200));
 
     @Container
     static GenericContainer<?> telegraf = new GenericContainer<>(TELEGRAF_IMAGE).withNetwork(network)
@@ -101,7 +101,7 @@ class TelegrafStatsdLineBuilderIntegrationTest {
             .increment());
 
         await().alias("Telegraf flushing and InfluxDB ingestion")
-            .atMost(5, TimeUnit.SECONDS)
+            .atMost(10, TimeUnit.SECONDS)
             .untilAsserted(
                     () -> verifyMetric("test=metric=equal", containsString("this_is_the"), containsString("tag=test")));
     }
@@ -114,7 +114,7 @@ class TelegrafStatsdLineBuilderIntegrationTest {
             .increment());
 
         await().alias("Telegraf flushing and InfluxDB ingestion")
-            .atMost(5, TimeUnit.SECONDS)
+            .atMost(10, TimeUnit.SECONDS)
             .untilAsserted(() -> verifyMetric("test_metric_comma", containsString("comma_key"),
                     containsString("comma_value")));
     }
@@ -127,7 +127,7 @@ class TelegrafStatsdLineBuilderIntegrationTest {
             .increment());
 
         await().alias("Telegraf flushing and InfluxDB ingestion")
-            .atMost(5, TimeUnit.SECONDS)
+            .atMost(10, TimeUnit.SECONDS)
             .untilAsserted(() -> verifyMetric("test_metric_space", containsString("space_key"),
                     containsString("space_value")));
     }


### PR DESCRIPTION
* Updates the `influxDB` testcontainer wait strategy in `TelegrafStatsdLineBuilderIntegrationTest` from `Wait.forHttp("/ping").forStatusCode(204)` to `Wait.forHttp("/ready").forPort(8086).forStatusCode(200)`.
* In InfluxDB 2.x, `/ping` returns `204 No Content` as soon as the HTTP engine begins listening, before the automated setup script (`DOCKER_INFLUXDB_INIT_MODE=setup`) finishes creating the organization, bucket, and API token. Waiting on `/ready` (200) ensures the container is ready for writes and queries before tests execute.
* Increases the Awaitility assertion timeout from 5 seconds to 10 seconds for CI stability.

See CI failure: https://app.circleci.com/pipelines/github/micrometer-metrics/micrometer/13249/workflows/8afd3163-dcb3-49bd-8c90-54e8a1df5ab7/jobs/76856/tests