### PR TITLE
Allow configuring custom observation conventions for JMS

### DIFF
--- a/docs/modules/ROOT/pages/reference/jms.adoc
+++ b/docs/modules/ROOT/pages/reference/jms.adoc
@@ -54,6 +54,26 @@ MessageConsumer consumer = session.createConsumer(topic);
 consumer.setMessageListener(message -> consumeMessage(message));
 ----
 
+=== Customizing the observations
+
+By default, the observations are created with the `DefaultJmsPublishObservationConvention` and
+`DefaultJmsProcessObservationConvention` conventions. If you need to change the observation name,
+the contextual name or the `KeyValues` that are recorded, you can provide your own conventions:
+
+[source,java]
+----
+import io.micrometer.jakarta9.instrument.jms.JmsInstrumentation;
+
+Session original = ...
+ObservationRegistry registry = ...
+JmsPublishObservationConvention publishConvention = ...
+JmsProcessObservationConvention processConvention = ...
+Session session = JmsInstrumentation.instrumentSession(original, registry, publishConvention, processConvention);
+----
+
+Passing `null` for either convention makes the instrumentation fall back to the default one, so you can
+customize only the observations you are interested in.
+
 == Observations
 
 This instrumentation will create 2 types of observations:

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsInstrumentation.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/JmsInstrumentation.java
@@ -17,6 +17,7 @@ package io.micrometer.jakarta9.instrument.jms;
 
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.Session;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Proxy;
 
@@ -64,13 +65,38 @@ public abstract class JmsInstrumentation {
 
     /**
      * Instrument the {@link Session} given as argument for observability and record
-     * observations using the provided Observation registry.
+     * observations using the provided Observation registry and the
+     * {@link DefaultJmsPublishObservationConvention default} conventions.
      * @param session the target session to proxy for instrumentation
      * @param registry the Observation registry to use
      * @return the instrumented session that should be used to record observations
      */
     public static Session instrumentSession(Session session, ObservationRegistry registry) {
-        SessionInvocationHandler handler = new SessionInvocationHandler(session, registry);
+        return instrumentSession(session, registry, null, null);
+    }
+
+    /**
+     * Instrument the {@link Session} given as argument for observability and record
+     * observations using the provided Observation registry and custom
+     * {@link io.micrometer.observation.ObservationConvention conventions}.
+     * @param session the target session to proxy for instrumentation
+     * @param registry the Observation registry to use
+     * @param customPublishConvention the convention to apply to
+     * {@link JmsObservationDocumentation#JMS_MESSAGE_PUBLISH "jms.message.publish"}
+     * observations, or {@code null} to use the
+     * {@link DefaultJmsPublishObservationConvention default} one
+     * @param customProcessConvention the convention to apply to
+     * {@link JmsObservationDocumentation#JMS_MESSAGE_PROCESS "jms.message.process"}
+     * observations, or {@code null} to use the
+     * {@link DefaultJmsProcessObservationConvention default} one
+     * @return the instrumented session that should be used to record observations
+     * @since 1.18.0
+     */
+    public static Session instrumentSession(Session session, ObservationRegistry registry,
+            @Nullable JmsPublishObservationConvention customPublishConvention,
+            @Nullable JmsProcessObservationConvention customProcessConvention) {
+        SessionInvocationHandler handler = new SessionInvocationHandler(session, registry, customPublishConvention,
+                customProcessConvention);
         return (Session) Proxy.newProxyInstance(session.getClass().getClassLoader(), new Class[] { Session.class },
                 handler);
     }

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageConsumerInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageConsumerInvocationHandler.java
@@ -20,6 +20,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageListener;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -44,9 +45,13 @@ class MessageConsumerInvocationHandler implements InvocationHandler {
 
     private final ObservationRegistry registry;
 
-    MessageConsumerInvocationHandler(MessageConsumer target, ObservationRegistry registry) {
+    private final @Nullable JmsProcessObservationConvention customConvention;
+
+    MessageConsumerInvocationHandler(MessageConsumer target, ObservationRegistry registry,
+            @Nullable JmsProcessObservationConvention customConvention) {
         this.target = target;
         this.registry = registry;
+        this.customConvention = customConvention;
     }
 
     @Override
@@ -54,7 +59,8 @@ class MessageConsumerInvocationHandler implements InvocationHandler {
         try {
             if ("setMessageListener".equals(method.getName()) && args[0] != null) {
                 MessageListener listener = (MessageListener) args[0];
-                return method.invoke(this.target, new ObservedMessageListener(listener, this.registry));
+                return method.invoke(this.target,
+                        new ObservedMessageListener(listener, this.registry, this.customConvention));
             }
             return method.invoke(this.target, args);
         }
@@ -69,14 +75,18 @@ class MessageConsumerInvocationHandler implements InvocationHandler {
 
         private final ObservationRegistry registry;
 
-        ObservedMessageListener(MessageListener delegate, ObservationRegistry registry) {
+        private final @Nullable JmsProcessObservationConvention customConvention;
+
+        ObservedMessageListener(MessageListener delegate, ObservationRegistry registry,
+                @Nullable JmsProcessObservationConvention customConvention) {
             this.delegate = delegate;
             this.registry = registry;
+            this.customConvention = customConvention;
         }
 
         @Override
         public void onMessage(Message message) {
-            Observation observation = JmsObservationDocumentation.JMS_MESSAGE_PROCESS.observation(null,
+            Observation observation = JmsObservationDocumentation.JMS_MESSAGE_PROCESS.observation(this.customConvention,
                     DEFAULT_CONVENTION, () -> new JmsProcessObservationContext(message), this.registry);
             observation.observe(() -> {
                 delegate.onMessage(message);

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageProducerInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/MessageProducerInvocationHandler.java
@@ -43,16 +43,20 @@ class MessageProducerInvocationHandler implements InvocationHandler {
 
     private final ObservationRegistry registry;
 
-    MessageProducerInvocationHandler(MessageProducer target, ObservationRegistry registry) {
+    private final @Nullable JmsPublishObservationConvention customConvention;
+
+    MessageProducerInvocationHandler(MessageProducer target, ObservationRegistry registry,
+            @Nullable JmsPublishObservationConvention customConvention) {
         this.target = target;
         this.registry = registry;
+        this.customConvention = customConvention;
     }
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         if ("send".equals(method.getName()) && args[0] != null) {
             Message message = findMessageArgument(args);
-            Observation observation = JmsObservationDocumentation.JMS_MESSAGE_PUBLISH.observation(null,
+            Observation observation = JmsObservationDocumentation.JMS_MESSAGE_PUBLISH.observation(this.customConvention,
                     DEFAULT_CONVENTION, () -> new JmsPublishObservationContext(message), this.registry);
             observation.start();
             try (Observation.Scope scope = observation.openScope()) {

--- a/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
+++ b/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/SessionInvocationHandler.java
@@ -19,6 +19,7 @@ import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.MessageProducer;
 import jakarta.jms.Session;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -39,14 +40,26 @@ class SessionInvocationHandler implements InvocationHandler {
 
     private final ObservationRegistry registry;
 
+    private final @Nullable JmsPublishObservationConvention customPublishConvention;
+
+    private final @Nullable JmsProcessObservationConvention customProcessConvention;
+
     /**
      * Create an invocation handler to be used for proxying a {@link Session}.
      * @param session the proxied session
      * @param registry the observation registry used for recording observations
+     * @param customPublishConvention the custom convention to apply to publish
+     * observations, or {@code null} to use the default one
+     * @param customProcessConvention the custom convention to apply to process
+     * observations, or {@code null} to use the default one
      */
-    SessionInvocationHandler(Session session, ObservationRegistry registry) {
+    SessionInvocationHandler(Session session, ObservationRegistry registry,
+            @Nullable JmsPublishObservationConvention customPublishConvention,
+            @Nullable JmsProcessObservationConvention customProcessConvention) {
         this.target = session;
         this.registry = registry;
+        this.customPublishConvention = customPublishConvention;
+        this.customProcessConvention = customProcessConvention;
     }
 
     @Override
@@ -56,14 +69,14 @@ class SessionInvocationHandler implements InvocationHandler {
             if (result instanceof MessageProducer) {
                 MessageProducer producer = (MessageProducer) result;
                 MessageProducerInvocationHandler producerHandler = new MessageProducerInvocationHandler(producer,
-                        this.registry);
+                        this.registry, this.customPublishConvention);
                 return Proxy.newProxyInstance(this.target.getClass().getClassLoader(),
                         new Class[] { MessageProducer.class }, producerHandler);
             }
             if (result instanceof MessageConsumer) {
                 MessageConsumer consumer = (MessageConsumer) result;
                 MessageConsumerInvocationHandler consumerHandler = new MessageConsumerInvocationHandler(consumer,
-                        this.registry);
+                        this.registry, this.customProcessConvention);
                 return Proxy.newProxyInstance(this.target.getClass().getClassLoader(),
                         new Class[] { MessageConsumer.class }, consumerHandler);
             }

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -20,7 +20,12 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
+import io.micrometer.common.KeyValues;
 import io.micrometer.jakarta9.instrument.jms.JmsInstrumentation;
+import io.micrometer.jakarta9.instrument.jms.JmsProcessObservationContext;
+import io.micrometer.jakarta9.instrument.jms.JmsProcessObservationConvention;
+import io.micrometer.jakarta9.instrument.jms.JmsPublishObservationContext;
+import io.micrometer.jakarta9.instrument.jms.JmsPublishObservationConvention;
 import io.micrometer.observation.tck.TestObservationRegistry;
 import jakarta.jms.*;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -34,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.jspecify.annotations.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -165,9 +171,58 @@ class JmsInstrumentationTests {
         }
     }
 
+    @Test
+    void shouldUseCustomPublishObservationConvention() throws Exception {
+        try (Session session = createInstrumentedSession(new CustomPublishObservationConvention(), null)) {
+            Topic topic = session.createTopic("test.send");
+            MessageProducer producer = session.createProducer(topic);
+            producer.send(session.createTextMessage("test content"));
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.publish")
+                .that()
+                .hasContextualNameEqualTo("custom publish")
+                .hasLowCardinalityKeyValue("custom.publish.key", "custom.publish.value");
+        }
+    }
+
+    @Test
+    void shouldUseCustomProcessObservationConvention() throws Exception {
+        try (Session session = createInstrumentedSession(null, new CustomProcessObservationConvention())) {
+            Topic topic = session.createTopic("test.send");
+            CountDownLatch latch = new CountDownLatch(1);
+            MessageConsumer consumer = session.createConsumer(topic);
+            consumer.setMessageListener(message -> latch.countDown());
+            MessageProducer producer = session.createProducer(topic);
+            producer.send(session.createTextMessage("test send"));
+            assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+            await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
+                    .that()
+                    .hasContextualNameEqualTo("custom process")
+                    .hasLowCardinalityKeyValue("custom.process.key", "custom.process.value"));
+        }
+    }
+
+    @Test
+    void shouldUseDefaultConventionsWhenCustomOnesAreNull() throws Exception {
+        try (Session session = createInstrumentedSession(null, null)) {
+            Topic topic = session.createTopic("test.send");
+            MessageProducer producer = session.createProducer(topic);
+            producer.send(session.createTextMessage("test content"));
+            assertThat(registry).hasObservationWithNameEqualTo("jms.message.publish")
+                .that()
+                .hasContextualNameEqualTo("test.send publish");
+        }
+    }
+
     private Session createInstrumentedSession() throws JMSException {
         Session session = jmsConnection.createSession();
         return JmsInstrumentation.instrumentSession(session, registry);
+    }
+
+    private Session createInstrumentedSession(@Nullable JmsPublishObservationConvention publishConvention,
+            @Nullable JmsProcessObservationConvention processConvention) throws JMSException {
+        Session session = jmsConnection.createSession();
+        return JmsInstrumentation.instrumentSession(session, registry, publishConvention, processConvention);
     }
 
     @AfterEach
@@ -180,6 +235,44 @@ class JmsInstrumentationTests {
     interface SessionConsumer {
 
         void accept(Session session) throws JMSException;
+
+    }
+
+    static class CustomPublishObservationConvention implements JmsPublishObservationConvention {
+
+        @Override
+        public String getName() {
+            return "jms.message.publish";
+        }
+
+        @Override
+        public String getContextualName(JmsPublishObservationContext context) {
+            return "custom publish";
+        }
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(JmsPublishObservationContext context) {
+            return KeyValues.of("custom.publish.key", "custom.publish.value");
+        }
+
+    }
+
+    static class CustomProcessObservationConvention implements JmsProcessObservationConvention {
+
+        @Override
+        public String getName() {
+            return "jms.message.process";
+        }
+
+        @Override
+        public String getContextualName(JmsProcessObservationContext context) {
+            return "custom process";
+        }
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(JmsProcessObservationContext context) {
+            return KeyValues.of("custom.process.key", "custom.process.value");
+        }
 
     }
 

--- a/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
+++ b/micrometer-test/src/test/java/io/micrometer/core/instrument/binder/jms/JmsInstrumentationTests.java
@@ -156,9 +156,12 @@ class JmsInstrumentationTests {
             MessageProducer producer = session.createProducer(topic);
             producer.send(session.createTextMessage("test send"));
             assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
-            assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
-                .that()
-                .hasLowCardinalityKeyValue("exception", "IllegalStateException");
+            // the listener counts the latch down before throwing, so the observation is
+            // only stopped with its error some time after the latch is released
+            await().atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(registry).hasObservationWithNameEqualTo("jms.message.process")
+                    .that()
+                    .hasLowCardinalityKeyValue("exception", "IllegalStateException"));
         }
     }
 


### PR DESCRIPTION
Closes gh-5492                                                                                                                                                           
                                                                                                                                                                           
  JmsInstrumentation always passed `null` as the custom convention, so the                                                                                                 
  observation name, contextual name and key values could not be customized                                                                                                 
  without a GlobalObservationConvention.                                                                                                                                   
                                                                                                                                                                           
  This adds an `instrumentSession` overload taking a                                                                                                                       
  JmsPublishObservationConvention and a JmsProcessObservationConvention,                                                                                                   
  following the same approach already used by InstrumentedTransport for the                                                                                                
  mail instrumentation. Passing `null` for a convention keeps the default one,                                                                                             
  so either observation can be customized on its own.                                                                                                                      
                                                                                                                                                                           
  The second commit fixes a race in the existing                                                                                                                           
  `shouldInstrumentMessageListenerWhenException` test, which the new tests                                                                                                 
  made surface reliably.