### PR TITLE
Add Kotlin extension functions for observing (suspending) blocks

### DIFF
--- a/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/AsContextElement.kt
+++ b/micrometer-core/src/main/kotlin/io/micrometer/core/instrument/kotlin/AsContextElement.kt
@@ -19,6 +19,8 @@ package io.micrometer.core.instrument.kotlin
 import io.micrometer.context.ContextRegistry
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
+import kotlinx.coroutines.withContext
+import java.util.function.Supplier
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -43,4 +45,44 @@ fun CoroutineContext.currentObservation(): Observation? {
         return element.currentObservation
     }
     return null
+}
+
+/**
+ * Observes the given [block] within an [Observation] named [name].
+ *
+ * @since 1.18.0
+ */
+fun <T> ObservationRegistry.observe(name: String, block: () -> T): T {
+    return Observation.createNotStarted(name, this).observe(Supplier { block() })
+}
+
+/**
+ * Observes the given suspending [block] within an [Observation] named [name].
+ *
+ * @since 1.18.0
+ */
+suspend fun <T> ObservationRegistry.observeSuspend(name: String, block: suspend () -> T): T {
+    return Observation.createNotStarted(name, this).observeSuspend(block)
+}
+
+/**
+ * Suspending equivalent of [Observation.observe], keeping this [Observation] current across
+ * coroutine suspension and resumption.
+ *
+ * @since 1.18.0
+ */
+suspend fun <T> Observation.observeSuspend(block: suspend () -> T): T {
+    start()
+    return try {
+        openScope().use {
+            withContext(observationRegistry.asContextElement()) {
+                block()
+            }
+        }
+    } catch (error: Throwable) {
+        error(error)
+        throw error
+    } finally {
+        stop()
+    }
 }

--- a/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
+++ b/micrometer-core/src/test/kotlin/io/micrometer/core/instrument/kotlin/AsContextElementKtTests.kt
@@ -19,9 +19,12 @@ package io.micrometer.core.instrument.kotlin
 import io.micrometer.context.ContextRegistry
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.tck.TestObservationRegistry
 import kotlinx.coroutines.*
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.BDDAssertions.then
 import org.junit.jupiter.api.Test
+import io.micrometer.observation.tck.TestObservationRegistryAssert.assertThat as assertThatObservationRegistry
 
 internal class AsContextElementKtTests {
 
@@ -60,5 +63,76 @@ internal class AsContextElementKtTests {
 
         then(element.currentObservation()).isSameAs(nextObservation)
         inScope.close()
+    }
+
+    @Test
+    fun `should observe blocking block from observation registry`() {
+        val registry = TestObservationRegistry.create()
+
+        val result = registry.observe("blocking.test") {
+            then(registry.currentObservation).isNotNull()
+            "test result"
+        }
+
+        then(result).isEqualTo("test result")
+        then(registry.currentObservation).isNull()
+        assertThatObservationRegistry(registry).hasSingleObservationThat()
+            .hasNameEqualTo("blocking.test")
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .doesNotHaveError()
+    }
+
+    @Test
+    fun `should keep observation current across suspension in suspending block`(): Unit = runBlocking {
+        val registry = TestObservationRegistry.create()
+        var observationBeforeSuspension: Observation? = null
+        var observationAfterDelay: Observation? = null
+        var observationAfterDispatcherSwitch: Observation? = null
+
+        val result = registry.observeSuspend("suspend.test") {
+            observationBeforeSuspension = registry.currentObservation
+            delay(10)
+            observationAfterDelay = registry.currentObservation
+            withContext(Dispatchers.Default) {
+                observationAfterDispatcherSwitch = registry.currentObservation
+            }
+            "test result"
+        }
+
+        then(result).isEqualTo("test result")
+        then(observationBeforeSuspension).isNotNull()
+        then(observationAfterDelay).isSameAs(observationBeforeSuspension)
+        then(observationAfterDispatcherSwitch).isSameAs(observationBeforeSuspension)
+        then(registry.currentObservation).isNull()
+        assertThatObservationRegistry(registry).hasSingleObservationThat()
+            .hasNameEqualTo("suspend.test")
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .doesNotHaveError()
+    }
+
+    @Test
+    fun `should record error from suspending block and rethrow it`(): Unit = runBlocking {
+        val registry = TestObservationRegistry.create()
+
+        assertThatExceptionOfType(IllegalStateException::class.java)
+            .isThrownBy {
+                runBlocking {
+                    registry.observeSuspend("suspend.error") {
+                        throw IllegalStateException("boom")
+                    }
+                }
+            }
+            .withMessage("boom")
+
+        then(registry.currentObservation).isNull()
+        assertThatObservationRegistry(registry).hasSingleObservationThat()
+            .hasNameEqualTo("suspend.error")
+            .hasBeenStarted()
+            .hasBeenStopped()
+            .thenError()
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessage("boom")
     }
 }


### PR DESCRIPTION
Kotlin users had to write their own helpers to wrap a block of code in an Observation. The blocking case is served well enough by `Observation.observe { ... }`, but there was no idiomatic, coroutine-aware equivalent for suspending code: because observation scope is thread-local based while a coroutine can suspend and resume on different threads, users had to combine `start`/`openScope`/`asContextElement`/`stop` by hand.

This adds three extension functions in the existing `io.micrometer.core.instrument.kotlin` package, reusing the existing `asContextElement()` coroutine propagation:

- `ObservationRegistry.observe(name) { ... }` for blocking blocks
- `ObservationRegistry.observeSuspend(name) { ... }` for suspending blocks
- `Observation.observeSuspend(registry) { ... }` for a pre-built Observation

`observeSuspend` starts the Observation, opens a scope so the started Observation is captured, then runs the block under `withContext(registry.asContextElement())` so the Observation stays current across suspension and dispatcher switches. Errors are recorded via `Observation.error(...)` and rethrown, and the Observation is always stopped.

Closes gh-4754