### PR TITLE
Add missing reflection hint for getProcessCpuTime

### DIFF
--- a/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
+++ b/micrometer-core/src/main/resources/META-INF/native-image/io.micrometer/micrometer-core/reflect-config.json
@@ -4,7 +4,8 @@
     "methods":[
       {"name":"getCpuLoad","parameterTypes":[] },
       {"name":"getProcessCpuLoad","parameterTypes":[] },
-      {"name":"getSystemCpuLoad","parameterTypes":[] }
+      {"name":"getSystemCpuLoad","parameterTypes":[] },
+      {"name":"getProcessCpuTime","parameterTypes":[] }
     ]
   },
   {


### PR DESCRIPTION
fix: add Missing hint for native compilation.

This hint is required due to reflection usage in io.micrometer.core.instrument.binder.system.ProcessorMetrics.

fixes: gh-7911