### PR TITLE
Make active LTT opt-in in DefaultMeterObservationHandler

### DIFF
--- a/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultMeterObservationHandlerBenchmark.java
+++ b/benchmarks/benchmarks-core/src/jmh/java/io/micrometer/benchmark/core/DefaultMeterObservationHandlerBenchmark.java
@@ -44,6 +44,8 @@ public class DefaultMeterObservationHandlerBenchmark {
 
     ObservationRegistry observationRegistry;
 
+    ObservationRegistry longTaskTimerObservationRegistry;
+
     ObservationRegistry noopRegistry;
 
     Timer timer;
@@ -53,7 +55,12 @@ public class DefaultMeterObservationHandlerBenchmark {
         this.timer = Timer.builder("cached.timer").tag("abc", "123").register(meterRegistry);
         this.observationRegistry = ObservationRegistry.create();
         this.observationRegistry.observationConfig()
-            .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build());
+        this.longTaskTimerObservationRegistry = ObservationRegistry.create();
+        this.longTaskTimerObservationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry)
+                .includeActiveObservationLongTaskTimer(true)
+                .build());
         this.noopRegistry = ObservationRegistry.create();
     }
 
@@ -117,6 +124,16 @@ public class DefaultMeterObservationHandlerBenchmark {
     @Benchmark
     public Observation observation() {
         Observation observation = Observation.createNotStarted("test.obs", observationRegistry)
+            .lowCardinalityKeyValue("abc", "123")
+            .start();
+        observation.stop();
+
+        return observation;
+    }
+
+    @Benchmark
+    public Observation observationWithActiveObservationLongTaskTimer() {
+        Observation observation = Observation.createNotStarted("test.obs.ltt", longTaskTimerObservationRegistry)
             .lowCardinalityKeyValue("abc", "123")
             .start();
         observation.stop();

--- a/docs/modules/ROOT/pages/observation/components.adoc
+++ b/docs/modules/ROOT/pages/observation/components.adoc
@@ -127,12 +127,12 @@ Micrometer provides `DefaultMeterObservationHandler`, an `ObservationHandler` im
 When registered on an `ObservationRegistry`, it translates Observation lifecycle events into the following meter types:
 
 * **Timer** (`<observation-name>`) -- Created on `stop`. Records the duration between `start` and `stop`. Tagged with all low cardinality key values and an `error` tag (set to the exception class name if an error was recorded, or `none` otherwise).
-* **LongTaskTimer** (`<observation-name>.active`) -- Created on `start`. Tracks the duration of in-progress observations. Stopped when the observation is stopped. Only tagged with low cardinality key values that are available at the time of `start`.
 * **Counter** (`<observation-name>.<event-name>`) -- Incremented when an event is signaled via `Observation.event(Event)`. Tagged with all low cardinality key values available at the time of the event.
+* **LongTaskTimer** (`<observation-name>.active`) -- _Opt-in; not created by default._ When included, created on `start` to track the duration of in-progress observations, and stopped when the observation is stopped. Only tagged with low cardinality key values that are available at the time of `start`.
 
 NOTE: Only low cardinality key values are used as meter tags. High cardinality key values are not included in meters because they can cause a cardinality explosion in the metrics backend.
 
-WARNING: Since the `LongTaskTimer` is created in the `onStart` method, it can only contain tags that are available by that time. Any low cardinality key values added after calling `start` on the `Observation` will not be included as tags on the `LongTaskTimer`.
+NOTE: As of 1.18.0, use `DefaultMeterObservationHandler.builder(MeterRegistry)` to create the handler; the constructors are deprecated and are planned for removal in 2.0. The deprecated constructors always create the `<observation-name>.active` `LongTaskTimer`, but the builder does not create it unless you ask for it. If you are migrating from a deprecated constructor and want to keep that meter, use `DefaultMeterObservationHandler.builder(registry).includeActiveObservationLongTaskTimer(true).build()`.
 
 The following example shows how to register `DefaultMeterObservationHandler` and the metrics it creates:
 
@@ -141,12 +141,14 @@ The following example shows how to register `DefaultMeterObservationHandler` and
 include::{include-java}/observation/ObservationHandlerTests.java[tags=default_meter_handler,indent=0]
 -----
 
-If you do not need the `LongTaskTimer` (for example, to reduce the number of created meters), you can disable it using `IgnoredMeters`:
+If you want to track in-progress observations, you can opt in to the `LongTaskTimer`:
 
 [source,java,subs=+attributes]
 -----
-include::{include-java}/observation/ObservationHandlerTests.java[tags=default_meter_handler_ignore_ltt,indent=0]
+include::{include-java}/observation/ObservationHandlerTests.java[tags=default_meter_handler_with_ltt,indent=0]
 -----
+
+WARNING: Since the `LongTaskTimer` is created in the `onStart` method, it can only contain tags that are available by that time. Any low cardinality key values added after calling `start` on the `Observation` will not be included as tags on the `LongTaskTimer`.
 
 [[micrometer-observation-events]]
 == Signaling Errors and Arbitrary Events

--- a/docs/modules/ROOT/pages/observation/components.adoc
+++ b/docs/modules/ROOT/pages/observation/components.adoc
@@ -132,8 +132,6 @@ When registered on an `ObservationRegistry`, it translates Observation lifecycle
 
 NOTE: Only low cardinality key values are used as meter tags. High cardinality key values are not included in meters because they can cause a cardinality explosion in the metrics backend.
 
-NOTE: As of 1.18.0, use `DefaultMeterObservationHandler.builder(MeterRegistry)` to create the handler; the constructors are deprecated and are planned for removal in 2.0. The deprecated constructors always create the `<observation-name>.active` `LongTaskTimer`, but the builder does not create it unless you ask for it. If you are migrating from a deprecated constructor and want to keep that meter, use `DefaultMeterObservationHandler.builder(registry).includeActiveObservationLongTaskTimer(true).build()`.
-
 The following example shows how to register `DefaultMeterObservationHandler` and the metrics it creates:
 
 [source,java,subs=+attributes]

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationConfiguringTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationConfiguringTests.java
@@ -73,7 +73,7 @@ class ObservationConfiguringTests {
                 return context;
             })
             // Example of using metrics
-            .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build());
 
         // Observation will be ignored because of the name
         then(Observation.start("to.ignore", () -> new MyContext("don't ignore"), registry).isNoop()).isTrue();

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationHandlerTests.java
@@ -115,44 +115,50 @@ class ObservationHandlerTests {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         ObservationRegistry registry = ObservationRegistry.create();
         // Register DefaultMeterObservationHandler to create metrics from observations
-        registry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+        registry.observationConfig().observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build());
 
         // Perform an observation
         Observation observation = Observation.createNotStarted("my.operation", registry)
             .lowCardinalityKeyValue("region", "us-east-1");
-        observation.start(); // LongTaskTimer "my.operation.active" starts here
+        observation.start();
         observation.event(Observation.Event.of("my.event")); // Counter
                                                              // "my.operation.my.event"
                                                              // incremented
-        observation.stop(); // Timer "my.operation" and LongTaskTimer stop
+        observation.stop(); // Timer "my.operation" is recorded here
 
         // Verify metrics were created:
         // Timer: my.operation (with tags: region=us-east-1, error=none)
         assertThat(meterRegistry.get("my.operation").timer().count()).isEqualTo(1);
         // Counter: my.operation.my.event (with tags: region=us-east-1)
         assertThat(meterRegistry.get("my.operation.my.event").counter().count()).isEqualTo(1);
+        // No LongTaskTimer, since it is not included by default
+        assertThat(meterRegistry.find("my.operation.active").longTaskTimer()).isNull();
         // end::default_meter_handler[]
     }
 
     @Test
-    void default_meter_observation_handler_ignore_long_task_timer() {
-        // tag::default_meter_handler_ignore_ltt[]
+    void default_meter_observation_handler_with_long_task_timer() {
+        // tag::default_meter_handler_with_ltt[]
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         ObservationRegistry registry = ObservationRegistry.create();
-        // You can disable the LongTaskTimer if you don't need it
+        // Opt in to the LongTaskTimer that tracks in-progress observations
         registry.observationConfig()
-            .observationHandler(new DefaultMeterObservationHandler(meterRegistry,
-                    DefaultMeterObservationHandler.IgnoredMeters.LONG_TASK_TIMER));
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry)
+                .includeActiveObservationLongTaskTimer(true)
+                .build());
 
-        Observation.createNotStarted("my.operation", registry)
+        Observation observation = Observation.createNotStarted("my.operation", registry)
             .lowCardinalityKeyValue("region", "us-east-1")
-            .start()
-            .stop();
+            .start(); // LongTaskTimer "my.operation.active" starts here
 
-        // Timer is created, but no LongTaskTimer
+        // While the observation is in progress, it is tracked as an active task
+        assertThat(meterRegistry.get("my.operation.active").longTaskTimer().activeTasks()).isEqualTo(1);
+
+        observation.stop(); // Timer "my.operation" and LongTaskTimer stop
+
         assertThat(meterRegistry.get("my.operation").timer().count()).isEqualTo(1);
-        assertThat(meterRegistry.find("my.operation.active").longTaskTimer()).isNull();
-        // end::default_meter_handler_ignore_ltt[]
+        assertThat(meterRegistry.get("my.operation.active").longTaskTimer().activeTasks()).isZero();
+        // end::default_meter_handler_with_ltt[]
     }
 
     @Test
@@ -181,7 +187,8 @@ class ObservationHandlerTests {
         ObservationRegistry observationRegistry = ObservationRegistry.create();
         // add metrics
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         observationRegistry.observationConfig().observationConvention(new GlobalTaxObservationConvention());
         // This will be applied to all observations
         observationRegistry.observationConfig().observationFilter(new CloudObservationFilter());

--- a/docs/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
+++ b/docs/src/test/java/io/micrometer/docs/observation/ObservationInstrumentingTests.java
@@ -88,7 +88,7 @@ class ObservationInstrumentingTests {
     void setup() {
         // tag::setup[]
         ObservationRegistry registry = ObservationRegistry.create();
-        registry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+        registry.observationConfig().observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build());
         // end::setup[]
 
         this.registry = registry;

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
@@ -103,8 +103,8 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
      * returned builder does <em>not</em> create the active observation
      * {@link LongTaskTimer} (named {@code <observation-name>.active}) unless
      * {@link Builder#includeActiveObservationLongTaskTimer(boolean)} is set to
-     * {@code true}. This differs from the deprecated constructors, which always create
-     * it.
+     * {@code true}. This differs from the deprecated constructors, which create it unless
+     * {@link IgnoredMeters#LONG_TASK_TIMER} is passed.
      * @param meterRegistry the MeterRegistry in which to register meters
      * @return a new builder
      * @since 1.18.0

--- a/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
+++ b/micrometer-core/src/main/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandler.java
@@ -25,14 +25,26 @@ import java.util.List;
 
 /**
  * Handler for {@link Timer.Sample} and {@link Counter}.
- *
- * WARNING: Since the {@link LongTaskTimer} needs to be created in the {@code onStart}
- * method, it can only contain tags that are available by that time. This means that if
- * you add a {@code lowCardinalityKeyValue} after calling {@code start} on the
- * {@link Observation}, that {@code KeyValue} will not be translated as a {@link Tag} on
- * the {@link LongTaskTimer}. Likewise, since the {@code KeyValuesProvider} is evaluated
- * in the {@code stop} method of the {@link Observation} (after start), those
- * {@code KeyValue} instances will not be used for the {@link LongTaskTimer}.
+ * <p>
+ * Use {@link #builder(MeterRegistry)} to create an instance. The builder does
+ * <em>not</em> create the active observation {@link LongTaskTimer} (named
+ * {@code <observation-name>.active}); opt in to it with
+ * {@link Builder#includeActiveObservationLongTaskTimer(boolean)}. The deprecated
+ * constructors always create it.
+ * <p>
+ * This class is not designed for extension. To customize behavior, implement
+ * {@link MeterObservationHandler} and delegate to an instance created by
+ * {@link #builder(MeterRegistry)}; every {@code ObservationHandler} lifecycle method has
+ * a no-op default, so only the methods you care about need to be delegated.
+ * <p>
+ * WARNING: When the active observation {@link LongTaskTimer} is included: since it needs
+ * to be created in the {@code onStart} method, it can only contain tags that are
+ * available by that time. This means that if you add a {@code lowCardinalityKeyValue}
+ * after calling {@code start} on the {@link Observation}, that {@code KeyValue} will not
+ * be translated as a {@link Tag} on the {@link LongTaskTimer}. Likewise, since the
+ * {@code KeyValuesProvider} is evaluated in the {@code stop} method of the
+ * {@link Observation} (after start), those {@code KeyValue} instances will not be used
+ * for the {@link LongTaskTimer}.
  *
  * @author Marcin Grzejszczak
  * @author Tommy Ludwig
@@ -43,15 +55,21 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
 
     private final MeterRegistry meterRegistry;
 
-    private final boolean shouldCreateLongTaskTimer;
+    private final boolean includeActiveObservationLongTaskTimer;
 
     /**
      * Creates the handler with the default configuration.
      * @param meterRegistry the MeterRegistry to use
+     * @deprecated since 1.18.0, use {@link #builder(MeterRegistry)} instead. Beware that
+     * this constructor creates a {@link LongTaskTimer} named
+     * {@code <observation-name>.active} in addition to the {@link Timer}, but
+     * {@code builder(meterRegistry).build()} does not. Use
+     * {@code builder(meterRegistry).includeActiveObservationLongTaskTimer(true).build()}
+     * to keep the behavior of this constructor.
      */
+    @Deprecated
     public DefaultMeterObservationHandler(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
-        this.shouldCreateLongTaskTimer = true;
+        this(builder(meterRegistry).includeActiveObservationLongTaskTimer(true));
     }
 
     /**
@@ -61,16 +79,43 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
      * @param metersToIgnore the Meters that should not be created when Observations are
      * handled
      * @since 1.13.0
+     * @deprecated since 1.18.0, use {@link #builder(MeterRegistry)} and
+     * {@link Builder#includeActiveObservationLongTaskTimer(boolean)} instead. Opting
+     * <em>out</em> by meter type does not scale as meters are added and cannot express a
+     * different default. {@code new DefaultMeterObservationHandler(registry)} maps to
+     * {@code builder(registry).includeActiveObservationLongTaskTimer(true).build()}, and
+     * {@code new DefaultMeterObservationHandler(registry, IgnoredMeters.LONG_TASK_TIMER)}
+     * maps to {@code builder(registry).build()}.
      */
+    @Deprecated
     public DefaultMeterObservationHandler(MeterRegistry meterRegistry, IgnoredMeters... metersToIgnore) {
-        this.meterRegistry = meterRegistry;
-        this.shouldCreateLongTaskTimer = Arrays.stream(metersToIgnore)
-            .noneMatch(ignored -> ignored == IgnoredMeters.LONG_TASK_TIMER);
+        this(builder(meterRegistry).includeActiveObservationLongTaskTimer(
+                Arrays.stream(metersToIgnore).noneMatch(ignored -> ignored == IgnoredMeters.LONG_TASK_TIMER)));
+    }
+
+    DefaultMeterObservationHandler(Builder builder) {
+        this.meterRegistry = builder.meterRegistry;
+        this.includeActiveObservationLongTaskTimer = builder.includeActiveObservationLongTaskTimer;
+    }
+
+    /**
+     * Returns a {@link Builder} for a {@code DefaultMeterObservationHandler}. The
+     * returned builder does <em>not</em> create the active observation
+     * {@link LongTaskTimer} (named {@code <observation-name>.active}) unless
+     * {@link Builder#includeActiveObservationLongTaskTimer(boolean)} is set to
+     * {@code true}. This differs from the deprecated constructors, which always create
+     * it.
+     * @param meterRegistry the MeterRegistry in which to register meters
+     * @return a new builder
+     * @since 1.18.0
+     */
+    public static Builder builder(MeterRegistry meterRegistry) {
+        return new Builder(meterRegistry);
     }
 
     @Override
     public void onStart(Observation.Context context) {
-        if (shouldCreateLongTaskTimer) {
+        if (includeActiveObservationLongTaskTimer) {
             LongTaskTimer.Sample longTaskSample = meterRegistry.more()
                 .longTaskTimer(context.getName() + ".active", createTags(context))
                 .start();
@@ -90,7 +135,7 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
         Timer.Sample sample = context.getRequired(Timer.Sample.class);
         sample.stop(this.meterRegistry.timer(context.getName(), tags));
 
-        if (shouldCreateLongTaskTimer) {
+        if (includeActiveObservationLongTaskTimer) {
             LongTaskTimer.Sample longTaskSample = context.getRequired(LongTaskTimer.Sample.class);
             longTaskSample.stop();
         }
@@ -121,10 +166,59 @@ public class DefaultMeterObservationHandler implements MeterObservationHandler<O
      * Meter types to ignore.
      *
      * @since 1.13.0
+     * @deprecated since 1.18.0 with no direct replacement. This enum names a <em>meter
+     * type</em> rather than a specific meter this handler creates, and its opt-out
+     * semantics cannot express a different default. Configure meters individually with
+     * {@link #builder(MeterRegistry)}, for example
+     * {@link Builder#includeActiveObservationLongTaskTimer(boolean)}.
      */
+    @Deprecated
     public enum IgnoredMeters {
 
         LONG_TASK_TIMER
+
+    }
+
+    /**
+     * Builder for {@code DefaultMeterObservationHandler}.
+     *
+     * @since 1.18.0
+     */
+    public static class Builder {
+
+        private final MeterRegistry meterRegistry;
+
+        private boolean includeActiveObservationLongTaskTimer;
+
+        Builder(MeterRegistry meterRegistry) {
+            this.meterRegistry = meterRegistry;
+        }
+
+        /**
+         * Whether to create the active observation {@link LongTaskTimer} (named
+         * {@code <observation-name>.active}), which tracks the duration of in-progress
+         * Observations, in addition to the {@link Timer} recorded when an Observation is
+         * stopped. Defaults to {@code false}.
+         * <p>
+         * The deprecated {@code DefaultMeterObservationHandler} constructors always
+         * create this {@link LongTaskTimer}; set this to {@code true} to keep that
+         * behavior when migrating to this builder.
+         * @param includeActiveObservationLongTaskTimer whether to create the active
+         * observation {@link LongTaskTimer}
+         * @return this builder
+         */
+        public Builder includeActiveObservationLongTaskTimer(boolean includeActiveObservationLongTaskTimer) {
+            this.includeActiveObservationLongTaskTimer = includeActiveObservationLongTaskTimer;
+            return this;
+        }
+
+        /**
+         * Build a {@code DefaultMeterObservationHandler}.
+         * @return a new {@code DefaultMeterObservationHandler}
+         */
+        public DefaultMeterObservationHandler build() {
+            return new DefaultMeterObservationHandler(this);
+        }
 
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/grpc/GrpcObservationTest.java
@@ -102,7 +102,7 @@ class GrpcObservationTest {
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
         observationRegistry.observationConfig()
             .observationHandler(new ObservationTextPublisher())
-            .observationHandler(new DefaultMeterObservationHandler(meterRegistry))
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build())
             .observationHandler(serverHandler)
             .observationHandler(clientHandler);
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/MicrometerHttpRequestExecutorTest.java
@@ -367,7 +367,8 @@ class MicrometerHttpRequestExecutorTest {
 
     private ObservationRegistry createObservationRegistry() {
         ObservationRegistry observationRegistry = ObservationRegistry.create();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         return observationRegistry;
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/httpcomponents/hc5/MicrometerHttpRequestExecutorTest.java
@@ -364,7 +364,8 @@ class MicrometerHttpRequestExecutorTest {
 
     private ObservationRegistry createObservationRegistry() {
         ObservationRegistry observationRegistry = ObservationRegistry.create();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         return observationRegistry;
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/jetty/JettyClientMetricsWithObservationTest.java
@@ -32,7 +32,10 @@ class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
     @Override
     void beforeEach() throws Exception {
         super.beforeEach();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry)
+                .includeActiveObservationLongTaskTimer(true)
+                .build());
         this.httpClient.getRequestListeners().removeIf(listener -> true);
         // noinspection deprecation
         this.httpClient.getRequestListeners()

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptorTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/binder/okhttp3/OkHttpObservationInterceptorTest.java
@@ -83,7 +83,8 @@ class OkHttpObservationInterceptorTest {
     @BeforeEach
     void setup() {
         observationRegistry.observationConfig().observationHandler(testHandler);
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         observationRegistry.observationConfig().observationHandler(new PropagatingHandler());
     }
 

--- a/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandlerTest.java
+++ b/micrometer-core/src/test/java/io/micrometer/core/instrument/observation/DefaultMeterObservationHandlerTest.java
@@ -15,17 +15,19 @@
  */
 package io.micrometer.core.instrument.observation;
 
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.Observation.Event;
+import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.net.SocketTimeoutException;
 
-import static io.micrometer.core.instrument.observation.DefaultMeterObservationHandler.IgnoredMeters.LONG_TASK_TIMER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -36,20 +38,67 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DefaultMeterObservationHandlerTest {
 
-    private ObservationRegistry observationRegistry;
-
     private MeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
         this.meterRegistry = new SimpleMeterRegistry();
-        this.observationRegistry = ObservationRegistry.create();
-        this.observationRegistry.observationConfig()
-            .observationHandler(new DefaultMeterObservationHandler(this.meterRegistry));
+    }
+
+    private ObservationRegistry registryWith(ObservationHandler<?> handler) {
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(handler);
+        return observationRegistry;
+    }
+
+    @Test
+    void shouldNotCreateActiveObservationLongTaskTimerByDefault() {
+        ObservationRegistry observationRegistry = registryWith(
+                DefaultMeterObservationHandler.builder(this.meterRegistry).build());
+
+        Observation observation = Observation.createNotStarted("test.observation", observationRegistry)
+            .lowCardinalityKeyValue("low", "1")
+            .highCardinalityKeyValue("high", "2")
+            .start()
+            .event(Event.of("test.event"));
+
+        assertThat(meterRegistry.find("test.observation.active").longTaskTimers()).isEmpty();
+
+        observation.stop();
+
+        assertThat(meterRegistry.get("test.observation").tags("low", "1", "error", "none").timer().count())
+            .isEqualTo(1);
+        assertThat(meterRegistry.get("test.observation.test.event").tags("low", "1").counter().count()).isEqualTo(1);
+
+        // strong guard: no LongTaskTimer registered under any name
+        assertThat(meterRegistry.getMeters()).extracting(meter -> meter.getId().getName())
+            .containsExactlyInAnyOrder("test.observation", "test.observation.test.event");
+    }
+
+    @Test
+    void shouldNotCreateActiveObservationLongTaskTimerWhenExplicitlyExcluded() {
+        ObservationRegistry observationRegistry = registryWith(
+                DefaultMeterObservationHandler.builder(this.meterRegistry)
+                    .includeActiveObservationLongTaskTimer(false)
+                    .build());
+
+        Observation.createNotStarted("test.observation", observationRegistry)
+            .lowCardinalityKeyValue("low", "1")
+            .start()
+            .stop();
+
+        assertThat(meterRegistry.find("test.observation.active").longTaskTimers()).isEmpty();
+        assertThat(meterRegistry.getMeters()).extracting(meter -> meter.getId().getType())
+            .doesNotContain(Meter.Type.LONG_TASK_TIMER);
     }
 
     @Test
     void shouldCreateAllMetersDuringAnObservationWithoutError() {
+        ObservationRegistry observationRegistry = registryWith(
+                DefaultMeterObservationHandler.builder(this.meterRegistry)
+                    .includeActiveObservationLongTaskTimer(true)
+                    .build());
+
         Observation observation = Observation.createNotStarted("test.observation", observationRegistry)
             .lowCardinalityKeyValue("low", "1")
             .highCardinalityKeyValue("high", "2")
@@ -72,6 +121,11 @@ class DefaultMeterObservationHandlerTest {
 
     @Test
     void shouldCreateAllMetersDuringAnObservationWithError() {
+        ObservationRegistry observationRegistry = registryWith(
+                DefaultMeterObservationHandler.builder(this.meterRegistry)
+                    .includeActiveObservationLongTaskTimer(true)
+                    .build());
+
         Observation observation = Observation.createNotStarted("test.observation", observationRegistry)
             .lowCardinalityKeyValue("low", "1")
             .highCardinalityKeyValue("high", "2")
@@ -94,25 +148,71 @@ class DefaultMeterObservationHandlerTest {
         assertThat(meterRegistry.get("test.observation.test.event").tags("low", "1").counter().count()).isEqualTo(1);
     }
 
-    @Test
-    void shouldNotCreateLongTaskTimerIfIgnored() {
-        this.observationRegistry = ObservationRegistry.create();
-        this.observationRegistry.observationConfig()
-            .observationHandler(new DefaultMeterObservationHandler(this.meterRegistry, LONG_TASK_TIMER));
+    @Nested
+    @SuppressWarnings("deprecation")
+    class DeprecatedConstructors {
 
-        Observation.createNotStarted("test.observation", observationRegistry)
-            .lowCardinalityKeyValue("low", "1")
-            .highCardinalityKeyValue("high", "2")
-            .start()
-            .event(Event.of("test.event"))
-            .stop();
+        @Test
+        void singleArgConstructorCreatesActiveObservationLongTaskTimer() {
+            ObservationRegistry observationRegistry = registryWith(new DefaultMeterObservationHandler(meterRegistry));
 
-        assertThat(meterRegistry.get("test.observation").tags("low", "1", "error", "none").timer().count())
-            .isEqualTo(1);
+            Observation observation = Observation.createNotStarted("test.observation", observationRegistry)
+                .lowCardinalityKeyValue("low", "1")
+                .start();
 
-        assertThat(meterRegistry.get("test.observation.test.event").tags("low", "1").counter().count()).isEqualTo(1);
+            assertThat(meterRegistry.get("test.observation.active").tags("low", "1").longTaskTimer().activeTasks())
+                .isEqualTo(1);
 
-        assertThat(meterRegistry.find("test.observation.active").longTaskTimers()).isEmpty();
+            observation.stop();
+
+            assertThat(meterRegistry.get("test.observation.active").tags("low", "1").longTaskTimer().activeTasks())
+                .isZero();
+        }
+
+        /**
+         * Pins the overload resolution documented for the 2.0 removal: with the
+         * single-arg constructor gone,
+         * {@code new DefaultMeterObservationHandler(registry)} would fall through to the
+         * varargs constructor with a zero-length array, which still creates the
+         * LongTaskTimer. Removing only the single-arg constructor therefore changes no
+         * behavior.
+         */
+        @Test
+        void varargsConstructorWithNoIgnoredMetersCreatesActiveObservationLongTaskTimer() {
+            ObservationRegistry observationRegistry = registryWith(new DefaultMeterObservationHandler(meterRegistry,
+                    new DefaultMeterObservationHandler.IgnoredMeters[0]));
+
+            Observation observation = Observation.createNotStarted("test.observation", observationRegistry)
+                .lowCardinalityKeyValue("low", "1")
+                .start();
+
+            assertThat(meterRegistry.get("test.observation.active").tags("low", "1").longTaskTimer().activeTasks())
+                .isEqualTo(1);
+
+            observation.stop();
+        }
+
+        @Test
+        void varargsConstructorWithIgnoredLongTaskTimerDoesNotCreateActiveObservationLongTaskTimer() {
+            ObservationRegistry observationRegistry = registryWith(new DefaultMeterObservationHandler(meterRegistry,
+                    DefaultMeterObservationHandler.IgnoredMeters.LONG_TASK_TIMER));
+
+            Observation.createNotStarted("test.observation", observationRegistry)
+                .lowCardinalityKeyValue("low", "1")
+                .highCardinalityKeyValue("high", "2")
+                .start()
+                .event(Event.of("test.event"))
+                .stop();
+
+            assertThat(meterRegistry.get("test.observation").tags("low", "1", "error", "none").timer().count())
+                .isEqualTo(1);
+
+            assertThat(meterRegistry.get("test.observation.test.event").tags("low", "1").counter().count())
+                .isEqualTo(1);
+
+            assertThat(meterRegistry.find("test.observation.active").longTaskTimers()).isEmpty();
+        }
+
     }
 
 }

--- a/micrometer-java11/src/test/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java
+++ b/micrometer-java11/src/test/java/io/micrometer/java11/instrument/binder/jdk/MicrometerHttpClientTests.java
@@ -66,7 +66,7 @@ class MicrometerHttpClientTests {
         ObservationRegistry observationRegistry = TestObservationRegistry.create();
         observationRegistry.observationConfig()
             .observationHandler(new ObservationHandler.AllMatchingCompositeObservationHandler(headerSettingHandler(),
-                    new DefaultMeterObservationHandler(meterRegistry)));
+                    DefaultMeterObservationHandler.builder(meterRegistry).build()));
 
         HttpRequest request = HttpRequest.newBuilder()
             .GET()

--- a/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsWithObservationTest.java
+++ b/micrometer-jetty12/src/test/java/io/micrometer/jetty12/client/JettyClientMetricsWithObservationTest.java
@@ -37,7 +37,10 @@ class JettyClientMetricsWithObservationTest extends JettyClientMetricsTest {
     @BeforeEach
     @Override
     void beforeEach() throws Exception {
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry)
+                .includeActiveObservationLongTaskTimer(true)
+                .build());
         super.beforeEach();
     }
 

--- a/micrometer-test-aspectj-ctw/src/test/java/io/micrometer/test/ctw/MeasuredClassTest.java
+++ b/micrometer-test-aspectj-ctw/src/test/java/io/micrometer/test/ctw/MeasuredClassTest.java
@@ -46,10 +46,17 @@ class MeasuredClassTest {
         System.out.println("java.version: " + System.getProperty("java.version"));
     }
 
+    @SuppressWarnings("deprecation")
     @BeforeEach
     void setUp() {
-        observationRegistry.observationConfig()
-            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
+        // Intentionally uses the deprecated constructor rather than
+        // DefaultMeterObservationHandler.builder(MeterRegistry): on Java < 17 builds this
+        // module compiles against a published micrometer-core SNAPSHOT instead of the
+        // local project (see this module's build.gradle and gh-6064), so API added in the
+        // current branch is not available here. This test only needs some
+        // MeterObservationHandler to verify compile-time weaving; which constructor is
+        // used is irrelevant to what it covers.
+        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
         // Global registry must be used because aspect gets created for us
         Metrics.addRegistry(registry);
         Observations.setRegistry(observationRegistry);

--- a/micrometer-test-aspectj-ctw/src/test/java/io/micrometer/test/ctw/MeasuredClassTest.java
+++ b/micrometer-test-aspectj-ctw/src/test/java/io/micrometer/test/ctw/MeasuredClassTest.java
@@ -48,7 +48,8 @@ class MeasuredClassTest {
 
     @BeforeEach
     void setUp() {
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         // Global registry must be used because aspect gets created for us
         Metrics.addRegistry(registry);
         Observations.setRegistry(observationRegistry);

--- a/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/test/ltw/MeasuredClassTest.java
+++ b/micrometer-test-aspectj-ltw/src/test/java/io/micrometer/test/ltw/MeasuredClassTest.java
@@ -42,7 +42,8 @@ class MeasuredClassTest {
 
     @BeforeEach
     void setUp() {
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         // Global registry must be used because aspect gets created for us
         Metrics.addRegistry(registry);
         Observations.setRegistry(observationRegistry);

--- a/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/instrument/InstrumentationVerificationTests.java
@@ -49,12 +49,19 @@ abstract class InstrumentationVerificationTests {
     /**
      * Helper method for creating a {@link TestObservationRegistry} to run the tests also
      * using the Observation API.
+     * <p>
+     * The registered handler uses the {@link DefaultMeterObservationHandler} defaults,
+     * which as of 1.18.0 do not include the active observation {@link LongTaskTimer}
+     * (named {@code <observation-name>.active}). Override this method and use
+     * {@link DefaultMeterObservationHandler.Builder#includeActiveObservationLongTaskTimer(boolean)}
+     * if your instrumentation verification needs it.
      * @return a {@link TestObservationRegistry} with a
      * {@link DefaultMeterObservationHandler} registered
      */
     protected TestObservationRegistry createObservationRegistryWithMetrics() {
         TestObservationRegistry observationRegistry = TestObservationRegistry.create();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(getRegistry()));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(getRegistry()).build());
         return observationRegistry;
     }
 

--- a/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
+++ b/micrometer-test/src/main/java/io/micrometer/core/tck/MeterRegistryCompatibilityKit.java
@@ -80,7 +80,8 @@ public abstract class MeterRegistryCompatibilityKit {
         // assigned here rather than at initialization so subclasses can use fields in
         // their registry() implementation
         registry = registry();
-        observationRegistry.observationConfig().observationHandler(new DefaultMeterObservationHandler(registry));
+        observationRegistry.observationConfig()
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
     }
 
     @Test
@@ -919,19 +920,14 @@ public abstract class MeterRegistryCompatibilityKit {
                 .lowCardinalityKeyValue("staticTag", "42")
                 .start();
 
-            // created after start, LongTaskTimer won't have it
+            // added after start, but the Timer is created on stop so it has this tag
             observation.lowCardinalityKeyValue("dynamicTag", "24");
 
             clock(registry).add(1, TimeUnit.SECONDS);
             observation.event(Observation.Event.of("testEvent", "event for testing"));
 
-            LongTaskTimer longTaskTimer = registry.more().longTaskTimer("myObservation.active", "staticTag", "42");
-            assertThat(longTaskTimer.activeTasks()).isEqualTo(1);
-
             observation.stop();
             clock(registry).add(step());
-
-            assertThat(longTaskTimer.activeTasks()).isEqualTo(0);
 
             Timer timer = registry.timer("myObservation", "error", KeyValue.NONE_VALUE, "staticTag", "42", "dynamicTag",
                     "24");
@@ -942,6 +938,38 @@ public abstract class MeterRegistryCompatibilityKit {
 
             Counter counter = registry.counter("myObservation.testEvent", "staticTag", "42", "dynamicTag", "24");
             assertThat(counter.count()).isEqualTo(1.0);
+
+            // the DefaultMeterObservationHandler defaults do not include it
+            assertThat(registry.find("myObservation.active").longTaskTimers()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("record with stateful Observation instance including the active observation LongTaskTimer")
+        void recordWithObservationIncludingActiveObservationLongTaskTimer() {
+            ObservationRegistry longTaskTimerObservationRegistry = ObservationRegistry.create();
+            longTaskTimerObservationRegistry.observationConfig()
+                .observationHandler(DefaultMeterObservationHandler.builder(registry)
+                    .includeActiveObservationLongTaskTimer(true)
+                    .build());
+
+            Observation observation = Observation
+                .createNotStarted("myLongTaskObservation", longTaskTimerObservationRegistry)
+                .lowCardinalityKeyValue("staticTag", "42")
+                .start();
+
+            // created after start, LongTaskTimer won't have it
+            observation.lowCardinalityKeyValue("dynamicTag", "24");
+
+            clock(registry).add(1, TimeUnit.SECONDS);
+
+            LongTaskTimer longTaskTimer = registry.more()
+                .longTaskTimer("myLongTaskObservation.active", "staticTag", "42");
+            assertThat(longTaskTimer.activeTasks()).isEqualTo(1);
+
+            observation.stop();
+            clock(registry).add(step());
+
+            assertThat(longTaskTimer.activeTasks()).isEqualTo(0);
         }
 
         @Test

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcObservationSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/GrpcObservationSample.java
@@ -47,7 +47,7 @@ public class GrpcObservationSample {
         ObservationRegistry observationRegistry = ObservationRegistry.create();
         observationRegistry.observationConfig()
             .observationHandler(new ObservationTextPublisher())
-            .observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+            .observationHandler(DefaultMeterObservationHandler.builder(meterRegistry).build());
 
         HealthStatusManager service = new HealthStatusManager();
 

--- a/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
+++ b/samples/micrometer-samples-core/src/main/java/io/micrometer/core/samples/ObservationHandlerSample.java
@@ -38,7 +38,7 @@ public class ObservationHandlerSample {
     public static void main(String[] args) throws InterruptedException {
         observationRegistry.observationConfig()
             .observationHandler(new ObservationTextPublisher())
-            .observationHandler(new DefaultMeterObservationHandler(registry));
+            .observationHandler(DefaultMeterObservationHandler.builder(registry).build());
         observationRegistry.observationConfig()
             .observationConvention(new CustomObservationConvention())
             .observationPredicate(new IgnoringObservationPredicate());


### PR DESCRIPTION
Deprecate existing constructors and introduce a builder that defaults to not including the active observation LongTaskTimer.

This is implemented in a way that is not a breaking change. It leaves the existing behavior of the constructors but marks them as deprecated. The non-deprecated builder has different default behavior.

I'm not sure this is the best way to evolve things but it avoids some problems. It is awkward to negate things with the enum `IgnoredMeters`. It's also potentially problematic to key on meter **types** because in theory there could be more than one meter of the same type created by the `DefaultMeterObservationHandler`. The varargs constructor shadows the single arg constructor making for some ambiguity if adding/evolving constructors.

The problems with this proposal are that everywhere instantiating `DefaultMeterObservationHandler` needs to be updated to get off deprecated API. The hope is this is limited impact because it should mostly be handled by frameworks. The other point to be aware of is that with no remaining non-deprecated constructors, this more clearly signals that this class is not designed for extension, and the JavaDoc has been updated to state as much. I'm not sure we ever did intend for it to be extended, and [a GitHub search](https://github.com/search?q=%22extends+DefaultMeterObservationHandler%22+language%3AJava&type=code) shows only two cases of that on GitHub.

Closes gh-7312