### PR TITLE
Document custom tags for Java HttpClient observations

### DIFF
--- a/docs/modules/ROOT/pages/reference/java-httpclient.adoc
+++ b/docs/modules/ROOT/pages/reference/java-httpclient.adoc
@@ -47,6 +47,25 @@ You can instrument this `HttpClient` as follows with an `ObservationRegistry`:
 include::{include-micrometer-java11-test}/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java[tags=observationInstrumentation,indent=0]
 ----
 
+When using an `ObservationRegistry`, you can customize the tags produced by the instrumentation with an `HttpClientObservationConvention`.
+Extend `DefaultHttpClientObservationConvention` and add to its low-cardinality key values to retain the default tags.
+For example, the following convention adds the request host as a low-cardinality `clientName` tag.
+Only use the request host as a low-cardinality tag when the client calls a bounded set of hosts.
+
+[source,java,subs=+attributes]
+----
+include::{include-micrometer-java11-test}/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java[tags=customConvention,indent=0]
+----
+
+Pass the custom convention to the instrumentation builder together with the `ObservationRegistry`.
+The following example creates a registry and registers a `DefaultMeterObservationHandler` to record metrics.
+If your framework already provides an `ObservationRegistry` configured to record metrics, you can use that registry instead.
+
+[source,java,subs=+attributes]
+----
+include::{include-micrometer-java11-test}/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java[tags=customConventionInstrumentation,indent=0]
+----
+
 Alternatively, if you are not using an `ObservationRegistry`, you can instrument with only a `MeterRegistry` as follows:
 
 [source,java,subs=+attributes]

--- a/micrometer-java11/src/test/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java
+++ b/micrometer-java11/src/test/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java
@@ -19,6 +19,7 @@ import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.micrometer.common.KeyValues;
 import io.micrometer.core.Issue;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
@@ -82,6 +83,36 @@ class MicrometerHttpClientTests {
 
         verify(anyRequestedFor(urlEqualTo("/metrics")).withHeader("foo", equalTo("bar")));
         thenMeterRegistryContainsHttpClientTags();
+    }
+
+    @Test
+    @Issue("#4962")
+    void shouldCustomizeTagsWithObservationConvention(WireMockRuntimeInfo wmInfo)
+            throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+            .GET()
+            .uri(URI.create(wmInfo.getHttpBaseUrl() + "/metrics"))
+            .build();
+
+        // tag::customConventionInstrumentation[]
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+
+        HttpClient observedClient = MicrometerHttpClient.instrumentationBuilder(httpClient, meterRegistry)
+            .observationRegistry(observationRegistry)
+            .customObservationConvention(new ClientNameObservationConvention())
+            .build();
+        // end::customConventionInstrumentation[]
+        observedClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        then(meterRegistry.get("http.client.requests")
+            .tag("clientName", request.uri().getHost())
+            .tag("method", "GET")
+            .tag("status", "200")
+            .tag("outcome", "SUCCESS")
+            .tag("uri", "UNKNOWN")
+            .timer()
+            .count()).isEqualTo(1);
     }
 
     @Test
@@ -200,6 +231,22 @@ class MicrometerHttpClientTests {
             }
         };
     }
+
+    // tag::customConvention[]
+    static class ClientNameObservationConvention extends DefaultHttpClientObservationConvention {
+
+        @Override
+        public KeyValues getLowCardinalityKeyValues(HttpClientContext context) {
+            HttpRequest.Builder requestBuilder = context.getCarrier();
+            if (requestBuilder == null) {
+                return super.getLowCardinalityKeyValues(context);
+            }
+            String host = requestBuilder.build().uri().getHost();
+            return super.getLowCardinalityKeyValues(context).and("clientName", host != null ? host : "UNKNOWN");
+        }
+
+    }
+    // end::customConvention[]
 
     static class StoreContextObservationHandler implements ObservationHandler<HttpClientContext> {
 


### PR DESCRIPTION
Document how to customize Java `HttpClient` metric tags with an `HttpClientObservationConvention` and a configured `ObservationRegistry`. The example preserves the default tags, adds the request host as `clientName` for clients calling a bounded set of hosts, and shows how to register a `DefaultMeterObservationHandler` to record metrics.

Include the examples from a compiled test that sends a request and verifies one recorded timer measurement with both the custom and default tags.

Fixes #4962

Validated with JDK 17:

- `:micrometer-java11:test` — 16 passed, 2 skipped, no failures or errors.
- `:micrometer-java11:checkFormat` — passed.
- `:docs:antora` — passed; verified both snippets expand in the generated page.

```sh
mise exec java@17 -- ./gradlew :micrometer-java11:test :micrometer-java11:checkFormat :docs:antora
```
