### PR TITLE
Set base unit for virtual thread scheduler parallelism

### DIFF
--- a/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
+++ b/micrometer-java21/src/main/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetrics.java
@@ -101,6 +101,7 @@ public class VirtualThreadMetrics implements MeterBinder, Closeable {
                 .findVirtual(clazz, "getQueuedVirtualThreadCount", MethodType.methodType(long.class));
 
             Gauge.builder(METER_NAME_PREFIX + "parallelism", platformMXBean, o -> invoke(getParallelism, o))
+                .baseUnit(BaseUnits.THREADS)
                 .description("Virtual thread scheduler's target parallelism")
                 .register(registry);
 

--- a/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
+++ b/micrometer-java21/src/test/java/io/micrometer/java21/instrument/binder/jdk/VirtualThreadMetricsJdk24Tests.java
@@ -50,6 +50,7 @@ class VirtualThreadMetricsJdk24Tests {
     void parallelism() {
         int expectedParallelism = Runtime.getRuntime().availableProcessors();
         assertThat(registry.get("jvm.threads.virtual.parallelism").gauge().value()).isEqualTo(expectedParallelism);
+        assertThat(registry.get("jvm.threads.virtual.parallelism").gauge().getId().getBaseUnit()).isEqualTo("threads");
     }
 
     @Test


### PR DESCRIPTION
Fixes #7945

## Summary

- Set `BaseUnits.THREADS` on `jvm.threads.virtual.parallelism`.
- Add a regression assertion for the gauge base unit.

The other Virtual Thread scheduler gauges already declare `threads`, but `parallelism` was missing the same metadata. This affects the latest stable Micrometer release, `1.17.1`.

## Verification

- `./gradlew :micrometer-java21:format`
- `./gradlew :micrometer-java21:checkFormat`
- `./gradlew :micrometer-java21:test --tests "io.micrometer.java21.instrument.binder.jdk.VirtualThreadMetricsJdk24Tests"`
- `./gradlew :micrometer-java21:check`
